### PR TITLE
fix: remove custom ruff setting for "lines-after-import"

### DIFF
--- a/devops/auto_ruff_fix.py
+++ b/devops/auto_ruff_fix.py
@@ -29,6 +29,7 @@ except ImportError:
 
 import anthropic
 
+
 @dataclass
 class RuffError:
     file_path: str

--- a/devops/aws/batch/compute_environment.py
+++ b/devops/aws/batch/compute_environment.py
@@ -9,6 +9,7 @@ import boto3
 from botocore.config import Config
 from tabulate import tabulate
 
+
 def get_boto3_client(service_name="batch"):
     """Get a boto3 client with standard configuration."""
     config = Config(retries={"max_attempts": 10, "mode": "standard"}, max_pool_connections=50)

--- a/devops/aws/batch/job_logs.py
+++ b/devops/aws/batch/job_logs.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import boto3
 from botocore.config import Config
 
+
 def get_boto3_client(service_name):
     """Get a boto3 client with standard configuration."""
     config = Config(retries={"max_attempts": 10, "mode": "standard"}, max_pool_connections=50)

--- a/devops/aws/batch/job_queue.py
+++ b/devops/aws/batch/job_queue.py
@@ -13,6 +13,7 @@ from tabulate import tabulate
 
 from .job import format_time_difference
 
+
 def get_boto3_client(service_name="batch"):
     """Get a boto3 client with standard configuration."""
     config = Config(retries={"max_attempts": 10, "mode": "standard"}, max_pool_connections=50)

--- a/devops/aws/batch/register_job_definition.py
+++ b/devops/aws/batch/register_job_definition.py
@@ -6,6 +6,7 @@ from pprint import pprint
 
 import boto3
 
+
 def get_role_arn(role_name, profile=None):
     """Look up the ARN for a given IAM role name."""
     try:

--- a/devops/aws/batch/task_logs.py
+++ b/devops/aws/batch/task_logs.py
@@ -13,6 +13,7 @@ from devops.aws.batch.job import (
     print_job_logs,
 )
 
+
 def get_batch_job_queues():
     """Get a list of all AWS Batch job queues."""
     batch = boto3.client("batch")

--- a/devops/aws/setup_sso.py
+++ b/devops/aws/setup_sso.py
@@ -8,6 +8,7 @@ import time
 import traceback
 from pathlib import Path
 
+
 # ANSI color codes for terminal output
 class Colors:
     HEADER = "\033[95m"

--- a/devops/sandbox/setup_machine.py
+++ b/devops/sandbox/setup_machine.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def run_command(command, check=True):
     """Run a shell command and return its output."""
     try:

--- a/devops/vast/do.py
+++ b/devops/vast/do.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import time
 
+
 def gen_search_cmd(args):
     """Generate the search command that matches the given criteria."""
     cmd_str = f'vastai search offers \

--- a/devops/wandb/project.py
+++ b/devops/wandb/project.py
@@ -3,6 +3,7 @@ import argparse
 import wandb
 import yaml
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--wandb_user", required=True)

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -22,12 +22,10 @@
 		"yaml.schemas": {
 			"envs/griddly/gdy-schema.json": "envs/griddly/power_grid/*.yaml"
 		},
-		"editor.formatOnSave": true,
 		"ruff.enable": true,
