### PR TITLE
feat: Add Transformer layer as LSTM alternative

### DIFF
--- a/configs/agent/transformer.yaml
+++ b/configs/agent/transformer.yaml
@@ -1,0 +1,115 @@
+# see reference_design.yaml for explanation of components
+_target_: metta.agent.metta_agent.MettaAgent
+
+observations:
+  obs_key: grid_obs
+
+clip_range: 0 # set to 0 to disable clipping
+analyze_weights_interval: 300
+l2_init_weight_update_interval: 0
+
+components:
+  #necessary layers: _core_, _action_embeds_, _action_, _value_
+  #necessary input_source: _obs_
+
+  _obs_:
+    _target_: metta.agent.lib.obs_shaper.ObsShaper
+    sources: 
+      null
+
+  obs_normalizer:
+    _target_: metta.agent.lib.observation_normalizer.ObservationNormalizer
+    sources:
+      - name: _obs_
+
+  cnn1:
+    _target_: metta.agent.lib.nn_layer_library.Conv2d
+    sources:
+      - name: obs_normalizer
+    nn_params:
+      out_channels: 64
+      kernel_size: 5
+      stride: 3
+
+  cnn2:
+    _target_: metta.agent.lib.nn_layer_library.Conv2d
+    sources:
+      - name: cnn1
+    nn_params:
+      out_channels: 64
+      kernel_size: 3
+      stride: 1
+
+  obs_flattener:
+    _target_: metta.agent.lib.nn_layer_library.Flatten
+    sources:
+      - name: cnn2
+
+  fc1:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: obs_flattener
+    nn_params:
+      out_features: 128
+
+  encoded_obs:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: fc1
+    nn_params:
+      out_features: 128
+
+  _core_:
+    _target_: metta.agent.lib.transformer.TransformerCore
+    sources:
+      - name: encoded_obs
+    output_size: 128
+    nn_params:
+      num_layers: 2
+      num_heads: 8
+      ffn_size: 128
+      context_size: 1024
+      gtrxl_gate: false
+
+  core_relu:
+    _target_: metta.agent.lib.nn_layer_library.ReLU
+    sources:
+      - name: _core_
+
+  critic_1:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: core_relu
+    nn_params:
+      out_features: 1024
+    nonlinearity: nn.Tanh
+    effective_rank: true
+
+  _value_:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: critic_1
+    nn_params:
+      out_features: 1
+    nonlinearity: null
+
+  actor_1:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: core_relu
+    nn_params:
+      out_features: 512
+
+  _action_embeds_:
+    _target_: metta.agent.lib.action.ActionEmbedding
+    sources:
+      null
+    nn_params:
+      num_embeddings: 100
+      embedding_dim: 16
+
+  _action_:
+    _target_: metta.agent.lib.actor.MettaActorSingleHead
+    sources:
+      - name: actor_1
+      - name: _action_embeds_

--- a/configs/trainer/transformer.yaml
+++ b/configs/trainer/transformer.yaml
@@ -1,0 +1,25 @@
+defaults:
+  - puffer
+  - _self_
+
+profiler_interval_epochs: 0
+
+forward_pass_minibatch_target_size: 72 # (agents (36 * 4))
+batch_size: 73728 # 144 * 1024
+minibatch_size: 18432 # 36 * 1024
+bptt_horizon: 1024
+update_epochs: 1
+
+clip_coef: 0.1
+ent_coef: 0.0002
+gae_lambda: 0.9
+gamma: 0.97
+vf_coef: 2.0
+average_reward: false
+
+optimizer:
+  type: adam
+  beta1: 0.967
+  beta2: 0.9999
+  eps: 1e-12
+  learning_rate: 0.0003

--- a/configs/user/gabrielk.yaml
+++ b/configs/user/gabrielk.yaml
@@ -1,45 +1,54 @@
 # @package __global__
 
-seed: null
-
 defaults:
