### PR TITLE
Allow partial recipe item transfers when inventory is insufficient

### DIFF
--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -29,16 +29,17 @@ protected:
     // #Converter_and_HasInventory_are_the_same_thing
     Converter* converter = static_cast<Converter*>(target);
 
-    for (size_t i = 0; i < converter->recipe_input.size(); i++) {
-      if (converter->recipe_input[i] > actor->inventory[i]) {
-        return false;
-      }
-    }
+    // for (size_t i = 0; i < converter->recipe_input.size(); i++) {
+    //   if (converter->recipe_input[i] > actor->inventory[i]) {
+    //     return false;
+    //   }
+    // }
 
     for (size_t i = 0; i < converter->recipe_input.size(); i++) {
-      actor->update_inventory(static_cast<InventoryItem>(i), -converter->recipe_input[i]);
-      converter->update_inventory(static_cast<InventoryItem>(i), converter->recipe_input[i]);
-      actor->stats.add(InventoryItemNames[i], "put", converter->recipe_input[i]);
+      unsigned int inv = std::min(converter->recipe_input[i], actor->inventory[i]);
+      actor->update_inventory(static_cast<InventoryItem>(i), -inv);
+      converter->update_inventory(static_cast<InventoryItem>(i), inv);
+      actor->stats.add(InventoryItemNames[i], "put", inv);
     }
 
     return true;


### PR DESCRIPTION
### TL;DR

Modified the PutRecipeItems action to handle partial recipe inputs gracefully.

### What changed?

- Removed the upfront inventory check that previously prevented actions when the actor didn't have all required recipe items
- Updated the inventory transfer logic to only transfer the minimum of what's required and what's available
- Changed to use `std::min()` to determine how many items to transfer from actor to converter

### How to test?

1. Try to put recipe items in a converter when you don't have all the required items
2. Verify that the action now succeeds and transfers whatever items you do have
3. Check that the actor's inventory is updated correctly
4. Confirm that the converter receives the correct number of items
5. Validate that the stats are updated with the actual transferred amounts

### Why make this change?

This change improves user experience by allowing partial recipe inputs instead of requiring all ingredients to be available before any can be transferred. Players can now incrementally add whatever ingredients they have available to converters, making the gameplay more flexible and intuitive.