### PR TITLE
update initial torch sync epoch

### DIFF
--- a/metta/rl/pufferlib/torch_profiler.py
+++ b/metta/rl/pufferlib/torch_profiler.py
@@ -43,7 +43,7 @@ class TorchProfiler:
         # Hardcoding _first_profile_epoch to keep cfgs clean.
         # It just needs to be greater than pytorch warmup cycles.
         # We may need to revisit if compiling models under "max-autotune".
-        self._first_profile_epoch = 50
+        self._first_profile_epoch = 300
 
     def on_epoch_end(self, epoch):
         should_profile_this_epoch = False


### PR DESCRIPTION
Single line change: increased the first profile epoch from 50 to 300 in the torch profiler. At 50, it would annoyingly stop training for people where trying to run locally or while actively remoted into a console for testing. 300 is when we sync with wandb and run sim anyways so it seemed like a good place to slot in the first trace. Ideally, the first trace should also run early enough that perf issues can be debugged without having to restart the run.