### PR TITLE
s3-public tf stack

### DIFF
--- a/devops/tf/s3-public/bucket.tf
+++ b/devops/tf/s3-public/bucket.tf
@@ -1,5 +1,66 @@
+locals {
+  bucket_name              = "softmax-public"
+  david_bloomin_account_id = "767406518141"
+}
+
 resource "aws_s3_bucket" "softmax_public" {
-  bucket = "softmax-public"
+  bucket = local.bucket_name
+
+}
+
+resource "aws_s3_bucket_policy" "softmax_public" {
+  bucket = aws_s3_bucket.softmax_public.id
+  policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action    = "s3:GetObject"
+          Effect    = "Allow"
+          Principal = "*"
+          Resource  = "${aws_s3_bucket.softmax_public.arn}/*"
+          Sid       = "AllowPublicRead"
+        },
+        {
+          Action = "s3:*"
+          Effect = "Allow"
+          Principal = {
+            AWS = [
+              "arn:aws:iam::${local.david_bloomin_account_id}:role/ecsTaskExecutionRole",
+              "arn:aws:iam::${local.david_bloomin_account_id}:role/s3_sync",
+              "arn:aws:iam::${local.david_bloomin_account_id}:root",
+            ]
+          }
+          Resource = [
+            aws_s3_bucket.softmax_public.arn,
+            "${aws_s3_bucket.softmax_public.arn}/*",
+          ]
+          Sid = "FullAccessFromDavidBloominAccount"
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+}
+
+resource "aws_s3_bucket_cors_configuration" "softmax_public" {
+  bucket = aws_s3_bucket.softmax_public.id
+
+  cors_rule {
+    allowed_headers = [
+      "*",
+    ]
+    allowed_methods = [
+      "GET",
+      "HEAD",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers = [
+      "ETag",
+      "x-amz-meta-custom-header",
+    ]
+  }
 }
 
 import {

--- a/devops/tf/s3-public/bucket.tf
+++ b/devops/tf/s3-public/bucket.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "softmax_public" {
+  bucket = "softmax-public"
+}

--- a/devops/tf/s3-public/bucket.tf
+++ b/devops/tf/s3-public/bucket.tf
@@ -1,3 +1,8 @@
 resource "aws_s3_bucket" "softmax_public" {
   bucket = "softmax-public"
 }
+
+import {
+  to = aws_s3_bucket.softmax_public
+  id = "softmax-public"
+}

--- a/devops/tf/s3-public/terraform.tf
+++ b/devops/tf/s3-public/terraform.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}


### PR DESCRIPTION
### TL;DR

Added Terraform configuration for the public S3 bucket used for hosting public assets.

### What changed?

- Created Terraform configuration for the `softmax-public` S3 bucket

- Added bucket policy that allows public read access to all objects
- Configured specific IAM roles from the David Bloomin account to have full access
- Set up CORS configuration to allow GET and HEAD requests from any origin

(these should duplicate the old settings, except that I removed the entry for my personal AWS account)

### Why make this change?

This change brings the existing public S3 bucket under infrastructure-as-code management, improving documentation and making future modifications more consistent and trackable. It ensures the bucket has the proper permissions for public access while maintaining secure write access for authorized roles.