### PR TITLE
add AWS_PROFILE to zshrc

### DIFF
--- a/devops/aws/setup_aws_profiles.sh
+++ b/devops/aws/setup_aws_profiles.sh
@@ -53,4 +53,5 @@ aws configure set profile.softmax-admin.sso_role_name AdministratorAccess
 aws configure set profile.softmax-admin.region us-east-1
 
 echo "AWS profiles have been configured successfully."
-echo "Login to AWS using: aws sso login --profile softmax-sso"
+echo "Login to AWS using: aws sso login --profile softmax"
+grep -q '^export AWS_PROFILE=' ~/.zshrc || echo -e '\nexport AWS_PROFILE=softmax' >> ~/.zshrc


### PR DESCRIPTION
### TL;DR

Updated AWS profile setup script to use the `softmax` profile as default and automatically configure it in the user's shell environment.

### What changed?

- Changed the login instruction from `aws sso login --profile softmax-sso` to `aws sso login --profile softmax`

- Added a line that appends `export AWS_PROFILE=softmax` to the user's `~/.zshrc` file if it doesn't already exist

### How to test?

1. Run the updated script: `./devops/aws/setup_aws_profiles.sh`
2. Verify that the login instructions show `softmax` as the profile
3. Check your `~/.zshrc` file to confirm it contains the `export AWS_PROFILE=softmax` line
4. Open a new terminal and verify that AWS commands use the `softmax` profile by default

### Why make this change?

This change streamlines the AWS workflow by setting a default profile in the user's shell environment, eliminating the need to specify the profile with each AWS command. It also ensures consistent profile naming in the documentation and configuration.