### PR TITLE
Fix WanDB log error when its disabled.

### DIFF
--- a/rl/pufferlib/trainer.py
+++ b/rl/pufferlib/trainer.py
@@ -136,11 +136,12 @@ class PufferTrainer:
         rating = results.get(self.last_pr.name, {}).get("rating", None)
 
         if rating is not None:
-            self.wandb_run.log({
-                "eval/glicko2": rating,
-                "train/agent_step": self.agent_step,
-                "train/epoch": self.epoch,
-            })
+            if self.wandb_run and self.cfg.wandb.track:
+                self.wandb_run.log({
+                    "eval/glicko2": rating,
+                    "train/agent_step": self.agent_step,
+                    "train/epoch": self.epoch,
+                })
 
         logger.info(f"Glicko2 scores: \n{formatted_results}")
 


### PR DESCRIPTION
Fixes: 
```
Traceback (most recent call last):
  File "/Users/me/p/metta/tools/train.py", line 31, in main
    trainer.train()
  File "/Users/me/p/metta/rl/pufferlib/trainer.py", line 107, in train
    self._evaluate_policy()
  File "/Users/me/p/metta/rl/pufferlib/trainer.py", line 140, in _evaluate_policy
    self.wandb_run.log({
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'log'
```