### PR TITLE
automatically pick account id in push_image

### DIFF
--- a/devops/docker/push_image.sh
+++ b/devops/docker/push_image.sh
@@ -1,7 +1,15 @@
-# docker login -u mettaai
-# docker push mettaai/metta:latest
-# docker push mettaai/metta-base:latest
+REGION=us-east-1
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 767406518141.dkr.ecr.us-east-1.amazonaws.com
-docker tag mettaai/metta:latest 767406518141.dkr.ecr.us-east-1.amazonaws.com/metta:latest
-docker push 767406518141.dkr.ecr.us-east-1.amazonaws.com/metta:latest
+if [ -z "$ACCOUNT_ID" ]; then
+  echo "Failed to get ACCOUNT_ID"
+  exit 1
+fi
+
+HOST="$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com"
+
+echo "Uploading metta image to $HOST"
+
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $HOST
+docker tag mettaai/metta:latest $HOST/metta:latest
+docker push $HOST/metta:latest


### PR DESCRIPTION
### TL;DR

Improved Docker image push script to dynamically fetch AWS account ID instead of hardcoding it.

### What changed?

- Modified `push_image.sh` to dynamically retrieve the AWS account ID using `aws sts get-caller-identity`
- Added error handling if account ID retrieval fails
- Introduced variables for region and host to improve maintainability
- Removed commented out Docker Hub push commands
- Added informative echo statement to indicate which repository the image is being uploaded to

### How to test?

1. Ensure AWS CLI is configured with appropriate credentials
2. Run `./devops/docker/push_image.sh`
3. Verify the script successfully pushes the Docker image to your ECR repository
4. Confirm the image appears in your ECR repository with the correct tag

### Why make this change?

The hardcoded AWS account ID in the script created maintenance issues and made it difficult to use in different environments or AWS accounts. This change makes the script more portable and secure by dynamically fetching the account ID from the current AWS credentials, allowing it to work correctly across different AWS accounts without modification.