### PR TITLE
improve (reduce) wandb dependence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |
           source venv/bin/activate
-          python -m tools.train +hardware=github
+          python -m tools.train +hardware=github wandb=off
           # Verify the output path exists
           ls -la $CHECKPOINT_PATH || echo "Warning: Checkpoint directory not created"
 
@@ -130,7 +130,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |
           source venv/bin/activate
-          python -m tools.replay +hardware=github policy_uri=$CHECKPOINT_PATH
+          python -m tools.replay +hardware=github policy_uri=$CHECKPOINT_PATH wandb=off
 
       - name: Debug on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -105,22 +105,22 @@ conda activate metta
 ### Run the training
 
 ```
-python -m tools.train run=my_experiment +hardware=macbook
+python -m tools.train run=my_experiment +hardware=macbook wandb=off
 ```
 
 ### Run the evaluation
 
 ```
-python -m tools.sim run=my_experiment +hardware=macbook
+python -m tools.sim run=my_experiment +hardware=macbook wandb=off
 ```
 
 ### Run the interactive simulation
 
 ```
-python -m tools.play run=my_experiment +hardware=macbook
+python -m tools.play run=my_experiment +hardware=macbook wandb=off
 ```
 
-Add `wandb=off` parameter if you're not a member of `metta-research` on wandb, or add your own wandb config in `configs/wandb`.
+If you're a member of `metta-research` on wandb, or you add your own wandb config in `configs/wandb`, you should be able to remove the `wandb=off` command. This is assumed for the rest of the readme.
 
 # Evaluating a model
 

--- a/configs/hardware/github.yaml
+++ b/configs/hardware/github.yaml
@@ -27,7 +27,3 @@ trainer:
       max_steps: 2
   # Don't actually try to upload the replay.
   replay_dry_run: true
-
-wandb:
-  enabled: false
-  track: false

--- a/metta/sim/eval_stats_db.py
+++ b/metta/sim/eval_stats_db.py
@@ -39,6 +39,7 @@ class EvalStatsDB:
         save_dir = run_dir.replace("analyze", "train").replace("eval", "train")
         uri = uri or os.path.join(save_dir, "eval_stats")
         if uri.startswith("wandb://"):
+            assert wandb_run is not None, f"wandb_run is required when loading from wandb. uri: {uri}"
             artifact_name = uri.split("/")[-1]
             return EvalStatsDbWandb(artifact_name, wandb_run)
         else:

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -25,8 +25,9 @@ def simulate_policy(cfg: DictConfig, wandb_run):
         for pr in policy_prs:
             logger.info(f"Evaluating policy {pr.uri}")
 
+            wandb_run_id = wandb_run and wandb_run.id
             eval = hydra.utils.instantiate(
-                cfg.eval, policy_store, pr, cfg.get("run_id", wandb_run.id), cfg_recursive_=False
+                cfg.eval, policy_store, pr, cfg.get("run_id", wandb_run_id), cfg_recursive_=False
             )
             simulate(eval, cfg, wandb_run)
             logger.info(f"Evaluation complete for policy {pr.uri}; logging stats")
@@ -37,7 +38,6 @@ def simulate_policies(cfg: DictConfig):
         for policy_uri in cfg.eval.policy_uris:
             cfg.eval.policy_uri = policy_uri
             simulate_policy(cfg, wandb_run)
-
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="eval")


### PR DESCRIPTION
This updates our readme commands to not depend on wandb in an explicit way, so the ideal of "commands in the readme should always work" is more attainable. This updates out github workflow tests to match the explicit turning off of wandb.

This also addresses two issues in code related to wandb usage. One where failure is reasonable, and the error is now a smidge better, and one where we were failing when wandb was none, but don't need to.

Testing:
ran
`AWS_ACCESS_KEY_ID=none AWS_SECRET_ACCESS_KEY=none python -m tools.train run=my_experiment +hardware=macbook wandb=off` locally. Saw no crashing.