### PR TITLE
Add import and entity palette to map editor

### DIFF
--- a/map_editor_ui/README.md
+++ b/map_editor_ui/README.md
@@ -5,5 +5,6 @@ A simple interface to draw ASCII maps.
 ## Usage
 
 1. Open the `index.html` in a browser.
-2. Draw a map
-+3. Click the `Copy ASCII` button
+2. Select an entity from the palette and draw on the grid.
+3. Use the `Load ASCII` button to import a map or paste directly into the preview box.
+4. Click the `Copy ASCII` button to copy the result.

--- a/map_editor_ui/index.html
+++ b/map_editor_ui/index.html
@@ -13,15 +13,18 @@
         <label for="mapHeight">Height:</label>
         <input type="number" id="mapHeight" value="30" min="3" max="100">
         <button id="createGridBtn">Create/Reset Grid</button>
-        <p class="controls-info">Left-click/Tap: Draw Wall | Right-click/Two-finger Tap: Erase Wall</p>
+        <p class="controls-info">Left-click/Tap: Draw | Right-click/Two-finger Tap: Erase</p>
     </div>
+
+    <div class="entity-selector" id="entitySelector"></div>
 
     <canvas id="mapCanvas"></canvas>
 
     <div class="preview-container">
         <h3>ASCII Preview:</h3>
-        <textarea id="asciiPreview" readonly rows="10" cols="50"></textarea>
+        <textarea id="asciiPreview" rows="10" cols="50"></textarea>
         <button id="copyAsciiBtn">Copy ASCII</button>
+        <button id="loadAsciiBtn">Load ASCII</button>
         <span id="copyStatusMessage" class="copy-status"></span>
     </div>
 

--- a/map_editor_ui/style.css
+++ b/map_editor_ui/style.css
@@ -49,6 +49,32 @@ body {
     text-align: center; /* Center the info text */
 }
 
+.entity-selector {
+    margin-top: 15px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+}
+
+.entity-btn {
+    background: transparent;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    padding: 2px;
+    cursor: pointer;
+}
+
+.entity-btn.selected {
+    border-color: #007bff;
+}
+
+.entity-btn img {
+    width: 20px;
+    height: 20px;
+    display: block;
+}
+
 #mapCanvas {
     border: 1px solid #333;
     cursor: crosshair;
@@ -94,6 +120,22 @@ body {
     background-color: #28a745;
     color: white;
     transition: background-color 0.2s;
+}
+
+#loadAsciiBtn {
+    display: block;
+    margin: 10px auto;
+    padding: 8px 15px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    background-color: #6c757d;
+    color: white;
+    transition: background-color 0.2s;
+}
+
+#loadAsciiBtn:hover {
+    background-color: #5a6268;
 }
 
 #copyAsciiBtn:hover {


### PR DESCRIPTION
## Summary
- enhance UI for map editor
- allow ASCII maps to be loaded from textarea
- add palette of entity icons to draw with more than walls
- update README for new usage instructions

## Testing
- `node --check map_editor_ui/script.js`