### PR TITLE
Enhance Mesh class to include a name property and update logging

### DIFF
--- a/deps/mettagrid/player/src/drawer.ts
+++ b/deps/mettagrid/player/src/drawer.ts
@@ -11,6 +11,7 @@ interface AtlasData {
  * Mesh class responsible for managing vertex data
  */
 class Mesh {
+  private name: string;
   private device: GPUDevice;
   private vertexBuffer: GPUBuffer | null = null;
   private indexBuffer: GPUBuffer | null = null;
@@ -28,7 +29,8 @@ class Mesh {
   public scissorEnabled: boolean = false;
   public scissorRect: [number, number, number, number] = [0, 0, 0, 0]; // x, y, width, height
 
-  constructor(device: GPUDevice, maxQuads: number = 1024 * 16) {
+  constructor(name: string, device: GPUDevice, maxQuads: number = 1024 * 8) {
+    this.name = name;
     this.device = device;
     this.maxQuads = maxQuads;
 
@@ -93,7 +95,7 @@ class Mesh {
 
   // Resize the maximum number of quads the mesh can hold.
   resizeMaxQuads(newMaxQuads: number): void {
-    console.log("Resizing max quads from", this.maxQuads, "to", newMaxQuads);
+    console.info("Resizing max ", this.name," quads from", this.maxQuads, "to", newMaxQuads);
 
     if (newMaxQuads <= this.maxQuads) {
       console.warn("New max quads must be larger than current max quads");
@@ -301,7 +303,7 @@ class Drawer {
     }
 
     // Otherwise, create a new mesh
-    const newMesh = new Mesh(this.device);
+    const newMesh = new Mesh(name, this.device);
     newMesh.createBuffers();
     this.meshes.set(name, newMesh);
     this.currentMesh = newMesh;

--- a/deps/mettagrid/player/src/main.ts
+++ b/deps/mettagrid/player/src/main.ts
@@ -377,9 +377,6 @@ function removeSuffix(str: string, suffix: string) {
 async function loadReplayText(replayData: any) {
   replay = JSON.parse(replayData);
 
-
-  console.log("pre replay: ", replay);
-
   // Go through each grid object and expand its key sequence.
   for (const gridObject of replay.grid_objects) {
     for (const key in gridObject) {
@@ -471,7 +468,7 @@ async function loadReplayText(replayData: any) {
     }
   }
 
-  console.log("post replay: ", replay);
+  console.info("replay: ", replay);
 
   // Set the scrubber max value to the max steps.
   scrubber.max = (replay.max_steps - 1).toString();


### PR DESCRIPTION
- Added a `name` property to the `Mesh` class for better identification.
- Modified the constructor to accept the `name` parameter.
- Updated logging in the `resizeMaxQuads` method to include the mesh name.
- Adjusted the creation of new `Mesh` instances in the `Drawer` class to pass the name.

This change improves the clarity of log messages and allows for better tracking of mesh instances.