-		"ruff.organizeImports": true,
-		"ruff.fixAll": true,
-		"ruff.configuration": "${workspaceFolder}/ruff.toml",
+		"ruff.nativeServer": "on",
 		"[python]": {
+			"editor.formatOnSave": true,
 			"editor.defaultFormatter": "charliermarsh.ruff",
 			"editor.codeActionsOnSave": {
 				"source.fixAll.ruff": "explicit",

--- a/metta/agent/feature_encoder.py
+++ b/metta/agent/feature_encoder.py
@@ -23,6 +23,7 @@ from metta.agent.lib.feature_normalizer import FeatureListNormalizer
 
 from .lib.util import embed_strings, make_nn_stack
 
+
 # this is not currently working
 class FeatureSetEncoder(nn.Module):
     def __init__(

--- a/metta/agent/lib/action.py
+++ b/metta/agent/lib/action.py
@@ -1,5 +1,6 @@
 import metta.agent.lib.nn_layer_library as nn_layer_library
 
+
 class ActionType(nn_layer_library.Linear):
     def __init__(self, action_type_size, **cfg):
         super().__init__(**cfg)

--- a/metta/agent/lib/feature_normalizer.py
+++ b/metta/agent/lib/feature_normalizer.py
@@ -6,6 +6,7 @@ from torch import nn
 
 from metta.agent.lib.metta_layer import LayerBase
 
+
 # this is not currently working
 class FeatureListNormalizer(LayerBase):
     def __init__(self, metta_agent, **cfg):

--- a/metta/agent/lib/merge_layer.py
+++ b/metta/agent/lib/merge_layer.py
@@ -4,6 +4,7 @@ from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
 
+
 class MergeLayerBase(LayerBase):
     def __init__(self, name, sources, **cfg):
         super().__init__(name)

--- a/metta/agent/lib/metta_layer.py
+++ b/metta/agent/lib/metta_layer.py
@@ -3,6 +3,7 @@ import torch
 from tensordict import TensorDict
 from torch import nn
 
+
 class LayerBase(nn.Module):
     """The base class for components that make up the Metta agent. All components
     are required to have a name and an input source, although the input source

--- a/metta/agent/lib/nn_layer_library.py
+++ b/metta/agent/lib/nn_layer_library.py
@@ -2,6 +2,7 @@ import torch.nn as nn
 
 from .metta_layer import LayerBase, ParamLayer
 
+
 class Linear(ParamLayer):
     def __init__(self, **cfg):
         super().__init__(**cfg)

--- a/metta/agent/lib/obs_shaper.py
+++ b/metta/agent/lib/obs_shaper.py
@@ -2,6 +2,7 @@ from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
 
+
 class ObsShaper(LayerBase):
     def __init__(self, obs_shape, num_objects, **cfg):
         super().__init__(**cfg)

--- a/metta/agent/lib/position.py
+++ b/metta/agent/lib/position.py
@@ -2,6 +2,7 @@ import math
 
 import torch
 
+
 def position_embeddings(width, height, embedding_dim=128):
     x = torch.linspace(-1, 1, width)
     y = torch.linspace(-1, 1, height)

--- a/metta/agent/resnet_encoder.py
+++ b/metta/agent/resnet_encoder.py
@@ -6,6 +6,7 @@ from torch import nn
 from metta.agent.lib.observation_normalizer import ObservationNormalizer
 from metta.agent.lib.util import name_to_activation
 
+
 class _ResidualBlock(nn.Module):
     def __init__(self, depth: int, activation: str):
         super().__init__()

--- a/metta/agent/util/distribution_utils.py
+++ b/metta/agent/util/distribution_utils.py
@@ -3,6 +3,7 @@ from typing import List, Union
 import torch
 from torch.distributions.utils import logits_to_probs
 
+
 def log_prob(logits, value):
     """
     Compute log probability of a value given logits.

--- a/metta/eval/heatmap.py
+++ b/metta/eval/heatmap.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import pandas as pd
 import plotly.graph_objects as go
 
+
 def format_metric(metric: str) -> str:
     """Format a metric name for display."""
     return metric.replace("_", " ").capitalize()

--- a/metta/eval/sim.py
+++ b/metta/eval/sim.py
@@ -12,6 +12,7 @@ from metta.rl.eval.eval_stats_logger import EvalStatsLogger
 from metta.rl.pufferlib.eval import Eval
 from metta.rl.wandb.wandb_context import WandbContext
 
+
 def simulate(eval: Eval, cfg: DictConfig, wandb_run):
     stats = eval.evaluate()
     stats_logger = EvalStatsLogger(cfg, wandb_run)

--- a/metta/rl/carbs/delete_runs.py
+++ b/metta/rl/carbs/delete_runs.py
@@ -3,6 +3,7 @@ from typing import List
 
 import wandb
 
+
 def delete_init_runs(sweep_id: str, entity: str, project: str) -> List[str]:
     deleted_runs = []
     api = wandb.Api()

--- a/metta/rl/eval/eval_stats_analyzer.py
+++ b/metta/rl/eval/eval_stats_analyzer.py
@@ -9,6 +9,7 @@ from tabulate import tabulate
 from metta.rl.eval.eval_stats_db import EvalStatsDB
 from metta.rl.eval.queries import total_metric
 
+
 class EvalStatsAnalyzer:
     def __init__(self, stats_db: EvalStatsDB, analysis: DictConfig, policy_uri: str, **kwargs):
         self.logger = logging.getLogger(__name__)

--- a/metta/rl/eval/queries.py
+++ b/metta/rl/eval/queries.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from omegaconf import OmegaConf
 
+
 def all_fields():
     return "SELECT * FROM eval_data"
 

--- a/metta/rl/pufferlib/dashboard/carbs.py
+++ b/metta/rl/pufferlib/dashboard/carbs.py
@@ -5,6 +5,7 @@ from metta.rl.carbs.carbs_controller import CarbsController
 from .dashboard import ROUND_OPEN, DashboardComponent, abbreviate, c1, c2
 from .training import Training
 
+
 class Carbs(DashboardComponent):
     def __init__(self, carbs_controller: CarbsController):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/dashboard.py
+++ b/metta/rl/pufferlib/dashboard/dashboard.py
@@ -10,6 +10,7 @@ from rich.table import Table
 
 from metta.util.logging import remap_io, restore_io
 
+
 class Dashboard(Thread):
     def __init__(self, cfg: OmegaConf, delay=1, components=None):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/dashboards.py
+++ b/metta/rl/pufferlib/dashboard/dashboards.py
@@ -9,6 +9,7 @@ from metta.rl.pufferlib.dashboard.utilization import Utilization
 from metta.rl.pufferlib.dashboard.wandb import WanDb
 from metta.rl.pufferlib.train import PufferTrainer
 
+
 def train_dashboard(trainer: PufferTrainer, logs_path: str):
     return Dashboard(
         trainer.cfg,

--- a/metta/rl/pufferlib/dashboard/logs.py
+++ b/metta/rl/pufferlib/dashboard/logs.py
@@ -4,6 +4,7 @@ from rich.table import Table
 
 from .dashboard import ROUND_OPEN, DashboardComponent, c1, c2
 
+
 class Logs(DashboardComponent):
     def __init__(self, logs_path: str, max_lines=5):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/policy.py
+++ b/metta/rl/pufferlib/dashboard/policy.py
@@ -4,6 +4,7 @@ from metta.rl.pufferlib.trainer import PolicyCheckpoint
 
 from .dashboard import ROUND_OPEN, DashboardComponent, abbreviate, c1, c2
 
+
 class Policy(DashboardComponent):
     def __init__(self, checkpoint: PolicyCheckpoint):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/training.py
+++ b/metta/rl/pufferlib/dashboard/training.py
@@ -5,6 +5,7 @@ from metta.rl.pufferlib.trainer import PufferTrainer
 from .dashboard import ROUND_OPEN, DashboardComponent, abbreviate, b2, c1, c2, duration, fmt_perf
 from .user_stats import UserStats
 
+
 class Training(DashboardComponent):
     def __init__(self, trainer: PufferTrainer):
         self.trainer = trainer

--- a/metta/rl/pufferlib/dashboard/user_stats.py
+++ b/metta/rl/pufferlib/dashboard/user_stats.py
@@ -2,6 +2,7 @@ from rich.table import Table
 
 from .dashboard import ROUND_OPEN, DashboardComponent, b2, c1, c2
 
+
 class UserStats(DashboardComponent):
     def __init__(self, stats: dict, max_stats=5):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/utilization.py
+++ b/metta/rl/pufferlib/dashboard/utilization.py
@@ -5,6 +5,7 @@ import metta.rl.pufferlib.utilization as utilization
 
 from .dashboard import DashboardComponent, b2, c1, c3
 
+
 class Utilization(DashboardComponent):
     def __init__(self):
         super().__init__()

--- a/metta/rl/pufferlib/dashboard/wandb.py
+++ b/metta/rl/pufferlib/dashboard/wandb.py
@@ -4,6 +4,7 @@ from rich.table import Table
 
 from .dashboard import DashboardComponent, b2, c1
 
+
 class WanDb(DashboardComponent):
     def __init__(self, wandb_cfg: OmegaConf):
         super().__init__()

--- a/metta/rl/pufferlib/experience.py
+++ b/metta/rl/pufferlib/experience.py
@@ -23,6 +23,7 @@ import pufferlib.pytorch
 import pufferlib.utils
 import torch
 
+
 class Experience:
     """Flat tensor storage and array views for faster indexing"""
 

--- a/metta/rl/pufferlib/kickstarter.py
+++ b/metta/rl/pufferlib/kickstarter.py
@@ -1,5 +1,6 @@
 import torch
 
+
 class Kickstarter:
     def __init__(self, cfg, policy_store, single_action_space):
         self.device = cfg.device

--- a/metta/rl/pufferlib/play.py
+++ b/metta/rl/pufferlib/play.py
@@ -6,6 +6,7 @@ from metta.agent.policy_store import PolicyStore
 from metta.rl.pufferlib.vecenv import make_vecenv
 from mettagrid.renderer.raylib.raylib_renderer import MettaGridRaylibRenderer
 
+
 def play(cfg: OmegaConf, policy_store: PolicyStore):
     device = cfg.device
     vecenv = make_vecenv(cfg.eval.env, cfg.vectorization, num_envs=1, render_mode="human")

--- a/metta/rl/pufferlib/profile.py
+++ b/metta/rl/pufferlib/profile.py
@@ -20,6 +20,7 @@ import pufferlib
 import pufferlib.pytorch
 import pufferlib.utils
 
+
 def _fmt_perf(time: float, uptime: float) -> float:
     return 100 * (time / uptime if uptime > 0 else 0)
 

--- a/metta/rl/pufferlib/replay_helper.py
+++ b/metta/rl/pufferlib/replay_helper.py
@@ -12,6 +12,7 @@ from metta.agent.policy_store import PolicyRecord
 from metta.rl.pufferlib.simulator import Simulator
 from metta.rl.wandb.wandb_context import WandbContext
 
+
 class ReplayHelper:
     """Helper class for generating and uploading replays."""
 

--- a/metta/rl/pufferlib/simulator.py
+++ b/metta/rl/pufferlib/simulator.py
@@ -5,6 +5,7 @@ from omegaconf import OmegaConf
 from metta.agent.policy_store import PolicyRecord
 from metta.rl.pufferlib.vecenv import make_vecenv
 
+
 class Simulator:
     """Simulate a policy for playing or tracing the environment"""
 

--- a/metta/rl/pufferlib/utilization.py
+++ b/metta/rl/pufferlib/utilization.py
@@ -5,6 +5,7 @@ from threading import Thread
 import psutil
 import torch
 
+
 class Utilization(Thread):
     def __init__(self, delay=1, maxlen=20):
         super().__init__()

--- a/metta/rl/pufferlib/vecenv.py
+++ b/metta/rl/pufferlib/vecenv.py
@@ -4,6 +4,7 @@ import pufferlib.utils
 import pufferlib.vector
 from omegaconf import DictConfig, OmegaConf
 
+
 def make_env_func(cfg: DictConfig, buf=None, render_mode="rgb_array"):
     return hydra.utils.instantiate(cfg, cfg, render_mode=render_mode, buf=buf)
 

--- a/metta/rl/sample_factory/agent_wrapper.py
+++ b/metta/rl/sample_factory/agent_wrapper.py
@@ -14,6 +14,7 @@ from torch import Tensor
 
 from metta.agent.metta_agent import MettaAgent
 
+
 class SampleFactoryAgentWrapper(ActorCritic):
     def __init__(self, agent: MettaAgent):
         super().__init__(

--- a/metta/rl/sample_factory/env_wrapper.py
+++ b/metta/rl/sample_factory/env_wrapper.py
@@ -4,6 +4,7 @@ import gymnasium as gym
 import numpy as np
 from sample_factory.envs.env_utils import TrainingInfoInterface
 
+
 class SampleFactoryEnvWrapper(gym.Env, TrainingInfoInterface):
     def __init__(self, env: gym.Env, env_id: int):
         TrainingInfoInterface.__init__(self)

--- a/metta/rl/sample_factory/predicting_actor_critic.py
+++ b/metta/rl/sample_factory/predicting_actor_critic.py
@@ -6,6 +6,7 @@ from sample_factory.algo.utils.tensor_dict import TensorDict
 from sample_factory.model.actor_critic import ActorCriticSharedWeights
 from sample_factory.utils.typing import Config
 
+
 class PredictingActorCritic(ActorCriticSharedWeights):
     def __init__(self, model_factory, obs_space, action_space, cfg: Config):
         super().__init__(model_factory, obs_space, action_space, cfg)

--- a/metta/rl/wandb/wandb_context.py
+++ b/metta/rl/wandb/wandb_context.py
@@ -4,6 +4,7 @@ import os
 import wandb
 from omegaconf import OmegaConf
 
+
 class WandbContext:
     def __init__(self, cfg, job_type=None, resume=True, name=None, run_id=None, data_dir=None):
         self.cfg = cfg

--- a/metta/util/config.py
+++ b/metta/util/config.py
@@ -6,6 +6,7 @@ import wandb
 from botocore.exceptions import ClientError, NoCredentialsError
 from omegaconf import DictConfig, OmegaConf
 
+
 def config_from_path(config_path: str, overrides: DictConfig = None) -> DictConfig:
     env_cfg = hydra.compose(config_name=config_path)
     if config_path.startswith("/"):

--- a/metta/util/datastruct.py
+++ b/metta/util/datastruct.py
@@ -1,5 +1,6 @@
 from omegaconf import DictConfig, ListConfig
 
+
 def flatten_config(obj, parent_key="", sep="."):
     """
     Recursively flatten a nested structure of DictConfig, ListConfig, dict, and list

--- a/metta/util/logging.py
+++ b/metta/util/logging.py
@@ -3,6 +3,7 @@ import sys
 
 from loguru import logger
 
+
 def remap_io(logs_path: str):
     os.makedirs(logs_path, exist_ok=True)
     stdout_log_path = os.path.join(logs_path, "out.log")

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,10 +19,7 @@ exclude = [
 [lint.isort]
 # Define import sections and their order
 known-third-party = ["wandb", "torch", "omegaconf"]
-known-first-party = [
-    "metta",
-    "mettagrid"
-] # Add your local package names here
+known-first-party = ["metta", "mettagrid"]
 section-order = [
     "future",
     "standard-library",
@@ -30,8 +27,6 @@ section-order = [
     "first-party",
     "local-folder",
 ]
-# Add blank lines between import sections
-lines-after-imports = 1
 
 [lint]
 # Rules to enable for linting

--- a/tests/eval/test_db.py
+++ b/tests/eval/test_db.py
@@ -11,6 +11,7 @@ import pytest
 
 from metta.eval.db import PolicyEvalDB
 
+
 @pytest.fixture
 def mock_db_connection():
     """Create a mock database connection for testing."""

--- a/tests/test_predicting_actor_critic.py
+++ b/tests/test_predicting_actor_critic.py
@@ -10,6 +10,7 @@ from torch import nn
 
 from metta.rl.sample_factory.predicting_actor_critic import PredictingActorCritic
 
+
 class MockObsPredictor(nn.Module):
     def __init__(self, obs_shape):
         super().__init__()

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -6,6 +6,7 @@ from omegaconf import DictConfig
 from metta.eval.report import generate_report
 from metta.util.runtime_configuration import setup_mettagrid_environment
 
+
 @hydra.main(version_base=None, config_path="../configs", config_name="analyzer")
 def main(cfg: DictConfig) -> None:
     setup_mettagrid_environment(cfg)

--- a/tools/autotune.py
+++ b/tools/autotune.py
@@ -1,6 +1,7 @@
 import hydra
 import pufferlib.vector
 
+
 def make_env():
     global env_config
     env = hydra.utils.instantiate(env_config.env, render_mode="human")

--- a/tools/batch_sim.py
+++ b/tools/batch_sim.py
@@ -4,6 +4,7 @@ from omegaconf import DictConfig
 from metta.eval import simulate_policies
 from metta.util.runtime_configuration import setup_mettagrid_environment
 
+
 @hydra.main(version_base=None, config_path="../configs", config_name="eval")
 def main(cfg: DictConfig):
     setup_mettagrid_environment(cfg)

--- a/tools/dump_src.py
+++ b/tools/dump_src.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+
 def dump_files(paths, extensions):
     for path in paths:
         for root, _, files in os.walk(path):

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -8,6 +8,7 @@ from metta.rl.wandb.wandb_context import WandbContext
 from metta.util.config import config_from_path, setup_metta_environment
 from metta.util.runtime_configuration import setup_mettagrid_environment
 
+
 @hydra.main(version_base=None, config_path="../configs", config_name="simulator")
 def main(cfg):
     setup_metta_environment(cfg)

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -5,6 +5,7 @@ from metta.eval import simulate_policy
 from metta.rl.wandb.wandb_context import WandbContext
 from metta.util.runtime_configuration import setup_mettagrid_environment
 
+
 @hydra.main(version_base=None, config_path="../configs", config_name="eval")
 def main(cfg: DictConfig):
     setup_mettagrid_environment(cfg)


### PR DESCRIPTION

There seems to be some problem with the vscode Ruff extension and this setting:

https://github.com/astral-sh/ruff-vscode/issues/738
