### PR TITLE
Add left vs right map, where agents need to choose a direction.

### DIFF
--- a/configs/env/mettagrid/maps/diversity/left_or_right.yaml
+++ b/configs/env/mettagrid/maps/diversity/left_or_right.yaml
@@ -1,0 +1,49 @@
+# Agents have to pick whether to go left or right -- there isn't
+# enough time for both.
+
+defaults:
+  - /env/mettagrid/mettagrid@
+  - _self_
+  
+game:
+  num_agents: 1
+  # Enough time to pick one direction, but not to dilly-dally.
+  max_steps: 25
+  
+  map_builder:
+    _target_: mettagrid.map.mapgen.MapGen
+    
+    width: 30
+    height: 5
+    border_width: 6
+    
+    root:
+      _target_: mettagrid.map.scenes.room_grid.RoomGrid
+      layout: [
+        [
+          "maybe_altars",
+          "empty",
+          "empty",
+          "agents",
+          "empty",
+          "empty",
+          "maybe_altars"
+        ]
+      ]
+      border_width: 0
+      children:
+        # Put the agents in the middle
+        - scene:
+            _target_: mettagrid.map.scenes.random.Random
+            agents: 1
+          where:
+            tags:
+              - agents
+        - scene:
+            _target_: mettagrid.map.scenes.random.Random
+            objects:
+              altar: 2
+          limit: 1
+          where:
+            tags:
+              - maybe_altars


### PR DESCRIPTION
This is a map where agents need to decide to go to the left or right to get reward -- not enough time to do both.

This is intended as a basic env for diversity training / eval.

This doesn't currently track whether the reward was placed on the left or right.