### PR TITLE
Add a basic python test for mettagrid

### DIFF
--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -379,13 +379,17 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<ObsType>> observa
     auto observation_info = _observations.request();
     auto shape = observation_info.shape;
     auto strides = observation_info.strides;
-    if (observation_info.ndim != 4 || shape[0] != num_agents || shape[1] != _obs_height || shape[2] != _obs_width || shape[3] != _grid_features.size()) {
+    if (observation_info.ndim != 4 || shape[0] != num_agents || shape[1] != _obs_height || shape[2] != _obs_width ||
+        shape[3] != _grid_features.size()) {
       std::stringstream ss;
-      ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << ", " << shape[3] << "] but expected ["
-         << num_agents << ", " << _obs_height << ", " << _obs_width << ", " << _grid_features.size() << "]";
+      ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << ", " << shape[3]
+         << "] but expected [" << num_agents << ", " << _obs_height << ", " << _obs_width << ", "
+         << _grid_features.size() << "]";
       throw std::runtime_error(ss.str());
     }
-    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) || strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) || strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
+    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) ||
+        strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) ||
+        strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
       // This suggests that the data size is wrong, or the data is otherwise not contiguous.
       throw std::runtime_error("observations has the wrong stride");
     }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -365,7 +365,7 @@ py::tuple MettaGrid::reset() {
   return py::make_tuple(_observations, py::dict());
 }
 
-void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> observations,
+void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<ObsType>> observations,
                             std::reference_wrapper<py::array_t<bool>> terminals,
                             std::reference_wrapper<py::array_t<bool>> truncations,
                             std::reference_wrapper<py::array_t<float>> rewards) {
@@ -385,7 +385,7 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> o
          << num_agents << ", " << _obs_height << ", " << _obs_width << ", " << _grid_features.size() << "]";
       throw std::runtime_error(ss.str());
     }
