### PR TITLE
Add continuity checks for mettagrid buffers

### DIFF
--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -178,8 +178,8 @@ MettaGrid::MettaGrid(py::dict env_cfg, py::array map) {
     }
   }
 
-  // Initialize buffers. It should be fine to do this at the end of initialization,
-  // since the buffers are likely to be re-set by the user anyways.
+  // Initialize buffers. The buffers are likely to be re-set by the user anyways,
+  // so nothing above should depend on them before this point.
   std::vector<ssize_t> shape = {static_cast<ssize_t>(num_agents),
                                 static_cast<ssize_t>(_obs_height),
                                 static_cast<ssize_t>(_obs_width),

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -379,13 +379,17 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<ObsType>> observa
     auto observation_info = _observations.request();
     auto shape = observation_info.shape;
     auto strides = observation_info.strides;
-    if (observation_info.ndim != 4 || shape[0] != num_agents || shape[1] != _obs_height || shape[2] != _obs_width || shape[3] != _grid_features.size()) {
+    if (observation_info.ndim != 4 || shape[0] != num_agents || shape[1] != _obs_height || shape[2] != _obs_width ||
+        shape[3] != _grid_features.size()) {
       std::stringstream ss;
-      ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << ", " << shape[3] << "] but expected ["
-         << num_agents << ", " << _obs_height << ", " << _obs_width << ", " << _grid_features.size() << "]";
+      ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << ", " << shape[3]
+         << "] but expected [" << num_agents << ", " << _obs_height << ", " << _obs_width << ", "
+         << _grid_features.size() << "]";
       throw std::runtime_error(ss.str());
     }
-    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) || strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) || strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
+    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) ||
+        strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) ||
+        strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
       // This suggests that the data size is wrong, or the data is otherwise not contiguous.
       throw std::runtime_error("observations has the wrong stride");
     }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -365,7 +365,7 @@ py::tuple MettaGrid::reset() {
   return py::make_tuple(_observations, py::dict());
 }
 
-void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> observations,
+void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<ObsType>> observations,
                             std::reference_wrapper<py::array_t<bool>> terminals,
                             std::reference_wrapper<py::array_t<bool>> truncations,
                             std::reference_wrapper<py::array_t<float>> rewards) {
@@ -385,7 +385,7 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> o
          << num_agents << ", " << _obs_height << ", " << _obs_width << ", " << _grid_features.size() << "]";
       throw std::runtime_error(ss.str());
     }
-    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(unsigned char)) {
+    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) || strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) || strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
       // This suggests that the data size is wrong, or the data is otherwise not contiguous.
       throw std::runtime_error("observations has the wrong stride");
     }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -369,6 +369,18 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> o
                             std::reference_wrapper<py::array_t<bool>> terminals,
                             std::reference_wrapper<py::array_t<bool>> truncations,
                             std::reference_wrapper<py::array_t<float>> rewards) {
+  if (!observations.flags() & py::array::c_style) {
+    throw std::runtime_error("Observations array must be C-contiguous");
+  }
+  if (!terminals.flags() & py::array::c_style) {
+    throw std::runtime_error("Terminals array must be C-contiguous");
+  }
+  if (!truncations.flags() & py::array::c_style) {
+    throw std::runtime_error("Truncations array must be C-contiguous");
+  }
+  if (!rewards.flags() & py::array::c_style) {
+    throw std::runtime_error("Rewards array must be C-contiguous");
+  }
   _observations = observations;
   _terminals = terminals;
   _truncations = truncations;

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -425,7 +425,6 @@ void MettaGrid::validate_buffers() {
   }
 }
 
