### PR TITLE
Refactor simulation job configs to be easier, and add tests

### DIFF
--- a/configs/replay_job.yaml
+++ b/configs/replay_job.yaml
@@ -1,15 +1,17 @@
 defaults:
   - common
   - wandb: metta_research
-  - /sim/sim_single@replay_job.sim
+  - sim: simple
   - _self_
 
-cmd: play
+run: ???
+policy_uri: ???
 
 replay_job:
-  sim:
-    env: env/mettagrid/simple
+  sim: ${sim}
   policy_uri: ${policy_uri}
   selector_type: top
   stats_dir: ${run_dir}/stats
   replay_dir: s3://softmax-public/replays/local
+
+cmd: play

--- a/configs/sim/simple.yaml
+++ b/configs/sim/simple.yaml
@@ -2,4 +2,4 @@ defaults:
   - sim_single
   - _self_
 
-env: env/mettagrid/simple
+env: /env/mettagrid/simple

--- a/configs/sim_job.yaml
+++ b/configs/sim_job.yaml
@@ -1,14 +1,18 @@
 defaults:
   - common
   - wandb: metta_research
-  - /sim/sim_suite@replay_job.simulation_suite
+  - sim: all
   - _self_
 
-cmd: sim
 run: ???
+policy_uri: ???
 
 sim_job:
-  policy_uris: ???
+  policy_uris:
+    - ${policy_uri}
+  simulation_suite: ${sim}
   stats_dir: ${run_dir}/stats
   stats_db_uri: ${run_dir}/stats.db
   replay_dir: ${run_dir}/replay_dir
+
+cmd: sim

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -33,7 +33,6 @@ analyzer:
       - metric: "heart.get"
 
 replay_job:
-  policy_uri: ${policy_uri}
   sim:
     env: /env/mettagrid/terrain_from_numpy
     env_overrides:
@@ -41,8 +40,6 @@ replay_job:
         max_steps: 10
 
 sim_job:
-  policy_uris:
-    - ${policy_uri}
   # policy_agents_pct: 1
 
   # env: /env/mettagrid/reward_dr

--- a/tests/tools/test_replay_job.py
+++ b/tests/tools/test_replay_job.py
@@ -1,12 +1,3 @@
-"""
-Unit‑tests for SimulationSuiteConfig ⇄ SimulationConfig behavior.
-Covered
--------
-* suite‑level defaults propagate into children
-* child‑level overrides win
-* missing required keys always raise (allow_missing removed)
-"""
-
 from typing import List
 
 import hydra

--- a/tests/tools/test_replay_job.py
+++ b/tests/tools/test_replay_job.py
@@ -1,0 +1,55 @@
+"""
+Unit‑tests for SimulationSuiteConfig ⇄ SimulationConfig behavior.
+Covered
+-------
+* suite‑level defaults propagate into children
+* child‑level overrides win
+* missing required keys always raise (allow_missing removed)
+"""
+
+from typing import List
+
+import hydra
+import pytest
+from hydra.core.global_hydra import GlobalHydra
+
+from tools.replay import ReplayJob
+
+
+@pytest.fixture(scope="session", autouse=True)
+def hydra_init_once():
+    GlobalHydra.instance().clear()
+    hydra.initialize(config_path="../../configs", version_base=None)
+
+
+@pytest.fixture
+def build_config():
+    def _build(overrides: List[str]):
+        hydra_cfg = hydra.compose(config_name="replay_job", overrides=overrides)
+        return ReplayJob(hydra_cfg.replay_job)
+
+    return _build
+
+
+def test_config_defaults(build_config):
+    cfg = build_config(["run=test"])
+    assert cfg.selector_type == "top"
+    assert cfg.policy_uri == "file://./train_dir/test/checkpoints"
+    assert cfg.sim.env == "/env/mettagrid/simple"
+
+
+def test_config_overrides(build_config):
+    cfg = build_config(
+        [
+            "run=test",
+            "sim.env=/env/mettagrid/teams",
+            "+sim.env_overrides.game.num_agents=36",
+            "policy_uri=test_policy",
+            "sim.num_episodes=10",
+        ]
+    )
+    print(cfg)
+    assert cfg.policy_uri == "test_policy"
+    assert cfg.sim.env == "/env/mettagrid/teams"
+    assert cfg.sim.num_episodes == 10
+    assert cfg.sim.env_overrides["game"]["num_agents"] == 36

