### PR TITLE
hotfix: resolver registration in multiprocessor VecEnv runs

### DIFF
--- a/metta/sim/vecenv.py
+++ b/metta/sim/vecenv.py
@@ -6,6 +6,7 @@ import pufferlib
 import pufferlib.vector
 from omegaconf import DictConfig, ListConfig
 
+from metta.util.resolvers import register_resolvers
 from mettagrid.replay_writer import ReplayWriter
 from mettagrid.stats_writer import StatsWriter
 
@@ -20,6 +21,9 @@ def make_env_func(
     replay_writer: Optional[ReplayWriter] = None,
     **kwargs,
 ):
+    # we are not calling into our configs hierarchy here so we need to manually register the custom resolvers
+    register_resolvers()
+
     # Create the environment instance
     env = hydra.utils.instantiate(
         cfg, cfg, render_mode=render_mode, buf=buf, stats_writer=stats_writer, replay_writer=replay_writer, **kwargs

--- a/metta/util/resolvers.py
+++ b/metta/util/resolvers.py
@@ -271,15 +271,18 @@ class ResolverRegistrar(Callback):
 
     def __init__(self):
         self.logger = setup_mettagrid_logger("ResolverRegistrar")
+        self.resolver_count = 0
         """Prepare for registration but don't register yet."""
 
     def on_run_start(self, config: DictConfig, **kwargs: Any) -> None:
         """Register resolvers at the start of a run."""
         self.register_resolvers()
+        self.logger.info(f"Registered {self.resolver_count} custom resolvers at the start of a run")
 
     def on_multirun_start(self, config: DictConfig, **kwargs: Any) -> None:
         """Register resolvers at the start of a multirun."""
         self.register_resolvers()
+        self.logger.info(f"Registered {self.resolver_count} custom resolvers at the start of a multirun")
 
     def on_job_start(self, config: DictConfig, **kwargs: Any) -> None:
         """Ensure resolvers are registered for each job."""
@@ -293,57 +296,54 @@ class ResolverRegistrar(Callback):
         configs/common.yaml, ensuring all resolvers are available before
         config interpolation happens.
         """
-        resolver_count = 0
 
         # Register all your resolvers
         OmegaConf.register_new_resolver("if", oc_if, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("uniform", oc_uniform, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("choose", oc_choose, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("div", oc_divide, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("subtract", oc_subtract, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("sub", oc_subtract, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("multiply", oc_multiply, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("mul", oc_multiply, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("add", oc_add, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("make_odd", oc_to_odd_min3, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("clamp", oc_clamp, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("make_integer", oc_make_integer, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("int", oc_make_integer, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("equals", oc_equals, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("eq", oc_equals, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("sampling", oc_scaled_range, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("gt", oc_greater_than, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("lt", oc_less_than, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("gte", oc_greater_than_or_equal, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("lte", oc_less_than_or_equal, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("scale", oc_scale, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("iir", oc_iir, replace=True)
-        resolver_count += 1
+        self.resolver_count += 1
         OmegaConf.register_new_resolver("now", oc_date_format, replace=True)
-        resolver_count += 1
-
-        self.logger.info(f"Registered {resolver_count} custom resolvers")
+        self.resolver_count += 1
         return self
 
 


### PR DESCRIPTION
Fix resolver registration in multiprocessor VecEnv runs

PR #478 passed tests but didn't properly register resolvers when running in multiprocessor vector environment mode, resulting in "can't find resolver" errors.

## Solution
- Added explicit resolver registration in the `make_env_func` before instantiating environments
- This ensures Hydra resolvers are properly registered in multiprocessor contexts where configs may not be loaded in the expected order

## Notes
- We should run CI on GPUs and multicore setups in CI to catch similar issues
- The current approach of relying on configs/common.yaml to register resolvers may be too implicit
- Alternative solutions could include:
  - Explicitly registering resolvers before any Hydra instantiate calls
  - Using Hydra callbacks (not available in Hydra core at the time of implementation)
  
  (I also adjusted the logging to avoid spamming the logs when we create a large number of vecenvs)

