### PR TITLE
Add installation step for Mettascope in setup_build.sh

### DIFF
--- a/devops/sandbox/Brewfile
+++ b/devops/sandbox/Brewfile
@@ -12,6 +12,7 @@ cask "session-manager-plugin"
 brew "withgraphite/tap/graphite"
 brew "spacelift-io/spacelift/spacectl"
 brew "uv"
+brew "npm"
 
 # Applications
 cask "cursor"

--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -191,3 +191,6 @@ if [ -z "$CI" ] && [ -z "$IS_DOCKER" ]; then
   source "$SCRIPT_DIR/sandbox/setup_vscode_workspace.sh"
   echo "✅ setup_build.sh completed successfully!"
 fi
+
+# ========== INSTALL METTASCOPE ==========
+bash "mettascope/install.sh"

--- a/mettascope/install.sh
+++ b/mettascope/install.sh
@@ -7,8 +7,8 @@ set -e
 
 # Install dependencies
 cd mettascope
-npm install -g typescript
-npm install
+npm install --force -g typescript
+npm install --force
 tsc
 
 # Generate atlas

--- a/mettascope/install.sh
+++ b/mettascope/install.sh
@@ -5,9 +5,6 @@
 # Fail on errors:
 set -e
 
-# Install npm
-brew install npm
-
 # Install dependencies
 cd mettascope
 npm install -g typescript

--- a/mettascope/install.sh
+++ b/mettascope/install.sh
@@ -10,6 +10,7 @@ brew install npm
 
 # Install dependencies
 cd mettascope
+npm install -g typescript
 npm install
 tsc
 

--- a/mettascope/install.sh
+++ b/mettascope/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script installs MettaScope dependencies.
+
+# Fail on errors:
+set -e
+
+# Install npm
+brew install npm
+
+# Install dependencies
+cd mettascope
+npm install
+tsc
+
+# Generate atlas
+python tools/gen_atlas.py


### PR DESCRIPTION
This commit introduces a new step in the setup_build.sh script to install Mettascope by executing the install.sh script located in the mettascope directory.