### PR TITLE
fix: drop high variance benchmark

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.py
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.py
@@ -47,22 +47,3 @@ def test_step_performance(benchmark, environment, single_action):
         rounds=10,  # Number of rounds to run
         warmup_rounds=0,  # Number of warmup rounds to discard
     )
-
-
-def test_get_stats_performance(benchmark, environment, single_action):
-    """Benchmark just the get_episode_stats method performance."""
-
-    np.random.seed(42)
-
-    # First perform some steps to have meaningful stats
-    for _ in range(10):
-        obs, rewards, terminated, truncated, infos = environment.step(single_action)
-        if np.any(terminated) or np.any(truncated):
-            environment.reset()
-
-    benchmark.pedantic(
-        environment._c_env.get_episode_stats,
-        iterations=500,  # Number of iterations per round
-        rounds=3,  # Number of rounds to run
-        warmup_rounds=0,  # Number of warmup rounds to discard
-    )


### PR DESCRIPTION

This PR removes the `test_get_stats_performance` benchmark from our test suite. This benchmark has been consistently flagged by bencher as failing due to its high variance between runs, creating noise in our CI pipeline without providing meaningful performance insights.

### Why
- The benchmark frequently reports false positives/negatives due to high variance
- This test doesn't measure critical performance paths in our codebase
- Removing it will make our CI more reliable and reduce noise in performance reports

### Impact
- More reliable CI pipeline
- Reduced false alarms in performance regression detection
- No negative impact on our ability to catch real performance regressions

This change is part of our effort to focus our benchmarking on stable, meaningful metrics that provide actionable insights.