### PR TITLE
Wrote a workaround to allow glicko2 to work when training on a pufferbox.

### DIFF
--- a/configs/evaluator/evaluator.yaml
+++ b/configs/evaluator/evaluator.yaml
@@ -1,5 +1,5 @@
-num_envs: 1024
-num_episodes: 1024
+num_envs: 128
+num_episodes: 128
 max_time_s: 60
 policy_agents_pct: 0.5
 

--- a/util/stats_library.py
+++ b/util/stats_library.py
@@ -390,7 +390,6 @@ class Glicko2Test(StatisticalTest):
                         s_i = 0.5  # Draw
                         s_j = 0.5
 
-                    #delete aux metrics after testing
                     verbose_results[policy_i]['total_score'] += score_i
                     verbose_results[policy_j]['total_score'] += score_j
                     if s_i == 1:
@@ -591,15 +590,20 @@ def update_scores(historical_scores, new_scores):
     return historical_scores
 
 def get_test_results(test: StatisticalTest, scores_path: str = None):
+    # SINGLE CHECK FOR EMPTY POLICY LIST:
+    if not test.policy_names:
+        print("No policies found. Skipping test altogether.")
+        return {}, "No results to format (no policies found)."
+
     historical_data = {}
     if scores_path and os.path.exists(scores_path):
         with open(scores_path, "r") as file:
             print(f"Loading historical data from {scores_path}")
             try:
                 historical_data = json.load(file)
+                test.withHistoricalData(historical_data)
             except json.JSONDecodeError:
                 print(f"Failed to load historical data from {scores_path}")
-            test.withHistoricalData(historical_data)
 
     results = test.evaluate()
     formatted_results = test.format_results(results)


### PR DESCRIPTION
Wanted to get a quick fix out before heading out for vacation; there might be a more elegant way to do this. There were a bunch of issues with how the process of evaluating and calculating stats attempted to find baselines to compare against as well as problems when running the policy against itself. 
The changes involve checks at several points. There is also code that changes the evaluate frequency to be at least as long as the checkpoint frequency because it can't evaluate unless there is a checkpoint saved model, at least that's how I see policy store working at this time. 