### PR TITLE
Add w&b charts during analysis

### DIFF
--- a/configs/eval/core_eval_suite.yaml
+++ b/configs/eval/core_eval_suite.yaml
@@ -1,0 +1,17 @@
+
+
+_target_: rl.pufferlib.eval.EvalSuite
+
+defaults:
+  - eval
+
+env: null #the env is set in evals:
+
+evals:
+
+  radial_maze:
+    env: env/mettagrid/cognitive_evals/radial_maze
+    policy_agents_pct: 1.0
+  navigating_obstacles:
+    env: env/mettagrid/cognitive_evals/navigating_obstacles
+    policy_agents_pct: 1.0

--- a/configs/eval/core_eval_suite.yaml
+++ b/configs/eval/core_eval_suite.yaml
@@ -15,3 +15,6 @@ evals:
   navigating_obstacles:
     env: env/mettagrid/cognitive_evals/navigating_obstacles
     policy_agents_pct: 1.0
+  simple:
+    env: env/mettagrid/simple
+    policy_agents_pct: 1.0

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -31,20 +31,14 @@ analyzer:
     metrics:
       - metric: episode_reward
 
-eval:
-  num_envs: 10
-  num_episodes: 16
-  max_time_s: 600
 
-
-  policy_uri: ${..policy_uri}
-  # npc_policy_uri: ${..npc_policy_uri}
-  eval_db_uri: ${..eval_db_uri} #file://daphne/sweep_stats
-  env_overrides:
-    # sampling: 0.7
-    game:
-      # num_agents: 360
-      max_steps: 10
+evals:
+  radial_maze:
+    env: env/mettagrid/cognitive_evals/radial_maze
+    policy_agents_pct: 1.0
+  navigating_obstacles:
+    env: env/mettagrid/cognitive_evals/navigating_obstacles
+    policy_agents_pct: 1.0
 
 wandb:
   checkpoint_interval: 1

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -14,8 +14,8 @@ trainer:
       num_agents: 36
       max_steps: 1000
 
-# policy_uri: wandb://run/b.daveey.t.64.dr90.e3b
-policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
+policy_uri: wandb://run/b.daveey.t.64.dr90.e3b
+# policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
 
 analyzer:
   eval_stats_uri: ${run_dir}/eval_stats
@@ -31,7 +31,7 @@ eval:
 wandb:
   checkpoint_interval: 1
 
-run_id: 1
+run_id: 2
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -2,7 +2,7 @@
 
 defaults:
   - override /agent: simple
-  - override /eval: simple
+  - override /eval: core_eval_suite
   - override /analyzer: eval_analyzer
 
 trainer:
@@ -32,21 +32,7 @@ analyzer:
       - metric: episode_reward
 
 eval:
-  num_envs: 10
-  num_episodes: 16
-  max_time_s: 600
-
   policy_uri: ${..policy_uri}
-  eval_db_uri: ${..eval_db_uri}
-
-evals:
-  radial_maze:
-    env: env/mettagrid/cognitive_evals/radial_maze
-    policy_agents_pct: 1.0
-  navigating_obstacles:
-    env: env/mettagrid/cognitive_evals/navigating_obstacles
-    policy_agents_pct: 1.0
-
 
 wandb:
   checkpoint_interval: 1

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -14,14 +14,8 @@ trainer:
       num_agents: 36
       max_steps: 1000
 
-# policy: wandb://run/b.daveey.train.maze.sm.dr.warm.0
-# baselines: wandb://run/b.daveey.train.maze.sm.11x11.0
-
-# policy_uri: wandb://run/b.daveey.sm.train.er.new.0
-# policy_uri: wandb://run/daveey.ar.cards.1
-# policy_uri: wandb://run/b.daveey.t.32.instant
-policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
-# npc_policy_uri: ${trained_policy_uri}
+policy_uri: wandb://run/b.daveey.t.64.dr90.e3b
+#   policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
 
 analyzer:
   eval_stats_uri: ${run_dir}/eval_stats

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -14,8 +14,8 @@ trainer:
       num_agents: 36
       max_steps: 1000
 
-policy_uri: wandb://run/b.daveey.t.64.dr90.e3b
-#   policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
+# policy_uri: wandb://run/b.daveey.t.64.dr90.e3b
+policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
 
 analyzer:
   eval_stats_uri: ${run_dir}/eval_stats
@@ -23,6 +23,7 @@ analyzer:
   analysis:
     metrics:
       - metric: episode_reward
+      - metric: "heart.get"
 
 eval:
   policy_uri: ${..policy_uri}
@@ -30,7 +31,7 @@ eval:
 wandb:
   checkpoint_interval: 1
 
