### PR TITLE
Improve EFS mounting in sandbox setup

### DIFF
--- a/devops/sandbox/mount_efs.sh
+++ b/devops/sandbox/mount_efs.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 
-# TODO - grab this from SSM parameter store
+export AWS_PROFILE=softmax
 ENDPOINT=$(aws ssm get-parameter --name /shared-efs/url --output text --query "Parameter.Value")
 
 DIR="/Volumes/metta-efs"

--- a/devops/sandbox/setup_machine.py
+++ b/devops/sandbox/setup_machine.py
@@ -58,7 +58,7 @@ def setup_efs():
     """Setup EFS."""
     print("Setting up EFS...")
     run_command(["sudo", "bash", str(Path(__file__).parent / "setup_efs.sh")])
-    print("EFS configured. Run './mount_efs.sh' to mount EFS.")
+    run_command(["sudo", "bash", str(Path(__file__).parent / "mount_efs.sh")])
 
 
 def install_skypilot():

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -221,6 +221,7 @@
 			"relu",
 			"softmax",
 			"skypilot",
+			"softmax",
 			"tensorclass",
 			"tensordict",
 			"timestep",


### PR DESCRIPTION
### TL;DR

Improved EFS mounting process and added automatic mounting during machine setup.

### What changed?

- Added `-e` flag to `mount_efs.sh` to exit on error
- Set `AWS_PROFILE=softmax` in `mount_efs.sh` instead of using a TODO comment
- Modified `setup_machine.py` to automatically mount EFS after configuration
