### PR TITLE
hotfix: don't install mettascope on CI or Docker

### DIFF
--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -192,5 +192,7 @@ if [ -z "$CI" ] && [ -z "$IS_DOCKER" ]; then
   echo "✅ setup_build.sh completed successfully!"
 fi
 
-# ========== INSTALL METTASCOPE ==========
-bash "mettascope/install.sh"
+if [ -z "$CI" ] && [ -z "$IS_DOCKER" ]; then
+  # ========== INSTALL METTASCOPE ==========
+  bash "mettascope/install.sh"
+fi


### PR DESCRIPTION

AWS runs are failing:

```
2025-05-16T02:03:01.250Z
mettascope/install.sh: line 10: npm: command not found
```