-run_id: 0
+run_id: 1
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -1,0 +1,58 @@
+# @package __global__
+
+defaults:
+  - override /agent: simple
+  - override /eval: simple
+  - override /analyzer: eval_analyzer
+
+trainer:
+  env: /env/mettagrid/bases
+  evaluate_interval: 200
+  env_overrides:
+    # sampling: 0.7
+    game:
+      num_agents: 36
+      max_steps: 1000
+
+# policy: wandb://run/b.daveey.train.maze.sm.dr.warm.0
+# baselines: wandb://run/b.daveey.train.maze.sm.11x11.0
+
+# policy_uri: wandb://run/b.daveey.sm.train.er.new.0
+# policy_uri: wandb://run/daveey.ar.cards.1
+# policy_uri: wandb://run/b.daveey.t.32.instant
+policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
+# npc_policy_uri: ${trained_policy_uri}
+eval_db_uri: wandb://artifacts/testing
+
+analyzer:
+  eval_stats_uri: ${run_dir}/eval_stats
+  policy_uri: ${..policy_uri}
+  analysis:
+    metrics:
+      - metric: episode_reward
+
+eval:
+  num_envs: 10
+  num_episodes: 16
+  max_time_s: 600
+
+
+  policy_uri: ${..policy_uri}
+  # npc_policy_uri: ${..npc_policy_uri}
+  eval_db_uri: ${..eval_db_uri} #file://daphne/sweep_stats
+  env_overrides:
+    # sampling: 0.7
+    game:
+      # num_agents: 360
+      max_steps: 10
+
+wandb:
+  checkpoint_interval: 1
+
+run_id: 13
+run: ${oc.env:USER}.local.${run_id}
+trained_policy_uri: ${run_dir}/checkpoints
+
+sweep_params: "sweep/fast"
+sweep_name: "${oc.env:USER}.local.sweep.${run_id}"
+seed: null

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -31,6 +31,13 @@ analyzer:
     metrics:
       - metric: episode_reward
 
+eval:
+  num_envs: 10
+  num_episodes: 16
+  max_time_s: 600
+
+  policy_uri: ${..policy_uri}
+  eval_db_uri: ${..eval_db_uri}
 
 evals:
   radial_maze:
@@ -39,6 +46,7 @@ evals:
   navigating_obstacles:
     env: env/mettagrid/cognitive_evals/navigating_obstacles
     policy_agents_pct: 1.0
+
 
 wandb:
   checkpoint_interval: 1

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -22,7 +22,6 @@ trainer:
 # policy_uri: wandb://run/b.daveey.t.32.instant
 policy_uri:  wandb://run/b.georgedeane.colored_mines_constrained
 # npc_policy_uri: ${trained_policy_uri}
-eval_db_uri: wandb://artifacts/testing
 
 analyzer:
   eval_stats_uri: ${run_dir}/eval_stats
@@ -37,7 +36,7 @@ eval:
 wandb:
   checkpoint_interval: 1
 
-run_id: 13
+run_id: 0
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -1,22 +1,117 @@
-import os
-import signal
 import logging
 import hydra
+import wandb
+import pandas as pd
 from omegaconf import DictConfig
 from rl.wandb.wandb_context import WandbContext
 from util.runtime_configuration import setup_metta_environment
 from rl.eval.eval_stats_db import EvalStatsDB
