### PR TITLE
fix: debug python CI

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -337,18 +337,7 @@ jobs:
       - name: Check deps
         run: |
           source venv/bin/activate
-          echo "content of repo"
-          ls -al
-
-          echo "contents of deps"
-          ls -la deps
-
-          echo "contents of deps/pufferlib"
-          ls -la deps/pufferlib
-
-          echo "contents of deps/pufferlib/pufferlib"
-          ls -la deps/pufferlib/pufferlib
-
+          
           for dep in \
             "pufferlib" \
             "carbs" \

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -89,7 +89,7 @@ jobs:
           PATHS="mettagrid/build
           mettagrid/**/*.so
           metta/**/*.so
-          /build
+          deps/**/*.so
           ~/.cache/pip
           venv"
           echo "paths<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -314,6 +314,24 @@ jobs:
           source venv/bin/activate
           bash ./devops/setup_build.sh
 
+      - name: Check deps
+        run: |
+          source venv/bin/activate
+          ls -la deps
+          ls -la deps/pufferlib
+
+          for dep in \
+            "pufferlib" \
+            "carbs" \
+            "wandb_carbs"
+          do
+            echo "Checking import for $dep..."
+            python -c "import $dep; print('✅ Found {} at {}'.format('$dep', __import__('$dep').__file__))" || {
+              echo "❌ Failed to import $dep"
+              exit 1
+            }
+          done
+
       - name: Check benchmark script
         run: |
           # Check if the file exists

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -86,12 +86,12 @@ jobs:
       - name: Set cache paths
         id: set-cache-paths
         run: |
-          PATHS="mettagrid/build
+          PATHS="venv
           mettagrid/**/*.so
           metta/**/*.so
           deps/**/*.so
           ~/.cache/pip
-          venv"
+          "
           echo "paths<<EOF" >> $GITHUB_OUTPUT
           echo "$PATHS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -317,8 +317,10 @@ jobs:
       - name: Check deps
         run: |
           source venv/bin/activate
+          echo "content of repo"
+          ls -al
+          echo "contents of deps"
           ls -la deps
-          ls -la deps/pufferlib
 
           for dep in \
             "pufferlib" \

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -89,7 +89,7 @@ jobs:
           PATHS="venv
           mettagrid/**/*.so
           metta/**/*.so
-          deps/**/*.so
+          deps/**/*.py
           ~/.cache/pip
           "
           echo "paths<<EOF" >> $GITHUB_OUTPUT
@@ -100,7 +100,15 @@ jobs:
         id: set-cache-key
         run: |
           # Create a hash that combines all relevant files
-          find mettagrid -type f \( -name "*.py" \) -exec sha256sum {} \; > /tmp/file_hashes.txt || true
+          find mettagrid -type f \( -name "*.py" \) -exec sha256sum {} \; > /tmp/mettagrid_file_hashes.txt || true
+          find deps -type f \( -name "*.py" \) -exec sha256sum {} \; > /tmp/deps_file_hashes.txt || true
+
+          # Add more project directories if they exist
+          find tests -type f \( -name "*.py" \) -exec sha256sum {} \; > /tmp/tests_file_hashes.txt || true
+          find examples -type f \( -name "*.py" \) -exec sha256sum {} \; > /tmp/examples_file_hashes.txt || true
+
+          # Hash configuration files
+          find . -maxdepth 1 -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" -o -name "*.toml" \) -exec sha256sum {} \; > /tmp/config_file_hashes.txt || true
 
           # Add setup.py and requirements.txt if they exist
           if [ -f "setup.py" ]; then
@@ -109,18 +117,30 @@ jobs:
           if [ -f "requirements.txt" ]; then
             sha256sum requirements.txt >> /tmp/file_hashes.txt
           fi
+          if [ -f "pyproject.toml" ]; then
+            sha256sum pyproject.toml >> /tmp/file_hashes.txt
+          fi
+          if [ -f "setup.cfg" ]; then
+            sha256sum setup.cfg >> /tmp/file_hashes.txt
+          fi
 
           # Add the cache paths to the hash calculation
           echo "${{ steps.set-cache-paths.outputs.paths }}" | sha256sum >> /tmp/file_hashes.txt
 
+          # Combine all hash files
+          cat /tmp/mettagrid_file_hashes.txt /tmp/deps_file_hashes.txt /tmp/tests_file_hashes.txt /tmp/examples_file_hashes.txt /tmp/config_file_hashes.txt /tmp/file_hashes.txt > /tmp/all_hashes.txt || true
+
           # Create the final hash
-          if [ -s "/tmp/file_hashes.txt" ]; then
-            HASH=$(sort /tmp/file_hashes.txt | sha256sum | cut -d' ' -f1)
+          if [ -s "/tmp/all_hashes.txt" ]; then
+            HASH=$(sort /tmp/all_hashes.txt | sha256sum | cut -d' ' -f1)
           else
             HASH="empty"
           fi
 
-          CACHE_KEY="py-build-${HASH}"
+          # Add Python version to the cache key
+          PYTHON_VERSION=$(python --version 2>&1 | cut -d' ' -f2)
+          CACHE_KEY="py-build-${PYTHON_VERSION}-${HASH}"
+
           echo "cache_key=${CACHE_KEY}" >> $GITHUB_OUTPUT
           echo "Created content-based hash key ${CACHE_KEY}"
 
@@ -189,26 +209,6 @@ jobs:
         run: |
           source venv/bin/activate
           bash ./devops/setup_build.sh
-
-      - name: Check deps
-        run: |
-          source venv/bin/activate
-          echo "content of repo"
-          ls -al
-          echo "contents of deps"
-          ls -la deps
-
-          for dep in \
-            "pufferlib" \
-            "carbs" \
-            "wandb_carbs"
-          do
-            echo "Checking import for $dep..."
-            python -c "import $dep; print('✅ Found {} at {}'.format('$dep', __import__('$dep').__file__))" || {
-              echo "❌ Failed to import $dep"
-              exit 1
-            }
-          done
 
   lint:
     name: "Lint"
@@ -339,8 +339,15 @@ jobs:
           source venv/bin/activate
           echo "content of repo"
           ls -al
+
           echo "contents of deps"
           ls -la deps
+
+          echo "contents of deps/pufferlib"
+          ls -la deps/pufferlib
+
+          echo "contents of deps/pufferlib/pufferlib"
+          ls -la deps/pufferlib/pufferlib
 
           for dep in \
             "pufferlib" \

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -190,6 +190,26 @@ jobs:
           source venv/bin/activate
           bash ./devops/setup_build.sh
 
+      - name: Check deps
+        run: |
+          source venv/bin/activate
+          echo "content of repo"
+          ls -al
+          echo "contents of deps"
+          ls -la deps
+
+          for dep in \
+            "pufferlib" \
+            "carbs" \
+            "wandb_carbs"
+          do
+            echo "Checking import for $dep..."
+            python -c "import $dep; print('✅ Found {} at {}'.format('$dep', __import__('$dep').__file__))" || {
+              echo "❌ Failed to import $dep"
+              exit 1
+            }
+          done
+
   lint:
     name: "Lint"
     needs: [graphite-ci-optimizer, setup-checks, setup-py]

--- a/devops/skypilot/config/train.yaml
+++ b/devops/skypilot/config/train.yaml
@@ -2,7 +2,7 @@ resources:
   cloud: aws
   region: us-east-1
   use_spot: true
-  accelerators: {L4: 1}
+  accelerators: { L4: 1 }
   cpus: 8+
   image_id: docker:metta:latest
 


### PR DESCRIPTION

We need to include the files we built in deps in the cache so that e.g. pufferlib is available for CI.