### PR TITLE
add job types to wandb runs so we can filter to job_type=train

### DIFF
--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -6,13 +6,9 @@ defaults:
   - override /analyzer: eval_analyzer
 
 trainer:
-  env: /env/mettagrid/bases
-  evaluate_interval: 200
-  env_overrides:
-    # sampling: 0.7
-    game:
-      num_agents: 36
-      max_steps: 1000
+  env: /env/mettagrid/multienv_mettagrid
+  evaluate_interval: 10
+
 
 policy_uri: wandb://run/b.daveey.t.64.dr90.1
 

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -12,7 +12,15 @@ trainer:
     game:
       num_agents: 36
       max_steps: 1000
-  evaluate_interval: 10
+  evaluate_interval: 50
+  checkpoint_interval: 50
+
+
+env:
+  semi_compact_obs: true
+  game:
+    max_steps: 2000
+
 
 
 policy_uri: wandb://run/b.daveey.t.64.dr90.1

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -7,7 +7,6 @@ defaults:
 
 trainer:
   env: /env/mettagrid/reward_dr
-  evaluate_interval: 200
   env_overrides:
     sampling: 0.7
     game:

--- a/configs/user/jack.yaml
+++ b/configs/user/jack.yaml
@@ -6,7 +6,13 @@ defaults:
   - override /analyzer: eval_analyzer
 
 trainer:
-  env: /env/mettagrid/multienv_mettagrid
+  env: /env/mettagrid/reward_dr
+  evaluate_interval: 200
+  env_overrides:
+    sampling: 0.7
+    game:
+      num_agents: 36
+      max_steps: 1000
   evaluate_interval: 10
 
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -60,7 +60,7 @@ def main(cfg: OmegaConf) -> int:
 
     logger.info(f"Training {cfg.run} on {cfg.device}")
     if os.environ.get("RANK", "0") == "0":
-        with WandbContext(cfg) as wandb_run:
+        with WandbContext(cfg, job_type="train") as wandb_run:
             train(cfg, wandb_run)
     else:
         train(cfg, None)


### PR DESCRIPTION
I would like to eliminate most/all runs that aren't training, but this seems like a useful tag regardless. I tested it with https://wandb.ai/metta-research/metta/runs/jack.wandb-runtype