### PR TITLE
Update check-test-tools to work on osx

### DIFF
--- a/mettagrid/Makefile
+++ b/mettagrid/Makefile
@@ -156,7 +156,7 @@ check-test-tools:
 	@(ldconfig -p 2>/dev/null | grep -q libgtest.so) || \
 		(test -f /usr/local/lib/libgtest.a) || \
 		(test -f /usr/local/lib/libgtest.dylib) || \
-		(test -f /opt/homebrew/Cellar/googletest/1.17.0/lib/libgtest.dylib) || \
+		(test -f /opt/homebrew/Cellar/googletest/1.17.0/lib/libgtest.a) || \
 		(pkg-config --exists gtest 2>/dev/null) || \
 		{ echo "Google Test library not found. Run 'make install-test-tools' to install."; exit 1; }
 	@echo "All required testing tools are installed."

--- a/mettagrid/Makefile
+++ b/mettagrid/Makefile
@@ -157,6 +157,7 @@ check-test-tools:
 		(test -f /usr/local/lib/libgtest.a) || \
 		(test -f /usr/local/lib/libgtest.dylib) || \
 		(test -f /opt/homebrew/Cellar/googletest/1.17.0/lib/libgtest.a) || \
+		(test -f /opt/homebrew/Cellar/googletest/1.17.0/lib/libgtest.dylib) || \
 		(pkg-config --exists gtest 2>/dev/null) || \
 		{ echo "Google Test library not found. Run 'make install-test-tools' to install."; exit 1; }
 	@echo "All required testing tools are installed."


### PR DESCRIPTION
### TL;DR

Fix googletest library check in Makefile to look for the static library instead of the dynamic library.

### What changed?

Updated the googletest library check in the Makefile to look for `libgtest.a` instead of `libgtest.dylib` in the Homebrew Cellar path. This change ensures the check correctly identifies the static library file that's actually present in the Homebrew installation.

### How to test?

1. Run `make check-test-tools` on a macOS system with Homebrew-installed googletest
2. Verify that the check passes without errors
3. Try running tests with `make test` to confirm everything works properly

### Why make this change?

The Homebrew installation of googletest 1.17.0 provides a static library (`.a`) rather than a dynamic library (`.dylib`). The previous check was looking for the wrong file type, which could cause the test tools verification to fail incorrectly on macOS systems using Homebrew.