### PR TITLE
Wait for the SSH key on the server to be ready.

### DIFF
--- a/devops/vast/do.py
+++ b/devops/vast/do.py
@@ -105,6 +105,7 @@ def show_command(args):
 def wait_for_ready(label):
     """ Wait for a machine with the given label to become ready. """
     instance = label_to_instance(label)
+    # Wait for the instance to become ready.
     while instance['actual_status'] != 'running':
         print(
           f"Waiting for instance {label} to become ready... "
@@ -112,6 +113,17 @@ def wait_for_ready(label):
         )
         time.sleep(5)
         instance = label_to_instance(label)
+    # Wait for the SSH key on the server to be ready.
+    ssh_host = instance['ssh_host']
+    ssh_port = instance['ssh_port']
+    cmd = f"ssh -o StrictHostKeyChecking=no -p {ssh_port} root@{ssh_host} 'echo 1'"
+    while True:
+      try:
+        subprocess.run(cmd, shell=True, check=True)
+        break
+      except Exception as e:
+        print(f"Waiting for instance {label} to become ready... {e}")
+        time.sleep(5)
 
 def ssh_command(args):
     """ SSH into a machine with the given label. """


### PR DESCRIPTION
When using vast some time the the server is ready but the SSH still fails. This appears because the SSH key takes awhile to be copied over. Wait until the SSH also works.