### PR TITLE
create ~/.aws if it didn't exist

### DIFF
--- a/devops/aws/setup_aws_profiles.sh
+++ b/devops/aws/setup_aws_profiles.sh
@@ -10,6 +10,8 @@
 if ! grep -q "\[sso-session softmax-sso\]" ~/.aws/config; then
   echo "Adding SSO session configuration..."
 
+  mkdir -p ~/.aws
+
   # Create a temporary file with the new config
   cat >> ~/.aws/config << EOF
 


### PR DESCRIPTION
Trivial fix, I triggered this while setting up a new laptop.