-    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(unsigned char)) {
+    if (strides[0] != _obs_height * _obs_width * _grid_features.size() * sizeof(ObsType) || strides[1] != _obs_width * _grid_features.size() * sizeof(ObsType) || strides[2] != _grid_features.size() * sizeof(ObsType) || strides[3] != sizeof(ObsType)) {
       // This suggests that the data size is wrong, or the data is otherwise not contiguous.
       throw std::runtime_error("observations has the wrong stride");
     }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -369,6 +369,18 @@ void MettaGrid::set_buffers(std::reference_wrapper<py::array_t<unsigned char>> o
                             std::reference_wrapper<py::array_t<bool>> terminals,
                             std::reference_wrapper<py::array_t<bool>> truncations,
                             std::reference_wrapper<py::array_t<float>> rewards) {
+  if (!observations.flags() & py::array::c_style) {
+    throw std::runtime_error("Observations array must be C-contiguous");
+  }
+  if (!terminals.flags() & py::array::c_style) {
+    throw std::runtime_error("Terminals array must be C-contiguous");
+  }
+  if (!truncations.flags() & py::array::c_style) {
+    throw std::runtime_error("Truncations array must be C-contiguous");
+  }
+  if (!rewards.flags() & py::array::c_style) {
+    throw std::runtime_error("Rewards array must be C-contiguous");
+  }
   _observations = observations;
   _terminals = terminals;
   _truncations = truncations;

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -84,6 +84,8 @@ private:
   // probably move ownership here.
   std::vector<Agent*> _agents;
 
+  // We'd prefer to store these as more raw c-style arrays, but we need to both
+  // operate on the memory directly and return them to python.
   py::array_t<unsigned char> _observations;
   py::array_t<bool> _terminals;
   py::array_t<bool> _truncations;

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -33,6 +33,7 @@ public:
                    std::reference_wrapper<py::array_t<bool>> terminals,
                    std::reference_wrapper<py::array_t<bool>> truncations,
                    std::reference_wrapper<py::array_t<float>> rewards);
+  void validate_buffers();
   py::dict grid_objects();
   py::list action_names();
   unsigned int current_timestep();

--- a/tests/test_mettagrid.py
+++ b/tests/test_mettagrid.py
@@ -77,7 +77,7 @@ def test_observation():
     print(obs)
     # Agent 0 starts at (1,1) and should see walls above and to the left
     # for now we treat the walls as "something non-empty"
-    assert obs[0, :, 0, 1].any(), "Expected wall above agent 0"
-    assert obs[0, :, 1, 0].any(), "Expected wall to left of agent 0"
-    assert not obs[0, :, 2, 1].any(), "Expected empty space below agent 0"
-    assert not obs[0, :, 1, 2].any(), "Expected empty space to right of agent 0"
+    assert obs[0, 0, 1, :].any(), "Expected wall above agent 0"
+    assert obs[0, 1, 0, :].any(), "Expected wall to left of agent 0"
+    assert not obs[0, 2, 1, :].any(), "Expected empty space below agent 0"
+    assert not obs[0, 1, 2, :].any(), "Expected empty space to right of agent 0"

--- a/tests/test_mettagrid.py
+++ b/tests/test_mettagrid.py
@@ -73,11 +73,11 @@ def test_truncation_at_max_steps():
 
 def test_observation():
     env = create_minimal_mettagrid_env()
+    wall_feature_idx = env.grid_features().index("wall")
     obs, info = env.reset()
-    print(obs)
     # Agent 0 starts at (1,1) and should see walls above and to the left
     # for now we treat the walls as "something non-empty"
-    assert obs[0, 0, 1, :].any(), "Expected wall above agent 0"
-    assert obs[0, 1, 0, :].any(), "Expected wall to left of agent 0"
+    assert obs[0, 0, 1, wall_feature_idx] == 1, "Expected wall above agent 0"
+    assert obs[0, 1, 0, wall_feature_idx] == 1, "Expected wall to left of agent 0"
     assert not obs[0, 2, 1, :].any(), "Expected empty space below agent 0"
     assert not obs[0, 1, 2, :].any(), "Expected empty space to right of agent 0"

--- a/tests/test_mettagrid.py
+++ b/tests/test_mettagrid.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from mettagrid.mettagrid_c import MettaGrid  # pylint: disable=E0611
+
+
+def create_minimal_mettagrid_env(max_steps=10, width=5, height=5):
+    """Helper function to create a MettaGrid environment with minimal config."""
+    # Define a simple map: all empty except for one agent
+    game_map = np.full((height, width), "empty", dtype="<U50")
+
+    # Place first agent in upper left
+    game_map[1, 1] = "agent.red"
+
+    # Place second agent in middle
+    mid_y = height // 2
+    mid_x = width // 2
+    game_map[mid_y, mid_x] = "agent.red"
+
+    env_config = {
+        "game": {
+            "max_steps": max_steps,
+            "num_agents": 2,
+            "obs_width": 3,
+            "obs_height": 3,
+            "actions": {
+                # don't really care about the actions for this test
+                "noop": {"enabled": True},
+                "move": {"enabled": True},
+                "rotate": {"enabled": True},
+                "attack": {"enabled": False},
+                "put_items": {"enabled": False},
+                "get_items": {"enabled": False},
+                "swap": {"enabled": False},
+                "change_color": {"enabled": False},
+            },
+            "groups": {"red": {"id": 0, "props": {}}},
+            "objects": {
+                "wall": {"type_id": 1, "hp": 100},
+                "block": {"type_id": 2, "hp": 100},
+            },
+            "agent": {
+                "inventory_size": 0,
+            },
+        }
+    }
+
+    return MettaGrid(env_config, game_map)
+
+
+def test_truncation_at_max_steps():
+    max_steps = 5
+    env = create_minimal_mettagrid_env(max_steps=max_steps)
+    obs, info = env.reset()
+
+    # Noop until time runs out
+    noop_action_idx = env.action_names().index("noop")
+    actions = np.full((2, 2), [noop_action_idx, 0], dtype=np.int64)
+
+    for step_num in range(1, max_steps + 1):
+        obs, rewards, terminals, truncations, info = env.step(actions)
+        if step_num < max_steps:
+            assert not np.any(truncations), f"Truncations should be False before max_steps at step {step_num}"
+            assert not np.any(terminals), f"Terminals should be False before max_steps at step {step_num}"
+        else:
+            assert np.all(truncations), f"Truncations should be True at max_steps (step {step_num})"
+            # As per current C++ code, terminals are not explicitly set true on truncation.
+            assert not np.any(terminals), f"Terminals should remain False at max_steps (step {step_num})"

--- a/tests/test_mettagrid.py
+++ b/tests/test_mettagrid.py
@@ -5,8 +5,12 @@ from mettagrid.mettagrid_c import MettaGrid  # pylint: disable=E0611
 
 def create_minimal_mettagrid_env(max_steps=10, width=5, height=5):
     """Helper function to create a MettaGrid environment with minimal config."""
-    # Define a simple map: all empty except for one agent
+    # Define a simple map: empty with walls around perimeter
     game_map = np.full((height, width), "empty", dtype="<U50")
+    game_map[0, :] = "wall"
+    game_map[-1, :] = "wall"
+    game_map[:, 0] = "wall"
+    game_map[:, -1] = "wall"
 
     # Place first agent in upper left
     game_map[1, 1] = "agent.red"
@@ -65,3 +69,15 @@ def test_truncation_at_max_steps():
             assert np.all(truncations), f"Truncations should be True at max_steps (step {step_num})"
             # As per current C++ code, terminals are not explicitly set true on truncation.
             assert not np.any(terminals), f"Terminals should remain False at max_steps (step {step_num})"
+
+
+def test_observation():
+    env = create_minimal_mettagrid_env()
+    obs, info = env.reset()
+    print(obs)
+    # Agent 0 starts at (1,1) and should see walls above and to the left
+    # for now we treat the walls as "something non-empty"
+    assert obs[0, :, 0, 1].any(), "Expected wall above agent 0"
+    assert obs[0, :, 1, 0].any(), "Expected wall to left of agent 0"
+    assert not obs[0, :, 2, 1].any(), "Expected empty space below agent 0"
+    assert not obs[0, :, 1, 2].any(), "Expected empty space to right of agent 0"


### PR DESCRIPTION
I had initially expected to write these in cpp, but they required numpy arrays. I tried to factor parts out to just use the underlying data directly, so we could have more pieces that didn't interface with Python, but since we need to be able to return the numpy arrays, we couldn't throw them away entirely.

I ended up deciding the Python tests seem totally reasonable for this, so here we are. We may want to add ones at the cpp level as well, if we better separate mettagrid into a python-facing class, and a non-python-facing class, but it's not clear there's an immediate benefit, since Python tests seem like better mini-integration tests.