### PR TITLE
Lock all Python requirements. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,9 @@ heavyball==1.7.2
 hydra-core==1.3.2
 matplotlib==3.9.2
 pydantic==2.11.3
-pydantic_core==2.33.1
 PyYAML==6.0.2
 raylib==5.5.0.1
 rich==13.9.4
-rich-argparse==1.6.0
 scipy==1.14.1
 tabulate==0.9.0
 termcolor==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,27 +7,29 @@ numpy==1.26.4
 # ==========================
 # Core Runtime Dependencies
 # ==========================
-boto3>=1.35.69
-colorama>=0.4.6
-duckdb>=1.2.0
-heavyball>=1.7.2
-hydra-core>=1.3.2
-matplotlib>=3.9.2
-pydantic>=2.11.1
-PyYAML>=6.0.2
-raylib>=5.5.0.1
-rich>=13.9.4
-scipy>=1.14.1
-tabulate>=0.9.0
+boto3==1.37.35
+colorama==0.4.6
+duckdb==1.2.0
+heavyball==1.7.2
+hydra-core==1.3.2
+matplotlib==3.9.2
+pydantic==2.11.3
+pydantic_core==2.33.1
+PyYAML==6.0.2
+raylib==5.5.0.1
+rich==13.9.4
+rich-argparse==1.6.0
+scipy==1.14.1
+tabulate==0.9.0
 termcolor==2.4.0
-tqdm>=4.67.1
+tqdm==4.67.1
 
 # ==========================
 # Machine Learning / RL
 # ==========================
-pettingzoo>=1.24.1
-tensordict==0.7.0
-torchrl>=0.6.0
+pettingzoo==1.24.1
+tensordict==0.8.1
+torchrl==0.6.0
 wandb==0.19.9
 
 # ==========================
@@ -39,20 +41,20 @@ shimmy==1.3.0
 # ==========================
 # server
 # ==========================
-fastapi>=0.115.5
-uvicorn>=0.32.1
+fastapi==0.115.5
+uvicorn==0.32.1
 
 # ==========================
 # Visualization & Media
 # ==========================
-imageio>=2.36.0
-plotly>=6.0.0
-pandas>=2.2.3
+imageio==2.36.0
+plotly==6.0.1
+pandas==2.2.3
 
 # ==========================
 # Testing & Linting
 # ==========================
-pytest>=8.3.3
+pytest==8.3.3
 pytest-cov==6.1.1
 ruff==0.11.5
 pyright==1.1.400
@@ -60,4 +62,4 @@ pyright==1.1.400
 # ==========================
 # Configuration & Utilities
 # ==========================
-python-dotenv>=1.1
+python-dotenv==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ tqdm==4.67.1
 # Machine Learning / RL
 # ==========================
 pettingzoo==1.24.1
-tensordict==0.8.1
+tensordict==0.7.0
 torchrl==0.6.0
 wandb==0.19.9
 


### PR DESCRIPTION
### TL;DR

Pin dependency versions in requirements.txt to ensure consistent builds so we don't spend hours debugging again.

When updating a dependency make sure you pin and test it!

### What changed?

I looked at deps on my mac and the pufferbox. I took the min version as mac usually gets packages after linux. And yeah most of the mac packages where older so I used them mostly. They mostly matched the >= version from before.


### How was it tested?

I tested it here by training:
* Pufferbox: https://wandb.ai/metta-research/metta/runs/andre_pufferbox_33
* AWS: https://wandb.ai/metta-research/metta/runs/andre_aws_34

### Why make this change?

Pinning exact dependency versions ensures reproducible builds across different environments and prevents unexpected behavior from dependency updates. This improves stability and makes debugging easier by eliminating version inconsistencies as a potential source of problems.