### PR TITLE
change default aws profile for cmd

### DIFF
--- a/devops/aws/batch/launch_cmd.py
+++ b/devops/aws/batch/launch_cmd.py
@@ -60,7 +60,7 @@ def main():
         parser.add_argument("--cpu-ram-gb", type=int, default=20, help="RAM per node in GB.")
         parser.add_argument("--copies", type=int, default=1, help="Number of job copies to submit.")
         parser.add_argument(
-            "--profile", default="stem", help="AWS profile to use. If not specified, uses the default profile."
+            "--profile", default="softmax-db", help="AWS profile to use. If not specified, uses the default profile."
         )
         parser.add_argument("--job-queue", default="metta-jq", help="AWS Batch job queue to use.")
         parser.add_argument("--skip-push-check", action="store_true", help="Skip checking if commits have been pushed.")

--- a/devops/aws/batch/launch_task.py
+++ b/devops/aws/batch/launch_task.py
@@ -258,7 +258,7 @@ def main():
     parser.add_argument("--gpu-cpus", type=int)
     parser.add_argument("--node-ram-gb", type=int)
     parser.add_argument("--copies", type=int, default=1)
-    parser.add_argument("--profile", default="stem")
+    parser.add_argument("--profile", default="softmax-db")
     parser.add_argument("--job-queue", default="metta-jq")
     parser.add_argument("--skip-push-check", action="store_true")
     parser.add_argument("--no-color", action="store_true")


### PR DESCRIPTION
Switched the default from "stem" to "softmax-db". Presumably we'll be moving off of this entirely in the short term, but this should improve things for new folks.

Testing:
Cleared `~/.aws`
Ran `devops/aws/setup_aws_profiles.sh`
Ran `devops/aws/cmd.sh launch --run sasmith.20250515.3 --cmd train`

Saw no crashing