### PR TITLE
Refactor drawFloor function in main.ts to use state for map size

### DIFF
--- a/deps/mettagrid/player/src/context3d.ts
+++ b/deps/mettagrid/player/src/context3d.ts
@@ -240,7 +240,7 @@ class Mesh {
   }
 }
 
-class Drawer {
+class Context3d {
   // Canvas and WebGPU state
   public canvas: HTMLCanvasElement;
   public device: GPUDevice | null;
@@ -987,4 +987,4 @@ class Drawer {
   }
 }
 
-export { Drawer };
+export { Context3d };

--- a/deps/mettagrid/player/src/main.ts
+++ b/deps/mettagrid/player/src/main.ts
@@ -567,10 +567,10 @@ function focusFullMap(panel: PanelInfo) {
 }
 
 // Draw the tiles that make up the floor.
-function drawFloor(mapSize: [number, number]) {
+function drawFloor() {
 
   // Compute the visibility map, each agent contributes to the visibility map.
-  const visibilityMap = new Grid(mapSize[0], mapSize[1]);
+  const visibilityMap = new Grid(state.replay.map_size[0], state.replay.map_size[1]);
 
   // Update the visibility map for a grid object.
   function updateVisibilityMap(gridObject: any) {
@@ -608,8 +608,8 @@ function drawFloor(mapSize: [number, number]) {
   }
 
   // Draw the floor, darker where there is no visibility.
-  for (let x = 0; x < mapSize[0]; x++) {
-    for (let y = 0; y < mapSize[1]; y++) {
+  for (let x = 0; x < state.replay.map_size[0]; x++) {
+    for (let y = 0; y < state.replay.map_size[1]; y++) {
       const color = visibilityMap.get(x, y) ? [1, 1, 1, 1] : [0.75, 0.75, 0.75, 1];
       drawer.drawSprite('objects/floor.png', x * Common.TILE_SIZE, y * Common.TILE_SIZE, color);
     }
@@ -1037,7 +1037,7 @@ function drawMap(panel: PanelInfo) {
   drawer.scale(panel.zoomLevel, panel.zoomLevel);
   drawer.translate(panel.panPos.x(), panel.panPos.y());
 
-  drawFloor(state.replay.map_size);
+  drawFloor();
   drawWalls();
   drawTrajectory();
   drawObjects();


### PR DESCRIPTION
Refactor drawFloor function in main.ts to use state for map size

- Updated the drawFloor function to remove the mapSize parameter and directly access the map size from the state object.
- Adjusted the nested loops to iterate over the dimensions defined in state.replay.map_size, improving code clarity and maintainability.

These changes streamline the drawing logic by centralizing map size management within the state object.

drawer -> context3d
I want to use drawing and draw for more user level operations, while context3d is the low level context like context2d.