### PR TITLE
Add SkyPilot launch scripts for AWS training jobs

### DIFF
--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -38,22 +38,13 @@ This script provides a convenient way to launch training jobs on AWS using SkyPi
 
 List all jobs:
 ```bash
-sky jobs list
-```
-
-View details of a specific job:
-```bash
-sky jobs show <JOB_ID>
+sky jobs queue
 ```
 
 View job logs:
 ```bash
 sky jobs logs <JOB_ID>
-```
-
-View controller logs:
-```bash
-sky controller logs
+sky jobs logs <JOB_ID> --controller
 ```
 
 ### Canceling Jobs

--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -1,0 +1,81 @@
+# SkyPilot Launch Script
+
+This script provides a convenient way to launch training jobs on AWS using SkyPilot.
+
+## Prerequisites
+
+- AWS credentials configured with `softmax-db-admin` profile
+- Access to AWS ECR in us-east-1 region
+- SkyPilot CLI installed and configured
+
+## Usage
+
+```bash
+./launch.sh <COMMAND> <RUN_ID> [COMMAND_ARGS...]
+```
+
+### Parameters
+
+- `COMMAND`: The main command to execute
+- `RUN_ID`: Unique identifier for the run
+- `COMMAND_ARGS`: Additional arguments to pass to the command
+
+## Examples
+
+1. Launch a training run with default parameters:
+```bash
+./launch.sh train my_experiment_001
+```
+
+2. Launch a training run with specific arguments:
+```bash
+./launch.sh train my_experiment_002 trainer.learning_rate=0.001 trainer.batch_size=32
+```
+
+## Job Management
+
+### Viewing Jobs
+
+List all jobs:
+```bash
+sky jobs list
+```
+
+View details of a specific job:
+```bash
+sky jobs show <JOB_ID>
+```
+
+View job logs:
+```bash
+sky jobs logs <JOB_ID>
+```
+
+View controller logs:
+```bash
+sky controller logs
+```
+
+### Canceling Jobs
+
+Cancel a specific job:
+```bash
+sky jobs cancel <JOB_ID>
+```
+
+Cancel all jobs:
+```bash
+sky jobs cancel --all
+```
+
+## Notes
+
+- The script automatically:
+  - Gets ECR login credentials
+  - Sets up environment variables
+  - Uses the current git commit hash
+  - Launches jobs in detached mode
+  - Uses the configuration from `./devops/skypilot/config/train.yaml`
+
+- Jobs are launched asynchronously and will run in the background
+- Monitor job status using SkyPilot CLI or AWS console

--- a/devops/skypilot/config/train.yaml
+++ b/devops/skypilot/config/train.yaml
@@ -1,0 +1,58 @@
+resources:
+  cloud: aws
+  region: us-east-1
+  use_spot: true
+  accelerators: {L4: 1}
+  cpus: 8+
+  image_id: docker:metta:latest
+
+setup: |
+  cd /workspace/metta
+  git checkout $METTA_GIT_REF
+  git pull
+  pip install -r requirements.txt
+
+  ./devops/checkout_and_build.sh
+  mkdir -p $WANDB_DIR
+
+run: |
+  cd /workspace/metta
+  source ./devops/env.sh
+
+  export NUM_GPUS=$SKYPILOT_NUM_GPUS_PER_NODE
+  export NUM_NODES=$SKYPILOT_NUM_NODES
+  export MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  export MASTER_PORT=8008
+  export NODE_INDEX=$SKYPILOT_NODE_RANK
+
+  ./devops/$METTA_CMD.sh \
+    +hardware=$METTA_HARDWARE \
+    run=$METTA_RUN_ID \
+    trainer.num_workers=$METTA_NUM_WORKERS \
+    $METTA_CMD_ARGS
+
+file_mounts:
+  # Wandb Credentials
+  ~/.netrc: ~/.netrc
+
+  /mnt/s3/softmax-public:
+    source: s3://softmax-public
+    mode: MOUNT
+
+  /workspace/metta/train_dir:
+    name: train-dir
+    store: s3
+    mode: MOUNT
+
+envs:
+  METTA_RUN_ID:
+  METTA_HARDWARE: aws
+  METTA_CMD: train
+  METTA_CMD_ARGS: ""
+  METTA_NUM_WORKERS: 4
+  METTA_GIT_REF: main
+  WANDB_DIR: ./wandb
+
+  SKYPILOT_DOCKER_USERNAME: AWS
+  SKYPILOT_DOCKER_PASSWORD: SKYPILOT_DOCKER_PASSWORD
+  SKYPILOT_DOCKER_SERVER: 767406518141.dkr.ecr.us-east-1.amazonaws.com

