### PR TITLE
feat: improve github smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
     env:
       CHECKPOINT_PATH: ./train_dir/my_experiment/checkpoints/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11.7'
 
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-pip
         with:
           path: |
@@ -42,7 +42,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Cache Git dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-git-deps
         with:
           path: deps
@@ -63,7 +63,7 @@ jobs:
           pip list
 
       - name: Cache Ruff
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-ruff
         with:
           path: ~/.cache/pip
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload training output
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: train-output
           path: train_dir/
@@ -108,7 +108,7 @@ jobs:
 
       - name: Download training output
         if: success()
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: train-output
           path: train_dir/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # Prevent hung jobs from consuming resources
     env:
-      CHECKPOINT_PATH: ./train_dir/my_experiment/checkpoints/
+      CHECKPOINT_PATH: ./train_dir/github_test/checkpoints/
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30  # Prevent hung jobs from consuming resources
+    timeout-minutes: 10  # Prevent hung jobs from consuming resources
+    env:
+      CHECKPOINT_PATH: ./train_dir/my_experiment/checkpoints/
     steps:
       - uses: actions/checkout@v3
 
@@ -73,7 +75,14 @@ jobs:
           pip install ruff==0.11.5
           ruff check --respect-gitignore .
 
-      - name: Run test training
+      - name: Run Pytest
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          source venv/bin/activate
+          pytest tests/ --maxfail=1 --disable-warnings -q
+
+      - name: Training smoke test
         id: training
         continue-on-error: false
         env:
@@ -85,23 +94,33 @@ jobs:
         run: |
           source venv/bin/activate
           python -m tools.train +hardware=github
+          # Verify the output path exists
+          ls -la $CHECKPOINT_PATH || echo "Warning: Checkpoint directory not created"
 
-      - name: Run Pytest
-        env:
-          PYTHONPATH: ${{ github.workspace }}
+      - name: Upload training output
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: train-output
+          path: train_dir/
+          retention-days: 1
+          if-no-files-found: error  # This will fail the workflow if no files are found
+
+      - name: Download training output
+        if: success()
+        uses: actions/download-artifact@v3
+        with:
+          name: train-output
+          path: train_dir/
+
+      - name: Verify training artifacts
+        if: success()
         run: |
           source venv/bin/activate
-          pytest tests/ --maxfail=1 --disable-warnings -q
+          ls -la train_dir/
+          ls -la $CHECKPOINT_PATH || echo "Checkpoint directory not found!"
 
-      - name: Cache training output
-        if: success()
-        uses: actions/cache@v3
-        id: cache-train-output
-        with:
-          path: train_dir
-          key: ${{ runner.os }}-train-dir-${{ github.sha }}
-
-      - name: Run trace
+      - name: Replay smoke test
         if: success()
         env:
           HYDRA_FULL_ERROR: 1
@@ -111,4 +130,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |
           source venv/bin/activate
-          python -m tools.replay +hardware=github policy_uri=./train_dir/my_experiment/checkpoints/
+          python -m tools.replay +hardware=github policy_uri=$CHECKPOINT_PATH
+
+      - name: Debug on failure
+        if: failure()
+        run: |
+          source venv/bin/activate
+          echo "Listing the contents of the workspace:"
+          find train_dir -type f -name "*.py" | sort
+          find train_dir -type d | sort

--- a/configs/eval/smoke_test.yaml
+++ b/configs/eval/smoke_test.yaml
@@ -1,0 +1,18 @@
+# This is meant as a smoke test, rather than a full evaluation.
+# It's used, e.g., as part of the Github Actions workflow.
+_target_: metta.sim.simulation.SimulationSuite
+
+defaults:
+  - eval
+
+env: null #the env is set in evals:
+
+num_envs: 1
+num_episodes: 1
+
+evals:
+  emptyspace_withinsight:
+    env: env/mettagrid/navigation/evals/emptyspace_withinsight
+    policy_agents_pct: 1.0
+
+selector_type: latest

--- a/configs/hardware/github.yaml
+++ b/configs/hardware/github.yaml
@@ -21,6 +21,10 @@ trainer:
   total_timesteps: 2
   evaluate_interval: 1
   replay_interval: 1
+  env_overrides:
+    game:
+      # This impacts the replay size.
+      max_steps: 2
   # Don't actually try to upload the replay.
   replay_dry_run: true
 

--- a/configs/hardware/github.yaml
+++ b/configs/hardware/github.yaml
@@ -1,6 +1,10 @@
 # @package __global__
 
