### PR TITLE
feat: skip CI test on draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10 # Prevent hung jobs from consuming resources
     env:


### PR DESCRIPTION
# Skip CI tests on draft PRs

This PR adds a condition to our GitHub workflow that prevents CI tests from running on draft pull requests.

## Why?
- Saves CI resources and compute time
- Allows developers to create draft PRs for early feedback without triggering expensive test runs
- Tests will automatically run when PR is marked "Ready for review"
- Still maintains our quality standards since all PRs must pass tests before merging

