### PR TITLE
Replace raylib with mettascope in tools.map.*

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -78,6 +78,7 @@
     "memcpy",
     "metta",
     "mettagrid",
+    "mettascope",
     "minibatch",
     "minibatches",
     "multinomial",

--- a/configs/user/berekuk.yaml
+++ b/configs/user/berekuk.yaml
@@ -1,14 +1,12 @@
 # @package __global__
 
 defaults:
-  - /hardware: macbook
-  - override /agent: simple
+  - /hardware: mac_parallel
+  - /agent: simple
   - _self_
 
-run: train5
-
-wandb:
-  entity: berekuk-personal
+run_id: 1
+run: ${oc.env:USER}.local.${run_id}
 
 policy_uri: wandb://run/${run}
 

--- a/metta/map/utils/show.py
+++ b/metta/map/utils/show.py
@@ -1,9 +1,7 @@
-import webbrowser
 from typing import Any, Literal, cast
 
 import hydra
 import numpy as np
-import uvicorn
 from omegaconf.omegaconf import OmegaConf
 
 import mettascope.server
@@ -27,15 +25,11 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
         env = MettaGridEnv(cast(Any, env_cfg), env_map=storable_map.grid, render_mode="none")
 
         file_path = write_local_map_preview(env)
-        server_url = "http://localhost:8000"
         url_path = file_path.split("mettascope/")[-1]
-
-        webbrowser.open(f"{server_url}/?replayUrl={url_path}")
 
         with hydra.initialize(version_base=None, config_path="../../../configs"):
             cfg = hydra.compose(config_name="replay_job")
-            app = mettascope.server.make_app(cfg)
-            uvicorn.run(app, host="0.0.0.0", port=8000)
+            mettascope.server.run(cfg, open_url=f"?replayUrl={url_path}")
 
     elif mode == "ascii":
         ascii_lines = grid_to_ascii(storable_map.grid)

--- a/metta/map/utils/show.py
+++ b/metta/map/utils/show.py
@@ -1,19 +1,24 @@
+import webbrowser
 from typing import Any, Literal, cast
 
+import hydra
 import numpy as np
+import uvicorn
 from omegaconf.omegaconf import OmegaConf
 
+import mettascope.server
 from metta.map.utils.storable_map import StorableMap, grid_to_ascii
+from metta.sim.map_preview import write_local_map_preview
 from mettagrid.mettagrid_env import MettaGridEnv
 
-ShowMode = Literal["raylib", "ascii", "ascii_border", "none"]
+ShowMode = Literal["mettascope", "ascii", "ascii_border", "none"]
 
 
 def show_map(storable_map: StorableMap, mode: ShowMode | None):
     if not mode or mode == "none":
         return
 
-    if mode == "raylib":
+    if mode == "mettascope":
         num_agents = np.count_nonzero(np.char.startswith(storable_map.grid, "agent"))
 
         env_cfg = OmegaConf.load("./configs/env/mettagrid/mettagrid.yaml")
@@ -21,11 +26,16 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
 
         env = MettaGridEnv(cast(Any, env_cfg), env_map=storable_map.grid, render_mode="none")
 
-        from mettagrid.renderer.raylib.raylib_renderer import MettaGridRaylibRenderer
+        file_path = write_local_map_preview(env)
+        server_url = "http://localhost:8000"
+        url_path = file_path.split("mettascope/")[-1]
 
-        renderer = MettaGridRaylibRenderer(env._c_env, env._env_cfg.game)
-        while True:
-            renderer.render_and_wait()
+        webbrowser.open(f"{server_url}/?replayUrl={url_path}")
+
+        with hydra.initialize(version_base=None, config_path="../../../configs"):
+            cfg = hydra.compose(config_name="replay_job")
+            app = mettascope.server.make_app(cfg)
+            uvicorn.run(app, host="0.0.0.0", port=8000)
 
     elif mode == "ascii":
         ascii_lines = grid_to_ascii(storable_map.grid)

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -49,7 +49,7 @@ class PufferTrainer:
     ):
         self.cfg = cfg
         self.trainer_cfg = cfg.trainer
