### PR TITLE
Make normalizations more robust to features being added / removed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "module": "tools.train",
             "args": [
-                "run=daphne.trainer.0",
+                "run=sasmith.local.20250117.3",
                 // "trainer.initial_policy.uri=wandb://run/p2.simple.train.rich.norm.auto.3",
                 // "env=mettagrid/a20_b4_40x40",
                 "env.game.max_steps=100",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "module": "tools.train",
             "args": [
-                "run=sasmith.local.20250117.3",
+                "run=daphne.trainer.0",
                 // "trainer.initial_policy.uri=wandb://run/p2.simple.train.rich.norm.auto.3",
                 // "env=mettagrid/a20_b4_40x40",
                 "env.game.max_steps=100",

--- a/agent/simple_encoder.py
+++ b/agent/simple_encoder.py
@@ -39,6 +39,9 @@ class SimpleConvAgent(nn.Module):
 
         self._obs_norm = None
         if cfg.normalize_features:
+            # ##ObservationDefinition
+            # Here we need to defined the maxima for each feature, so we can normalize.
+            # This means that this needs to be updated if we change what's observable grid objects.
             obs_norms = [
                 1, # 'agent',
                 1, # 'agent:hp',
@@ -57,9 +60,9 @@ class SimpleConvAgent(nn.Module):
                 1, # 'generator:ready',
                 1, # 'converter',
                 30, # 'converter:hp',
-                5, # 'converter:input_resource',
-                5, # 'converter:output_resource',
-                100, # 'converter:output_energy',
+                # 5, # 'converter:input_resource',
+                # 5, # 'converter:output_resource',
+                # 100, # 'converter:output_energy',
                 1, # 'converter:ready',
                 1, # 'altar',
                 30, # 'altar:hp',

--- a/agent/simple_encoder.py
+++ b/agent/simple_encoder.py
@@ -7,6 +7,38 @@ from torch import nn
 
 from agent.feature_encoder import FeatureListNormalizer
 
+# ##ObservationNormalization
+# These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
+# but here we are. If you add / remove a feature, you should add / remove the corresponding normalization.
+OBS_NORMALIZATIONS = {
+    'agent': 1,
+    'agent:hp': 1,
+    'agent:frozen': 1,
+    'agent:energy': 255,
+    'agent:orientation': 1,
+    'agent:shield': 1,
+    'agent:inv:r1': 5,
+    'agent:inv:r2': 5,
+    'agent:inv:r3': 5,
+    'wall': 1,
+    'wall:hp': 10,
+    'generator': 1,
+    'generator:hp': 30,
+    'generator:r1': 30,
+    'generator:ready': 1,
+    'converter': 1,
+    'converter:hp': 30,
+    'converter:input_resource': 5,
+    'converter:output_resource': 5,
+    'converter:output_energy': 100,
+    'converter:ready': 1,
+    'altar': 1,
+    'altar:hp': 30,
+    'altar:ready': 1,
+    'last_action': 10,
+    'last_action_argument': 10,
+    'agent:kinship': 10,
+}
 
 class SimpleConvAgent(nn.Module):
 
@@ -39,44 +71,8 @@ class SimpleConvAgent(nn.Module):
 
         self._obs_norm = None
         if cfg.normalize_features:
-            # ##ObservationDefinition
-            # Here we need to defined the maxima for each feature, so we can normalize.
-            # This means that this needs to be updated if we change what's observable grid objects.
-            obs_norms = [
-                1, # 'agent',
-                1, # 'agent:hp',
-                1, # 'agent:frozen',
-                255, # 'agent:energy',
-                1, # 'agent:orientation',
-                1, # 'agent:shield',
-                5, # 'agent:inv:r1',
-                5, # 'agent:inv:r2',
-                5, # 'agent:inv:r3',
-                1, # 'wall',
-                10, # 'wall:hp',
-                1, # 'generator',
-                30, # 'generator:hp',
-                30, # 'generator:r1',
-                1, # 'generator:ready',
-                1, # 'converter',
-                30, # 'converter:hp',
-                # 5, # 'converter:input_resource',
-                # 5, # 'converter:output_resource',
-                # 100, # 'converter:output_energy',
-                1, # 'converter:ready',
-                1, # 'altar',
-                30, # 'altar:hp',
-                1, # 'altar:ready'
-            ]
-            if cfg.track_last_action:
-                obs_norms.extend([
-                    10, # 'last_action'
-                    10, # 'last_action_argument'
-                ])
-            if cfg.kinship.enabled and cfg.kinship.observed:
-                obs_norms.extend([
-                    10, # 'agent:kinship'
-                ])
+            # #ObservationNormalization
+            obs_norms = [OBS_NORMALIZATIONS[k] for k in grid_features]
             self._obs_norm = torch.tensor(obs_norms, dtype=torch.float32)
             self._obs_norm = self._obs_norm.view(1, self._num_objects, 1, 1)
 


### PR DESCRIPTION
Currently our normalizations are a hard coded list, and we need to make sure the match the features being provided by (e.g.) objects.pyx. This change switches to use the already-provided feature names to generate an appropriate list. This makes it easier / more robust to change the features we're using.

It's still more brittle than I'd like, in case anyone wants to improve this further. It's also slightly more work that need to be done when creating the encoder; but since we're already operating in Python space, I assume this isn't hyper performance sensitive.

Tested by removing some observations from Converters in objects.pyx, recompiling, and running training on my mac. This ran without crashing.