### PR TITLE
fix: python lint CI needs a venv

### DIFF
--- a/.github/workflows/deploy-mettascope.yml
+++ b/.github/workflows/deploy-mettascope.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install pixie-python
 
       - name: Debug Output

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -185,7 +185,6 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install and compile deps (cache miss fallback)
@@ -212,6 +211,7 @@ jobs:
 
       - name: Install Ruff
         run: |
+          python -m venv venv
           source venv/bin/activate
           pip install ruff==0.11.5
 
@@ -254,7 +254,6 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install and compile deps (cache miss fallback)
@@ -310,7 +309,6 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install and compile deps (cache miss fallback)
@@ -523,7 +521,6 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Install and compile deps (cache miss fallback)


### PR DESCRIPTION
provide a venv for py lint in CI 
use old versions of pip