### PR TITLE
feat: Automated Stale PR Labeling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Label stale pull requests'
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs at midnight every day
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 3
+          days-before-close: -1  # Negative value means don't close automatically
+          stale-pr-label: 'stale'
+          stale-pr-message: 'This PR has been marked as stale due to 3 days of inactivity.'
+          remove-stale-when-updated: true


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically labels pull requests as "stale" when they haven't had any activity for 3 days.

## Details:
- Uses the official GitHub `actions/stale@v9` action
- Runs automatically at midnight daily
- Can also be triggered manually via workflow_dispatch
- Applies the "stale" label to PRs with no activity for 3 days
- Does NOT automatically close PRs (days-before-close is set to -1)
- Automatically removes the "stale" label when a PR receives new activity

## Why this is useful:
- Improves PR visibility and management
- Helps identify PRs that might need attention
- Encourages contributors to keep PRs active or close them if no longer relevant
- Reduces the manual work needed to monitor PR status

This should help our team maintain better visibility of our pull requests and ensure that nothing falls through the cracks.