### PR TITLE
eval smoke test

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -316,7 +316,7 @@ jobs:
       - name: Run evals smoke test
         id: eval_smoke_test
         env:
-          WANDB_API_KEY: WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           AWS_ACCESS_KEY_ID: set_but_not_used
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -316,7 +316,7 @@ jobs:
       - name: Run evals smoke test
         id: eval_smoke_test
         env:
-          WANDB_API_KEY: set_but_not_used
+          WANDB_API_KEY: WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           AWS_ACCESS_KEY_ID: set_but_not_used
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         run: |

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -190,7 +190,7 @@ jobs:
           uv run --no-project pytest --maxfail=1 --disable-warnings -q
 
   smoke-test:
-    name: "Training Smoke Test"
+    name: "Smoke Tests"
     needs: [graphite-ci-optimizer, setup-checks, setup-py]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false')
@@ -310,6 +310,35 @@ jobs:
           name: replay-benchmark-results
           path: |
             smoke_test_replay_benchmark_results.json
+          retention-days: 1
+          if-no-files-found: warn
+
+      - name: Run evals smoke test
+        id: eval_smoke_test
+        env:
+          WANDB_API_KEY: set_but_not_used
+          AWS_ACCESS_KEY_ID: set_but_not_used
+          AWS_SECRET_ACCESS_KEY: set_but_not_used
+        run: |
+          source .github/scripts/benchmark.sh
+          benchmark "evals" "./run_evals.sh smoke_test"
+
+      - name: Save evals benchmark
+        id: save_evals_benchmark
+        if: steps.eval_smoke_test.outcome == 'success'
+        uses: ./.github/actions/save-benchmarks
+        with:
+          name: evals_smoke_test
+          metrics: '{"duration": ${{ steps.eval_smoke_test.outputs.duration }}, "memory_usage": ${{ steps.eval_smoke_test.outputs.memory_usage }}}'
+          filename: smoke_test_evals_benchmark_results.json
+
+      - name: Upload evals benchmark file
+        if: steps.save_evals_benchmark.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: evals-benchmark-results
+          path: |
+            smoke_test_evals_benchmark_results.json
           retention-days: 1
           if-no-files-found: warn
 

