### PR TITLE
Make group_rewards local instead of a member variable

### DIFF
--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -67,9 +67,6 @@ private:
   py::dict _cfg;
   std::map<unsigned int, float> _group_reward_pct;
   std::map<unsigned int, unsigned int> _group_sizes;
-  // TODO: it's not clear why we need two of these, or why they need to be numpy arrays.
-  // See if we can change that.
-  py::array_t<double> _group_rewards;
   std::unique_ptr<Grid> _grid;
   std::unique_ptr<EventManager> _event_manager;
   unsigned int _current_timestep;


### PR DESCRIPTION
Replace numpy array for group rewards with a standard C++ vector, and make it a local variable.