-  - override /hardware: aws
-  - override /env/mettagrid@env: simple
-  - override /agent: resnet
+  - override /agent: transformer
+  - override /analyzer: eval_analyzer
+  - override /trainer: transformer
   - _self_
 
-# policy: file://.train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
-# baselines: file://.train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
 
-# evaluator:
-#   policy:
-#     uri: ${...policy_uri}
-# baselines:
-#   uri: ${...baseline_uri}
-
-policy_uri: file://./train_dir/gabrielk.local.train.resnet/checkpoints/model_0000.pt
-baseline_uri: file://./train_dir/gabrielk.local.train.simple/checkpoints/model_0000.pt
-
-env:
-  game:
-    max_steps: 100
+device: cuda
+# vectorization: multiprocessing
+vectorization: serial
 
 trainer:
-  evaluate_interval: 2
+  num_workers: 2
+  async_factor: 1
+  zero_copy: true
+  # checkpoint_interval: 300
+  # env: /env/mettagrid/simple
+  env_overrides:
+    sampling: 0.7
+    game:
+      num_agents: 36
+      max_steps: 1023 # 1024 - 1
 
-evaluator:
-  policy:
-    uri: ${...policy_uri}
-  baselines:
-    uri: ${...baseline_uri}
+# analyzer:
+#   eval_stats_uri: ${run_dir}/eval_stats
+#   policy_uri: ${..policy_uri}
+#   analysis:
+#     metrics:
+#       - metric: episode_reward
+#   output_path: navigation_results/navigation.html
 
-wandb:
-  enabled: false
-  track: false
-  checkpoint_interval: 1
+# eval:
+#   env: /env/mettagrid/navigation/training/varied_terrain
 
-sweep:
-  metric: action.use
+#   policy_uri: ${..policy_uri}
+#   eval_db_uri: ${..eval_db_uri}
+#   policy_uris:
+#     - "wandb://run/b.daphne.navigation_terrain_training_v2"
+#     - "wandb://run/b.georgedeane.navigation_terrain_training_v2"
+#     - "wandb://run/b.daphne.navigation_terrain_training"
 
-cmd: ???
-run: ${oc.env:USER}.local.${cmd}.simple
+# wandb:
+#   enabled: false
+#   track: false
+
+run_id: 30
+run: ${oc.env:USER}.local.${run_id}
+trained_policy_uri: ${run_dir}/checkpoints
+
+sweep_params: "sweep/fast"
+sweep_name: "${oc.env:USER}.local.sweep.${run_id}"
+seed: null

