### PR TITLE
fix: min `--threshold-max-sample-size` is 2

### DIFF
--- a/.github/workflows/cpp-checks.yml
+++ b/.github/workflows/cpp-checks.yml
@@ -310,6 +310,7 @@ jobs:
           echo "Bencher token SHA256: $(echo -n "$BENCHER_API_TOKEN" | sha256sum)"
 
       # Main Branch Upload section
+      # note that "threshold-max-sample-size" has a minimum value of 2 - the new data and the reference
       - name: Upload to Bencher (Main Branch Baseline)
         if: github.ref == 'refs/heads/main'
         env:
@@ -324,11 +325,11 @@ jobs:
                 --project mettagrid-sv3f5i2k \
                 --token "$BENCHER_API_TOKEN" \
                 --branch main \
-                --thresholds-reset \
                 --threshold-measure latency \
                 --threshold-test percentage \
-                --threshold-max-sample-size 1 \
+                --threshold-max-sample-size 2 \
                 --threshold-upper-boundary 0.20 \
+                --thresholds-reset \
                 --testbed ubuntu-latest \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \
@@ -389,12 +390,13 @@ jobs:
                 --token "$BENCHER_API_TOKEN" \
                 --branch "$GITHUB_HEAD_REF" \
                 --start-point "main" \
-                --testbed ubuntu-latest \
-                --thresholds-reset \
+                --start-point-reset \
                 --threshold-measure latency \
                 --threshold-test percentage \
-                --threshold-max-sample-size 1 \
+                --threshold-max-sample-size 2 \
                 --threshold-lower-boundary 0.10 \
+                --thresholds-reset \
+                --testbed ubuntu-latest \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \
                 --file "$file" > /dev/null
@@ -423,12 +425,8 @@ jobs:
                 --branch "$GITHUB_HEAD_REF" \
                 --start-point "main" \
                 --start-point-reset \
+                --start-point-clone-thresholds \
                 --testbed ubuntu-latest \
-                --thresholds-reset \
-                --threshold-measure latency \
-                --threshold-test percentage \
-                --threshold-max-sample-size 1 \
-                --threshold-upper-boundary 0.20 \
                 --err \
                 --adapter cpp_google \
                 --github-actions "$GITHUB_TOKEN" \

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -609,6 +609,7 @@ jobs:
           echo "Bencher token SHA256: $(echo -n "$BENCHER_API_TOKEN" | sha256sum)"
 
       # Main Branch Upload section
+      # note that "threshold-max-sample-size" has a minimum value of 2 - the new data and the reference
       - name: Upload to Bencher (Main Branch Baseline)
         if: github.ref == 'refs/heads/main'
         env:
@@ -619,12 +620,12 @@ jobs:
             --project mettagrid-sv3f5i2k \
             --token "$BENCHER_API_TOKEN" \
             --branch main \
-            --testbed ubuntu-latest \
-            --thresholds-reset \
             --threshold-measure latency \
             --threshold-test percentage \
-            --threshold-max-sample-size 1 \
+            --threshold-max-sample-size 2 \
             --threshold-upper-boundary 0.20 \
+            --thresholds-reset \
+            --testbed ubuntu-latest \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json > /dev/null
@@ -680,12 +681,13 @@ jobs:
             --token "$BENCHER_API_TOKEN" \
             --branch "$GITHUB_HEAD_REF" \
             --start-point "main" \
-            --testbed ubuntu-latest \
+            --start-point-reset \
             --thresholds-reset \
             --threshold-measure latency \
             --threshold-test percentage \
-            --threshold-max-sample-size 1 \
+            --threshold-max-sample-size 2 \
             --threshold-lower-boundary 0.10 \
+            --testbed ubuntu-latest \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json > /dev/null
@@ -705,13 +707,10 @@ jobs:
             --token "$BENCHER_API_TOKEN" \
             --branch "$GITHUB_HEAD_REF" \
             --start-point "main" \
-            --testbed ubuntu-latest \
-            --thresholds-reset \
-            --threshold-measure latency \
-            --threshold-test percentage \
-            --threshold-max-sample-size 1 \
-            --threshold-upper-boundary 0.20 \
+            --start-point-reset \
+            --start-point-clone-thresholds \
             --err \
+            --testbed ubuntu-latest \
             --adapter python_pytest \
             --github-actions "$GITHUB_TOKEN" \
             --file combined_benchmark_results.json


### PR DESCRIPTION
Bencher considers the reference point and the data point to be in the sample set so the minimum size is 2