### PR TITLE
Make replay_job.policy_uri default to the global policy_uri to restore previous behavior.

### DIFF
--- a/configs/replay_job.yaml
+++ b/configs/replay_job.yaml
@@ -9,7 +9,7 @@ cmd: play
 replay_job:
   sim:
     env: env/mettagrid/simple
-  policy_uri: ???
+  policy_uri: ${policy_uri}
   selector_type: top
   stats_dir: ${run_dir}/stats
   replay_dir: s3://softmax-public/replays/local


### PR DESCRIPTION
There is no reason to break people's yaml files if we don't have to.
This keeps config from churning. 