### PR TITLE
Add back an expanded assertion

### DIFF
--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -149,8 +149,8 @@ class PufferTrainer:
         )
 
         # validate that policy matches environment
-        self.metta_agent: MettaAgent = self.policy  # type: ignore
-        # assert isinstance(self.metta_agent, MettaAgent)
+        self.metta_agent: MettaAgent | DistributedMettaAgent = self.policy  # type: ignore
+        assert isinstance(self.metta_agent, (MettaAgent, DistributedMettaAgent)), self.metta_agent
         _env_shape = metta_grid_env.single_observation_space.shape
         environment_shape = tuple(_env_shape) if isinstance(_env_shape, list) else _env_shape
 


### PR DESCRIPTION
This adds back an assertion about the type of `metta_agent`.

This assertion was added by @rjwalters to add code clarity. It was originally added to make the type information we were showing -- that metta_agent was a `MettaAgent`. This turned out to be wrong, since it could also be a `DistributedMettaAgent`.

I don't have a strong opinion on the value of the assertion; but I'd fixed it this way before the assertion was commented out (or at least, before that change got to my branch), so I figured I'd propose this fix.