-logger = logging.getLogger("analyze.py")
+from typing import Dict, Any
+from collections.abc import Set
+
+def graph_policy_eval_metrics(
+    metric_to_df: Dict[str, pd.DataFrame], 
+    wandb_run
+):
+    """
+    Parameters:
+    - metric_to_df: Dictionary mapping metric names to their corresponding DataFrames
+                   Each DataFrame should have columns: policy_name, eval_name, mean_{metric}, std_{metric}
+    - wandb_run: wandb run object to which the visualizations will be logged
+                       
+    """
+    logger = logging.getLogger("graph_policy_eval_metrics")
+    # Get all metric names
+    metric_names = list(metric_to_df.keys())
+    
+    # Get all dataframes
+    dataframes = [metric_to_df[metric] for metric in metric_names]
+    
+    # Get unique evaluation environments from all dataframes
+    all_eval_names: Set[str] = set()
+    for df in dataframes:
+        if 'eval_name' in df.columns:
+            all_eval_names.update(df['eval_name'].unique())
+    
+    eval_names = sorted(list(all_eval_names))
+    
+    # Process each evaluation environment
+    for eval_name in eval_names:
+        # Get a shorter version of the eval name for titles
+        short_eval_name = eval_name.split('/')[-1]
+        
+        # Process each metric
+        for metric in metric_names:
+            df = metric_to_df[metric]
+            
+            # Skip if this dataframe doesn't have this eval_name
+            if 'eval_name' not in df.columns or eval_name not in df['eval_name'].values:
+                continue
+            
+            # Filter the dataframe for this evaluation environment
+            eval_data = df[df['eval_name'] == eval_name].copy()
+            
+            if not eval_data.empty:
+                # Extract the policy names and metric values
+                policy_names = eval_data['policy_name'].tolist()
+                # Use 3rd column to avoid any formatting differences on metric name
+                mean_values = eval_data.iloc[:, 2].tolist()
+                
+
+                data = [[label, val] for label, val in zip(policy_names, mean_values)]                
+                chart_title = f"{short_eval_name} - {metric}"
+                chart = wandb.plot.bar(
+                    wandb.Table(data=data, columns=["Policy", f"Mean {metric}"]),
+                    "Policy", 
+                    f"Mean {metric}",
+                    title=chart_title
+                )
+                
+                # Log the chart to W&B
+                wandb_run.log({chart_title: chart})
+                
+                # Also log the raw data as a table for reference
+                table_data = []
+                for policy, mean in zip(policy_names, mean_values):
+                    table_data.append([policy, mean])
+                
+                table = wandb.Table(
+                    data=table_data, 
+                    columns=["Policy", f"Mean {metric}"]
+                )
+                wandb_run.log({f"{chart_title} (data)": table})
+                
+                logger.info(f"Created W&B visualization for: {chart_title}")
+    
+
+
+def construct_metric_to_df_map(cfg: DictConfig, dfs: list) -> Dict[str, pd.DataFrame]:
+
+    # Extract metrics from config
+    metrics = [m.metric for m in cfg.analyzer.analysis.metrics]
+    
+    # Ensure we have the same number of metrics and dataframes
+    if len(metrics) != len(dfs):
+        raise ValueError(f"Mismatch between metrics ({len(metrics)}) and dataframes ({len(dfs)})")
+    
+    metric_to_df = {}
+    for metric, df in zip(metrics, dfs):
+        metric_to_df[metric] = df
+    
+    return metric_to_df
 
 @hydra.main(version_base=None, config_path="../configs", config_name="analyzer")
-
 def main(cfg: DictConfig) -> None:
     setup_metta_environment(cfg)
 
     with WandbContext(cfg) as wandb_run:
         eval_stats_db = EvalStatsDB.from_uri(cfg.eval.eval_db_uri, cfg.run_dir, wandb_run)
         analyzer =  hydra.utils.instantiate(cfg.analyzer, eval_stats_db)
-        analyzer.analyze()
+        dfs, _ = analyzer.analyze()
+
+        metric_to_df = construct_metric_to_df_map(cfg, dfs)
+        graph_policy_eval_metrics(metric_to_df, wandb_run)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -81,18 +81,8 @@ def graph_policy_eval_metrics(
                 wandb_run.log({f"{chart_title} (data)": table})
                 
                 logger.info(f"Created W&B visualization for: {chart_title}")
-
+    
 def construct_metric_to_df_map(cfg: DictConfig, dfs: list) -> Dict[str, pd.DataFrame]:
-    """
-    Construct a dictionary mapping metrics to their corresponding dataframes.
-    
-    Parameters:
-    - cfg: The hydra config object containing metrics configuration
-    - dfs: List of dataframes returned by analyzer.analyze(), assumed to be in the same order as metrics in config
-    
-    Returns:
-    - Dictionary mapping metric names to their dataframes
-    """
     # Extract metrics from config
     metrics = [m.metric for m in cfg.analyzer.analysis.metrics]
     
@@ -112,11 +102,12 @@ def main(cfg: DictConfig) -> None:
 
     with WandbContext(cfg) as wandb_run:
         eval_stats_db = EvalStatsDB.from_uri(cfg.eval.eval_db_uri, cfg.run_dir, wandb_run)
-        analyzer = hydra.utils.instantiate(cfg.analyzer, eval_stats_db)
+        analyzer =  hydra.utils.instantiate(cfg.analyzer, eval_stats_db)
         dfs, _ = analyzer.analyze()
 
         metric_to_df = construct_metric_to_df_map(cfg, dfs)
         graph_policy_eval_metrics(metric_to_df, wandb_run)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This (very hacky) commit adds some charts to W&B. Each chart is keyed by (eval, metric). Each chart then is a simple bar graph with one bar per policy in the eval DB.

There's a lot of work to be done here, including:
- better organization of the dataframes [current code makes assumptions about order/strucutre of DFs returned by analysis that may not always hold true]
- better workflow for generating eval db across multiple policies (and checkpoints?) in one shot, rather than needing to run eval N times to create graphs for N Policies
- this code should likely be moved outside the analysis *script* and into the analysis *library* so that similar charts can be generated during training

However, this serves the purpose of a very starting MVP that can be used ad-hoc as we explore.

