### PR TITLE
fix: adjust bencher thresholds

### DIFF
--- a/.github/workflows/cpp-checks.yml
+++ b/.github/workflows/cpp-checks.yml
@@ -324,11 +324,11 @@ jobs:
                 --project mettagrid-sv3f5i2k \
                 --token "$BENCHER_API_TOKEN" \
                 --branch main \
-                --threshold-measure latency \
-                --threshold-test t_test \
-                --threshold-max-sample-size 64 \
-                --threshold-upper-boundary 0.99 \
                 --thresholds-reset \
+                --threshold-measure latency \
+                --threshold-test percentage \
+                --threshold-max-sample-size 4 \
+                --threshold-upper-boundary 0.20 \
                 --testbed ubuntu-latest \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \
@@ -391,10 +391,6 @@ jobs:
                 --start-point "main" \
                 --start-point-clone-thresholds \
                 --start-point-reset \
-                --threshold-measure latency \
-                --threshold-test percentage \
-                --threshold-max-sample-size 64 \
-                --threshold-upper-boundary 0.25 \
                 --testbed ubuntu-latest \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -620,11 +620,11 @@ jobs:
             --token "$BENCHER_API_TOKEN" \
             --branch main \
             --testbed ubuntu-latest \
-            --threshold-measure latency \
-            --threshold-test t_test \
-            --threshold-max-sample-size 64 \
-            --threshold-upper-boundary 0.99 \
             --thresholds-reset \
+            --threshold-measure latency \
+            --threshold-test percentage \
+            --threshold-max-sample-size 4 \
+            --threshold-upper-boundary 0.20 \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json > /dev/null
@@ -675,6 +675,7 @@ jobs:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+
           bencher run \
             --project mettagrid-sv3f5i2k \
             --token "$BENCHER_API_TOKEN" \
@@ -683,10 +684,6 @@ jobs:
             --start-point-clone-thresholds \
             --start-point-reset \
             --testbed ubuntu-latest \
-            --threshold-measure latency \
-            --threshold-test percentage \
-            --threshold-max-sample-size 64 \
-            --threshold-upper-boundary 0.25 \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json > /dev/null


### PR DESCRIPTION

previously we were comparing PRs to the last 64 data points -- but since our benchmarks are still changing a lot we don't have enough stability for this large of a window to be relevant yet