--- a/tests/tools/test_sim_job.py
+++ b/tests/tools/test_sim_job.py
@@ -1,0 +1,54 @@
+"""
+Unit‑tests for SimulationSuiteConfig ⇄ SimulationConfig behavior.
+Covered
+-------
+* suite‑level defaults propagate into children
+* child‑level overrides win
+* missing required keys always raise (allow_missing removed)
+"""
+
+from typing import List
+
+import hydra
+import pytest
+from hydra.core.global_hydra import GlobalHydra
+
+from tools.sim import SimJob
+
+
+@pytest.fixture(scope="session", autouse=True)
+def hydra_init_once():
+    GlobalHydra.instance().clear()
+    hydra.initialize(config_path="../../configs", version_base=None)
+
+
+@pytest.fixture
+def build_config():
+    def _build(overrides: List[str]):
+        hydra_cfg = hydra.compose(config_name="sim_job", overrides=overrides)
+        return SimJob(hydra_cfg.sim_job)
+
+    return _build
+
+
+def test_config_defaults(build_config):
+    cfg = build_config(["run=test"])
+    assert cfg.selector_type == "top"
+    assert cfg.policy_uris == ["file://./train_dir/test/checkpoints"]
+    assert cfg.simulation_suite.name == "all"
+
+
+def test_config_overrides(build_config):
+    cfg = build_config(
+        [
+            "run=test",
+            "sim=smoke_test",
+            "policy_uri=test_policy",
+            "sim.num_episodes=10",
+        ]
+    )
+    print(cfg)
+    assert cfg.policy_uris == ["test_policy"]
+    assert cfg.simulation_suite.name == "smoke_test"
+    assert cfg.simulation_suite.num_episodes == 10
+    assert cfg.simulation_suite.simulations["emptyspace_withinsight"].num_episodes == 10

--- a/tests/tools/test_sim_job.py
+++ b/tests/tools/test_sim_job.py
@@ -1,12 +1,3 @@
-"""
-Unit‑tests for SimulationSuiteConfig ⇄ SimulationConfig behavior.
-Covered
--------
-* suite‑level defaults propagate into children
-* child‑level overrides win
-* missing required keys always raise (allow_missing removed)
-"""
-
 from typing import List
 
 import hydra

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -4,6 +4,7 @@ import platform
 import webbrowser
 
 import hydra
+from omegaconf import OmegaConf
 
 from metta.agent.policy_store import PolicyStore
 from metta.sim.simulation import Simulation
@@ -29,8 +30,8 @@ def main(cfg):
     setup_metta_environment(cfg)
     setup_mettagrid_environment(cfg)
 
-    logger = setup_mettagrid_logger("replay")
-    logger.info(f"Replaying {cfg.run}")
+    logger = setup_mettagrid_logger("metta.tools.sim")
+    logger.info(f"Sim job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
 
     with WandbContext(cfg) as wandb_run:
         policy_store = PolicyStore(cfg, wandb_run)

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -30,8 +30,8 @@ def main(cfg):
     setup_metta_environment(cfg)
     setup_mettagrid_environment(cfg)
 
-    logger = setup_mettagrid_logger("metta.tools.sim")
-    logger.info(f"Sim job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
+    logger = setup_mettagrid_logger("metta.tools.replay")
+    logger.info(f"Replay job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
 
     with WandbContext(cfg) as wandb_run:
         policy_store = PolicyStore(cfg, wandb_run)


### PR DESCRIPTION
### TL;DR

Refactored simulation and replay job configurations to improve clarity and consistency, with added unit tests for simulation suite configuration behavior.

### What changed?

We now support easier override syntax, some examples:

python -m tools.sim run=daveey.local.0 +hardware=macbook policy_uri=wandb://run/daveey.dist.2x4 sim=navigation 

python -m tools.replay run=daveey.local.0 +hardware=macbook policy_uri=wandb://run/daveey.dist.2x4 sim.env=/env/mettagrid/teams
