### PR TITLE
Fix pylance errors in config creation

### DIFF
--- a/metta/eval/analysis_config.py
+++ b/metta/eval/analysis_config.py
@@ -3,6 +3,7 @@ from metta.util.config import Config
 
 
 class AnalysisConfig(Config):
+    __init__ = Config.__init__
     # Policy URI to analyze
     policy_uri: str | None = None
     policy_selector: PolicySelectorConfig = PolicySelectorConfig()

--- a/metta/eval/dashboard/dashboard_config.py
+++ b/metta/eval/dashboard/dashboard_config.py
@@ -4,6 +4,7 @@ from metta.util.config import Config
 
 
 class DashboardConfig(Config):
+    __init__ = Config.__init__
     # Output options
     num_output_policies: int | Literal["all"] = 20
     metric: str = "reward"

--- a/metta/sim/simulation_config.py
+++ b/metta/sim/simulation_config.py
@@ -10,6 +10,8 @@ from metta.util.config import Config
 class SimulationConfig(Config):
     """Configuration for a single simulation run."""
 
+    __init__ = Config.__init__
+
     # Core simulation config
     num_episodes: int
     max_time_s: int = 120
@@ -20,6 +22,8 @@ class SimulationConfig(Config):
 
 class SingleEnvSimulationConfig(SimulationConfig):
     """Configuration for a single simulation run."""
+
+    __init__ = SimulationConfig.__init__
 
     env: str
     env_overrides: Optional[dict] = None

--- a/metta/util/config.py
+++ b/metta/util/config.py
@@ -25,6 +25,9 @@ class Config(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    # Sub-classes of Config class should use the `__init__ = Config.__init__` trick to satisfy Pylance.
+    # Without this, Pylance will complain about 0 positional arguments, because it looks up Pydantic's
+    # __init__ method, which takes no positional arguments.
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if len(args) == 1 and not kwargs and isinstance(args[0], (DictConfig, dict)):
             super().__init__(**self.prepare_dict(args[0]))

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -18,6 +18,7 @@ from mettagrid.util.file import http_url
 
 # TODO: This job can be replaced with sim now that Simulations create replays
 class ReplayJob(Config):
+    __init__ = Config.__init__
     sim: SingleEnvSimulationConfig
     policy_uri: str
     selector_type: str

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -26,12 +26,14 @@ from metta.util.runtime_configuration import setup_mettagrid_environment
 SMOKE_TEST_NUM_SIMS = 1
 SMOKE_TEST_MIN_SCORE = 0.9
 
+
 # --------------------------------------------------------------------------- #
 # Config objects                                                              #
 # --------------------------------------------------------------------------- #
 
 
 class SimJob(Config):
+    __init__ = Config.__init__
     simulation_suite: SimulationSuiteConfig
     policy_uris: List[str]
     selector_type: str = "top"
@@ -110,7 +112,6 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Sim job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
 
     sim_job = SimJob(cfg.sim_job)
-    assert isinstance(sim_job, SimJob), f"Expected SimJob instance, got {type(sim_job).__name__}"
 
     if sim_job.smoke_test:
         logger.info("Limiting simulations to %d", SMOKE_TEST_NUM_SIMS)

--- a/tools/train.py
+++ b/tools/train.py
@@ -19,6 +19,7 @@ from metta.util.wandb.wandb_context import WandbContext
 
 # TODO: populate this more
 class TrainJob(Config):
+    __init__ = Config.__init__
     evals: SimulationSuiteConfig
     map_preview_uri: Optional[str] = None
 


### PR DESCRIPTION
`pyright tools metta | tail -1`: 314 -> 308 errors.

### TL;DR

Added `__init__ = Config.__init__` to Config subclasses to fix Pylance type checking issues.

### What changed?

Added the line `__init__ = Config.__init__` (or equivalent parent class's `__init__`) to all Config subclasses across the codebase. This includes:
- `AnalysisConfig`
- `DashboardConfig`
- `SimulationConfig` and `SingleEnvSimulationConfig`
- `ReplayJob`
- `SimJob`
- `TrainJob`

Also added a comment in the base `Config` class explaining why this pattern is necessary:
```python
# Sub-classes of Config class should use the `__init__ = Config.__init__` trick to satisfy Pylance.
# Without this, Pylance will complain about 0 positional arguments, because it looks up Pydantic's
# __init__ method, which takes no positional arguments.
```

### How to test?

1. Verify that Pylance no longer shows type errors when instantiating Config subclasses
2. Run existing tests to ensure functionality is preserved
3. Try creating instances of the modified Config subclasses to confirm they still work as expected

### Why make this change?

This change fixes type checking issues with Pylance. Without this fix, Pylance incorrectly complains about 0 positional arguments when instantiating Config subclasses because it looks up Pydantic's `__init__` method instead of the custom one in the `Config` class. This explicit inheritance of the `__init__` method ensures proper type checking while maintaining the same functionality.