### PR TITLE
Add a link to Interactive demo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A reinforcement learning codebase focusing on the emergence of cooperation and a
 
 <p align="middle">
 <img src="docs/readme_showoff.gif" alt="Metta learning example video">
+<br>
+<a href="https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fandre_pufferbox_33%2Freplay.77200.json.z&play=true">Interactive demo</a>
 </p>
 
 Metta AI is an open-source research project investigating the emergence of cooperation and alignment in multi-agent AI systems. By creating a model organism for complex multi-agent gridworld environments, the project aims to study the impact of social dynamics, such as kinship and mate selection, on learning and cooperative behaviors of AI agents.

--- a/mettagrid/player/src/worldmap.ts
+++ b/mettagrid/player/src/worldmap.ts
@@ -184,7 +184,7 @@ function drawObjects() {
 
       // Draw the color layer.
       var colorIdx = getAttr(gridObject, "color");
-      if (colorIdx !== undefined) {
+      if (colorIdx >= 0 && colorIdx < Common.COLORS.length) {
         ctx.drawSprite(
           state.replay.object_images[type][2],
           x * Common.TILE_SIZE,
@@ -598,7 +598,7 @@ export function updateReadout() {
       var value = getAttr(state.selectedGridObject, key);
       if (key == "type") {
         value = state.replay.object_types[value] + " (" + value + ")";
-      } else if (key == "color") {
+      } else if (key == "color" && value >= 0 && value < Common.COLORS.length) {
         value = Common.COLORS[value][0] + " (" + value + ")";
       }
       readout += key + ": " + value + "\n";


### PR DESCRIPTION
Added a line break and an interactive demo link below the GIF in the README. The link directs users to a pre-configured replay of a Metta simulation.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/v4zW1GBUDMzvdl2baVN1/f0d2912d-273b-4157-a36f-1be0b0112120.png)