-        self._env_cfg = config_from_path(self.trainer_cfg.env, self.trainer_cfg.env_overrides)
+        self.env_cfg = config_from_path(self.trainer_cfg.env, self.trainer_cfg.env_overrides)
         self.sim_suite_config = sim_suite_config
 
         self._master = True
@@ -770,7 +770,7 @@ class PufferTrainer:
     def _make_vecenv(self):
         """Create a vectorized environment."""
         # Create the vectorized environment
-        self.target_batch_size = self.trainer_cfg.forward_pass_minibatch_target_size // self._env_cfg.game.num_agents
+        self.target_batch_size = self.trainer_cfg.forward_pass_minibatch_target_size // self.env_cfg.game.num_agents
         if self.target_batch_size < 2:  # pufferlib bug requires batch size >= 2
             self.target_batch_size = 2
 
@@ -784,7 +784,7 @@ class PufferTrainer:
             )
 
         self.vecenv = make_vecenv(
-            self._env_cfg,
+            self.env_cfg,
             self.cfg.vectorization,
             num_envs=num_envs,
             batch_size=self.batch_size,

--- a/metta/sim/map_preview.py
+++ b/metta/sim/map_preview.py
@@ -15,22 +15,8 @@ from mettagrid.util.file import write_file
 logger = logging.getLogger(__name__)
 
 
-def upload_map_preview(
-    env_config: DictConfig,
-    s3_path: Optional[str] = None,
-    wandb_run: Optional[wandb_run.Run] = None,
-):
-    """
-    Builds a map preview of the simulation environment and uploads it to S3.
-
-    Args:
-        cfg: Configuration for the simulation
-        s3_path: Path to upload the map preview to
-        wandb_run: Weights & Biases run object for logging
-    """
+def write_map_preview_file(preview_path: str, env: MettaGridEnv, gzipped: bool):
     logger.info("Building map preview...")
-
-    env = MettaGridEnv(env_config, render_mode=None)
 
     preview = {
         "version": 1,
@@ -43,21 +29,48 @@ def upload_map_preview(
         "grid_objects": list(env.grid_objects.values()),
     }
 
-    # Compress data with deflate
-    preview_data = json.dumps(preview)  # Convert to JSON string
-    preview_bytes = preview_data.encode("utf-8")  # Encode to bytes
-    compressed_data = zlib.compress(preview_bytes)  # Compress the bytes
+    preview_data = json.dumps(preview).encode("utf-8")  # Convert to JSON string
+    if gzipped:
+        # Compress data with deflate
+        preview_data = zlib.compress(preview_data)
+
+    with open(preview_path, "wb") as f:
+        f.write(preview_data)
+
+
+def write_local_map_preview(env: MettaGridEnv):
+    with tempfile.NamedTemporaryFile(delete=False, dir="./mettascope/local/", suffix=".json") as temp_file:
+        # Create directory and save compressed file
+        preview_path = temp_file.name
+        os.makedirs(os.path.dirname(preview_path), exist_ok=True)
+
+        # no gzip locally - fastapi doesn't recognize .json.z files
+        write_map_preview_file(preview_path, env, gzipped=False)
+
+    return preview_path
+
+
+def upload_map_preview(
+    env_config: DictConfig,
+    s3_path: str,
+    wandb_run: Optional[wandb_run.Run] = None,
+):
+    """
+    Builds a map preview of the simulation environment and uploads it to S3.
+
+    Args:
+        cfg: Configuration for the simulation
+        s3_path: Path to upload the map preview to
+        wandb_run: Weights & Biases run object for logging
+    """
+
+    env = MettaGridEnv(env_config, render_mode=None)
 
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         # Create directory and save compressed file
         preview_path = temp_file.name
         os.makedirs(os.path.dirname(preview_path), exist_ok=True)
-        with open(preview_path, "wb") as f:
-            f.write(compressed_data)
-
-    if s3_path is None:
-        logger.info("No S3 path provided, skipping upload")
-        return
+        write_map_preview_file(preview_path, env, gzipped=True)
 
     # Upload to S3 using our new utility function
     try:

--- a/mettascope/local/README.md
+++ b/mettascope/local/README.md
@@ -1,0 +1,1 @@
+This directory is used to store temporary replay files to preview them locally.

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -11,111 +11,107 @@ from omegaconf import DictConfig
 
 import mettascope.replays as replays
 
-
-class App(FastAPI):
-    cfg: DictConfig
-
-
-app = App()
-
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-@app.get("/", response_class=HTMLResponse)
-async def get_client():
-    try:
-        with open("mettascope/index.html", "r") as file:
-            html_content = file.read()
-        return HTMLResponse(content=html_content)
-    except FileNotFoundError as err:
-        raise HTTPException(status_code=404, detail="Client HTML file not found") from err
+def make_app(cfg: DictConfig):
+    app = FastAPI()
 
+    @app.get("/", response_class=HTMLResponse)
+    async def get_client():
+        try:
+            with open("mettascope/index.html", "r") as file:
+                html_content = file.read()
+            return HTMLResponse(content=html_content)
+        except FileNotFoundError as err:
+            raise HTTPException(status_code=404, detail="Client HTML file not found") from err
 
-@app.get("/style.css")
-async def get_style_css():
-    try:
-        with open("mettascope/style.css", "r") as file:
-            css_content = file.read()
-        return HTMLResponse(content=css_content, media_type="text/css")
-    except FileNotFoundError as err:
-        raise HTTPException(status_code=404, detail="Client HTML file not found") from err
+    @app.get("/style.css")
+    async def get_style_css():
+        try:
+            with open("mettascope/style.css", "r") as file:
+                css_content = file.read()
+            return HTMLResponse(content=css_content, media_type="text/css")
+        except FileNotFoundError as err:
+            raise HTTPException(status_code=404, detail="Client HTML file not found") from err
 
+    # Mount a directory for static files
+    app.mount("/data", StaticFiles(directory="mettascope/data"), name="data")
+    app.mount("/dist", StaticFiles(directory="mettascope/dist"), name="dist")
+    app.mount("/local", StaticFiles(directory="mettascope/local"), name="local")
 
-# Mount a directory for static files
-app.mount("/data", StaticFiles(directory="mettascope/data"), name="data")
-app.mount("/dist", StaticFiles(directory="mettascope/dist"), name="dist")
+    @app.websocket("/ws")
+    async def websocket_endpoint(
+        websocket: WebSocket,
+    ):
+        await websocket.accept()
 
+        async def send_message(**kwargs):
+            await websocket.send_json(kwargs)
 
-@app.websocket("/ws")
-async def websocket_endpoint(
-    websocket: WebSocket,
-):
-    await websocket.accept()
+        logger.info("Received websocket connection!")
+        await send_message(type="message", message="Connecting!")
 
-    async def send_message(**kwargs):
-        await websocket.send_json(kwargs)
+        # Create a simulation that we are going to play.
+        sim = replays.create_simulation(cfg)
+        sim.start_simulation()
+        env = sim.get_env()
+        replay = sim.get_replay()
 
-    logger.info("Received websocket connection!")
-    await send_message(type="message", message="Connecting!")
+        await send_message(type="replay", replay=replay)
 
-    # Create a simulation that we are going to play.
-    sim = replays.create_simulation(app.cfg)
-    sim.start_simulation()
-    env = sim.get_env()
-    replay = sim.get_replay()
+        current_step = 0
+        action_message = None
+        total_rewards = np.zeros(env.num_agents)
 
-    await send_message(type="replay", replay=replay)
+        while True:
+            # While the client we are sending messages to it.
 
-    current_step = 0
-    action_message = None
-    total_rewards = np.zeros(env.num_agents)
+            if current_step < 1000:
+                await send_message(type="message", message="Step!")
 
-    while True:
-        # While the client we are sending messages to it.
+                actions = sim.generate_actions()
+                if action_message is not None:
+                    agent_id = action_message["agent_id"]
+                    actions[agent_id][0] = action_message["action"][0]
+                    actions[agent_id][1] = action_message["action"][1]
+                sim.step_simulation(actions)
 
-        if current_step < 1000:
-            await send_message(type="message", message="Step!")
+                grid_objects = []
+                for i, grid_object in enumerate(env.grid_objects.values()):
+                    if len(grid_objects) <= i:
+                        grid_objects.append({})
+                    for key, value in grid_object.items():
+                        grid_objects[i][key] = value
+                    if "agent_id" in grid_object:
+                        agent_id = grid_object["agent_id"]
+                        grid_objects[i]["action_success"] = bool(env.action_success[agent_id])
+                        grid_objects[i]["action"] = actions[agent_id].tolist()
+                        grid_objects[i]["reward"] = env.rewards[agent_id].item()
+                        total_rewards[agent_id] += env.rewards[agent_id]
+                        grid_objects[i]["total_reward"] = total_rewards[agent_id].item()
 
-            actions = sim.generate_actions()
-            if action_message is not None:
-                agent_id = action_message["agent_id"]
-                actions[agent_id][0] = action_message["action"][0]
-                actions[agent_id][1] = action_message["action"][1]
-            sim.step_simulation(actions)
+                await send_message(type="replay_step", replay_step={"step": current_step, "grid_objects": grid_objects})
 
-            grid_objects = []
-            for i, grid_object in enumerate(env.grid_objects.values()):
-                if len(grid_objects) <= i:
-                    grid_objects.append({})
-                for key, value in grid_object.items():
-                    grid_objects[i][key] = value
-                if "agent_id" in grid_object:
-                    agent_id = grid_object["agent_id"]
-                    grid_objects[i]["action_success"] = bool(env.action_success[agent_id])
-                    grid_objects[i]["action"] = actions[agent_id].tolist()
-                    grid_objects[i]["reward"] = env.rewards[agent_id].item()
-                    total_rewards[agent_id] += env.rewards[agent_id]
-                    grid_objects[i]["total_reward"] = total_rewards[agent_id].item()
+                current_step += 1
 
-            await send_message(type="replay_step", replay_step={"step": current_step, "grid_objects": grid_objects})
+            if current_step > 1:
+                message = await websocket.receive_json()
+                if message["type"] == "action":
+                    action_message = message
+                # yield control to other coroutines
+                await asyncio.sleep(0)
 
-            current_step += 1
+        sim.end_simulation()
 
-        if current_step > 1:
-            message = await websocket.receive_json()
-            if message["type"] == "action":
-                action_message = message
-            # yield control to other coroutines
-            await asyncio.sleep(0)
-
-    sim.end_simulation()
+    return app
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
 def main(cfg):
-    app.cfg = cfg
+    app = make_app(cfg)
 
     uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import webbrowser
 
 import hydra
 import numpy as np
@@ -109,11 +110,22 @@ def make_app(cfg: DictConfig):
     return app
 
 
-@hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
-def main(cfg):
+def run(cfg: DictConfig, open_url: str | None = None):
     app = make_app(cfg)
 
+    if open_url:
+        server_url = "http://localhost:8000"
+
+        @app.on_event("startup")
+        async def _open_browser():
+            webbrowser.open(f"{server_url}{open_url}")
+
     uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+@hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
+def main(cfg):
+    run(cfg)
 
 
 if __name__ == "__main__":

--- a/tools/map/gen.py
+++ b/tools/map/gen.py
@@ -77,6 +77,10 @@ def main():
     args = parser.parse_args()
 
     show_mode = args.show_mode
+    if not show_mode and not args.output_uri:
+        # if not asked to save, show the map
+        show_mode = "mettascope"
+
     output_uri = args.output_uri
     count = args.count
     cfg_path = args.cfg_path

--- a/tools/map/view.py
+++ b/tools/map/view.py
@@ -5,6 +5,7 @@ from typing import get_args
 from metta.map.load_random import get_random_map_uri
 from metta.map.utils.show import ShowMode, show_map
 from metta.map.utils.storable_map import StorableMap
+from metta.util.resolvers import register_resolvers
 from tools.map.gen import uri_is_file
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,8 @@ def main():
     )
     parser.add_argument("uri", type=str, help="URI of the map to view")
     args = parser.parse_args()
+
+    register_resolvers()
 
     uri = args.uri
 

--- a/tools/map/view.py
+++ b/tools/map/view.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.INFO)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--show-mode", choices=get_args(ShowMode), help="Show the map in the specified mode", default="ascii"
+        "--show-mode", choices=get_args(ShowMode), help="Show the map in the specified mode", default="mettascope"
     )
     parser.add_argument("uri", type=str, help="URI of the map to view")
     args = parser.parse_args()

