### PR TITLE
Add user launch configs

### DIFF
--- a/configs/user/daveey/eval.yaml
+++ b/configs/user/daveey/eval.yaml
@@ -1,0 +1,16 @@
+# @package __global__
+
+run: ${user.name}.local.eval.1
+
+defaults:
+  - /user/sandbox
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.train.norm.feat
+  baselines:
+    uri: wandb://run/p2.train.norm.feat
+    range: 5
+  num_envs: 10
+  num_episodes: 20
+  max_time_s: 6000

--- a/configs/user/daveey/play.yaml
+++ b/configs/user/daveey/play.yaml
@@ -1,0 +1,25 @@
+# @package __global__
+
+run: ${user.name}.local.play.1
+
+defaults:
+  - /user/sandbox
+  - override /env/mettagrid@env: a20_b4_40x40
+
+env:
+  sampling: 0.5
+  game:
+    max_steps: 10000
+  num_agents: 20
+  map:
+    room:
+      width: 40
+      height: 40
+    objects:
+      agent:
+        energy_reward: 1
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.plu.1
+

--- a/configs/user/daveey/sweep.yaml
+++ b/configs/user/daveey/sweep.yaml
@@ -1,0 +1,10 @@
+# @package __global__
+
+run: ${user.name}.local.sweep.1
+
+defaults:
+  - /user/sandbox
+  - override /sweep: fast
+
+sweep:
+  metric: action.use

--- a/configs/user/daveey/train.yaml
+++ b/configs/user/daveey/train.yaml
@@ -1,0 +1,24 @@
+# @package __global__
+
+run: ${user.name}.local.train.1
+
+defaults:
+  - /user/sandbox
+# These control what other config files we load. This is useful for, e.g., loading a specific map. Specific configuration values can still be overridden below.
+#   - override /agent: simple.medium
+#     For env, we want to load the file from the env/mettagrid directory, but we want to load the config into the env section.
+#   - override /env/mettagrid@env: a20_b4_40x40
+
+# Here we can override any config values.
+# agent:
+#   key: value
+
+env:
+  sampling: 0.1
+
+trainer:
+  evaluate_interval: 2
+
+wandb:
+  track: true
+  checkpoint_interval: 1

--- a/configs/user/example/eval.yaml
+++ b/configs/user/example/eval.yaml
@@ -1,0 +1,16 @@
+# @package __global__
+
+run: ${user.name}.local.eval.1
+
+defaults:
+  - /user/sandbox
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.train.norm.feat
+  baselines:
+    uri: wandb://run/p2.train.norm.feat
+    range: 5
+  num_envs: 10
+  num_episodes: 20
+  max_time_s: 6000

--- a/configs/user/example/play.yaml
+++ b/configs/user/example/play.yaml
@@ -1,0 +1,25 @@
+# @package __global__
+
+run: ${user.name}.local.play.1
+
+defaults:
+  - /user/sandbox
+  - override /env/mettagrid@env: a20_b4_40x40
+
+env:
+  sampling: 0.5
+  game:
+    max_steps: 10000
+  num_agents: 20
+  map:
+    room:
+      width: 40
+      height: 40
+    objects:
+      agent:
+        energy_reward: 1
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.plu.1
+

--- a/configs/user/example/sweep.yaml
+++ b/configs/user/example/sweep.yaml
@@ -1,0 +1,10 @@
+# @package __global__
+
+run: ${user.name}.local.sweep.1
+
+defaults:
+  - /user/sandbox
+  - override /sweep: fast
+
+sweep:
+  metric: action.use

--- a/configs/user/example/train.yaml
+++ b/configs/user/example/train.yaml
@@ -1,0 +1,24 @@
+# @package __global__
+
+run: ${user.name}.local.train.1
+
+defaults:
+  - /user/sandbox
+# These control what other config files we load. This is useful for, e.g., loading a specific map. Specific configuration values can still be overridden below.
+#   - override /agent: simple.medium
+#     For env, we want to load the file from the env/mettagrid directory, but we want to load the config into the env section.
+#   - override /env/mettagrid@env: a20_b4_40x40
+
+# Here we can override any config values.
+# agent:
+#   key: value
+
+env:
+  sampling: 0.1
+
+trainer:
+  evaluate_interval: 2
+
+wandb:
+  track: true
+  checkpoint_interval: 1

--- a/configs/user/sandbox.yaml
+++ b/configs/user/sandbox.yaml
@@ -1,0 +1,10 @@
+# @package __global__
+
+# Relatively common settings for sandbox runs, to reduce clutter in other configs.
+
+env:
+  game:
+    max_steps: 100
+
+wandb:
+  enabled: true

--- a/configs/user/sasmith/eval.yaml
+++ b/configs/user/sasmith/eval.yaml
@@ -1,0 +1,16 @@
+# @package __global__
+
+run: ${user.name}.local.eval.1
+
+defaults:
+  - /user/sandbox
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.train.norm.feat
+  baselines:
+    uri: wandb://run/p2.train.norm.feat
+    range: 5
+  num_envs: 10
+  num_episodes: 20
+  max_time_s: 6000

--- a/configs/user/sasmith/play.yaml
+++ b/configs/user/sasmith/play.yaml
@@ -1,0 +1,25 @@
+# @package __global__
+
+run: ${user.name}.local.play.1
+
+defaults:
+  - /user/sandbox
+  - override /env/mettagrid@env: a20_b4_40x40
+
+env:
+  sampling: 0.5
+  game:
+    max_steps: 10000
+  num_agents: 20
+  map:
+    room:
+      width: 40
+      height: 40
+    objects:
+      agent:
+        energy_reward: 1
+
+evaluator:
+  policy:
+    uri: wandb://run/p2.plu.1
+

--- a/configs/user/sasmith/sweep.yaml
+++ b/configs/user/sasmith/sweep.yaml
@@ -1,0 +1,10 @@
+# @package __global__
+
+run: ${user.name}.local.sweep.1
+
+defaults:
+  - /user/sandbox
+  - override /sweep: fast
+
+sweep:
+  metric: action.use

--- a/configs/user/sasmith/train.yaml
+++ b/configs/user/sasmith/train.yaml
@@ -1,0 +1,24 @@
+# @package __global__
+
+run: ${user.name}.local.train.1
+
+defaults:
+  - /user/sandbox
+# These control what other config files we load. This is useful for, e.g., loading a specific map. Specific configuration values can still be overridden below.
+#   - override /agent: simple.medium
+#     For env, we want to load the file from the env/mettagrid directory, but we want to load the config into the env section.
+#   - override /env/mettagrid@env: a20_b4_40x40
+
+# Here we can override any config values.
+# agent:
+#   key: value
+
+env:
+  sampling: 0.1
+
+trainer:
+  evaluate_interval: 2
+
+wandb:
+  track: true
+  checkpoint_interval: 1


### PR DESCRIPTION
This adds config yamls that take over a lot of what launch.json used to do. This is missing the corresponding launch.json changes to use the configs, since we want to test them with less disruption to other folks.

The layout still has some smell. There's certainly room for common setups for each run type, to further minimize what needs to be in each user config. Dave's also excited about getting all of a user's configs into a single file, and being able to pull out a specific section, but I haven't gotten that to work.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209230815163490

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209239112253087) by [Unito](https://www.unito.io)
