### PR TITLE
Simple Resnet

### DIFF
--- a/agent/lib/observation_normalizer.py
+++ b/agent/lib/observation_normalizer.py
@@ -1,0 +1,50 @@
+import torch
+from torch import nn
+
+
+# ##ObservationNormalization
+# These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
+# but here we are. If you add / remove a feature, you should add / remove the corresponding normalization.
+OBS_NORMALIZATIONS = {
+    'agent': 1,
+    'agent:hp': 1,
+    'agent:frozen': 1,
+    'agent:energy': 255,
+    'agent:orientation': 1,
+    'agent:shield': 1,
+    'agent:inv:r1': 5,
+    'agent:inv:r2': 5,
+    'agent:inv:r3': 5,
+    'wall': 1,
+    'wall:hp': 10,
+    'generator': 1,
+    'generator:hp': 30,
+    'generator:r1': 30,
+    'generator:ready': 1,
+    'converter': 1,
+    'converter:hp': 30,
+    'converter:input_resource': 5,
+    'converter:output_resource': 5,
+    'converter:output_energy': 100,
+    'converter:ready': 1,
+    'altar': 1,
+    'altar:hp': 30,
+    'altar:ready': 1,
+    'last_action': 10,
+    'last_action_argument': 10,
+    'agent:kinship': 10,
+}
+
+class ObservationNormalizer(nn.Module):
+    def __init__(self, grid_features: list[str]):
+        super().__init__()
+
+        num_objects = len(grid_features)
+        
+        obs_norm = torch.tensor([OBS_NORMALIZATIONS[k] for k in grid_features], dtype=torch.float32)
+        obs_norm = obs_norm.view(1, num_objects, 1, 1)
+
+        self.register_buffer('obs_norm', obs_norm)
+
+    def forward(self, obs):
+        return obs / self.obs_norm

--- a/agent/lib/util.py
+++ b/agent/lib/util.py
@@ -71,3 +71,13 @@ def embed_string(s, embedding_dim=128):
 
     return embedding
 
+def name_to_activation(activation: str):
+    match activation:
+        case 'relu':
+            return nn.ReLU()
+        case 'leaky_relu':
+            return nn.LeakyReLU()
+        case 'tanh':
+            return nn.Tanh()
+        case _:
+            raise ValueError(f"Unknown activation: {activation}")

