### PR TITLE
fix wandb type in WandbContext and ReplayHelper; install pyright

### DIFF
--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -21,10 +21,10 @@ import torch
 import wandb
 from omegaconf import DictConfig, ListConfig
 from torch import nn
-from wandb.sdk import wandb_run
 
 from metta.agent.metta_agent import make_policy
 from metta.rl.pufferlib.policy import load_policy
+from metta.util.wandb.wandb_context import WandbRun
 
 logger = logging.getLogger("policy_store")
 
@@ -56,7 +56,7 @@ class PolicyRecord:
 
 
 class PolicyStore:
-    def __init__(self, cfg: ListConfig | DictConfig, wandb_run: wandb_run.Run):
+    def __init__(self, cfg: ListConfig | DictConfig, wandb_run: WandbRun | None):
         self._cfg = cfg
         self._device = cfg.device
         self._wandb_run = wandb_run

--- a/metta/sim/replay_helper.py
+++ b/metta/sim/replay_helper.py
@@ -12,7 +12,7 @@ import wandb
 from metta.agent.policy_store import PolicyRecord
 from metta.sim.simulation_config import SimulationConfig
 from metta.util.file import s3_url, upload_to_s3
-from metta.util.wandb.wandb_context import WandbContext
+from metta.util.wandb.wandb_context import WandbRun
 from mettagrid.mettagrid_env import MettaGridEnv
 
 
@@ -20,7 +20,7 @@ class ReplayHelper:
     """Helper class for generating and uploading replays."""
 
     def __init__(
-        self, config: SimulationConfig, env: MettaGridEnv, policy_record: PolicyRecord, wandb_run: WandbContext
+        self, config: SimulationConfig, env: MettaGridEnv, policy_record: PolicyRecord, wandb_run: WandbRun | None
     ):
         self.config = config
         self.policy_record = policy_record

--- a/metta/util/wandb/wandb_context.py
+++ b/metta/util/wandb/wandb_context.py
@@ -6,9 +6,15 @@ import socket
 import pkg_resources
 import requests
 import wandb
+import wandb.errors
+import wandb.sdk.wandb_run
+import wandb.util
 from omegaconf import OmegaConf
 
 logger = logging.getLogger(__name__)
+
+# Alias type for easier usage (other modules can import this type)
+WandbRun = wandb.sdk.wandb_run.Run
 
 
 def check_wandb_version() -> bool:
@@ -60,7 +66,7 @@ class WandbContext:
 
         check_wandb_version()
 
-    def __enter__(self) -> wandb.apis.public.Run:
+    def __enter__(self) -> WandbRun | None:
         if not self.cfg.wandb.enabled:
             assert not self.cfg.wandb.track, "wandb.track won't work if wandb.enabled is False"
             return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ pandas>=2.2.3
 pytest>=8.3.3
 pytest-cov==6.1.1
 ruff==0.11.5
+pyright==1.1.400
 
 # ==========================
 # Configuration & Utilities


### PR DESCRIPTION
- types in ReplayHelper were broken, fixed
- reexported WandbRun from wandb_context.py for easier typing
- installed pyright (no CI yet), error count before/after: 284 -> 279