### PR TITLE
Add layouts to room_grid

### DIFF
--- a/deps/mettagrid/mettagrid/map/scenes/room_grid.py
+++ b/deps/mettagrid/mettagrid/map/scenes/room_grid.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from mettagrid.map.node import Node
 from mettagrid.map.scene import Scene
@@ -23,7 +23,7 @@ class RoomGrid(Scene):
 
     The right wall is there because rooms are equally sized, and there's some extra space on the right.
 
-    By default, each room will be tagged with "room_{row}_{col}". If layout is provided,
+    By default, each room will be tagged with "room" and "room_{row}_{col}". If layout is provided,
     the tags will be taken from the layout instead; and in this case rows and columns will
     be inferred from the layout.
     """
@@ -32,10 +32,10 @@ class RoomGrid(Scene):
         self,
         rows: Optional[int] = None,
         columns: Optional[int] = None,
-        layout: Optional[List[List[str]]] = None,
+        layout: Optional[list[list[str]]] = None,
         border_width: int = 1,
         border_object: str = "wall",
-        children: Optional[List[Any]] = None,
+        children: Optional[list[Any]] = None,
     ):
         super().__init__(children=children)
         self._layout = layout
@@ -52,11 +52,11 @@ class RoomGrid(Scene):
         self._border_width = border_width
         self._border_object = border_object
 
-    def _tag(self, row: int, col: int) -> str:
+    def _tags(self, row: int, col: int) -> list[str]:
         if self._layout is not None:
-            return self._layout[row][col]
+            return [self._layout[row][col]]
         else:
-            return f"room_{row}_{col}"
+            return ["room", f"room_{row}_{col}"]
 
     def _render(self, node: Node):
         room_width = (node.width - self._border_width * (self._columns - 1)) // self._columns
@@ -70,4 +70,4 @@ class RoomGrid(Scene):
                 x = col * (room_width + self._border_width)
                 y = row * (room_height + self._border_width)
                 node.grid[y : y + room_height, x : x + room_width] = "empty"
-                node.make_area(x, y, room_width, room_height, tags=[self._tag(row, col)])
+                node.make_area(x, y, room_width, room_height, tags=self._tags(row, col))

--- a/tests/deps/mettagrid/mettagrid/map/test_room_grid.py
+++ b/tests/deps/mettagrid/mettagrid/map/test_room_grid.py
@@ -20,19 +20,21 @@ def node():
 def test_room_grid_with_rows_columns(node):
     # Test creating a 2x3 grid of rooms
     scene = RoomGrid(rows=2, columns=3, border_width=1, border_object="wall")
-    scene._render(node)
+    scene.render(node)
 
     # Verify the grid structure
     # Should have walls at inner borders
     assert np.array_equal(node.grid[4, :], ["wall"] * 10)  # Horizontal border
     assert np.array_equal(node.grid[:, 2], ["wall"] * 10)  # Vertical border
 
+    areas = node.select_areas({})
+
     # Verify room areas are created. The 4x2 shape is due to the border width.
-    assert len(node._areas) == 6
-    assert all(area.grid.shape == (4, 2) for area in node._areas)
+    assert len(areas) == 6
+    assert all(area.grid.shape == (4, 2) for area in areas)
 
     # Verify room positions
-    room_positions = [(area.grid[0, 0], area.grid[-1, -1]) for area in node._areas]
+    room_positions = [(area.grid[0, 0], area.grid[-1, -1]) for area in areas]
     assert all(pos[0] == "empty" and pos[1] == "empty" for pos in room_positions)
 
 
@@ -40,13 +42,15 @@ def test_room_grid_with_layout(node):
     # Test creating rooms with a specific layout and tags
     layout = [["room1", "room2"], ["room3", "room4"]]
     scene = RoomGrid(layout=layout, border_width=1, border_object="wall")
-    scene._render(node)
+    scene.render(node)
+
+    areas = node.select_areas({})
 
     # Verify room areas are created with correct tags
-    assert len(node._areas) == 4
-    assert all(area.grid.shape == (4, 4) for area in node._areas)
+    assert len(areas) == 4
+    assert all(area.grid.shape == (4, 4) for area in areas)
 
     # Verifying that the tagged areas are where we expect them to be is a pain,
     # so for now just verify that the tags are what we expect.
-    room_tags = [area.tags[0] for area in node._areas]
+    room_tags = [area.tags[0] for area in areas]
     assert set(room_tags) == {"room1", "room2", "room3", "room4"}

--- a/tests/deps/mettagrid/mettagrid/map/test_room_grid.py
+++ b/tests/deps/mettagrid/mettagrid/map/test_room_grid.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+
+from deps.mettagrid.mettagrid.map.node import Node
+from deps.mettagrid.mettagrid.map.scenes.room_grid import RoomGrid
+
+
+class MockScene:
+    def render(self, node):
+        pass
+
+
+@pytest.fixture
+def node():
+    # Create a 10x10 grid for testing
+    grid = np.full((10, 10), "empty", dtype="<U50")
+    return Node(MockScene(), grid)
+
+
+def test_room_grid_with_rows_columns(node):
+    # Test creating a 2x3 grid of rooms
+    scene = RoomGrid(rows=2, columns=3, border_width=1, border_object="wall")
+    scene._render(node)
+
+    # Verify the grid structure
+    # Should have walls at inner borders
+    assert np.array_equal(node.grid[4, :], ["wall"] * 10)  # Horizontal border
+    assert np.array_equal(node.grid[:, 2], ["wall"] * 10)  # Vertical border
+
+    # Verify room areas are created. The 4x2 shape is due to the border width.
+    assert len(node._areas) == 6
+    assert all(area.grid.shape == (4, 2) for area in node._areas)
+
+    # Verify room positions
+    room_positions = [(area.grid[0, 0], area.grid[-1, -1]) for area in node._areas]
+    assert all(pos[0] == "empty" and pos[1] == "empty" for pos in room_positions)
+
+
+def test_room_grid_with_layout(node):
+    # Test creating rooms with a specific layout and tags
+    layout = [["room1", "room2"], ["room3", "room4"]]
+    scene = RoomGrid(layout=layout, border_width=1, border_object="wall")
+    scene._render(node)
+
+    # Verify room areas are created with correct tags
+    assert len(node._areas) == 4
+    assert all(area.grid.shape == (4, 4) for area in node._areas)
+
+    # Verifying that the tagged areas are where we expect them to be is a pain,
+    # so for now just verify that the tags are what we expect.
+    room_tags = [area.tags[0] for area in node._areas]
+    assert set(room_tags) == {"room1", "room2", "room3", "room4"}


### PR DESCRIPTION
Adds the option to provide a layout to RoomGrid, which will create a room in which areas have a given tag. Expands the automatically-added tags to include "room_x_y", since cursor auto-completed to doing this, and it seemed like a good idea.

This adds layouts to RoomGrid instead of creating a RoomLayout since when I made the latter, the code seemed overly duplicative.

Adds tests.