### PR TITLE
Set up tests to run in a merge queue

### DIFF
--- a/.github/workflows/cpp-checks.yml
+++ b/.github/workflows/cpp-checks.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
   workflow_dispatch: {}

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: {}
 
 # Set default permissions that will be inherited by called workflows


### PR DESCRIPTION
This configures our tests to run on the merge queue, once it's set up.

Note that branches should only join the merge queue once they've already passed tests themselves, and what the merge queue adds is protection against semantic conflicts.