### PR TITLE
fix Simulator configs: update NPC uri to reference an action robust agent

### DIFF
--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -56,7 +56,7 @@ simulations:
   simple_npc:
     env: env/mettagrid/simple
     policy_agents_pct: 0.5
-    npc_policy_uri: wandb://run/b.daveey.t.8.rdr9.3
+    npc_policy_uri: wandb://run/b.alex.robust.npc.s.s.004
 
 
 


### PR DESCRIPTION
the NPC was pointing to a deprecated model architecture and was therefore causing simulator to crash. Trained a placeholder model on the new architecture and changed the URI accordingly. 

Future work: train a strong NPC on the new, action-robust model architecture. 