--- a/tools/play.py
+++ b/tools/play.py
@@ -9,9 +9,9 @@ import mettascope.server as server
 
 @hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
 def main(cfg):
-    server.app.cfg = cfg
+    app = server.make_app(cfg)
 
-    uvicorn.run(server.app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 
 
 if __name__ == "__main__":

--- a/tools/play.py
+++ b/tools/play.py
@@ -1,19 +1,14 @@
 # Starts a websocket server that allows you to play as a metta agent.
-import webbrowser
 
 import hydra
-import uvicorn
 
 import mettascope.server as server
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="replay_job")
 def main(cfg):
-    app = server.make_app(cfg)
-
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    server.run(cfg, open_url="?wsUrl=%2Fws")
 
 
 if __name__ == "__main__":
-    webbrowser.open("http://localhost:8000/?wsUrl=%2Fws")
     main()

--- a/tools/train.py
+++ b/tools/train.py
@@ -46,7 +46,7 @@ def train(cfg, wandb_run, logger: Logger):
     trainer = hydra.utils.instantiate(
         cfg.trainer, cfg, wandb_run, policy_store=policy_store, sim_suite_config=train_job.evals
     )
-    if trainer.env_cfg._target_ == "metta.env.mettagrid_env.MettaGridEnv":
+    if train_job.map_preview_uri and trainer.env_cfg._target_ == "metta.env.mettagrid_env.MettaGridEnv":
         # TODO: upload_map_preview() calls MettaGridEnv directly, which will break if our target is MettaGridEnvSet
         # Should we upload a preview for MettaGridEnvSet?
         upload_map_preview(trainer.env_cfg, train_job.map_preview_uri, wandb_run)

