### PR TITLE
Standardize policy uri

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |
           source venv/bin/activate
-          python -m tools.replay +hardware=github policy_uri=$CHECKPOINT_PATH
+          python -m tools.replay +hardware=github
 
       - name: Debug on failure
         if: failure()

--- a/configs/analyzer.yaml
+++ b/configs/analyzer.yaml
@@ -9,8 +9,6 @@ defaults:
 
 cmd: eval
 run: ???
-data_dir: ./train_dir
-run_dir: ${data_dir}/${run}
 
 torch_deterministic: true
 vectorization: multiprocessing

--- a/configs/analyzer/eval_analyzer.yaml
+++ b/configs/analyzer/eval_analyzer.yaml
@@ -1,6 +1,6 @@
 _target_: metta.sim.eval_stats_analyzer.EvalStatsAnalyzer
 
-policy_uri: ???
+policy_uri: ${..policy_uri}
 
 view_type: all
 output_path: /tmp/dashboard.html

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -2,6 +2,7 @@ run: ???
 dist_cfg_path: null
 data_dir: ./train_dir
 run_dir: ${data_dir}/${run}
+policy_uri: file://${run_dir}/checkpoints
 
 torch_deterministic: true
 vectorization: multiprocessing

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -9,9 +9,6 @@ defaults:
 
 cmd: eval
 eval_db_uri: null
-run: ???
-data_dir: ./train_dir
-run_dir: ${data_dir}/${run}
 
 torch_deterministic: true
 vectorization: multiprocessing

--- a/configs/eval/eval.yaml
+++ b/configs/eval/eval.yaml
@@ -1,6 +1,6 @@
 _target_: metta.sim.Simulation
 
-policy_uri: ???
+policy_uri: ${..policy_uri}
 env: ???
 env_overrides: null
 npc_policy_uri: null

--- a/configs/simulator.yaml
+++ b/configs/simulator.yaml
@@ -4,6 +4,5 @@ defaults:
   - wandb: metta_research
   - _self_
 
-policy_uri: ???
 env: env/mettagrid-base/simple
 env_overrides: null

--- a/configs/user/example.yaml
+++ b/configs/user/example.yaml
@@ -24,7 +24,7 @@ eval:
 
 run_id: 1
 run: ${oc.env:USER}.local.${run_id}
-trained_policy_uri: ${run_dir}/checkpoints
+trained_policy_uri: file://${run_dir}/checkpoints
 
 sweep_params: "sweep/fast"
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"


### PR DESCRIPTION
This updates a number of yaml files to make `policy_uri` have a default value that matches out default `run_dir`. This makes the commands in our readme work better, and follows a principle of "if you don't need to give the directory to train, you should need to give it to evaluate".

This also ties together a few places where we define policy_uri in the config. It still ends up in multiple places (root, eval), but at least this copying now happens more automatically.

This also addresses some key duplication in some of the configs, where keys that were defined in `common.yaml` were being duplicated (to the same value) in things that inherited from `common.yaml`.

Test:
ran
`AWS_ACCESS_KEY_ID=none AWS_SECRET_ACCESS_KEY=none python -m tools.replay run=my_experiment +hardware=macbook wandb=off` locally