### PR TITLE
Update forward_pass_minibatch_target_size

### DIFF
--- a/configs/trainer/puffer.yaml
+++ b/configs/trainer/puffer.yaml
@@ -37,11 +37,10 @@ cpu_offload: false
 compile: false
 compile_mode: reduce-overhead
 
-forward_pass_minibatch_target_size: 4096
+forward_pass_minibatch_target_size: 2048
 async_factor: 2
 
 stats:
   overview:
     episode/reward.mean: episode_reward
   step: train/agent_step
-


### PR DESCRIPTION
I am consistently getting better performance with this parameter, I think it should be the default