--- a/agent/resnet_encoder.py
+++ b/agent/resnet_encoder.py
@@ -1,0 +1,100 @@
+import torch
+from torch import nn
+from omegaconf import OmegaConf
+from pufferlib.pytorch import layer_init
+
+
+from agent.lib.util import name_to_activation
+from agent.lib.observation_normalizer import ObservationNormalizer
+
+class _ResidualBlock(nn.Module):
+    def __init__(self, depth: int, activation: str):
+        super().__init__()
+        self.conv1 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
+        self.conv2 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
+        self.activation = name_to_activation(activation)
+    
+    def forward(self, x):
+        xp = self.activation(self.conv1(x))
+        xp = self.activation(self.conv2(xp))
+        return x + xp
+    
+class _IMPALAishBlock(nn.Module):
+    def __init__(self, input_channels: int, depth: int, activation: str):
+        super().__init__()
+        self.conv = layer_init(nn.Conv2d(input_channels, depth, kernel_size=3, stride=1, padding="same"))
+        self.pool = nn.MaxPool2d(kernel_size=3, stride=2)
+        self.residual1 = _ResidualBlock(depth, activation)
+        self.residual2 = _ResidualBlock(depth, activation)
+    
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.pool(x)
+        x = self.residual1(x)
+        x = self.residual2(x)
+        return x
+
+
+def _convolution_shape(shape, kernel_size, stride):
+    return tuple((x - kernel_size) // stride + 1 for x in shape)
+
+def _product(iterable):
+    prod = 1
+    for i in iterable:
+        prod *= i
+    return prod
+
+class IMPALAishCNN(nn.Module):
+    def __init__(self,
+                 obs_space,
+                 grid_features: list[str],
+                 global_features: list[str],
+                 **cfg):
+        super().__init__()
+        cfg = OmegaConf.create(cfg)
+
+        grid_shape = obs_space[cfg.obs_key].shape
+
+        self._output_dim = cfg.fc.output_dim
+        self._obs_key = cfg.obs_key
+        self.activation = name_to_activation(cfg.activation)
+
+        self.object_normalizer = None
+        if cfg.normalize_features:
+            self.object_normalizer = ObservationNormalizer(grid_features)
+        
+        if isinstance(cfg.cnn_channels, int):
+            channels = (grid_shape[0], cfg.cnn_channels)
+        else:
+            channels = (grid_shape[0], *cfg.cnn_channels)
+
+        grid_width_height = grid_shape[1:]
+
+        cnn_blocks = []
+        for in_channels, out_channels in zip(channels, channels[1:]):
+            cnn_blocks.append(_IMPALAishBlock(in_channels, out_channels, cfg.activation))
+            grid_width_height = _convolution_shape(grid_width_height, 3, 2)
+
+        self.cnn_layers = nn.Sequential(*cnn_blocks)
+
+        cnn_flattened_size = _product(grid_width_height) * channels[-1]
+        self.fc_layer = layer_init(nn.Linear(cnn_flattened_size, self._output_dim))
+
+
+    def forward(self, obs_dict):
+        obs = obs_dict[self._obs_key]
+
+        if self.object_normalizer is not None:
+            obs = self.object_normalizer(obs)
+
+        x = self.cnn_layers(obs)
+        x = torch.flatten(x, start_dim=1)
+        
+        x = self.activation(x)
+        x = self.fc_layer(x)
+        x = self.activation(x)
+
+        return x
+
+    def output_dim(self):
+        return self._output_dim

--- a/agent/simple_encoder.py
+++ b/agent/simple_encoder.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import torch
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, ListConfig
 from pufferlib.pytorch import layer_init
 from torch import nn
 
@@ -92,6 +92,115 @@ class SimpleConvAgent(nn.Module):
             self._normalizer(obs)
 
         return self.network(obs)
+
+    def output_dim(self):
+        return self._output_dim
+    
+
+def switch_activation(activation: str):
+    if activation == 'relu':
+        return nn.ReLU()
+    elif activation == 'leaky_relu':
+        return nn.LeakyReLU()
+    elif activation == 'tanh':
+        return nn.Tanh()
+    else:
+        raise ValueError(f"Unknown activation: {activation}")
+
+
+class _ResidualBlock(nn.Module):
+    def __init__(self, depth: int, activation: str):
+        super().__init__()
+        self.conv1 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
+        self.conv2 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
+        self.activation = switch_activation(activation)
+    
+    def forward(self, x):
+        xp = self.activation(self.conv1(x))
+        xp = self.activation(self.conv2(xp))
+        return x + xp
+    
+class _IMPALAishBlock(nn.Module):
+    def __init__(self, input_channels: int, depth: int, activation: str):
+        super().__init__()
+        self.conv = layer_init(nn.Conv2d(input_channels, depth, kernel_size=3, stride=1, padding="same"))
+        self.pool = nn.MaxPool2d(kernel_size=3, stride=2)
+        self.residual1 = _ResidualBlock(depth, activation)
+        self.residual2 = _ResidualBlock(depth, activation)
+    
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.pool(x)
+        x = self.residual1(x)
+        x = self.residual2(x)
+        return x
+
+
+def _convolution_shape(shape, kernel_size, stride):
+    return tuple((x - kernel_size) // stride + 1 for x in shape)
+
+def _product(iterable):
+    prod = 1
+    for i in iterable:
+        prod *= i
+    return prod
+
+class IMPALAishCNN(nn.Module):
+    def __init__(self,
+                 obs_space,
+                 grid_features: List[str],
+                 global_features: List[str],
+                 **cfg):
+        super().__init__()
+        cfg = OmegaConf.create(cfg)
+
+        grid_shape = obs_space[cfg.obs_key].shape
+
+        self._output_dim = cfg.fc.output_dim
+        self._obs_key = cfg.obs_key
+        self._num_objects = grid_shape[0]
+        self.activation = switch_activation(cfg.activation)
+
+
+        self._obs_norm = None
+        if cfg.normalize_features:
+            obs_norms = [OBS_NORMALIZATIONS[k] for k in grid_features]
+            self._obs_norm = torch.tensor(obs_norms, dtype=torch.float32)
+            self._obs_norm = self._obs_norm.view(1, self._num_objects, 1, 1)
+        
+        cnn_channels: ListConfig[int] | int = cfg.cnn_channels
+        if isinstance(cnn_channels, int):
+            cnn_channels = [cnn_channels]
+
+        channels = (grid_shape[0], *cnn_channels)
+        grid_width_height = grid_shape[1:]
+
+        cnn_blocks = []
+        for in_channels, out_channels in zip(channels, channels[1:]):
+            cnn_blocks.append(_IMPALAishBlock(in_channels, out_channels, cfg.activation))
+            grid_width_height = _convolution_shape(grid_width_height, 3, 2)
+
+        self.cnn_layers = nn.Sequential(*cnn_blocks)
+
+        cnn_flattened_size = _product(grid_width_height) * channels[-1]
+        self.fc_layer = layer_init(nn.Linear(cnn_flattened_size, self._output_dim))
+
+
+    def forward(self, obs_dict):
+        obs = obs_dict[self._obs_key]
+
+        if self._obs_norm is not None:
+            self._obs_norm = self._obs_norm.to(obs.device)
+            obs = obs / self._obs_norm
+
+        x = self.cnn_layers(obs)
+        x = torch.flatten(x, start_dim=1)
+        
+        x = self.activation(x)
+        x = self.fc_layer(x)
+        x = self.activation(x)
+
+        return x
 
     def output_dim(self):
         return self._output_dim

--- a/agent/simple_encoder.py
+++ b/agent/simple_encoder.py
@@ -1,51 +1,18 @@
-from typing import List
-
 import torch
-from omegaconf import OmegaConf, ListConfig
+from omegaconf import OmegaConf
+from agent.lib.observation_normalizer import ObservationNormalizer
 from pufferlib.pytorch import layer_init
 from torch import nn
 
 from agent.feature_encoder import FeatureListNormalizer
 
-# ##ObservationNormalization
-# These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
-# but here we are. If you add / remove a feature, you should add / remove the corresponding normalization.
-OBS_NORMALIZATIONS = {
-    'agent': 1,
-    'agent:hp': 1,
-    'agent:frozen': 1,
-    'agent:energy': 255,
-    'agent:orientation': 1,
-    'agent:shield': 1,
-    'agent:inv:r1': 5,
-    'agent:inv:r2': 5,
-    'agent:inv:r3': 5,
-    'wall': 1,
-    'wall:hp': 10,
-    'generator': 1,
-    'generator:hp': 30,
-    'generator:r1': 30,
-    'generator:ready': 1,
-    'converter': 1,
-    'converter:hp': 30,
-    'converter:input_resource': 5,
-    'converter:output_resource': 5,
-    'converter:output_energy': 100,
-    'converter:ready': 1,
-    'altar': 1,
-    'altar:hp': 30,
-    'altar:ready': 1,
-    'last_action': 10,
-    'last_action_argument': 10,
-    'agent:kinship': 10,
-}
 
 class SimpleConvAgent(nn.Module):
 
     def __init__(self,
                  obs_space,
-                 grid_features: List[str],
-                 global_features: List[str],
+                 grid_features: list[str],
+                 global_features: list[str],
                  **cfg):
         super().__init__()
         cfg = OmegaConf.create(cfg)
@@ -73,134 +40,22 @@ class SimpleConvAgent(nn.Module):
         if cfg.auto_normalize:
             self._normalizer = FeatureListNormalizer(
                 grid_features, obs_space[self._obs_key].shape[1:])
-
-        self._obs_norm = None
+            
+        self.object_normalizer = None
         if cfg.normalize_features:
-            # #ObservationNormalization
-            obs_norms = [OBS_NORMALIZATIONS[k] for k in grid_features]
-            self._obs_norm = torch.tensor(obs_norms, dtype=torch.float32)
-            self._obs_norm = self._obs_norm.view(1, self._num_objects, 1, 1)
+            self.object_normalizer = ObservationNormalizer(grid_features)
+            
 
     def forward(self, obs_dict):
         obs = obs_dict[self._obs_key]
 
-        if self._obs_norm is not None:
-            self._obs_norm = self._obs_norm.to(obs.device)
-            obs = obs / self._obs_norm
+        if self.object_normalizer is not None:
+            obs = self.object_normalizer(obs)
 
         if self._normalizer:
             self._normalizer(obs)
 
         return self.network(obs)
-
-    def output_dim(self):
-        return self._output_dim
-    
-
-def switch_activation(activation: str):
-    if activation == 'relu':
-        return nn.ReLU()
-    elif activation == 'leaky_relu':
-        return nn.LeakyReLU()
-    elif activation == 'tanh':
-        return nn.Tanh()
-    else:
-        raise ValueError(f"Unknown activation: {activation}")
-
-
-class _ResidualBlock(nn.Module):
-    def __init__(self, depth: int, activation: str):
-        super().__init__()
-        self.conv1 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
-        self.conv2 = layer_init(nn.Conv2d(depth, depth, kernel_size=3, stride=1, padding="same"))
-        self.activation = switch_activation(activation)
-    
-    def forward(self, x):
-        xp = self.activation(self.conv1(x))
-        xp = self.activation(self.conv2(xp))
-        return x + xp
-    
-class _IMPALAishBlock(nn.Module):
-    def __init__(self, input_channels: int, depth: int, activation: str):
-        super().__init__()
-        self.conv = layer_init(nn.Conv2d(input_channels, depth, kernel_size=3, stride=1, padding="same"))
-        self.pool = nn.MaxPool2d(kernel_size=3, stride=2)
-        self.residual1 = _ResidualBlock(depth, activation)
-        self.residual2 = _ResidualBlock(depth, activation)
-    
-    def forward(self, x):
-        x = self.conv(x)
-        x = self.pool(x)
-        x = self.residual1(x)
-        x = self.residual2(x)
-        return x
-
-
-def _convolution_shape(shape, kernel_size, stride):
-    return tuple((x - kernel_size) // stride + 1 for x in shape)
-
-def _product(iterable):
-    prod = 1
-    for i in iterable:
-        prod *= i
-    return prod
-
-class IMPALAishCNN(nn.Module):
-    def __init__(self,
-                 obs_space,
-                 grid_features: List[str],
-                 global_features: List[str],
-                 **cfg):
-        super().__init__()
-        cfg = OmegaConf.create(cfg)
-
-        grid_shape = obs_space[cfg.obs_key].shape
-
-        self._output_dim = cfg.fc.output_dim
-        self._obs_key = cfg.obs_key
-        self._num_objects = grid_shape[0]
-        self.activation = switch_activation(cfg.activation)
-
-
-        self._obs_norm = None
-        if cfg.normalize_features:
-            obs_norms = [OBS_NORMALIZATIONS[k] for k in grid_features]
-            self._obs_norm = torch.tensor(obs_norms, dtype=torch.float32)
-            self._obs_norm = self._obs_norm.view(1, self._num_objects, 1, 1)
-        
-        cnn_channels: ListConfig[int] | int = cfg.cnn_channels
-        if isinstance(cnn_channels, int):
-            cnn_channels = [cnn_channels]
-
-        channels = (grid_shape[0], *cnn_channels)
-        grid_width_height = grid_shape[1:]
-
-        cnn_blocks = []
-        for in_channels, out_channels in zip(channels, channels[1:]):
-            cnn_blocks.append(_IMPALAishBlock(in_channels, out_channels, cfg.activation))
-            grid_width_height = _convolution_shape(grid_width_height, 3, 2)
-
-        self.cnn_layers = nn.Sequential(*cnn_blocks)
-
-        cnn_flattened_size = _product(grid_width_height) * channels[-1]
-        self.fc_layer = layer_init(nn.Linear(cnn_flattened_size, self._output_dim))
-
-
-    def forward(self, obs_dict):
-        obs = obs_dict[self._obs_key]
-
-        if self._obs_norm is not None:
-            self._obs_norm = self._obs_norm.to(obs.device)
-            obs = obs / self._obs_norm
-
-        x = self.cnn_layers(obs)
-        x = torch.flatten(x, start_dim=1)
-        
-        x = self.activation(x)
-        x = self.fc_layer(x)
-        x = self.activation(x)
-
-        return x
 
     def output_dim(self):
         return self._output_dim

--- a/configs/agent/resnet.yaml
+++ b/configs/agent/resnet.yaml
@@ -2,7 +2,7 @@ defaults:
 - simple
 
 observation_encoder:
-  _target_: agent.simple_encoder.IMPALAishCNN
+  _target_: agent.resnet_encoder.IMPALAishCNN
   cnn_channels: [32, 64]
   activation: leaky_relu
   obs_key: grid_obs

--- a/configs/agent/resnet.yaml
+++ b/configs/agent/resnet.yaml
@@ -1,0 +1,22 @@
+defaults:
+- simple
+
+observation_encoder:
+  _target_: agent.simple_encoder.IMPALAishCNN
+  cnn_channels: [32, 64]
+  activation: leaky_relu
+  obs_key: grid_obs
+  normalize_features: true
+  auto_normalize: false
+  track_last_action: ${env.track_last_action}
+  kinship: ${env.game.kinship}
+
+  fc:
+    layers: 1
+    output_dim: 128
+
+critic:
+  hidden_sizes: [128]
+
+actor:
+  hidden_sizes: [128]

--- a/configs/user/gabrielk.yaml
+++ b/configs/user/gabrielk.yaml
@@ -1,0 +1,44 @@
+# @package __global__
+
+seed: null
+
+defaults:
+  - override /hardware: aws
+  - override /env/mettagrid@env: simple
+  - override /agent: resnet
+
+# policy: file://.train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
+# baselines: file://.train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
+
+# evaluator:
+#   policy:
+#     uri: ${...policy_uri}
+  # baselines:
+  #   uri: ${...baseline_uri}
+
+policy_uri: file://./train_dir/gabrielk.local.train.resnet/checkpoints/model_0000.pt
+baseline_uri: file://./train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
+
+env:
+  game:
+    max_steps: 100
+
+trainer:
+  evaluate_interval: 2
+
+evaluator:
+  policy:
+    uri: ${...policy_uri}
+  baselines:
+    uri: ${...baseline_uri}
+
+wandb:
+  enabled: false
+  track: false
+  checkpoint_interval: 1
+
+sweep:
+  metric: action.use
+
+cmd: ???
+run: ${oc.env:USER}.local.${cmd}.simple


### PR DESCRIPTION
* Split out the  ObservationNormalizer so that it can be used for different observation encoders without duplicating code
* Adds a impala like resnet observation encoder, largely similar to the resnet implementation in amago.
  - Testing with two impala blcoks (10 convolutions and one linear layer total)
  - The final layer before the linear layer is (64, 2, 2) which is flattened to 256 with the default config
  - So far it seems promising but still needs more evaluation

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1209230969804461/1209294693704844) by [Unito](https://www.unito.io)
