### PR TITLE
Remove python functions from ObservationEncoder

### DIFF
--- a/deps/mettagrid/mettagrid/grid_env.pyx
+++ b/deps/mettagrid/mettagrid/grid_env.pyx
@@ -318,7 +318,6 @@ cdef class GridEnv:
 
     @property
     def observation_space(self):
-        space = self._obs_encoder.observation_space()
         return gym.spaces.Box(
             0,
             255,

--- a/deps/mettagrid/mettagrid/mettagrid.pyx
+++ b/deps/mettagrid/mettagrid/mettagrid.pyx
@@ -164,7 +164,7 @@ cdef class MettaGrid(GridEnv):
 
     cpdef grid_objects(self):
         cdef GridObject *obj
-        cdef ObsType[:] obj_data = np.zeros(len(self.grid_features()), dtype=self._obs_encoder.obs_np_type())
+        cdef ObsType[:] obj_data = np.zeros(len(self.grid_features()), dtype=np.uint8)
         cdef unsigned int obj_id, i
         cdef ObservationEncoder obs_encoder = self._obs_encoder
         cdef vector[unsigned int] offsets

--- a/deps/mettagrid/mettagrid/observation_encoder.pxd
+++ b/deps/mettagrid/mettagrid/observation_encoder.pxd
@@ -14,6 +14,4 @@ cdef class ObservationEncoder:
     cdef encode(self, GridObject *obj, ObsType[:] obs)
     cdef _encode(self, GridObject *obj, ObsType[:] obs, vector[unsigned int] offsets)
     cdef vector[string] feature_names(self)
-    cpdef observation_space(self)
-    cpdef obs_np_type(self)
 

--- a/deps/mettagrid/mettagrid/observation_encoder.pyx
+++ b/deps/mettagrid/mettagrid/observation_encoder.pyx
@@ -1,6 +1,3 @@
-import numpy as np
-import gymnasium as gym
-
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.map cimport map
@@ -14,9 +11,6 @@ from mettagrid.objects.converter cimport Converter
 from mettagrid.objects.wall cimport Wall
 
 cdef class ObservationEncoder:
-    cpdef obs_np_type(self):
-        return np.uint8
-    
     cdef init(self, unsigned int obs_width, unsigned int obs_height):
         self._obs_width = obs_width
         self._obs_height = obs_height
@@ -57,14 +51,3 @@ cdef class ObservationEncoder:
 
     cdef vector[string] feature_names(self):
         return self._feature_names
-    
-    cpdef observation_space(self):
-        type_info = np.iinfo(self.obs_np_type())
-
-        return gym.spaces.Box(
-                    low=type_info.min, high=type_info.max,
-                    shape=(
-                        len(self.feature_names()),
-                        self._obs_height, self._obs_width),
-            dtype=self.obs_np_type()
-        )


### PR DESCRIPTION
This removes certain Python functions from ObservationEncoder, making it more possible for it to be fully cpp.

In both cases, the functions blurred the line between the grid and observations. Since I wanted to move the ObservationEncoder into cpp, I pushed these into the grid as needed, but long term we'll need to develop a clearer divide.

* _obs_encoder.observation_space isn't meaningfully used -- things just use the grid's understanding of observation width and height instead.
* _obs_encoder.obs_np_type was used, but it was constant and it's hard coded for now. At some point I think we'll care about the the data types we're using, and it seems likely we solve that with templating.

Tested via compilation.