### PR TITLE
allow --job-name arg to launch task

### DIFF
--- a/devops/aws/batch/launch_task.py
+++ b/devops/aws/batch/launch_task.py
@@ -67,7 +67,7 @@ def submit_batch_job(args, task_args):
     batch = session.client("batch")
 
     random_id = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
-    job_name = args.run.replace(".", "_") + "_" + random_id
+    job_name = args.job_name if args.job_name else args.run.replace(".", "_") + "_" + random_id
     job_queue = args.job_queue
 
     request = {
@@ -243,6 +243,7 @@ def main():
     parser = argparse.ArgumentParser(description="Launch an AWS Batch task with a wandb key.")
     parser.add_argument("--cluster", default="metta", help="The name of the ECS cluster.")
     parser.add_argument("--run", required=True, help="The run id.")
+    parser.add_argument("--job-name", help="The job name. If not specified, will use run id with random suffix.")
     parser.add_argument(
         "--cmd", required=True, choices=["train", "sweep", "evolve", "sandbox"], help="The command to run."
     )


### PR DESCRIPTION
### TL;DR

Added support for custom job names in AWS Batch task launcher.

### What changed?

- Added a new `--job-name` command line argument to the AWS Batch task launcher
- Modified the job name generation logic to use the provided job name if specified, otherwise falling back to the previous behavior of using the run ID with a random suffix

