### PR TITLE
update skypilot patch to fix yaml serialization issue

### DIFF
--- a/devops/tf/eks/skypilot/skypilot-chart/files/ecr.patch
+++ b/devops/tf/eks/skypilot/skypilot-chart/files/ecr.patch
@@ -1,7 +1,8 @@
---- sky/provision/docker_utils.py.orig	2025-05-13 17:47:35
-+++ sky/provision/docker_utils.py 17:47:33
+diff -ur sky/provision/docker_utils.py sky-patched/provision/docker_utils.py
+--- sky/provision/docker_utils.py	2025-05-15 13:21:57
++++ sky-patched/provision/docker_utils.py	2025-05-15 13:21:09
 @@ -49,6 +49,23 @@
-
+ 
      @classmethod
      def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
 +        server = d[constants.DOCKER_SERVER_ENV_VAR]
@@ -24,3 +25,16 @@
          return cls(
              username=d[constants.DOCKER_USERNAME_ENV_VAR],
              password=d[constants.DOCKER_PASSWORD_ENV_VAR],
+diff -ur sky/resources.py sky-patched/resources.py
+--- sky/resources.py	2025-05-15 13:21:12
++++ sky-patched/resources.py	2025-05-15 13:21:10
+@@ -1574,9 +1574,6 @@
+             config['disk_tier'] = self.disk_tier.value
+         add_if_not_none('ports', self.ports)
+         add_if_not_none('labels', self.labels)
+-        if self._docker_login_config is not None:
+-            config['_docker_login_config'] = dataclasses.asdict(
+-                self._docker_login_config)
+         if self._docker_username_for_runpod is not None:
+             config['_docker_username_for_runpod'] = (
+                 self._docker_username_for_runpod)

--- a/devops/tf/eks/skypilot/skypilot-chart/templates/api-deployment.yaml
+++ b/devops/tf/eks/skypilot/skypilot-chart/templates/api-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           cat << 'PATCH' > /tmp/ecr.patch
 {{ .Files.Get "files/ecr.patch" | indent 10 }}
           PATCH
-          patch /opt/conda/lib/python3.10/site-packages/sky/provision/docker_utils.py /tmp/ecr.patch
+          patch -p0 -d /opt/conda/lib/python3.10/site-packages </tmp/ecr.patch
 
           {{- if .Values.apiService.preDeployHook }}
           {{ .Values.apiService.preDeployHook | nindent 10 }}


### PR DESCRIPTION
Already deployed to production.

Diffs of diffs are not very readable, compare these side by side to see what's changed:

Before:
https://github.com/Metta-AI/metta/blob/87f246978f3def94cd38303afe7dce659dad71b7/devops/tf/eks/skypilot/skypilot-chart/files/ecr.patch

After:
https://github.com/Metta-AI/metta/blob/89c43d4c3a7ba8bdb8727c45a29e1976e2db7f9d/devops/tf/eks/skypilot/skypilot-chart/files/ecr.patch

# Update ECR patch for SkyPilot

### TL;DR

Updated the ECR patch to properly handle AWS ECR authentication and fixed the patch application command.

### What changed?

- Added a diff for `resources.py` to remove Docker login config from serialization
- Updated the patch command in `api-deployment.yaml` to use `-p0 -d` flags for proper directory-based patching