--- a/tools/train.py
+++ b/tools/train.py
@@ -11,7 +11,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 from metta.agent.policy_store import PolicyStore
 from metta.sim.map_preview import upload_map_preview
 from metta.sim.simulation_config import SimulationSuiteConfig
-from metta.util.config import Config, config_from_path, setup_metta_environment
+from metta.util.config import Config, setup_metta_environment
 from metta.util.logging import setup_mettagrid_logger
 from metta.util.runtime_configuration import setup_mettagrid_environment
 from metta.util.wandb.wandb_context import WandbContext
@@ -43,15 +43,14 @@ def train(cfg, wandb_run, logger: Logger):
 
     policy_store = PolicyStore(cfg, wandb_run)
 
-    env_cfg = config_from_path(cfg.trainer.env, cfg.trainer.env_overrides)
-    if env_cfg._target_ == "metta.env.mettagrid_env.MettaGridEnv":
-        # TODO: upload_map_preview() calls MettaGridEnv directly, which will break if our target is MettaGridEnvSet
-        # Should we upload a preview for MettaGridEnvSet?
-        upload_map_preview(env_cfg, train_job.map_preview_uri, wandb_run)
-
     trainer = hydra.utils.instantiate(
         cfg.trainer, cfg, wandb_run, policy_store=policy_store, sim_suite_config=train_job.evals
     )
+    if trainer.env_cfg._target_ == "metta.env.mettagrid_env.MettaGridEnv":
+        # TODO: upload_map_preview() calls MettaGridEnv directly, which will break if our target is MettaGridEnvSet
+        # Should we upload a preview for MettaGridEnvSet?
+        upload_map_preview(trainer.env_cfg, train_job.map_preview_uri, wandb_run)
+
     trainer.train()
     trainer.close()
 


### PR DESCRIPTION
# Map Preview with Mettascope

This PR adds support for viewing maps locally using Mettascope instead of Raylib. Key changes:

- Replace "raylib" show mode with "mettascope" in map visualization
- Add functionality to write map previews to local files
- Refactor server.py to use a factory pattern for creating the FastAPI app
- Add a local directory for storing map previews
- Fix tools.map.view by registering resolvers
- Expose env_cfg in the trainer for easier access
- Update map preview upload to handle local files

This makes it easier to visualize maps during development without requiring S3 uploads.