-
 void MettaGrid::set_buffers(py::array_t<unsigned char>& observations,
                             py::array_t<bool>& terminals,
                             py::array_t<bool>& truncations,
@@ -659,7 +658,12 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def(py::init<py::dict, py::array>())
       .def("reset", &MettaGrid::reset)
       .def("step", &MettaGrid::step)
-      .def("set_buffers", &MettaGrid::set_buffers, py::arg("observations").noconvert(), py::arg("terminals").noconvert(), py::arg("truncations").noconvert(), py::arg("rewards").noconvert())
+      .def("set_buffers",
+           &MettaGrid::set_buffers,
+           py::arg("observations").noconvert(),
+           py::arg("terminals").noconvert(),
+           py::arg("truncations").noconvert(),
+           py::arg("rewards").noconvert())
       .def("grid_objects", &MettaGrid::grid_objects)
       .def("action_names", &MettaGrid::action_names)
       .def("current_timestep", &MettaGrid::current_timestep)

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -373,6 +373,8 @@ void MettaGrid::validate_buffers() {
     auto observation_info = _observations.request();
     auto shape = observation_info.shape;
     auto strides = observation_info.strides;
+    // An example risk for the stride is that the data is laid out like a
+    // fortran array, and is thus not contiguous.
     if (observation_info.ndim != 4 || shape[0] != num_agents || shape[1] != _obs_height || shape[2] != _obs_width ||
         shape[3] != _grid_features.size()) {
       std::stringstream ss;
@@ -424,10 +426,10 @@ void MettaGrid::validate_buffers() {
 }
 
 
-void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<ObsType>> observations,
-                            std::reference_wrapper<py::array_t<bool>> terminals,
-                            std::reference_wrapper<py::array_t<bool>> truncations,
-                            std::reference_wrapper<py::array_t<float>> rewards) {
+void MettaGrid::set_buffers(py::array_t<unsigned char>& observations,
+                            py::array_t<bool>& terminals,
+                            py::array_t<bool>& truncations,
+                            py::array_t<float>& rewards) {
   _observations = observations;
   _terminals = terminals;
   _truncations = truncations;
@@ -657,7 +659,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def(py::init<py::dict, py::array>())
       .def("reset", &MettaGrid::reset)
       .def("step", &MettaGrid::step)
-      .def("set_buffers", &MettaGrid::set_buffers)
+      .def("set_buffers", &MettaGrid::set_buffers, py::arg("observations").noconvert(), py::arg("terminals").noconvert(), py::arg("truncations").noconvert(), py::arg("rewards").noconvert())
       .def("grid_objects", &MettaGrid::grid_objects)
       .def("action_names", &MettaGrid::action_names)
       .def("current_timestep", &MettaGrid::current_timestep)

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -29,10 +29,10 @@ public:
   // Python API methods
   py::tuple reset();
   py::tuple step(py::array_t<int> actions);
-  void set_buffers(std::reference_wrapper<py::array_t<unsigned char>> observations,
-                   std::reference_wrapper<py::array_t<bool>> terminals,
-                   std::reference_wrapper<py::array_t<bool>> truncations,
-                   std::reference_wrapper<py::array_t<float>> rewards);
+  void set_buffers(py::array_t<unsigned char>& observations,
+                   py::array_t<bool>& terminals,
+                   py::array_t<bool>& truncations,
+                   py::array_t<float>& rewards);
   void validate_buffers();
   py::dict grid_objects();
   py::list action_names();

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -84,6 +84,8 @@ private:
   // probably move ownership here.
   std::vector<Agent*> _agents;
 
+  // We'd prefer to store these as more raw c-style arrays, but we need to both
+  // operate on the memory directly and return them to python.
   py::array_t<unsigned char> _observations;
   py::array_t<bool> _terminals;
   py::array_t<bool> _truncations;

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -33,6 +33,7 @@ public:
                    std::reference_wrapper<py::array_t<bool>> terminals,
                    std::reference_wrapper<py::array_t<bool>> truncations,
                    std::reference_wrapper<py::array_t<float>> rewards);
+  void validate_buffers();
   py::dict grid_objects();
   py::list action_names();
   unsigned int current_timestep();

--- a/tests/mettagrid/mettagrid/test_mettagrid.py
+++ b/tests/mettagrid/mettagrid/test_mettagrid.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pytest
+
+from mettagrid.mettagrid_c import MettaGrid  # pylint: disable=E0611
+
+NUM_AGENTS = 2
+OBS_HEIGHT = 3
+OBS_WIDTH = 3
+
+
+def create_minimal_mettagrid_env(max_steps=10, width=5, height=5):
+    """Helper function to create a MettaGrid environment with minimal config."""
+    # Define a simple map: empty with walls around perimeter
+    game_map = np.full((height, width), "empty", dtype="<U50")
+    game_map[0, :] = "wall"
+    game_map[-1, :] = "wall"
+    game_map[:, 0] = "wall"
+    game_map[:, -1] = "wall"
+
+    # Place first agent in upper left
+    game_map[1, 1] = "agent.red"
+
+    # Place second agent in middle
+    mid_y = height // 2
+    mid_x = width // 2
+    game_map[mid_y, mid_x] = "agent.red"
+
+    env_config = {
+        "game": {
+            "max_steps": max_steps,
+            "num_agents": NUM_AGENTS,
+            "obs_width": OBS_WIDTH,
+            "obs_height": OBS_HEIGHT,
+            "actions": {
+                # don't really care about the actions for this test
+                "noop": {"enabled": True},
+                "move": {"enabled": True},
+                "rotate": {"enabled": True},
+                "attack": {"enabled": False},
+                "put_items": {"enabled": False},
+                "get_items": {"enabled": False},
+                "swap": {"enabled": False},
+                "change_color": {"enabled": False},
+            },
+            "groups": {"red": {"id": 0, "props": {}}},
+            "objects": {
+                "wall": {"type_id": 1, "hp": 100},
+                "block": {"type_id": 2, "hp": 100},
+            },
+            "agent": {
+                "inventory_size": 0,
+            },
+        }
+    }
+
+    return MettaGrid(env_config, game_map)
+
+
+def test_truncation_at_max_steps():
+    max_steps = 5
+    env = create_minimal_mettagrid_env(max_steps=max_steps)
+    obs, info = env.reset()
+
+    # Noop until time runs out
+    noop_action_idx = env.action_names().index("noop")
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+
+    for step_num in range(1, max_steps + 1):
+        obs, rewards, terminals, truncations, info = env.step(actions)
+        if step_num < max_steps:
+            assert not np.any(truncations), f"Truncations should be False before max_steps at step {step_num}"
+            assert not np.any(terminals), f"Terminals should be False before max_steps at step {step_num}"
+        else:
+            assert np.all(truncations), f"Truncations should be True at max_steps (step {step_num})"
+            # As per current C++ code, terminals are not explicitly set true on truncation.
+            assert not np.any(terminals), f"Terminals should remain False at max_steps (step {step_num})"
+
+
+def test_observation():
+    env = create_minimal_mettagrid_env()
+    wall_feature_idx = env.grid_features().index("wall")
+    obs, info = env.reset()
+    # Agent 0 starts at (1,1) and should see walls above and to the left
+    # for now we treat the walls as "something non-empty"
+    assert obs[0, 0, 1, wall_feature_idx] == 1, "Expected wall above agent 0"
+    assert obs[0, 1, 0, wall_feature_idx] == 1, "Expected wall to left of agent 0"
+    assert not obs[0, 2, 1, :].any(), "Expected empty space below agent 0"
+    assert not obs[0, 1, 2, :].any(), "Expected empty space to right of agent 0"
+
+
+class TestSetBuffers:
+    def test_set_buffers_wrong_shape(self):
+        env = create_minimal_mettagrid_env()
+        num_features = len(env.grid_features())
+        terminals = np.zeros(NUM_AGENTS, dtype=bool)
+        truncations = np.zeros(NUM_AGENTS, dtype=bool)
+        rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
+
+        # Wrong number of agents
+        observations = np.zeros((3, OBS_HEIGHT, OBS_WIDTH, num_features), dtype=np.uint8)
+        with pytest.raises(RuntimeError, match="observations"):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+        # Wrong observation height
+        observations = np.zeros((NUM_AGENTS, OBS_HEIGHT + 1, OBS_WIDTH, num_features), dtype=np.uint8)
+        with pytest.raises(RuntimeError, match="observations"):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+        # Wrong observation width
+        observations = np.zeros((NUM_AGENTS, OBS_HEIGHT, OBS_WIDTH - 1, num_features), dtype=np.uint8)
+        with pytest.raises(RuntimeError, match="observations"):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+        # Wrong number of features
+        observations = np.zeros((NUM_AGENTS, OBS_HEIGHT, OBS_WIDTH, num_features + 1), dtype=np.uint8)
+        with pytest.raises(RuntimeError, match="observations"):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+    def test_set_buffers_wrong_dtype(self):
+        env = create_minimal_mettagrid_env()
+        num_features = len(env.grid_features())
+        observations = np.zeros((NUM_AGENTS, OBS_HEIGHT, OBS_WIDTH, num_features), dtype=np.float32)
+        terminals = np.zeros(NUM_AGENTS, dtype=bool)
+        truncations = np.zeros(NUM_AGENTS, dtype=bool)
+        rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
+
+        with pytest.raises(TypeError):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+    def test_set_buffers_non_contiguous(self):
+        env = create_minimal_mettagrid_env()
+        num_features = len(env.grid_features())
+        observations = np.asfortranarray(np.zeros((NUM_AGENTS, OBS_HEIGHT, OBS_WIDTH, num_features), dtype=np.uint8))
+        terminals = np.zeros(NUM_AGENTS, dtype=bool)
+        truncations = np.zeros(NUM_AGENTS, dtype=bool)
+        rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
+
+        with pytest.raises(RuntimeError, match="observations has the wrong stride"):
+            env.set_buffers(observations, terminals, truncations, rewards)
+
+    def test_set_buffers_happy_path(self):
+        env = create_minimal_mettagrid_env()
+        num_features = len(env.grid_features())
+        observations = np.zeros((NUM_AGENTS, OBS_HEIGHT, OBS_WIDTH, num_features), dtype=np.uint8)
+        terminals = np.zeros(NUM_AGENTS, dtype=bool)
+        truncations = np.zeros(NUM_AGENTS, dtype=bool)
+        rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
+
+        env.set_buffers(observations, terminals, truncations, rewards)
+        observations_from_env, info = env.reset()
+        np.testing.assert_array_equal(observations_from_env, observations)


### PR DESCRIPTION
This adds shape and size checks for the buffers that mettagrid uses. This makes sure the shapes match what we expect, and defends against some continuity issues around fortran-vs-c sizes.

This also corrects the default buffers we set to match the shape we expect, which may solve some viewer-like bugs.

Tested by running existing tests, smoke testing training locally, and added unit tests.