### PR TITLE
Improve SkyPilot training scripts

### DIFF
--- a/configs/env/mettagrid/mapgen_auto.yaml
+++ b/configs/env/mettagrid/mapgen_auto.yaml
@@ -4,9 +4,9 @@ defaults:
   - _self_
 
 game:
-  num_agents: 10
+  num_agents: 24
 
   map_builder:
     root:
       config:
-        num_agents: 10
+        num_agents: 24

--- a/devops/sandbox/setup_machine.py
+++ b/devops/sandbox/setup_machine.py
@@ -75,8 +75,11 @@ def main():
 
     install_homebrew()
     run_brew_bundle(force=args.brew_force, no_fail=args.brew_no_fail)
-    setup_efs()
     install_skypilot()
+
+    # disable for now, it's too slow
+    # setup_efs()
+
     print("Machine setup complete!")
 
 

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -11,6 +11,8 @@ setup: |
   git fetch
   git checkout $METTA_GIT_REF
   pip install -r requirements.txt
+  python setup.py build_ext --inplace
+  pip install -e .
 
   ./devops/build_mettagrid.sh
   mkdir -p $WANDB_DIR
@@ -28,7 +30,6 @@ run: |
   ./devops/$METTA_CMD.sh \
     +hardware=$METTA_HARDWARE \
     run=$METTA_RUN_ID \
-    trainer.num_workers=$METTA_NUM_WORKERS \
     $METTA_CMD_ARGS
 
 file_mounts:
@@ -49,10 +50,9 @@ envs:
   METTA_HARDWARE: aws
   METTA_CMD: train
   METTA_CMD_ARGS: ""
-  METTA_NUM_WORKERS: 4
   METTA_GIT_REF: main
   WANDB_DIR: ./wandb
 
   SKYPILOT_DOCKER_USERNAME: AWS
-  SKYPILOT_DOCKER_PASSWORD: SKYPILOT_DOCKER_PASSWORD
+  SKYPILOT_DOCKER_PASSWORD: "SKYPILOT_DOCKER_PASSWORD"
   SKYPILOT_DOCKER_SERVER: 767406518141.dkr.ecr.us-east-1.amazonaws.com

--- a/devops/skypilot/install.sh
+++ b/devops/skypilot/install.sh
@@ -1,4 +1,4 @@
-#! /bin/zsh -e
+#! /bin/bash -e
 
 # Create a new virtual environment using uv
 uv venv .venv/skypilot --python=3.11 --no-project

--- a/devops/skypilot/launch_sandbox.sh
+++ b/devops/skypilot/launch_sandbox.sh
@@ -53,12 +53,12 @@ source .venv/skypilot/bin/activate
 
 export SKYPILOT_DOCKER_PASSWORD=$(aws ecr get-login-password --region us-east-1)
 
-AWS_PROFILE=softmax-db-admin sky jobs launch \
+AWS_PROFILE=softmax-db-admin sky launch \
   --gpus L4:$gpus \
   --num-nodes $nodes \
   --cpus $cpus\+ \
-  --name $RUN_ID \
-  ./devops/skypilot/config/sk_train.yaml \
+  --cluster $RUN_ID \
+  ./devops/skypilot/config/train.yaml \
   --env SKYPILOT_DOCKER_PASSWORD \
   --env METTA_RUN_ID=$RUN_ID \
   --env METTA_CMD=$CMD \

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -1,0 +1,22 @@
+export AWS_PROFILE=softmax-db-admin
+
+#sky
+alias sky=".venv/skypilot/bin/sky"
+
+# list jobs
+alias jq="sky jobs queue --skip-finished"
+alias jqa="sky jobs queue"
+
+# cancel job
+alias jk="sky jobs cancel"
+alias jc="sky jobs cancel"
+alias jkl="sky jobs cancel"
+
+# get logs
+alias jl="sky jobs logs"
+alias jlc="sky jobs logs --controller"
+alias jll='sky jobs logs $(jq | grep -A1 TASK | grep -v TASK | awk "{print \$1}")'
+alias jllc='sky jobs logs --controller $(jq | grep -A1 TASK | grep -v TASK | awk "{print \$1}")'
+
+# launch training
+alias lt="./devops/skypilot/launch.sh train"

--- a/devops/train.sh
+++ b/devops/train.sh
@@ -5,6 +5,11 @@ args="${@:1}"
 source ./devops/env.sh
 ./devops/build_mettagrid.sh
 
+if [ -z "$NUM_CPUS" ]; then
+    NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
+    NUM_CPUS=$((NUM_CPUS / 2))
+fi
+echo "NUM_CPUS: $NUM_CPUS"
 NUM_GPUS=${NUM_GPUS:-1}
 echo "NUM_GPUS: $NUM_GPUS"
 NUM_NODES=${NUM_NODES:-1}
@@ -20,12 +25,13 @@ echo "Running train with args: $args"
 PYTHONPATH=$PYTHONPATH:.
 
 torchrun \
-  --nnodes=$NUM_NODES \
-  --nproc-per-node=$NUM_GPUS \
-  --master-addr=$MASTER_ADDR \
-  --master-port=$MASTER_PORT \
-  --node-rank=$NODE_INDEX \
-  tools/train.py \
-  wandb.enabled=true \
-  wandb.track=true \
-  $args
+    --nnodes=$NUM_NODES \
+    --nproc-per-node=$NUM_GPUS \
+    --master-addr=$MASTER_ADDR \
+    --master-port=$MASTER_PORT \
+    --node-rank=$NODE_INDEX \
+    tools/train.py \
+    trainer.num_workers=$NUM_CPUS \
+    wandb.enabled=true \
+    wandb.track=true \
+    $args


### PR DESCRIPTION
### TL;DR

Increase agent count in MetaGrid and improve training infrastructure setup.

### What changed?

- Disabled EFS setup in setup_machine.py as it was too slow
- Enhanced the SkyPilot training configuration:
  - Added Python package build and installation steps
  - Removed hardcoded num_workers parameter
- Improved the train.sh script to automatically detect and use available CPU cores
- Increased the number of agents in MetaGrid from 10 to 24 in the mapgen_auto.yaml configuration
