### PR TITLE
Make buffer checking cleaner

### DIFF
--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -29,10 +29,10 @@ public:
   // Python API methods
   py::tuple reset();
   py::tuple step(py::array_t<int> actions);
-  void set_buffers(py::array_t<unsigned char>& observations,
-                   py::array_t<bool>& terminals,
-                   py::array_t<bool>& truncations,
-                   py::array_t<float>& rewards);
+  void set_buffers(py::array_t<unsigned char, py::array::c_style>& observations,
+                   py::array_t<bool, py::array::c_style>& terminals,
+                   py::array_t<bool, py::array::c_style>& truncations,
+                   py::array_t<float, py::array::c_style>& rewards);
   void validate_buffers();
   py::dict grid_objects();
   py::list action_names();

--- a/tests/mettagrid/mettagrid/test_mettagrid.py
+++ b/tests/mettagrid/mettagrid/test_mettagrid.py
@@ -135,7 +135,7 @@ class TestSetBuffers:
         truncations = np.zeros(NUM_AGENTS, dtype=bool)
         rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
 
-        with pytest.raises(RuntimeError, match="observations has the wrong stride"):
+        with pytest.raises(TypeError):
             env.set_buffers(observations, terminals, truncations, rewards)
 
     def test_set_buffers_happy_path(self):


### PR DESCRIPTION
Using py::array::c_style, we can move some of the type checking of buffers to be pybind's responsibility. This lets us clean up validate_buffers.

Tested via existing unit tests.