### PR TITLE
fix: build fast_gae in setup_build script

### DIFF
--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -25,7 +25,12 @@ echo "Installing main project requirements..."
 pip install -r requirements.txt
 
 # ========== CHECKOUT AND BUILD DEPENDENCIES ==========
+echo "Calling devops/checkout_and_build script..."
 bash "$SCRIPT_DIR/checkout_and_build.sh"
+
+# ========== BUILD FAST_GAE ==========
+echo "Building from setup.py (metta cython components)"
+python setup.py build_ext --inplace
 
 # ========== SANITY CHECK ==========
 echo "Sanity check: verifying all local deps are importable"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ annotate = os.getenv("ANNOTATE", "0") == "1"
 BUILD_DIR = "build"
 if debug:
     BUILD_DIR = "build_debug"
-
 os.makedirs(BUILD_DIR, exist_ok=True)
 
 setup(
@@ -47,8 +46,4 @@ setup(
     ),
     description="",
     url="https://github.com/Metta-AI/metta",
-    install_requires=[
-        "numpy",
-        "cython==3.0.11",
-    ],
 )


### PR DESCRIPTION
This PR integrates the fast_gae Cython module build step into our setup process.

## Changes
- Added `python setup.py build_ext --inplace` to the setup_build.sh script to build Cython components
- Removed redundant dependencies from setup.py as they're already covered in requirements.txt