--- a/run_basicobjectuse_evals.sh
+++ b/run_basicobjectuse_evals.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Define the list of policy URIs
 POLICIES=(
   "b.daveey.t.8.rdr9.3"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -35,13 +35,6 @@ for i in "${!POLICIES[@]}"; do
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/navigation_db \
     $MAYBE_SMOKE_TEST
-  
-  python3 -m tools.sim \
-    sim=memory \
-    run=memory$IDX \
-    policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/memory_db \
-    $MAYBE_SMOKE_TEST
 
   if [ -n "$MAYBE_SMOKE_TEST" ]; then
     continue
@@ -54,6 +47,13 @@ for i in "${!POLICIES[@]}"; do
     run=multiagent$IDX \
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/multiagent_db \
+    $MAYBE_SMOKE_TEST
+
+    python3 -m tools.sim \
+    sim=memory \
+    run=memory$IDX \
+    policy_uri=wandb://run/$POLICY_URI \
+    +eval_db_uri=wandb://artifacts/memory_db \
     $MAYBE_SMOKE_TEST
 
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -5,13 +5,13 @@ POLICIES=(
   "b.daphne.navigation0"
 )
 MESSAGE="Running full sequence eval"
-POLICY_LIMIT_ARG="" # no limit
+MAYBE_SMOKETEST=""
 
 if [ "$1" = "smoketest" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0")
-  POLICY_LIMIT_ARG="+sim_job.simulation_limit=1"
+  MAYBE_SMOKETEST="+sim_job.maybe_smoketest=True"
   MESSAGE="Running smoketest eval"
 fi
 
@@ -26,19 +26,19 @@ for i in "${!POLICIES[@]}"; do
     run=navigation$IDX \
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/navigation_db \
-    $POLICY_LIMIT_ARG
+    $MAYBE_SMOKETEST
 
   python3 -m tools.sim \
     sim=multiagent \
     run=multiagent$IDX \
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/multiagent_db \
-    $POLICY_LIMIT_ARG
+    $MAYBE_SMOKETEST
 
   python3 -m tools.sim \
     sim=memory \
     run=memory$IDX \
     policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/memory_db
-    $POLICY_LIMIT_ARG
+    +eval_db_uri=wandb://artifacts/memory_db \
+    $MAYBE_SMOKETEST
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -11,7 +11,7 @@ if [ "$1" = "smoke_test" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0:v12")
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 +seed=31415926535"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -51,7 +51,7 @@ if [ "$1" = "smoke_test" ]; then
   #   ... because you're adding a new eval family on which we can't score well, please add the new eval
   #       family after the smoke test terminates.
   POLICIES=("b.daphne.navigation0:v12")
-  # Use a fixed seed to tests are deterministic. It's okay to change this seed if you have
+  # Use a fixed seed so tests are deterministic. It's okay to change this seed if you have
   # a reason -- we just don't want tests to fail spuriously.
   MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415"
   MESSAGE="Running smoke test eval"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -28,17 +28,4 @@ for i in "${!POLICIES[@]}"; do
     +eval_db_uri=wandb://artifacts/navigation_db \
     $MAYBE_SMOKETEST
 
-  python3 -m tools.sim \
-    sim=multiagent \
-    run=multiagent$IDX \
-    policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/multiagent_db \
-    $MAYBE_SMOKETEST
-
-  python3 -m tools.sim \
-    sim=memory \
-    run=memory$IDX \
-    policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/memory_db \
-    $MAYBE_SMOKETEST
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -51,6 +51,8 @@ if [ "$1" = "smoke_test" ]; then
   #   ... because you're adding a new eval family on which we can't score well, please add the new eval
   #       family after the smoke test terminates.
   POLICIES=("b.daphne.navigation0:v12")
+  # Use a fixed seed to tests are deterministic. It's okay to change this seed if you have
+  # a reason -- we just don't want tests to fail spuriously.
   MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -1,31 +1,16 @@
 #!/bin/bash
 
-# Define the list of policy URIs
+# Define the list of policy URIs to evaluate on a normal run.
 POLICIES=(
-  "b.daphne.terrain_prioritized_styles_pretrained_r"
-  "b.daphne.terrain_prioritized_styles2"
-  "terrain_prioritized_styles_pretrained_mpmc"
-  "terrain_prioritized_styles_pretrained"
-  "b.terrain_prioritized_styles_nb"
-  "b.terrain_prioritized_styles_pretrained_nb"
-  "b.terrain_prioritized_styles"
-  "b.terrain_prioritized_styles_pretrained"
-  "b.georgedeane.terrain_multienv"
-  "b.daphne.terrain_multienv_3_no_blocks3"
-  "terrain_multienv_3_single_agent"
-  "b.daphne.terrain_multienv_prioritized_multienv_cylinders2"
-  "b.daphne.terrain_multienv_prioritized_multienv_cylinders"
-  "b.georgedeane.terrain_massive_empty_world_pretrained"
-  "b.georgedeane.terrain_extra_hard:v1"
-  "b.daphne.terrain_varied_cyl_lab_pretrained"
-  "b.daphne.terrain_prioritized_styles"
-  "b.daphne.terrain_prioritized_styles_pretrained"
-  "george_memory_pretrained"
-  "b.daphne.terrain_multiagent_48_norewardsharing"
-  "b.daphne.terrain_multiagent_24_norewardsharing"
-  "b.daphne.terrain_multiagent_24_rewardsharing"
-  "b.daphne.terrain_multiagent_48_rewardsharing"
+  "b.daphne.navigation0"
 )
+
+if [ "$1" = "smoketest" ]; then
+  # This should be a policy that gets a known score, so we can check
+  # that the eval is working.
+  POLICIES=("b.daphne.navigation0")
+  POLICY_LIMIT_ARG="+sim_job.simulation_limit=1"
+fi
 
 for i in "${!POLICIES[@]}"; do
   POLICY_URI=${POLICIES[$i]}
@@ -37,17 +22,20 @@ for i in "${!POLICIES[@]}"; do
     sim=navigation \
     run=navigation$IDX \
     policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/navigation_db
+    +eval_db_uri=wandb://artifacts/navigation_db \
+    $POLICY_LIMIT_ARG
 
   python3 -m tools.sim \
     sim=multiagent \
     run=multiagent$IDX \
     policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/multiagent_db
+    +eval_db_uri=wandb://artifacts/multiagent_db \
+    $POLICY_LIMIT_ARG
 
   python3 -m tools.sim \
     sim=memory \
     run=memory$IDX \
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/memory_db
+    $POLICY_LIMIT_ARG
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -4,18 +4,21 @@
 POLICIES=(
   "b.daphne.navigation0"
 )
+MESSAGE="Running full sequence eval"
+POLICY_LIMIT_ARG="" # no limit
 
 if [ "$1" = "smoketest" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0")
   POLICY_LIMIT_ARG="+sim_job.simulation_limit=1"
+  MESSAGE="Running smoketest eval"
 fi
 
 for i in "${!POLICIES[@]}"; do
   POLICY_URI=${POLICIES[$i]}
 
-  echo "Running full sequence eval for policy $POLICY_URI"
+  echo "$MESSAGE for policy $POLICY_URI"
   RANDOM_NUM=$((RANDOM % 1000))
   IDX="${IDX}_${RANDOM_NUM}"
   python3 -m tools.sim \

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -55,7 +55,9 @@ if [ "$1" = "smoke_test" ]; then
   POLICIES=("b.daphne.navigation0:v12")
   # Use a fixed seed so tests are deterministic. It's okay to change this seed if you have
   # a reason -- we just don't want tests to fail spuriously.
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415"
+  # Use device=cpu since we're probably on github. We should probably address this via
+  # hardware=..., but for the most part this shouldn't matter for eval.
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415 device=cpu"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -11,7 +11,7 @@ if [ "$1" = "smoke_test" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0:v12")
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 seed=31415926535"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 seed=31415"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -8,10 +8,15 @@ MESSAGE="Running full sequence eval"
 MAYBE_SMOKE_TEST=""
 
 if [ "$1" = "smoke_test" ]; then
-  # This should be a policy that gets a known score, so we can check
-  # that the eval is working.
+  # If you're updating this smoke test:
+  #   ... because you changed code in a way that invalidates old policies, please train a new policy
+  #       that scores well enough on existing evals, and add it here.
+  #   ... because you're adding a new eval family on which we can score well, please add a new policy
+  #       that scores well on that eval family, and add it here.
+  #   ... because you're adding a new eval family on which we can't score well, please add the new eval
+  #       family after the smoke test terminates.
   POLICIES=("b.daphne.navigation0:v12")
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 seed=31415"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -2,7 +2,42 @@
 
 # Define the list of policy URIs to evaluate on a normal run.
 POLICIES=(
-  "b.daphne.navigation0"
+    "daveey.dist.2x4"
+    "navigation_training:v35"
+    "b.daphne.navigation0"
+    "daphne_navigation_train"
+    "b.daphne.navigation1"
+    "b.daphne.navigation3"
+    "b.daphne.navigation4"
+    "gd2_sharing24_03"
+    "gd2_sharing24_06"
+    "gd2_sharing_48"
+    "gd2_sharing_24"
+    "gd2_sharing48_03"
+    "gd2_sharing48_06"
+    "MRM_test_mettabox"
+    "georged_48_no_sharing"
+    "georged_24_no_sharing"
+    "dd_object_use_easy2"
+    "daphne.3object_use_no_colors"
+    "daphne.3object_use_colors"
+    "daphne.2object_use_colors_pretrained"
+    "b.daphne.USER.navigation_before_refactor"
+
+    "b.daphne.object_use_colored_converters"
+    "b.daphne.object_use_onlyred"
+    "b.daphne.object_use_colored_converters_ent0.05"
+    "b.daphne.object_use_onlyred_ent0.05"
+
+    "b.daphne.object_use_colored_converters2"
+    "b.daphne.object_use_onlyred2"
+    "b.daphne.object_use_colored_converters_ent0.052"
+    "b.daphne.object_use_onlyred_ent0.052"
+
+    "b.georgedeane.george_sequence_no_increment"
+    "b.georgedeane.george_sequence_incremental"
+    "george_sequence_incremental"
+    "george2_multienv_noincrement"
 )
 MESSAGE="Running full sequence eval"
 MAYBE_SMOKE_TEST=""
@@ -42,18 +77,20 @@ for i in "${!POLICIES[@]}"; do
   # Tests below this line aren't part of smoke tests, since we either
   # aren't scoring well enough to include them, or have some other reason.
 
-  python3 -m tools.sim \
-    sim=multiagent \
-    run=multiagent$IDX \
-    policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/multiagent_db \
-    $MAYBE_SMOKE_TEST
+  # We also don't want to upload to dashboards for these.
 
-    python3 -m tools.sim \
-    sim=memory \
-    run=memory$IDX \
-    policy_uri=wandb://run/$POLICY_URI \
-    +eval_db_uri=wandb://artifacts/memory_db \
-    $MAYBE_SMOKE_TEST
+  python3 -m tools.sim \
+      sim=memory \
+      run=memory$IDX \
+      policy_uri=wandb://run/$POLICY_URI \
+      sim_job.stats_db_uri=wandb://stats/memory_db \
+      $MAYBE_SMOKE_TEST
+
+  python3 -m tools.sim \
+      sim=object_use \
+      run=objectuse$IDX \
+      policy_uri=wandb://run/$POLICY_URI \
+      sim_job.stats_db_uri=wandb://stats/objectuse_db \
+      $MAYBE_SMOKE_TEST
 
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -11,7 +11,7 @@ if [ "$1" = "smoke_test" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0:v12")
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 +seed=31415926535"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9 seed=31415926535"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Define the list of policy URIs to evaluate on a normal run.
 POLICIES=(
     "daveey.dist.2x4"

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -10,7 +10,7 @@ MAYBE_SMOKETEST=""
 if [ "$1" = "smoketest" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
-  POLICIES=("b.daphne.navigation0")
+  POLICIES=("b.daphne.navigation0:v12")
   MAYBE_SMOKETEST="+sim_job.maybe_smoketest=True"
   MESSAGE="Running smoketest eval"
 fi

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -5,14 +5,17 @@ POLICIES=(
   "b.daphne.navigation0"
 )
 MESSAGE="Running full sequence eval"
-MAYBE_SMOKETEST=""
+MAYBE_SMOKE_TEST=""
 
-if [ "$1" = "smoketest" ]; then
+if [ "$1" = "smoke_test" ]; then
   # This should be a policy that gets a known score, so we can check
   # that the eval is working.
   POLICIES=("b.daphne.navigation0:v12")
-  MAYBE_SMOKETEST="+sim_job.maybe_smoketest=True"
-  MESSAGE="Running smoketest eval"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True +sim_job.smoke_test_min_reward=0.9"
+  MESSAGE="Running smoke test eval"
+elif [ -n "$1" ]; then
+  echo "Invalid argument: $1"
+  exit 1
 fi
 
 for i in "${!POLICIES[@]}"; do
@@ -26,6 +29,6 @@ for i in "${!POLICIES[@]}"; do
     run=navigation$IDX \
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/navigation_db \
-    $MAYBE_SMOKETEST
+    $MAYBE_SMOKE_TEST
 
 done

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -35,5 +35,25 @@ for i in "${!POLICIES[@]}"; do
     policy_uri=wandb://run/$POLICY_URI \
     +eval_db_uri=wandb://artifacts/navigation_db \
     $MAYBE_SMOKE_TEST
+  
+  python3 -m tools.sim \
+    sim=memory \
+    run=memory$IDX \
+    policy_uri=wandb://run/$POLICY_URI \
+    +eval_db_uri=wandb://artifacts/memory_db \
+    $MAYBE_SMOKE_TEST
+
+  if [ -n "$MAYBE_SMOKE_TEST" ]; then
+    continue
+  fi
+  # Tests below this line aren't part of smoke tests, since we either
+  # aren't scoring well enough to include them, or have some other reason.
+
+  python3 -m tools.sim \
+    sim=multiagent \
+    run=multiagent$IDX \
+    policy_uri=wandb://run/$POLICY_URI \
+    +eval_db_uri=wandb://artifacts/multiagent_db \
+    $MAYBE_SMOKE_TEST
 
 done

--- a/run_evals_latest.sh
+++ b/run_evals_latest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Define the list of policy URIs
 POLICIES=(
   "b.daphne.terrain_prioritized_styles_pretrained_r"

--- a/run_memory_evals.sh
+++ b/run_memory_evals.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Define the list of policy URIs
 POLICIES=(
   # "navigation_infinite_cooldown_sweep"

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -74,7 +74,7 @@ def simulate_policy(
             vectorization=cfg.vectorization,
         )
         results = sim.simulate()
-        print(results)
+        print(results.stats_db.query("SELECT * FROM episode_stats"))
         if sim_job.maybe_smoketest:
             return
         # ------------------------------------------------------------------ #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -23,7 +23,7 @@ from metta.util.config import Config
 from metta.util.logging import setup_mettagrid_logger
 from metta.util.runtime_configuration import setup_mettagrid_environment
 
-SMOKE_TEST_NUM_SIMS = 5
+SMOKE_TEST_NUM_SIMS = 1
 SMOKE_TEST_MIN_SCORE = 0.9
 
 # --------------------------------------------------------------------------- #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -80,9 +80,11 @@ def simulate_policy(
         results = sim.simulate()
 
         if sim_job.smoke_test:
-            rewards_df = results.stats_db.query("SELECT AVG(value) FROM agent_metrics WHERE metric = 'reward'")
+            rewards_df = results.stats_db.query(
+                "SELECT AVG(value) AS avg_reward FROM agent_metrics WHERE metric = 'reward'"
+            )
             assert len(rewards_df) == 1, f"Expected 1 reward during a smoke test, got {len(rewards_df)}"
-            reward = rewards_df.iloc[0]["value"]
+            reward = rewards_df.iloc[0]["avg_reward"]
             logger.info("Reward is %s", reward)
             assert reward >= SMOKE_TEST_MIN_SCORE, f"Reward is {reward}, expected at least {SMOKE_TEST_MIN_SCORE}"
             return

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -74,7 +74,8 @@ def simulate_policy(
             vectorization=cfg.vectorization,
         )
         results = sim.simulate()
-        print(results.stats_db.query("SELECT * FROM episode_stats"))
+        print(results.stats_db.tables())
+        print(results.stats_db.query("SELECT * FROM episode_metrics"))
         if sim_job.maybe_smoketest:
             return
         # ------------------------------------------------------------------ #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -76,8 +76,10 @@ def simulate_policy(
         results = sim.simulate()
 
         if sim_job.maybe_smoketest:
-            rewards = results.stats_db.query("SELECT value FROM agent_metrics WHERE metric = 'reward'")
-            print(rewards)
+            rewards_df = results.stats_db.query("SELECT value FROM agent_metrics WHERE metric = 'reward'")
+            assert len(rewards_df) == 1
+            reward = rewards_df.iloc[0]["value"]
+            print(reward)
             return
         # ------------------------------------------------------------------ #
         # Export                                                             #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -75,7 +75,7 @@ def simulate_policy(
         )
         results = sim.simulate()
         print(results.stats_db.tables())
-        print(results.stats_db.query("SELECT * FROM episode_metrics"))
+        print(results.stats_db.query("SELECT * FROM agent_metrics"))
         if sim_job.maybe_smoketest:
             return
         # ------------------------------------------------------------------ #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -76,7 +76,7 @@ def simulate_policy(
         results = sim.simulate()
 
         if sim_job.maybe_smoketest:
-            rewards = results.stats_db.query("SELECT reward FROM agent_metrics")
+            rewards = results.stats_db.query("SELECT value FROM agent_metrics WHERE metric = 'reward'")
             print(rewards)
             return
         # ------------------------------------------------------------------ #

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -74,9 +74,10 @@ def simulate_policy(
             vectorization=cfg.vectorization,
         )
         results = sim.simulate()
-        print(results.stats_db.tables())
-        print(results.stats_db.query("SELECT * FROM agent_metrics"))
+
         if sim_job.maybe_smoketest:
+            rewards = results.stats_db.query("SELECT reward FROM agent_metrics")
+            print(rewards)
             return
         # ------------------------------------------------------------------ #
         # Export                                                             #


### PR DESCRIPTION
Add a smoke test for evals.

This refactors the run_evals script and sim.py to allow us to indicate we're running a smoke test. The smoke test runs on a much stripped down number of evals and simulations.

This also updates the policies we're using in run_evals to match https://github.com/Metta-AI/metta/blob/daphne-evaluation/run_evals.sh.