### PR TITLE
mettaconf - experimental implementation

### DIFF
--- a/deps/mettagrid/mettaconf/__init__.py
+++ b/deps/mettagrid/mettaconf/__init__.py
@@ -1,0 +1,68 @@
+import os
+import pathlib
+from typing import IO, Any, Union
+
+from omegaconf import OmegaConf
+from omegaconf.base import DictKeyType
+from omegaconf.dictconfig import DictConfig
+from omegaconf.listconfig import ListConfig
+
+
+class PatchedDictConfig(DictConfig):
+    def _get_impl(self, key: DictKeyType, default_value: Any, validate_key: bool = True) -> Any:
+        if not isinstance(key, str):
+            # `key$load` feature is only supported for string keys
+            return super()._get_impl(key, default_value, validate_key)
+
+        if key.endswith("$load"):
+            return super()._get_impl(key, default_value, validate_key)
+
+        load_key = f"{key}$load"
+        load_val = None
+        if load_key in self:
+            source_file = self._metadata._source_file  # type: ignore
+            load_val = MettaConf.load(os.path.join(os.path.dirname(source_file), self[load_key]))
+
+        if load_val is None:
+            # no load key, fall back to the default implementation
+            return super()._get_impl(key, default_value, validate_key)
+
+        if key not in self:
+            # we have `key$load` but no `key`
+            return load_val
+
+        # both `key` and `key$load` exist
+        val = super()._get_impl(key, default_value, validate_key)
+        val = OmegaConf.merge(load_val, val)
+
+        return val
+
+
+class PatchedListConfig(ListConfig):
+    pass
+
+
+def patch_cfg(cfg: Union[DictConfig, ListConfig], source: str) -> Union[PatchedDictConfig, PatchedListConfig]:
+    # pick the correct subclass
+    if not isinstance(cfg, DictConfig):
+        target_cls = PatchedDictConfig
+    else:
+        target_cls = PatchedListConfig
+
+    object.__setattr__(cfg, "__class__", target_cls)
+
+    # stash the filename on the existing metadata object
+    cfg._metadata._source_file = source  # type: ignore
+
+    return cfg  # type: ignore
+
+
+class MettaConf(OmegaConf):
+    @staticmethod
+    def load(file_: Union[str, pathlib.Path, IO[Any]]) -> Union[DictConfig, ListConfig]:
+        cfg = OmegaConf.load(file_)
+
+        if isinstance(file_, (str, pathlib.Path)):
+            cfg = patch_cfg(cfg, str(file_))
+
+        return cfg

--- a/deps/mettagrid/mettaconf/__init__.py
+++ b/deps/mettagrid/mettaconf/__init__.py
@@ -39,12 +39,13 @@ class PatchedDictConfig(DictConfig):
 
 
 class PatchedListConfig(ListConfig):
+    # TODO
     pass
 
 
 def patch_cfg(cfg: Union[DictConfig, ListConfig], source: str) -> Union[PatchedDictConfig, PatchedListConfig]:
     # pick the correct subclass
-    if not isinstance(cfg, DictConfig):
+    if isinstance(cfg, DictConfig):
         target_cls = PatchedDictConfig
     else:
         target_cls = PatchedListConfig

--- a/deps/mettagrid/tests/mettaconf_test.py
+++ b/deps/mettagrid/tests/mettaconf_test.py
@@ -1,0 +1,63 @@
+from mettaconf import MettaConf
+
+
+def write_config(filename, content):
+    with open(str(filename), "w") as f:
+        f.write(content)
+
+
+def test_basic(tmpdir):
+    filename = str(tmpdir / "1.yaml")
+    write_config(
+        filename,
+        """
+mykey:
+    foo: 5
+        """,
+    )
+    cfg = MettaConf.load(filename)
+    assert cfg.mykey.foo == 5
+
+
+def test_load_only(tmpdir):
+    f1 = str(tmpdir / "1.yaml")
+    f2 = str(tmpdir / "2.yaml")
+    write_config(
+        f1,
+        """
+mykey$load: ./2.yaml
+        """,
+    )
+    write_config(
+        f2,
+        """
+foo: 5
+        """,
+    )
+    cfg = MettaConf.load(f1)
+    assert cfg.mykey.foo == 5
+
+
+def test_load_and_override(tmpdir):
+    f1 = str(tmpdir / "1.yaml")
+    f2 = str(tmpdir / "2.yaml")
+    write_config(
+        f1,
+        """
+mykey$load: ./2.yaml
+mykey:
+    bar: 10
+    baz: 11
+        """,
+    )
+    write_config(
+        f2,
+        """
+foo: 5
+bar: 6
+        """,
+    )
+    cfg = MettaConf.load(f1)
+    assert cfg.mykey.foo == 5
+    assert cfg.mykey.bar == 10
+    assert cfg.mykey.baz == 11

--- a/deps/mettagrid/tests/mettaconf_test.py
+++ b/deps/mettagrid/tests/mettaconf_test.py
@@ -61,3 +61,23 @@ bar: 6
     assert cfg.mykey.foo == 5
     assert cfg.mykey.bar == 10
     assert cfg.mykey.baz == 11
+
+
+def test_load_nested(tmpdir):
+    f1 = str(tmpdir / "1.yaml")
+    f2 = str(tmpdir / "2.yaml")
+    write_config(
+        f1,
+        """
+a:
+    b$load: ./2.yaml
+        """,
+    )
+    write_config(
+        f2,
+        """
+foo: 5
+        """,
+    )
+    cfg = MettaConf.load(f1)
+    assert cfg.a.b.foo == 5


### PR DESCRIPTION
Mettaconf adds this feature on top of omegaconf:
```yaml
foo$load: ./file/name.yaml
# optionally:
foo:
  key: override
```

- code is in mettagrid because we need mettagrid to use it, and because the preliminary plan is to experiment with replacing Hydra in mettagrid first
- I'm not sure yet how fragile this is, or how viable is this approach, submitting early to gather opinions