### PR TITLE
Fix broken imports due to move.

### DIFF
--- a/mettascope/replays.py
+++ b/mettascope/replays.py
@@ -58,7 +58,7 @@ def generate_replay(sim) -> dict:
 
 if __name__ == "__main__":
 
-    @hydra.main(version_base=None, config_path="../../configs", config_name="replay_job")
+    @hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
     def main(cfg):
         start = time.time()
         sim = create_simulation(cfg)

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -99,14 +99,12 @@ async def websocket_endpoint(
                     total_rewards[agent_id] += env.rewards[agent_id]
                     grid_objects[i]["total_reward"] = total_rewards[agent_id].item()
 
-            print("replay_step step=", current_step)
             await send_message(type="replay_step", replay_step={"step": current_step, "grid_objects": grid_objects})
 
             current_step += 1
 
         if current_step > 1:
             message = await websocket.receive_json()
-            print("message", message)
             if message["type"] == "action":
                 action_message = message
             # yield control to other coroutines

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -113,7 +113,7 @@ async def websocket_endpoint(
     sim.end_simulation()
 
 
-@hydra.main(version_base=None, config_path="../../configs", config_name="replay_job")
+@hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
 def main(cfg):
     app.cfg = cfg
 

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from omegaconf import DictConfig
 
-import mettagrid.player.replays as replays
+import mettascope.replays as replays
 
 
 class App(FastAPI):

--- a/tools/play.py
+++ b/tools/play.py
@@ -4,7 +4,7 @@ import webbrowser
 import hydra
 import uvicorn
 
-import mettagrid.player.server as server
+import mettascope.server as server
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="replay_job")


### PR DESCRIPTION
# Fix broken imports due to move

- Updated imports from `mettagrid.player.replays` to `mettascope.replays`
- Updated imports from `mettagrid.player.server` to `mettascope.server`
- Removed debug print statements