### PR TITLE
Fix the fact that some vars need to be pre simulation step others post simulation step.

### DIFF
--- a/metta/sim/replay_helper.py
+++ b/metta/sim/replay_helper.py
@@ -56,6 +56,7 @@ class ReplayHelper:
 
             actions_array = actions.cpu().numpy()
 
+            # Add pre simulation data, position, hp, etc.
             for i, grid_object in enumerate(simulator.grid_objects()):
                 if len(grid_objects) <= i:
                     # Add new grid object.
@@ -66,6 +67,13 @@ class ReplayHelper:
                 if "agent_id" in grid_object:
                     agent_id = grid_object["agent_id"]
                     self._add_sequence_key(grid_objects[i], "action", step, actions_array[agent_id].tolist())
+
+            simulator.step(actions)
+
+            # Add post simulation data, like action success.
+            for i, grid_object in enumerate(simulator.grid_objects()):
+                if "agent_id" in grid_object:
+                    agent_id = grid_object["agent_id"]
                     self._add_sequence_key(
                         grid_objects[i], "action_success", step, bool(simulator.env.action_success[agent_id])
                     )
@@ -73,8 +81,6 @@ class ReplayHelper:
                     self._add_sequence_key(
                         grid_objects[i], "total_reward", step, simulator.total_rewards[agent_id].item()
                     )
-
-            simulator.step(actions)
 
             step += 1
 


### PR DESCRIPTION
### TL;DR

Fixed replay generation by moving action success recording after simulation step.

### What changed?

Reordered the code in `generate_replay` to properly record action success and rewards after the simulation step is executed. Previously, these values were being recorded before the step was taken, which meant they were capturing stale data.

The changes:
1. Added comments to clarify pre and post simulation data collection
2. Moved the `simulator.step(actions)` call before recording action success and rewards
3. Split the grid object processing into two loops - one before the step (for position, hp, etc.) and one after (for action success and rewards)

### How to test?

Run a simulation with replay generation and verify that:
1. Action success values in the replay correctly reflect the outcome of actions
2. Total rewards are properly recorded after each step - and not previous step!
3. The replay visualization shows accurate action results

### Why make this change?

The previous implementation was recording action success and rewards before the simulation step was executed, which meant the replay data contained incorrect information about action outcomes. This fix ensures that action results are properly captured after the actions have been processed by the simulator.