### PR TITLE
Turns out you can't trust the map size from grid env, just compute what it should be.

### DIFF
--- a/deps/mettagrid/player/src/replay.ts
+++ b/deps/mettagrid/player/src/replay.ts
@@ -213,6 +213,16 @@ async function loadReplayText(replayData: any) {
     }
   }
 
+  // Map size is not to be trusted. Recompute map size just in case.
+  state.replay.map_size[0] = 0;
+  state.replay.map_size[1] = 0;
+  for (const gridObject of state.replay.grid_objects) {
+    let x = getAttr(gridObject, "c") + 1;
+    let y = getAttr(gridObject, "r") + 1;
+    state.replay.map_size[0] = Math.max(state.replay.map_size[0], x);
+    state.replay.map_size[1] = Math.max(state.replay.map_size[1], y);
+  }
+
   console.info("replay: ", state.replay);
 
   // Set the scrubber max value to the max steps.


### PR DESCRIPTION
### TL;DR

Recalculate map size from grid objects to ensure accuracy in replays.

### What changed?

Added code to recompute the map size in the `loadReplayText` function by iterating through all grid objects and finding the maximum x and y coordinates. This ensures the map size is accurate even if the original data is incorrect.

### How to test?

Look at: https://metta-ai.github.io/metta/?replayUrl=https://softmax-public.s3.us-east-1.amazonaws.com/replays/daphne.navigation/replay.21600.json.z

### Why make this change?

The original map size data in replays cannot always be trusted. By recalculating the dimensions based on the actual grid objects' positions, we ensure that the replay visualization uses the correct map boundaries, preventing potential display issues or gameplay inconsistencies.