### PR TITLE
Initial sort_keys fix. Needs review

### DIFF
--- a/rl/pufferlib/experience.py
+++ b/rl/pufferlib/experience.py
@@ -71,7 +71,8 @@ class Experience:
         self.bptt_horizon = bptt_horizon
         self.minibatch_size = minibatch_size
         self.device = device
-        self.sort_keys = []
+        self.sort_keys = np.zeros((batch_size, 3), dtype=np.int32)
+        self.sort_keys[:, 0] = np.arange(batch_size)
         self.ptr = 0
         self.step = 0
 
@@ -82,29 +83,42 @@ class Experience:
     def store(self, obs, value, action, logprob, reward, done, env_id, mask):
         # Mask learner and Ensure indices do not exceed batch size
         ptr = self.ptr
-        indices = torch.where(mask)[0].numpy()[:self.batch_size - ptr]
-        end = ptr + len(indices)
+        indices = np.where(mask)[0]
+        num_indices = indices.size
+        end = ptr + num_indices
+        dst = slice(ptr, end)
 
-        self.obs[ptr:end] = obs.to(self.obs.device, non_blocking=True)[indices]
-        self.values_np[ptr:end] = value.cpu().numpy()[indices]
-        self.actions_np[ptr:end] = action[indices]
-        self.logprobs_np[ptr:end] = logprob.cpu().numpy()[indices]
-        self.rewards_np[ptr:end] = reward.cpu().numpy()[indices]
-        self.dones_np[ptr:end] = done.cpu().numpy()[indices]
-        self.sort_keys.extend([(env_id[i], self.step) for i in indices])
+        # Zero-copy indexing for contiguous env_id
+        if num_indices == mask.size and isinstance(env_id, slice):
+            gpu_inds = cpu_inds = slice(0, min(self.batch_size - ptr, num_indices))
+        else:
+            cpu_inds = indices[:self.batch_size - ptr]
+            gpu_inds = torch.as_tensor(indices).to(self.obs.device, non_blocking=True)
+
+        self.obs[dst] = obs.to(self.obs.device, non_blocking=True)[cpu_inds]
+        self.values_np[dst] = value.cpu().numpy()[cpu_inds]
+        self.actions_np[dst] = action[cpu_inds]
+        self.logprobs_np[dst] = logprob.cpu().numpy()[cpu_inds]
+        self.rewards_np[dst] = reward.cpu().numpy()[cpu_inds]
+        self.dones_np[dst] = done.cpu().numpy()[cpu_inds]
+        if isinstance(env_id, slice):
+            self.sort_keys[dst, 1] = np.arange(cpu_inds.start, cpu_inds.stop, dtype=np.int32)
+        else:
+            self.sort_keys[dst, 1] = env_id[cpu_inds]
+
+        self.sort_keys[dst, 2] = self.step
         self.ptr = end
         self.step += 1
 
     def sort_training_data(self):
-        idxs = np.asarray(sorted(
-            range(len(self.sort_keys)), key=self.sort_keys.__getitem__))
+        idxs = np.lexsort((self.sort_keys[:, 2], self.sort_keys[:, 1]))
         self.b_idxs_obs = torch.as_tensor(idxs.reshape(
                 self.minibatch_rows, self.num_minibatches, self.bptt_horizon
             ).transpose(1,0,-1)).to(self.obs.device).long()
         self.b_idxs = self.b_idxs_obs.to(self.device, non_blocking=True)
         self.b_idxs_flat = self.b_idxs.reshape(
             self.num_minibatches, self.minibatch_size)
-        self.sort_keys = []
+        self.sort_keys[:, 1:] = 0
         return idxs
 
     def flatten_batch(self, advantages_np):

--- a/rl/pufferlib/trainer.py
+++ b/rl/pufferlib/trainer.py
@@ -203,7 +203,18 @@ class PufferTrainer:
         while not experience.full:
             with profile.env:
                 o, r, d, t, info, env_id, mask = self.vecenv.recv()
-                env_id = env_id.tolist()
+
+                # Zero-copy indexing for contiguous env_id
+
+                # David: This was originally self.config.env_batch_size == 1, but you have scaling
+                # configured differently in metta. You want the whole forward pass batch to come
+                # from one core to reduce indexing overhead.
+                contiguous_env_ids = self.vecenv.agents_per_batch == self.vecenv.agents_per_env[0]
+                if contiguous_env_ids:
+                    gpu_env_id = cpu_env_id = slice(env_id[0], env_id[-1] + 1)
+                else:
+                    cpu_env_id = env_id
+                    gpu_env_id = torch.as_tensor(env_id).to(self.device, non_blocking=True)
 
             with profile.eval_misc:
                 num_steps = sum(mask)
@@ -217,13 +228,13 @@ class PufferTrainer:
             with profile.eval_forward, torch.no_grad():
                 # TODO: In place-update should be faster. Leaking 7% speed max
                 # Also should be using a cuda tensor to index
-                e3b = e3b_inv[env_id] if self.use_e3b else None
+                e3b = e3b_inv[gpu_env_id] if self.use_e3b else None
 
-                h = lstm_h[:, env_id]
-                c = lstm_c[:, env_id]
+                h = lstm_h[:, gpu_env_id]
+                c = lstm_c[:, gpu_env_id]
                 actions, logprob, _, value, (h, c), next_e3b, intrinsic_reward = policy(o_device, (h, c), e3b=e3b)
-                lstm_h[:, env_id] = h
-                lstm_c[:, env_id] = c
+                lstm_h[:, gpu_env_id] = h
+                lstm_c[:, gpu_env_id] = c
                 if self.use_e3b:
                     e3b_inv[env_id] = next_e3b
                     r += intrinsic_reward.cpu()
@@ -236,7 +247,7 @@ class PufferTrainer:
                 actions = actions.cpu().numpy()
                 mask = torch.as_tensor(mask)# * policy.mask)
                 o = o if self.trainer_cfg.cpu_offload else o_device
-                self.experience.store(o, value, actions, logprob, r, d, env_id, mask)
+                self.experience.store(o, value, actions, logprob, r, d, cpu_env_id, mask)
 
                 for i in info:
                     for k, v in pufferlib.utils.unroll_nested_dict(i):


### PR DESCRIPTION
David: This reduces overhead from storing sort_keys as a Python list, which is up to 30% of total compute for fast envs. More perf optimizations are coming, but our repos have diverged quite substantially, so I'd like to wait until we have a stable version (i.e. we know if we're keeping p3o and e3b) so I don't waste your time dealing with a big merge. There's only one thing you need to do to make sure this is used effectively: set your batch size such that all the data for each forward-pass during evaluate() comes from 1 cpu core. This makes env ids contiguous, so you can index with slices (fast) instead of doing a really slow copy. It's a short diff