--- a/metta/agent/lib/attention.py
+++ b/metta/agent/lib/attention.py
@@ -1,0 +1,172 @@
+import math
+import torch
+from torch import nn, Tensor
+from torch.nn import functional as F
+
+from torch.nn.attention.flex_attention import flex_attention, BlockMask
+
+
+def apply_rope(inputs: Tensor, time_steps: Tensor, max_wavelength: int = 10_000) -> Tensor:
+    """
+    args:
+    inputs -- (batch, sequence, head, hidden)
+    position -- (batch, sequence) -- the value is the index of the position for the inputs
+    max_wavelength -- int
+
+    returns:
+    (batch, sequence, head, hidden)
+    """
+    dtype = inputs.dtype
+    device = inputs.device
+    head_dim = inputs.shape[-1]
+
+    fraction = 2 * torch.arange(0, head_dim // 2, dtype=dtype, device=device) / head_dim
+    timescale = (max_wavelength**fraction).to(dtype=dtype, device=device)
+    # timescale could be cached but I'm not sure it matter if torch compile is used
+
+    sinusoid_inp = time_steps[..., None] / timescale[None, None, :]
+    sinusoid_inp = sinusoid_inp[..., None, :]
+
+    sin = torch.sin(sinusoid_inp)
+    cos = torch.cos(sinusoid_inp)
+
+    first_half, second_half = torch.chunk(inputs, 2, -1)
+    first_part = first_half * cos - second_half * sin
+    second_part = second_half * cos + first_half * sin
+    out = torch.concatenate([first_part, second_part], -1)
+
+    return out
+
+
+def flex_attention_wrapper(query: Tensor, key: Tensor, value: Tensor, block_mask: BlockMask | None) -> Tensor:
+    """
+    Applies flex attention to sequence first data. Optionally takes in a block mask for casual attention,
+    this has good performance because it can use sparsity to save compute on masked out parts.
+    """
+
+    # batch seq heads dim -> batch heads seq dim
+    key = key.transpose(-3, -2).contiguous()
+    query = query.transpose(-3, -2).contiguous()
+    value = value.transpose(-3, -2).contiguous()
+
+    out = flex_attention(query, key, value, block_mask=block_mask)
+
+    batch, _, seq, _ = out.shape
+
+    # batch heads seq qkv -> batch seq (heads qkv)
+    # out = rearrange(out, "... heads seq dim -> ... seq (heads dim)")
+    out = out.transpose(-3, -2).contiguous().reshape(batch, seq, -1)
+    return out
+
+
+def position_mask(time_steps: Tensor, max_seq_length: int) -> Tensor:
+    """
+    Generates a casual mask for einsum attention.
+    args
+    time_steps -- (batch, sequence), for inference this can be (batch, 1) where the value is the index of the position
+    max_seq_length -- this should be the size of the kv cache
+    """
+    seq_range = torch.arange(max_seq_length, dtype=torch.int64, device=time_steps.device)
+    mask = seq_range[None, None, :] <= time_steps[:, None]
+    return mask[:, None, :, :]
+
+
+def einsum_attention(query: Tensor, key: Tensor, value: Tensor, time_steps: Tensor) -> Tensor:
+    """
+    Computes casual self attention, this isn't as efficient as flex attention but can use different masking with recompiling with end to end torch.compile
+    """
+
+    max_seq_length = key.size(-3)
+    mask = position_mask(time_steps, max_seq_length)
+
+    depth = float(query.shape[-1])
+    query = query / math.sqrt(depth)
+
+    attn_weights = torch.einsum("...qhd,...khd->...hqk", query, key)
+
+    big_neg = torch.finfo(attn_weights.dtype).min
+    attn_weights = torch.where(mask, attn_weights, big_neg)
+
+    attn_weights = F.softmax(attn_weights, -1)
+
+    x = torch.einsum("...hqk,...khd->...qhd", attn_weights, value)
+
+    batch, seq, _, _ = x.shape
+
+    x = x.reshape(batch, seq, -1)
+    return x
+
+
+class AttentionBlock(nn.Module):
+    def __init__(self, num_heads: int, d_model: int, *, dtype: torch.dtype = torch.float32):
+        super().__init__()
+        self.num_heads = num_heads
+        self.d_model = d_model
+        self.dtype = dtype
+        self.has_kv_cache = False
+
+        if self.d_model % self.num_heads != 0:
+            raise ValueError(
+                f"Memory dimension ({self.d_model}) must be divisible by 'num_heads' heads ({self.num_heads})."
+            )
+
+        self.head_dim = self.d_model // self.num_heads
+
+        self.in_proj = nn.Linear(
+            self.d_model,
+            self.num_heads * self.head_dim * 3,
+            bias=True,
+            dtype=self.dtype,
+        )
+
+        self.out_proj = nn.Linear(
+            self.num_heads * self.head_dim,
+            self.d_model,
+            bias=True,
+            dtype=self.dtype,
+        )
+
+    def ensure_kv_cache(self, batch_size: int, context_size: int, device: torch.device, dtype: torch.dtype):
+        if self.has_kv_cache and self.key_cache.shape[0] == batch_size:
+            return
+        
+        shape = (batch_size, context_size, self.num_heads, self.head_dim)
+        key_cache = torch.zeros(shape, device=device, dtype=dtype)
+        value_cache = torch.zeros(shape, device=device, dtype=dtype)
+
+        self.register_buffer("key_cache", key_cache, persistent=False)
+        self.register_buffer("value_cache", value_cache, persistent=False)
+        self.has_kv_cache = True
+
+    def update_kv_cache(self, time_steps: Tensor, key: Tensor, value: Tensor):
+        batch_idx = torch.arange(self.key_cache.shape[0], device=time_steps.device, dtype=torch.int64)
+        batch_idx = batch_idx[:, None]
+        self.key_cache[batch_idx, time_steps] = key
+        self.value_cache[batch_idx, time_steps] = value
+
+        return self.key_cache, self.value_cache
+
+    def forward(self, inputs: torch.Tensor, time_steps: Tensor, block_mask: BlockMask | None = None) -> torch.Tensor:
+        in_proj: torch.Tensor = self.in_proj(inputs)
+
+        # batch seq (heads qkv) -> batch seq heads qkv
+        batch, seq, _ = inputs.shape
+        in_proj = in_proj.view(batch, seq, self.num_heads, -1)
+
+        query, key, value = torch.chunk(in_proj, 3, -1)
+
+        query = apply_rope(query, time_steps)
+        key = apply_rope(key, time_steps)
+
+        if self.has_kv_cache and not self.training:
+            key, value = self.update_kv_cache(time_steps, key, value)
+
+        if block_mask is not None:
+            # TODO: macos likely can not use flex attention
+            # inference can't use flex attention because of the block mask, there is a work around but it's not worth it imo
+            x = flex_attention_wrapper(query, key, value, block_mask=block_mask)
+        else:
+            x = einsum_attention(query, key, value, time_steps)
+        x = self.out_proj(x)
+
+        return x

--- a/metta/agent/lib/lstm.py
+++ b/metta/agent/lib/lstm.py
@@ -33,7 +33,7 @@ class LSTM(LayerBase):
     def _forward(self, td: TensorDict):
         x = td["x"]
         hidden = td[self._sources[0]["name"]]
-        state = td["state"]
+        state = td.get("state")
 
         if state is not None:
             split_size = self.num_layers

--- a/metta/agent/lib/transformer.py
+++ b/metta/agent/lib/transformer.py
@@ -1,0 +1,208 @@
+import os
+from functools import lru_cache
+
+import torch
+import torch.nn as nn
+from tensordict import TensorDict
+from torch import Tensor
+from torch.nn.attention.flex_attention import BlockMask, create_block_mask
+
+from metta.agent.lib.attention import AttentionBlock
+from metta.agent.lib.metta_layer import LayerBase
+
+
+class FFBlock(nn.Module):
+    def __init__(self, in_features: int, hidden_features: int, *, activation: nn.Module | None = None):
+        super().__init__()
+        self.d_model = in_features
+        self.hidden_features = hidden_features
+
+        self.activation = activation if activation is not None else nn.ReLU()
+        self.up_proj = nn.Linear(in_features, hidden_features, bias=True)
+        self.down_proj = nn.Linear(hidden_features, in_features, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.up_proj(x)
+        x = self.activation(x)
+        x = self.down_proj(x)
+        return x
+
+
+class GLUBlock(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        *,
+        activation: nn.Module | None = None,
+    ):
+        super().__init__()
+        self.d_model = in_features
+        self.hidden_features = hidden_features
+        self.activation = activation if activation is not None else nn.ReLU()
+
+        self.up_proj = nn.Linear(in_features, hidden_features * 2, bias=True)
+        self.down_proj = nn.Linear(hidden_features, in_features, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.up_proj(x)
+
+        x, gate = torch.chunk(x, 2, -1)
+        x = self.activation(x) * gate
+        x = self.down_proj(x)
+        return x
+
+
+class GatingMechanism(torch.nn.Module):
+    def __init__(self, hidden_features, bg=0.1):
+        super(GatingMechanism, self).__init__()
+        self.Wr = torch.nn.Linear(hidden_features, hidden_features)
+        self.Ur = torch.nn.Linear(hidden_features, hidden_features)
+        self.Wz = torch.nn.Linear(hidden_features, hidden_features)
+        self.Uz = torch.nn.Linear(hidden_features, hidden_features)
+        self.Wg = torch.nn.Linear(hidden_features, hidden_features)
+        self.Ug = torch.nn.Linear(hidden_features, hidden_features)
+        self.bg = bg
+
+        self.sigmoid = torch.nn.Sigmoid()
+        self.tanh = torch.nn.Tanh()
+
+    def forward(self, x, y):
+        r = self.sigmoid(self.Wr(y) + self.Ur(x))
+        z = self.sigmoid(self.Wz(y) + self.Uz(x) - self.bg)
+        h = self.tanh(self.Wg(y) + self.Ug(torch.mul(r, x)))
+        g = torch.mul(1 - z, x) + torch.mul(z, h)
+        return g
+
+
+class TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        num_heads: int,
+        hidden_features: int,
+        ffn_size: int,
+        *,
+        activation: nn.Module | None = None,
+        glu: bool = True,
+        gtrxl_gate: bool = True,
+    ):
+        super().__init__()
+        self.gtrxl_gate = gtrxl_gate
+
+        self.attention_norm = nn.LayerNorm(hidden_features)
+        self.attention = AttentionBlock(num_heads, hidden_features)
+
+        self.ffn_norm = nn.LayerNorm(hidden_features)
+        ff_block = GLUBlock if glu else FFBlock
+        self.ffn = ff_block(hidden_features, ffn_size, activation=activation)
+
+        if gtrxl_gate:
+            self.attention_gate = GatingMechanism(hidden_features)
+            self.ffn_gate = GatingMechanism(hidden_features)
+
+    def forward(self, x: Tensor, time_steps: Tensor, block_mask: BlockMask | None = None) -> Tensor:
+        attention_input = self.attention_norm(x)
+        attention = self.attention(attention_input, time_steps, block_mask=block_mask)
+        x = self.attention_gate(x, attention) if self.gtrxl_gate else x + attention
+
+        feed_forward_input = self.ffn_norm(x)
+        feed_forward = self.ffn(feed_forward_input)
+        x = self.ffn_gate(x, feed_forward) if self.gtrxl_gate else x + feed_forward
+
+        return x
+
+
+@lru_cache()
+def _create_block_mask(seq_len: int) -> BlockMask:
+    """
+    Returns a block mask for flex attention, this is expensive and can't be generated inside torch compile.
+    """
+
+    def causal(b, h, q_idx, kv_idx):
+        return q_idx >= kv_idx
+
+    return create_block_mask(causal, B=None, H=None, Q_LEN=seq_len, KV_LEN=seq_len)
+
+
+_compile = os.name == 'posix'
+_flex_attention = os.name == 'posix'
+
+
+class TransformerCore(LayerBase):
+    def __init__(self, obs_shape, hidden_size: int, **cfg):
+        super().__init__(**cfg)
+        self.obs_shape = obs_shape
+        self.hidden_size = hidden_size
+
+        self.num_layers = self._nn_params["num_layers"]
+        self.num_heads = self._nn_params["num_heads"]
+        self.ffn_size = self._nn_params["ffn_size"]
+        self.context_size = self._nn_params["context_size"]
+
+        self.activation = nn.ReLU()
+        self.glu = False
+        self.gtrxl_gate = self._nn_params.get("gtrxl_gate", False)
+
+    def _initialize(self):
+        self._out_tensor_shape = [self.hidden_size]
+
+        layers = []
+        for _ in range(self.num_layers):
+            layers.append(
+                TransformerLayer(
+                    self.num_heads,
+                    self.hidden_size,
+                    self.ffn_size,
+                    activation=self.activation,
+                    glu=self.glu,
+                    gtrxl_gate=self.gtrxl_gate,
+                )
+            )
+        self.layers = nn.ModuleList(layers)
+        self.layer_norm = nn.LayerNorm(self.hidden_size)
+
+    def ensure_kv_cache(self, batch_size: int, device: torch.device, dtype: torch.dtype = torch.float32):
+        for layer in self.layers:
+            layer.attention.ensure_kv_cache(batch_size, self.context_size, device, dtype)
+
+    def _forward(self, td: TensorDict) -> TensorDict:
+        x = td["x"]
+        hidden = td[self._sources[0]["name"]]
+
+        x_shape, space_shape = x.shape, self.obs_shape
+        x_n, space_n = len(x_shape), len(space_shape)
+        if x_shape[-space_n:] != space_shape:
+            raise ValueError("Invalid input tensor shape", x.shape)
+
+        if x_n == space_n + 1:
+            B, TT = x_shape[0], 1
+        elif x_n == space_n + 2:
+            B, TT = x_shape[:2]
+        else:
+            raise ValueError("Invalid input tensor shape", x.shape)
+
+        hidden = hidden.reshape(B, TT, self._in_tensor_shapes[0][0])
+        time_steps = td.get("time_steps")
+
+        if self.training:
+            assert TT == self.context_size
+            block_mask = _create_block_mask(self.context_size) if _flex_attention else None
+            if time_steps is None:
+                time_steps = torch.arange(self.context_size, dtype=torch.long, device=hidden.device)[None, :]
+            self._inner_forward(hidden.clone(), time_steps, block_mask)
+        else:
+            self.ensure_kv_cache(B, hidden.device, hidden.dtype)
+            self._inner_forward(hidden.clone(), time_steps, None)
+
+        hidden = hidden.reshape(B * TT, self.hidden_size)
+
+        td[self._name] = hidden
+        return td
+
+    @torch.compile(mode="max-autotune", dynamic=True, fullgraph=True, disable=not _compile)
+    def _inner_forward(self, hidden: torch.Tensor, time_steps: torch.Tensor, block_mask: BlockMask | None) -> torch.Tensor:
+        for layer in self.layers:
+            hidden = layer(hidden, time_steps, block_mask)
+        hidden = self.layer_norm(hidden)
+
+        return hidden

--- a/metta/rl/pufferlib/experience.py
+++ b/metta/rl/pufferlib/experience.py
@@ -66,11 +66,13 @@ class Experience:
         self.truncateds_np = np.asarray(self.truncateds)
         self.values_np = np.asarray(self.values)
 
-        assert lstm is not None
-        assert lstm_total_agents > 0
-        shape = (lstm.num_layers, lstm_total_agents, lstm.hidden_size)
-        self.lstm_h = torch.zeros(shape).to(device, non_blocking=True)
-        self.lstm_c = torch.zeros(shape).to(device, non_blocking=True)
+        self.lstm_h = None
+        self.lstm_c = None
+        if lstm is not None:
+            assert lstm_total_agents > 0
+            shape = (lstm.num_layers, lstm_total_agents, lstm.hidden_size)
+            self.lstm_h = torch.zeros(shape).to(device, non_blocking=True)
+            self.lstm_c = torch.zeros(shape).to(device, non_blocking=True)
 
         num_minibatches = batch_size / minibatch_size
         self.num_minibatches = int(num_minibatches)

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -167,12 +167,16 @@ class Simulation:
         logger.info(f"Simulation settings: {self._config}")
 
         obs, _ = self._vecenv.reset()
+        time_steps = torch.zeros((self._vecenv.num_agents, 1), dtype=torch.long, device=self._device)
         policy_state = PolicyState()
         npc_state = PolicyState()
 
         game_stats = []
         start = time.time()
 
+        self._policy_pr.policy().eval()
+        if self._npc_pr is not None:
+            self._npc_pr.policy().eval()
         # Track environment completion status
         env_dones = [False] * self._num_envs
 
@@ -182,16 +186,19 @@ class Simulation:
                 obs = torch.as_tensor(obs).to(device=self._device)
                 # observations that correspond to policy agent
                 my_obs = obs[self._policy_idxs]
+                policy_time_steps = time_steps[self._policy_idxs]
 
                 # Parallelize across opponents
                 policy = self._policy_pr.policy()  # policy to evaluate
-                policy_actions, _, _, _, _ = policy(my_obs, policy_state)
+                policy_actions, _, _, _, _ = policy(my_obs, policy_state, time_steps=policy_time_steps)
 
                 # Iterate opponent policies
                 if self._npc_pr is not None:
                     npc_obs = obs[self._npc_idxs]
+                    npc_time_steps = time_steps[self._npc_idxs]
+
                     npc_policy = self._npc_pr.policy()
-                    npc_actions, _, _, _, _ = npc_policy(npc_obs, npc_state)
+                    npc_actions, _, _, _, _ = npc_policy(npc_obs, npc_state, time_steps=npc_time_steps)
 
             actions = policy_actions
             if self._npc_agents_per_env > 0:
@@ -213,6 +220,9 @@ class Simulation:
                         self._replay_helpers[env_idx].log_pre_step(actions_per_env[env_idx].squeeze())
             # Step the environment
             obs, rewards, dones, truncated, infos = self._vecenv.step(actions_np)
+            time_steps += 1
+            time_steps[dones] = 0
+            time_steps[truncated] = 0
 
             if self._replay_helpers is not None:
                 rewards_per_env = rewards.reshape(self._num_envs, self._agents_per_env)

--- a/metta/sim/simulator.py
+++ b/metta/sim/simulator.py
@@ -34,18 +34,23 @@ class Simulator:
         self.num_steps = num_steps
         self.dones = np.zeros(self.vecenv.num_agents)
         self.trunc = np.zeros(self.vecenv.num_agents)
+        self.time_steps = torch.zeros((self.num_agents, 1), dtype=torch.long, device=self.device)
+
 
     def actions(self):
         """Get the actions for the current timestep"""
         with torch.no_grad():
             obs = torch.as_tensor(self.obs).to(device=self.device)
-            actions, _, _, _, _ = self.policy(obs, self.policy_state)
+            actions, _, _, _, _ = self.policy(obs, self.policy_state, time_steps=self.time_steps)
         return actions
 
     def step(self, actions):
         """Step the simulator forward one timestep"""
         (self.obs, self.rewards, self.dones, self.trunc, self.infos) = self.vecenv.step(actions.cpu().numpy())
         self.total_rewards += self.rewards
+        self.time_steps +=1
+        self.time_steps[self.dones] = 0
+        self.time_steps[self.trunc] = 0
 
     def done(self):
         """Check if the episode is done"""
@@ -90,15 +95,20 @@ def play(config: SimulationConfig, policy_record: PolicyRecord):
 
     rewards = np.zeros(vecenv.num_agents)
     total_rewards = np.zeros(vecenv.num_agents)
+    time_steps = torch.zeros((vecenv.num_agents, 1), dtype=torch.long, device=torch.device(device))
 
     while True:
         with torch.no_grad():
             obs = torch.as_tensor(obs).to(device=device)
 
             # Parallelize across opponents
+
+            policy.eval()
             actions, _, _, _, _ = policy(obs, policy_state)
             if actions.dim() == 0:  # scalar tensor like tensor(2)
                 actions = torch.tensor([actions.item()])
+            
+            time_steps += 1
 
         renderer.update(
             actions.cpu().numpy(),


### PR DESCRIPTION
Introduces a Transformer core layer designed as a drop-in substitute for the existing LSTM layer.

This implementation assumes that the backpropagation through time (BPTT) window matches the episode length. This requires careful batch length configuration.

Example Configuration:
---------------------
forward_pass_minibatch_target_size = num_agents * num_workers batch_size = forward_pass_minibatch_target_size * context_size minibatch_size = context_size # Or any multiple
bptt_horizon = context_size
game.max_steps = context_size - 1

vectorization = serial
---------------------

To utilize the Transformer, episode timesteps are passed as input to the policy. The expected shapes are:
- Inference: (batch, 1)
- Training: (batch, context_size)

Positional indices must align correctly with the input dimensions for proper functioning.

Note: Causal masking during training currently assumes positions increase monotonically from left to right.