### PR TITLE
fix: don't deploy mettascope on merge-group checks

### DIFF
--- a/.github/workflows/deploy-mettascope.yml
+++ b/.github/workflows/deploy-mettascope.yml
@@ -6,12 +6,6 @@ on:
     paths:
       - "mettagrid/player/**" # Run when any file in player directory changes
       - ".github/workflows/**" # Run when workflow files change
-  merge_group:
-    types: [checks_requested]
-    branches: [main]
-    paths:
-      - "mettagrid/player/**" # Run when any file in player directory changes
-      - ".github/workflows/**" # Run when workflow files change
   workflow_dispatch: {} # Allow manual triggers
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION

This must have slipped in by pattern matching but it is probably not what we want.

This adjusts MettaScope deployment to only run on pushes to main or manual workflows.