--- a/devops/skypilot/config/train.yaml
+++ b/devops/skypilot/config/train.yaml
@@ -8,8 +8,8 @@ resources:
 
 setup: |
   cd /workspace/metta
+  git fetch
   git checkout $METTA_GIT_REF
-  git pull
   pip install -r requirements.txt
 
   ./devops/checkout_and_build.sh

--- a/devops/skypilot/install.sh
+++ b/devops/skypilot/install.sh
@@ -1,0 +1,24 @@
+#! /bin/zsh -e
+
+# Recommended: use a new conda env to avoid package conflicts.
+# SkyPilot requires 3.7 <= python <= 3.11.
+conda create -y -n sky python=3.10
+conda activate sky
+
+# Choose your cloud:
+
+pip install "skypilot[kubernetes]"
+pip install "skypilot[aws]"
+pip install "skypilot[gcp]"
+pip install "skypilot[azure]"
+pip install "skypilot[oci]"
+pip install "skypilot[lambda]"
+pip install "skypilot[runpod]"
+pip install "skypilot[fluidstack]"
+pip install "skypilot[paperspace]"
+pip install "skypilot[cudo]"
+pip install "skypilot[ibm]"
+pip install "skypilot[scp]"
+pip install "skypilot[vsphere]"
+pip install "skypilot[nebius]"
+pip install "skypilot[all]"

--- a/devops/skypilot/install.sh
+++ b/devops/skypilot/install.sh
@@ -1,24 +1,8 @@
 #! /bin/zsh -e
 
-# Recommended: use a new conda env to avoid package conflicts.
-# SkyPilot requires 3.7 <= python <= 3.11.
-conda create -y -n sky python=3.10
-conda activate sky
+# Create a new virtual environment using uv
+uv venv .venv/skypilot --python=3.11 --no-project
+source .venv/skypilot/bin/activate
 
-# Choose your cloud:
-
-pip install "skypilot[kubernetes]"
-pip install "skypilot[aws]"
-pip install "skypilot[gcp]"
-pip install "skypilot[azure]"
-pip install "skypilot[oci]"
-pip install "skypilot[lambda]"
-pip install "skypilot[runpod]"
-pip install "skypilot[fluidstack]"
-pip install "skypilot[paperspace]"
-pip install "skypilot[cudo]"
-pip install "skypilot[ibm]"
-pip install "skypilot[scp]"
-pip install "skypilot[vsphere]"
-pip install "skypilot[nebius]"
-pip install "skypilot[all]"
+# Install SkyPilot with all cloud providers
+uv pip install "skypilot"

--- a/devops/skypilot/install.sh
+++ b/devops/skypilot/install.sh
@@ -5,4 +5,4 @@ uv venv .venv/skypilot --python=3.11 --no-project
 source .venv/skypilot/bin/activate
 
 # Install SkyPilot with all cloud providers
-uv pip install "skypilot"
+uv pip install skypilot==0.9.2 --prerelease=allow

--- a/devops/skypilot/install.sh
+++ b/devops/skypilot/install.sh
@@ -6,3 +6,5 @@ source .venv/skypilot/bin/activate
 
 # Install SkyPilot with all cloud providers
 uv pip install skypilot==0.9.2 --prerelease=allow
+uv pip install "skypilot[aws]"
+uv pip install "skypilot[vast]"

--- a/devops/skypilot/launch.sh
+++ b/devops/skypilot/launch.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Ensure script is run with bash
+if [ -z "$BASH_VERSION" ]; then
+  echo "This script must be run with bash" >&2
+  exit 1
+fi
+
 if [ $# -lt 2 ]; then
   echo "Usage: $0 CMD RUN_ID"
   exit 1
@@ -11,18 +17,53 @@ RUN_ID=$2
 shift 2
 CMD_ARGS="$@"
 
+# Defaults
+export METTA_GIT_REF=$(git rev-parse HEAD)
+gpus=1
+nodes=1
+cpus=8
+
+for arg in "$@"; do
+  case $arg in
+    --git-branch=*)
+      value="${arg#*=}"
+      export METTA_GIT_REF=$(git rev-parse "$value")
+      echo "METTA_GIT_REF: $METTA_GIT_REF"
+      CMD_ARGS=$(echo "$CMD_ARGS" | sed -E "s/--git-branch=[^ ]* ?//g")
+      ;;
+    --gpus=*)
+      gpus="${arg#*=}"
+      echo "gpus: $gpus"
+      CMD_ARGS=$(echo "$CMD_ARGS" | sed -E "s/--gpus=[^ ]* ?//g")
+      ;;
+    --nodes=*)
+      nodes="${arg#*=}"
+      echo "nodes: $nodes"
+      CMD_ARGS=$(echo "$CMD_ARGS" | sed -E "s/--nodes=[^ ]* ?//g")
+      ;;
+    --cpus=*)
+      cpus="${arg#*=}"
+      echo "cpus: $cpus"
+      CMD_ARGS=$(echo "$CMD_ARGS" | sed -E "s/--cpus=[^ ]* ?//g")
+      ;;
+  esac
+done
+
 source .venv/skypilot/bin/activate
 
 export SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
 
 AWS_PROFILE=softmax-db-admin sky jobs launch \
