### PR TITLE
Fix issue with deploy script.

### DIFF
--- a/.github/workflows/deploy_mettascope.yml
+++ b/.github/workflows/deploy_mettascope.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "player/**" # Run when any file in player directory changes
+      - "deps/mettagrid/player/**" # Run when any file in player directory changes
       - ".github/workflows/**" # Run when workflow files change
   workflow_dispatch: # Allow manual triggers
 


### PR DESCRIPTION
### TL;DR

Updated the path pattern for triggering the MettaScope deployment workflow. Turns out I was updating the deploy file and it was triggering a build, but when I stopped the builds stopped happening.

### What changed?

Modified the file path pattern in the `deploy_mettascope.yml` workflow to monitor changes in `deps/mettagrid/player/**` instead of `player/**`. This change reflects the updated location of the player directory within the repository structure.

### How to test?

1. Make a change to a file in the `deps/mettagrid/player/` directory
2. Verify that the MettaScope deployment workflow is triggered
3. Make a change to a file outside this directory and confirm the workflow is not triggered (unless it's in `.github/workflows/`)

### Why make this change?

The player directory has been moved from the root level to `deps/mettagrid/player/` during the mono repo migration. This update ensures the deployment workflow correctly triggers when relevant files are modified in their new location, maintaining the automation functionality as intended.