### PR TITLE
Fix setup_build.sh to checkout mettagrid with git pull.

### DIFF
--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -37,6 +37,11 @@ git fetch
 if [ -n "$METTAGRID_REF" ]; then
   echo "Checking out mettagrid reference: $METTAGRID_REF"
   git checkout "$METTAGRID_REF"
+  git pull origin "$METTAGRID_REF"
+else
+  echo "No mettagrid reference specified, checking out main"
+  git checkout main
+  git pull
 fi
 
 echo "Installing mettagrid in to $(pwd)"


### PR DESCRIPTION
Setup_build was changed to only update mettagrid when `METTAGRID_REF` was set. Changing it always update, even when METTAGRID_REF is not set. Just use main branch then.