### PR TITLE
install spacectl

### DIFF
--- a/devops/sandbox/Brewfile
+++ b/devops/sandbox/Brewfile
@@ -9,6 +9,7 @@ brew "googletest"
 brew "google-benchmark"
 cask "session-manager-plugin"
 brew "withgraphite/tap/graphite"
+brew "spacelift-io/spacelift/spacectl"
 
 # Applications
 cask "cursor"


### PR DESCRIPTION
### TL;DR

Added Spacelift CLI tool to the sandbox Brewfile.

### What changed?

Added `brew "spacelift-io/spacelift/spacectl"` to the sandbox Brewfile, which installs the Spacelift command-line interface (spacectl).

### How to test?

1. Run `brew bundle --file=devops/sandbox/Brewfile`
2. Verify that spacectl is installed by running `spacectl version`

### Why make this change?

The Spacelift CLI tool allows for interaction with Spacelift's infrastructure as code platform from the command line, enabling developers to manage stacks, runs, and other Spacelift resources locally. This addition will help streamline infrastructure management workflows.