### PR TITLE
fix sandbox script and add readme

### DIFF
--- a/devops/sandbox.sh
+++ b/devops/sandbox.sh
@@ -9,6 +9,5 @@ echo "Running sandbox"
 
 while true; do
     echo "Running sandbox"
-    ./devops/sandbox.sh
     sleep 100
 done

--- a/devops/sandbox/README.md
+++ b/devops/sandbox/README.md
@@ -1,0 +1,17 @@
+to setup a new mac:
+
+python devops/aws/setup_machine.py
+
+to launch a sandbox on aws:
+
+./devops/aws/cmd.sh launch  --cmd=sandbox --run=sandbox --job-name=<sandbox_name>
+
+to connect to the sandbox:
+
+./devops/aws/cmd.sh ssh --job-name=<sandbox_name>
+
+to stop the sandbox:
+
+./devops/aws/cmd.sh stop <sandbox_name>
+
+

--- a/devops/sandbox/README.md
+++ b/devops/sandbox/README.md
@@ -1,17 +1,42 @@
-to setup a new mac:
+# Sandbox Management Guide
 
+This guide provides instructions for setting up and managing sandbox environments on AWS.
+
+## Initial Setup
+
+To set up a new Mac machine:
+
+```bash
 python devops/aws/setup_machine.py
+```
 
-to launch a sandbox on aws:
+## Sandbox Operations
 
-./devops/aws/cmd.sh launch  --cmd=sandbox --run=sandbox --job-name=<sandbox_name>
+### Launching a Sandbox
 
-to connect to the sandbox:
+To launch a new sandbox on AWS:
 
+```bash
+./devops/aws/cmd.sh launch --cmd=sandbox --run=sandbox --job-name=<sandbox_name>
+```
+
+### Connecting to a Sandbox
+
+To connect to an existing sandbox:
+
+1. First claim it in Asana: [Dev Cluster](https://app.asana.com/1/1209016784099267/project/1209353759349008/task/1210106185904866?focus=true)
+2. Then connect using:
+
+```bash
 ./devops/aws/cmd.sh ssh --job-name=<sandbox_name>
+```
 
-to stop the sandbox:
+### Stopping a Sandbox
 
+To stop a running sandbox:
+
+```bash
 ./devops/aws/cmd.sh stop <sandbox_name>
+```
 
 


### PR DESCRIPTION
e### TL;DR

Fixed an infinite recursion bug in the sandbox script and added documentation for sandbox setup and management.

### What changed?

- Removed the self-referential call to `./devops/sandbox.sh` inside the sandbox script that was causing infinite recursion
- Added a new README.md file in the `devops/sandbox` directory with instructions for:
  - Setting up a new Mac machine
  - Launching a sandbox on AWS
  - Connecting to a sandbox via SSH
  - Stopping a sandbox

### How to test?

1. Run the sandbox script to verify it no longer causes infinite recursion
2. Follow the instructions in the new README to:
   - Set up a new machine: `python devops/aws/setup_machine.py`
   - Launch a sandbox: `./devops/aws/cmd.sh launch --cmd=sandbox --run=sandbox --job-name=<sandbox_name>`
   - Connect to the sandbox: `./devops/aws/cmd.sh ssh --job-name=<sandbox_name>`
   - Stop the sandbox: `./devops/aws/cmd.sh stop <sandbox_name>`

### Why make this change?

The sandbox script had a critical bug where it was calling itself recursively, which would eventually crash the system. Additionally, there was no clear documentation on how to set up and manage sandboxes, making it difficult for new team members to use this functionality.