### PR TITLE
feat: Enable cuDNN Auto-Tuner for Performance Optimization

### DIFF
--- a/metta/util/runtime_configuration.py
+++ b/metta/util/runtime_configuration.py
@@ -18,6 +18,7 @@ def seed_everything(seed, torch_deterministic):
     if seed is not None:
         torch.manual_seed(seed)
     torch.backends.cudnn.deterministic = torch_deterministic
+    torch.backends.cudnn.benchmark = True
 
 
 def setup_mettagrid_environment(cfg):


### PR DESCRIPTION

This PR enables the cuDNN Auto-Tuner by setting `torch.backends.cudnn.benchmark = True` in our runtime configuration. This optimization allows cuDNN to automatically select the most efficient algorithmic implementation for the specific hardware when input sizes remain constant.

Reference: [How to Train Your PyTorch Models Much Faster](https://levelup.gitconnected.com/how-to-train-your-pytorch-models-much-faster-14737c8c9770)

See also the [upstream commit](https://github.com/PufferAI/PufferLib/commit/397c262408aeaeea5ae093c0084bf65136a2f355) in PufferLib