-run: my_experiment
+defaults:
+  # Full fledged evaluation is heavier than we want for Github Actions.
+  - override /eval: smoke_test
+
+run: github_test
 device: cpu
 vectorization: serial
 
@@ -11,11 +15,14 @@ trainer:
   minibatch_size: 1024
   forward_pass_minibatch_target_size: 2
   async_factor: 1
-  checkpoint_interval: 10
+  checkpoint_interval: 1
   bptt_horizon: 8
   num_steps: 32
   total_timesteps: 2
-
+  evaluate_interval: 1
+  replay_interval: 1
+  # Don't actually try to upload the replay.
+  replay_dry_run: true
 
 wandb:
   enabled: false

--- a/configs/simulator.yaml
+++ b/configs/simulator.yaml
@@ -1,5 +1,6 @@
 defaults:
   - common
+  - eval: null
   - wandb: metta_research
 
 policy_uri: ???

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -151,12 +151,12 @@ class PufferTrainer:
         self.train_start = time.time()
         logger.info("Starting training")
 
-        # it doesn't make sense to evaluate more often than checkpointing since we need a saved policy to evaluate
         if (
             self.trainer_cfg.evaluate_interval != 0
             and self.trainer_cfg.evaluate_interval < self.trainer_cfg.checkpoint_interval
         ):
-            self.trainer_cfg.evaluate_interval = self.trainer_cfg.checkpoint_interval
+            # it doesn't make sense to evaluate more often than checkpointing since we need a saved policy to evaluate
+            raise ValueError("evaluate_interval must be at least as large as checkpoint_interval")
 
         logger.info(f"Training on {self.device}")
         while self.agent_step < self.trainer_cfg.total_timesteps:
@@ -205,9 +205,11 @@ class PufferTrainer:
         self.cfg.eval.policy_uri = self.last_pr.uri
         self.cfg.analyzer.policy_uri = self.last_pr.uri
 
-        eval = hydra.utils.instantiate(
-            self.cfg.eval, self.policy_store, self.last_pr, self.cfg.get("run_id", self.wandb_run.id), _recursive_=False
-        )
+        run_id = self.cfg.get("run_id")
+        if run_id is None and self.wandb_run is not None:
+            run_id = self.wandb_run.id
+
+        eval = hydra.utils.instantiate(self.cfg.eval, self.policy_store, self.last_pr, run_id, _recursive_=False)
         stats = eval.simulate()
 
         try:
@@ -534,7 +536,9 @@ class PufferTrainer:
     def _generate_and_upload_replay(self):
         if self._master:
             logger.info("Generating and saving a replay to wandb and S3.")
-            self.replay_helper.generate_and_upload_replay(self.epoch)
+            self.replay_helper.generate_and_upload_replay(
+                self.epoch, dry_run=self.trainer_cfg.get("replay_dry_run", False)
+            )
 
     def _process_stats(self):
         for k in list(self.stats.keys()):

--- a/metta/sim/replay_helper.py
+++ b/metta/sim/replay_helper.py
@@ -112,10 +112,11 @@ class ReplayHelper:
         link_summary = {"replays/link": wandb.Html(f'<a href="{player_url}">MetaScope Replay (Epoch {epoch})</a>')}
         self.wandb_run.log(link_summary)
 
-    def generate_and_upload_replay(self, epoch: int):
+    def generate_and_upload_replay(self, epoch: int, dry_run: bool = False):
         """Generate a replay and upload it to S3 and log the link to WandB."""
         replay_path = f"{self.cfg.run_dir}/replays/replay.{epoch}.json.z"
         self.generate_replay(replay_path)
 
         replay_url = f"replays/{self.cfg.run}/replay.{epoch}.json.z"
-        self.upload_replay(replay_path, replay_url, epoch)
+        if not dry_run:
+            self.upload_replay(replay_path, replay_url, epoch)


### PR DESCRIPTION
This updates our github smoke test to run evaluation and replay code as well.

Because we're now smoke testing eval code, this hit a couple of issues that I addressed:
* (pretty trivial) we were silently overwriting `self.trainer_cfg.evaluate_interval` when is was smaller than `self.trainer_cfg.checkpoint_interval`
* (is the cause for me doing this, since I was hitting this error) our evaluation was always failing if wandb wasn't used. I'm not confident that it fully works without wandb now, but I've address the crash I was hitting

Testing:
Ran the github training locally, and saw that the smoke test ran training / evaluation, and passed after the above fixes.