### PR TITLE
MultiLeftOrRight scene; order_by_seed feature

### DIFF
--- a/configs/env/mettagrid/maps/diversity/multi_left_or_right.yaml
+++ b/configs/env/mettagrid/maps/diversity/multi_left_or_right.yaml
@@ -1,0 +1,22 @@
+# Multi-room version of `left_or_right.yaml`.
+
+defaults:
+  - /env/mettagrid/mettagrid@
+  - _self_
+
+game:
+  num_agents: 32
+  # Enough time to pick one direction, but not to dilly-dally.
+  max_steps: 25
+
+  map_builder:
+    _target_: mettagrid.map.mapgen.MapGen
+
+    width: 200
+    height: 100
+    border_width: 1
+
+    root:
+      _target_: metta.map.scenes.multi_left_and_right.MultiLeftAndRight
+      rows: 4
+      columns: 8

--- a/metta/map/scenes/multi_left_and_right.py
+++ b/metta/map/scenes/multi_left_and_right.py
@@ -1,0 +1,85 @@
+from numpy import random
+
+from mettagrid.map.scene import Scene
+from mettagrid.map.scenes.random import Random
+from mettagrid.map.scenes.room_grid import RoomGrid
+
+
+class MultiLeftAndRight(Scene):
+    """
+    Produce multiple left-or-right maps in a grid, with agents assigned randomly
+    to teams, and rooms all identical otherwise.
+    """
+
+    def __init__(self, rows: int, columns: int):
+        # Pregenerate seeds so that we could make rooms deterministic.
+        agent_seed = random.randint(0, int(1e9))
+        altar_seed = random.randint(0, int(1e9))
+        altar_side_seed = random.randint(0, int(1e9))
+
+        agent_groups = [
+            "team_1",
+            "team_2",
+        ]
+
+        super().__init__(
+            children=[
+                {
+                    "where": "full",
+                    "scene": RoomGrid(
+                        rows=rows,
+                        columns=columns,
+                        border_width=1,
+                        children=[
+                            {
+                                # This scene is mostly identical to `left_or_right.yaml`.
+                                # It adds seeds and place agents into groups.
+                                "scene": RoomGrid(
+                                    border_width=0,
+                                    layout=[
+                                        [
+                                            "maybe_altars",
+                                            "empty",
+                                            "empty",
+                                            "agents",
+                                            "empty",
+                                            "empty",
+                                            "maybe_altars",
+                                        ],
+                                    ],
+                                    children=[
+                                        {
+                                            "scene": lambda agent_group=agent_group: Random(
+                                                # agents=1,
+                                                agents={
+                                                    agent_group: 1,
+                                                },
+                                                seed=agent_seed,
+                                            ),
+                                            "where": {"tags": ["agents"]},
+                                        },
+                                        {
+                                            "scene": lambda: Random(
+                                                objects={"altar": 2},
+                                                seed=altar_seed,
+                                            ),
+                                            "where": {"tags": ["maybe_altars"]},
+                                            "limit": 1,
+                                            "order_by": "random",
+                                            "order_by_seed": altar_side_seed,
+                                        },
+                                    ],
+                                ),
+                                "lock": "rooms",
+                                # Place this scene in 1/len(agent_groups) of the rooms.
+                                "limit": rows * columns // len(agent_groups),
+                            }
+                            for agent_group in agent_groups
+                        ],
+                    ),
+                }
+            ]
+        )
+
+    def _render(self, node):
+        pass

--- a/mettagrid/mettagrid/map/node.py
+++ b/mettagrid/mettagrid/map/node.py
@@ -1,4 +1,3 @@
-import random
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -92,7 +91,8 @@ class Node:
             offset = query.get("offset")
             if order_by == "random":
                 assert offset is None, "offset is not supported for random order"
-                selected_areas = random.sample(selected_areas, k=limit)
+                rng = np.random.default_rng(query.get("order_by_seed"))
+                selected_areas = rng.choice(selected_areas, size=int(limit), replace=False)  # type: ignore
             elif order_by == "first":
                 offset = offset or 0
                 selected_areas = selected_areas[offset : offset + limit]

--- a/mettagrid/mettagrid/map/scene.py
+++ b/mettagrid/mettagrid/map/scene.py
@@ -23,6 +23,9 @@ def make_scene(cfg: SceneCfg) -> "Scene":
             cfg = cfg[1:]
         cfg = cast(SceneCfg, OmegaConf.load(f"{scenes_root}/{cfg}"))
 
+    if callable(cfg):
+        cfg = cfg()  # useful for creating unique scene objects when dealing with seeds
+
     if isinstance(cfg, Scene):
         # already an instance, maybe recursive=True was enabled
         return cfg

--- a/mettagrid/mettagrid/map/scenes/random.py
+++ b/mettagrid/mettagrid/map/scenes/random.py
@@ -18,7 +18,7 @@ class Random(Scene):
     def __init__(
         self,
         objects: Optional[DictConfig | dict] = None,
-        agents: int | DictConfig = 0,
+        agents: int | DictConfig | dict = 0,
         too_many_is_ok: bool = True,
         seed: MaybeSeed = None,
     ):
@@ -33,8 +33,10 @@ class Random(Scene):
 
         if isinstance(self._agents, int):
             agents = ["agent.agent"] * self._agents
-        elif isinstance(self._agents, DictConfig):
+        elif isinstance(self._agents, (DictConfig, dict)):
             agents = ["agent." + str(agent) for agent, na in self._agents.items() for _ in range(na)]
+        else:
+            raise ValueError(f"Invalid agents: {self._agents}")
 
         # Find empty cells in the grid
         empty_mask = node.grid == "empty"


### PR DESCRIPTION
As requested by Lars.

I had to copy-paste left_or_right yaml config to Python. The better solution would be to move it to a scene and reuse, but scenes root is currently in mettagrid, so can't do that right now.

This PR creates a precedent of `metta.map.scenes.*` files; I'd argue that we should move all mapgen code to `metta.map.*` and leave mettagrid minimal/agnostic to map builder implementations.