+  --gpus L4:$gpus \
+  --num-nodes $nodes \
+  --cpus $cpus\+ \
   --name $RUN_ID \
   ./devops/skypilot/config/train.yaml \
-  --env SKYPILOT_DOCKER_PASSWORD=SKYPILOT_DOCKER_PASSWORD \
+  --env SKYPILOT_DOCKER_PASSWORD \
   --env METTA_RUN_ID=$RUN_ID \
   --env METTA_CMD=$CMD \
   --env METTA_CMD_ARGS="$CMD_ARGS" \
-  --env METTA_GIT_REF=$(git rev-parse HEAD) \
+  --env METTA_GIT_REF \
   --detach-run \
   --async \
   --yes

--- a/devops/skypilot/launch.sh
+++ b/devops/skypilot/launch.sh
@@ -11,7 +11,7 @@ RUN_ID=$2
 shift 2
 CMD_ARGS="$@"
 
-source .venv/bin/activate
+source .venv/skypilot/bin/activate
 
 export SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
 

--- a/devops/skypilot/launch.sh
+++ b/devops/skypilot/launch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 CMD RUN_ID"
+  exit 1
+fi
+
+CMD=$1
+RUN_ID=$2
+shift 2
+CMD_ARGS="$@"
+
+SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
+
+AWS_PROFILE=softmax-db-admin sky jobs launch \
+  --name $RUN_ID \
+  ./devops/skypilot/config/train.yaml \
+  --env SKYPILOT_DOCKER_PASSWORD=$SKYPILOT_DOCKER_PASSWORD \
+  --env METTA_RUN_ID=$RUN_ID \
+  --env METTA_CMD=$CMD \
+  --env METTA_CMD_ARGS="$CMD_ARGS" \
+  --env METTA_GIT_REF=$(git rev-parse HEAD) \
+  --detach-run \
+  --async \
+  --yes

--- a/devops/skypilot/launch.sh
+++ b/devops/skypilot/launch.sh
@@ -11,12 +11,14 @@ RUN_ID=$2
 shift 2
 CMD_ARGS="$@"
 
-SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
+source .venv/bin/activate
+
+export SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
 
 AWS_PROFILE=softmax-db-admin sky jobs launch \
   --name $RUN_ID \
   ./devops/skypilot/config/train.yaml \
-  --env SKYPILOT_DOCKER_PASSWORD=$SKYPILOT_DOCKER_PASSWORD \
+  --env SKYPILOT_DOCKER_PASSWORD=SKYPILOT_DOCKER_PASSWORD \
   --env METTA_RUN_ID=$RUN_ID \
   --env METTA_CMD=$CMD \
   --env METTA_CMD_ARGS="$CMD_ARGS" \

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -200,6 +200,7 @@
 			"clipfrac",
 			"coef",
 			"cooldown",
+			"cpus",
 			"dones",
 			"heavyball",
 			"kickstarter",
@@ -218,6 +219,7 @@
 			"PYTHONPATH",
 			"raylib",
 			"relu",
+			"softmax",
 			"skypilot",
 			"tensorclass",
 			"tensordict",
@@ -228,7 +230,8 @@
 			"vecenv",
 			"venv",
 			"vloss",
-			"wandb"
+			"wandb",
+			"xlarge"
 		]
 	}
 }


### PR DESCRIPTION
# Add SkyPilot Launch Scripts for AWS Training Jobs

### TL;DR

Added scripts and configuration to launch training jobs on AWS using SkyPilot.

### What changed?

- Added `launch.sh` script to easily start training jobs on AWS
- Created SkyPilot configuration in `config/train.yaml` with AWS-specific settings
- Added installation script for SkyPilot dependencies
- Included comprehensive documentation in README.md
- Updated VSCode workspace dictionary with relevant terms

### How to test?

1. Install SkyPilot using the provided installation script:
   ```bash
   ./devops/skypilot/install.sh
   ```

2. Launch a training job:
   ```bash
   ./devops/skypilot/launch.sh train my_experiment_001
   ```

3. Monitor the job:
   ```bash
   sky jobs list
   sky jobs logs <JOB_ID>
   ```

### Why make this change?

This change streamlines the process of launching training jobs on AWS cloud infrastructure using SkyPilot, making it easier to run experiments at scale. The implementation handles AWS ECR authentication, environment setup, and job management automatically, reducing operational overhead for the team.