### PR TITLE
Fix success action tracing in C++ and cython.

### DIFF
--- a/deps/mettagrid/mettagrid/actions/get_output.hpp
+++ b/deps/mettagrid/mettagrid/actions/get_output.hpp
@@ -43,14 +43,18 @@ protected:
         // collect resources from a converter that's in the middle of processing a queue.
         continue;
       }
-      // The actor will destroy anything it can't hold. That's not intentional, so feel free
-      // to fix it.
-      actor->stats.add(InventoryItemNames[i], "get", converter->inventory[i]);
-      actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
-      converter->update_inventory(static_cast<InventoryItem>(i), -converter->inventory[i]);
+      // Only take resources if the converter has some.
+      if (converter->inventory[i] > 0) {
+        // The actor will destroy anything it can't hold. That's not intentional, so feel free
+        // to fix it.
+        actor->stats.add(InventoryItemNames[i], "get", converter->inventory[i]);
+        actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
+        converter->update_inventory(static_cast<InventoryItem>(i), -converter->inventory[i]);
+        return true;
+      }
     }
 
-    return true;
+    return false;
   }
 };
 

--- a/deps/mettagrid/mettagrid/actions/get_output.hpp
+++ b/deps/mettagrid/mettagrid/actions/get_output.hpp
@@ -37,6 +37,9 @@ protected:
       return false;
     }
 
+    // Actions is only successful if we take at least one item.
+    bool items_taken = false;
+
     for (size_t i = 0; i < InventoryItem::InventoryCount; i++) {
       if (converter->recipe_output[i] == 0) {
         // We only want to take things the converter can produce. Otherwise it's a pain to
@@ -50,11 +53,11 @@ protected:
         actor->stats.add(InventoryItemNames[i], "get", converter->inventory[i]);
         actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
         converter->update_inventory(static_cast<InventoryItem>(i), -converter->inventory[i]);
-        return true;
+        items_taken = true;
       }
     }
 
-    return false;
+    return items_taken;
   }
 };
 

--- a/deps/mettagrid/mettagrid/grid_env.pyx
+++ b/deps/mettagrid/mettagrid/grid_env.pyx
@@ -166,6 +166,11 @@ cdef class GridEnv:
         self._rewards[:] = 0
         self._observations[:, :, :, :] = 0
 
+        # Clear the success flags.
+        # Note: we can't do self._action_success[:] = False, because it's a vector.
+        for i in range(self._action_success.size()):
+            self._action_success[i] = 0
+
         self._current_timestep += 1
         self._event_manager.process_events(self._current_timestep)
 
@@ -173,8 +178,6 @@ cdef class GridEnv:
         for p in range(self._max_action_priority + 1):
             for idx in range(self._agents.size()):
                 action = actions[idx][0]
-                # Clear the success flag, as we can continue early.
-                self._action_success[idx] = False
                 if action < 0 or action >= self._num_action_handlers:
                     printf("Invalid action: %d\n", action)
                     continue

--- a/deps/mettagrid/mettagrid/grid_env.pyx
+++ b/deps/mettagrid/mettagrid/grid_env.pyx
@@ -167,7 +167,10 @@ cdef class GridEnv:
         self._observations[:, :, :, :] = 0
 
         # Clear the success flags.
-        # Note: we can't do self._action_success[:] = False, because it's a vector.
+        # Note: we can't do self._action_success[:] = False for very strange reason!
+        # It's a vector but cython still complies but it fails in some unrelated place instead.
+        # Its either memory corruption or cython dynamic-compiled type issue.
+        # Very spooky beware, if you change this:
         for i in range(self._action_success.size()):
             self._action_success[i] = 0
 

--- a/deps/mettagrid/mettagrid/grid_env.pyx
+++ b/deps/mettagrid/mettagrid/grid_env.pyx
@@ -173,6 +173,8 @@ cdef class GridEnv:
         for p in range(self._max_action_priority + 1):
             for idx in range(self._agents.size()):
                 action = actions[idx][0]
+                # Clear the success flag, as we can continue early.
+                self._action_success[idx] = False
                 if action < 0 or action >= self._num_action_handlers:
                     printf("Invalid action: %d\n", action)
                     continue

--- a/deps/mettagrid/mettagrid/grid_env.pyx
+++ b/deps/mettagrid/mettagrid/grid_env.pyx
@@ -167,10 +167,6 @@ cdef class GridEnv:
         self._observations[:, :, :, :] = 0
 
         # Clear the success flags.
-        # Note: we can't do self._action_success[:] = False for very strange reason!
-        # It's a vector but cython still complies but it fails in some unrelated place instead.
-        # Its either memory corruption or cython dynamic-compiled type issue.
-        # Very spooky beware, if you change this:
         for i in range(self._action_success.size()):
             self._action_success[i] = 0
 


### PR DESCRIPTION
### TL;DR

* Fix stale data in success tracking. If we took one of the many continue branches success ended up having stale - mostly true - data, which made many of the bad actions sucessful.

* Fix the GetOutput action to only return success when items are actually taken and properly reset action success flags between steps.

### What changed?

- Added code in `grid_env.pyx` to properly clear action success flags between environment steps
- Modified the `GetOutput` action handler to only return success when at least one item is taken from a converter
- Added a check to only take resources if the converter actually has some (inventory > 0)

### How to test?

1. Run a replay. See that many of the invalid attack and attack nearest actions don't show up now.

### Why make this change?

The previous implementation would return success when it should not, making it look like way more actions were taken.