### PR TITLE
Remove MettaAgent type assertion in trainer.py

### DIFF
--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -150,7 +150,7 @@ class PufferTrainer:
 
         # validate that policy matches environment
         self.metta_agent: MettaAgent = self.policy  # type: ignore
-        assert isinstance(self.metta_agent, MettaAgent)
+        # assert isinstance(self.metta_agent, MettaAgent)
         _env_shape = metta_grid_env.single_observation_space.shape
         environment_shape = tuple(_env_shape) if isinstance(_env_shape, list) else _env_shape
 


### PR DESCRIPTION
### TL;DR

Commented out the type assertion for `metta_agent` in the PufferLib trainer.

### What changed?

Commented out the line `assert isinstance(self.metta_agent, MettaAgent)` in the `__init__` method of the PufferLib trainer. This removes a runtime type check that was previously enforcing the policy to be a `MettaAgent` instance.
