### PR TITLE
fix: have bencher compare to edge performance on `main`

### DIFF
--- a/.github/workflows/cpp-checks.yml
+++ b/.github/workflows/cpp-checks.yml
@@ -327,7 +327,7 @@ jobs:
                 --thresholds-reset \
                 --threshold-measure latency \
                 --threshold-test percentage \
-                --threshold-max-sample-size 4 \
+                --threshold-max-sample-size 1 \
                 --threshold-upper-boundary 0.20 \
                 --testbed ubuntu-latest \
                 --adapter cpp_google \
@@ -370,8 +370,8 @@ jobs:
             echo "Warning: Main branch does not exist or cannot be accessed. Will skip PR performance comparison."
           fi
 
-      # PR Performance Changes section - Only runs if main branch has benchmarks
-      - name: Upload to Bencher (PR Performance Changes)
+      # First PR Performance run - Check for improvements (will NOT fail on alerts)
+      - name: Check for Performance Improvements
         if: |
           github.event_name == 'pull_request' && 
           !github.event.pull_request.head.repo.fork && 
@@ -389,12 +389,50 @@ jobs:
                 --token "$BENCHER_API_TOKEN" \
                 --branch "$GITHUB_HEAD_REF" \
                 --start-point "main" \
-                --start-point-clone-thresholds \
-                --start-point-reset \
                 --testbed ubuntu-latest \
+                --thresholds-reset \
+                --threshold-measure latency \
+                --threshold-test percentage \
+                --threshold-max-sample-size 1 \
+                --threshold-lower-boundary 0.10 \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \
                 --file "$file" > /dev/null
+            done
+          else
+            echo "NO TEST RESULTS FOUND"
+          fi
+
+      # Second PR Performance run - Check for regressions (WILL fail on alerts)
+      - name: Check for Performance Regressions
+        if: |
+          github.event_name == 'pull_request' && 
+          !github.event.pull_request.head.repo.fork && 
+          steps.check-main-benchmark.outputs.main_benchmark_exists == 'true'
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd mettagrid/benchmark_output
+          ls -al
+          if ls *.json 1> /dev/null 2>&1; then
+            for file in *.json; do
+              bencher run \
+                --project mettagrid-sv3f5i2k \
+                --token "$BENCHER_API_TOKEN" \
+                --branch "$GITHUB_HEAD_REF" \
+                --start-point "main" \
+                --start-point-reset \
+                --testbed ubuntu-latest \
+                --thresholds-reset \
+                --threshold-measure latency \
+                --threshold-test percentage \
+                --threshold-max-sample-size 1 \
+                --threshold-upper-boundary 0.20 \
+                --err \
+                --adapter cpp_google \
+                --github-actions "$GITHUB_TOKEN" \
+                --file "$file" 
             done
           else
             echo "NO TEST RESULTS FOUND"

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -623,7 +623,7 @@ jobs:
             --thresholds-reset \
             --threshold-measure latency \
             --threshold-test percentage \
-            --threshold-max-sample-size 4 \
+            --threshold-max-sample-size 1 \
             --threshold-upper-boundary 0.20 \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
@@ -665,8 +665,8 @@ jobs:
             echo "Warning: Main branch does not exist or cannot be accessed. Will skip PR performance comparison."
           fi
 
-      # PR Performance Changes section - Only runs if main branch has benchmarks
-      - name: Upload to Bencher (PR Performance Changes)
+      # First PR Performance run - Check for improvements (will NOT fail on alerts)
+      - name: Check for Performance Improvements
         if: |
           (github.event_name == 'pull_request') && 
           (!github.event.pull_request.head.repo.fork) && 
@@ -675,15 +675,43 @@ jobs:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-
           bencher run \
             --project mettagrid-sv3f5i2k \
             --token "$BENCHER_API_TOKEN" \
             --branch "$GITHUB_HEAD_REF" \
             --start-point "main" \
-            --start-point-clone-thresholds \
-            --start-point-reset \
             --testbed ubuntu-latest \
+            --thresholds-reset \
+            --threshold-measure latency \
+            --threshold-test percentage \
+            --threshold-max-sample-size 1 \
+            --threshold-lower-boundary 0.10 \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json > /dev/null
+
+      # Second PR Performance run - Check for regressions (WILL fail on alerts)
+      - name: Check for Performance Regressions
+        if: |
+          (github.event_name == 'pull_request') && 
+          (!github.event.pull_request.head.repo.fork) && 
+          (steps.check-main-benchmark.outputs.main_benchmark_exists == 'true')
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bencher run \
+            --project mettagrid-sv3f5i2k \
+            --token "$BENCHER_API_TOKEN" \
+            --branch "$GITHUB_HEAD_REF" \
+            --start-point "main" \
+            --testbed ubuntu-latest \
+            --thresholds-reset \
+            --threshold-measure latency \
+            --threshold-test percentage \
+            --threshold-max-sample-size 1 \
+            --threshold-upper-boundary 0.20 \
+            --err \
+            --adapter python_pytest \
+            --github-actions "$GITHUB_TOKEN" \
+            --file combined_benchmark_results.json


### PR DESCRIPTION

This PR updates our benchmarking strategy to better capture both performance improvements and regressions:

1. We now compare each benchmark only against the most recent result (changed from comparing against 4 previous runs)
2. We've added a two-step approach to benchmark analysis:
   - First, we check for 10% or greater performance improvements (generates alerts but doesn't fail the build)
   - Then, we check for 20% or greater performance regressions (generates alerts AND fails the build)

## Benefits
- **Better signal-to-noise ratio**: By comparing only to the most recent benchmark result, we reduce noise and get more meaningful comparisons
- **Highlight improvements**: We now explicitly detect and highlight performance improvements of 10% or better
- **Maintain regression safety**: We continue to fail builds on significant performance regressions (20% or worse)

## Implementation
- Updated both Python and C++ benchmark configurations
- Used explicit threshold configurations with `--thresholds-reset` for clarity
- Maintained compatibility with existing Bencher project setup

This approach lets us celebrate performance wins while still protecting against performance degradation.