### PR TITLE
Deal with missing keys better in policy_fitness

### DIFF
--- a/rl/eval/eval_stats_analyzer.py
+++ b/rl/eval/eval_stats_analyzer.py
@@ -124,17 +124,14 @@ class EvalStatsAnalyzer:
 
         evals = metric_data[eval].unique()
 
-        if len(evals) > 1:
-            candidate_data = pd.DataFrame(metric_data.loc[candidate_uri]).set_index(eval)
-            baseline_data = metric_data.loc[baseline_policies].set_index(eval)
+        candidate_data = pd.DataFrame(metric_data.loc[[candidate_uri]]).set_index(eval)
+        baseline_data = metric_data.loc[baseline_policies].set_index(eval)
 
         for eval in evals:
-            if len(evals) == 1:
-                candidate_mean = metric_data.loc[candidate_uri][metric_mean] or 0
-                baseline_mean = np.mean(metric_data.loc[baseline_policies][metric_mean]) or 0
-            else:
-                candidate_mean = candidate_data.loc[eval][metric_mean] or 0
-                baseline_mean = np.mean(baseline_data.loc[eval][metric_mean]) or 0
+            # Here the candidates get a score of 0 if the eval is not in the data. We should
+            # consider some sort of "N/A" instead.
+            candidate_mean = candidate_data.loc[eval][metric_mean] if eval in candidate_data else 0
+            baseline_mean = np.mean(baseline_data.loc[eval][metric_mean]) if eval in baseline_data else 0
 
             fitness = candidate_mean - baseline_mean
 


### PR DESCRIPTION
We were previously branching based on whether we had one or multiple evals. We presumably did this because `dataframe.loc[x]` returns a different type depending on whether `x` is unique in the dataframe or not. This protection wasn't quite perfect, since the size of `evals` is based on the candidate policy and the baseline policies, so it's possible for `evals` to have size greater than 1, but for `candidate_uri` to still only have one eval, and thus have `metric_data.loc[candidate_uri]` be "the wrong type".

I haven't fully figured out if we should be trying to process evals that we didn't even perform for our candidate. It seems a little silly. So it's possible that part of "the right solution" is to filter down `evals` more. However, in this diff I'm side stepping that question. Instead, I'm changing `dataframe.loc[x]` to `dataframe.loc[[x]]`. The latter has a consistent return type / dimensions regardless of whether `x` is a unique key in `dataframe`. This avoids us needing to differentiate between situations where we have unique keys and not, and fixes a crash I was hitting.

This also updates how we were providing some default values. Previously we appeared to crash when keys were missing, and now we should return 0 when keys are missing. It's possible that the default values were covering a different case than I was hitting here, so there could be a regression if our dataframe is sometimes missing `metric_mean`, but this would be surprising to me.

I've added https://app.asana.com/1/1209016784099267/project/1209185339447618/task/1209967199782635 to track adding unit tests here.