### PR TITLE
Supporting Externally Trained Policies Part 1

### DIFF
--- a/.github/workflows/aws-train.yml
+++ b/.github/workflows/aws-train.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-python-uv
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
@@ -73,6 +73,13 @@ jobs:
           
           echo "Generated run name: $RUN_NAME"
           echo "run_name=$RUN_NAME" >> $GITHUB_OUTPUT
+
+      - name: Set up Weights & Biases credentials
+        run: |
+          echo "machine api.wandb.ai" > $HOME/.netrc
+          echo "login user" >> $HOME/.netrc
+          echo "password ${{ secrets.WANDB_API_KEY }}" >> $HOME/.netrc
+          chmod 600 $HOME/.netrc
 
       - name: Launch AWS Batch job
         run: |

--- a/.github/workflows/aws-train.yml
+++ b/.github/workflows/aws-train.yml
@@ -83,6 +83,7 @@ jobs:
             --timeout-minutes=${{ github.event.inputs.timeout_minutes }} \
             --skip-validation \
             --skip-push-check \
+            --profile="" \
             trainer.env=${{ github.event.inputs.trainer_env }}
 
       - name: Output job details

--- a/.github/workflows/aws-train.yml
+++ b/.github/workflows/aws-train.yml
@@ -1,0 +1,99 @@
+name: Launch AWS Training Job
+
+# This workflow can be manually triggered from the GitHub UI
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_minutes:
+        description: 'Job timeout in minutes (auto-termination)'
+        required: true
+        default: '60'
+        type: number
+      trainer_env:
+        description: 'Training environment configuration'
+        required: true
+        default: 'env/mettagrid/simple'
+        type: string
+      pr_number:
+        description: 'PR number (if applicable, leave empty otherwise)'
+        required: false
+        type: string
+
+
+jobs:
+  launch-batch-job:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for AWS credentials
+      contents: read # This is required to checkout the repository
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python and uv
+        id: setup-python-uv
+        uses: ./.github/actions/setup-python-uv
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Get current commit hash
+        id: get_commit_hash
+        run: |
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "Commit hash: $COMMIT_HASH"
+
+      - name: Generate run name
+        id: generate_run_name
+        run: |
+          # Get short commit hash
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          
+          # Get current timestamp in a format suitable for filenames
+          TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
+          
+          # Get branch name
+          BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9]/_/g')
+          
+          # Generate the run name
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            # Include PR number in run name if provided
+            RUN_NAME="github.pr${{ github.event.inputs.pr_number }}.$COMMIT_HASH.$TIMESTAMP"
+            echo "Using PR #${{ github.event.inputs.pr_number }} in run name"
+          else
+            # Use branch name if no PR number provided
+            RUN_NAME="github.$BRANCH.$COMMIT_HASH.$TIMESTAMP"
+            echo "Using branch name '$BRANCH' in run name"
+          fi
+          
+          echo "Generated run name: $RUN_NAME"
+          echo "run_name=$RUN_NAME" >> $GITHUB_OUTPUT
+
+      - name: Launch AWS Batch job
+        run: |
+          python -m devops.aws.batch.launch_task \
+            --cmd=train \
+            --run=${{ steps.generate_run_name.outputs.run_name }} \
+            --git-commit=${{ steps.get_commit_hash.outputs.commit_hash }} \
+            --timeout-minutes=${{ github.event.inputs.timeout_minutes }} \
+            --skip-validation \
+            --skip-push-check \
+            trainer.env=${{ github.event.inputs.trainer_env }}
+
+      - name: Output job details
+        run: |
+          echo "Training job launched with the following details:"
+          echo "Run name: ${{ steps.generate_run_name.outputs.run_name }}"
+          echo "Commit hash: ${{ steps.get_commit_hash.outputs.commit_hash }}"
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "Pull Request: #${{ github.event.inputs.pr_number }}"
+          else
+            echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+          fi
+          echo "Auto-termination: After ${{ github.event.inputs.timeout_minutes }} minutes"
+          echo "Environment: ${{ github.event.inputs.trainer_env }}"

--- a/configs/agent.yaml
+++ b/configs/agent.yaml
@@ -1,0 +1,1 @@
+policy_class: null

--- a/configs/agent.yaml
+++ b/configs/agent.yaml
@@ -1,1 +1,0 @@
-policy_class: null

--- a/configs/agent/example.yaml
+++ b/configs/agent/example.yaml
@@ -1,0 +1,4 @@
+_target_: metta.agent.external.example.Recurrent
+hidden_size: 512 
+cnn_channels: 128 
+

--- a/configs/agent/lstm_transformer.yaml
+++ b/configs/agent/lstm_transformer.yaml
@@ -1,0 +1,3 @@
+_target_: metta.agent.external.lstm_transformer.Recurrent
+hidden_size: 384 
+cnn_channels: 128

--- a/configs/analyze_job.yaml
+++ b/configs/analyze_job.yaml
@@ -9,3 +9,5 @@ policy_uri: ???
 analysis:
   eval_db_uri: ${eval_db_uri}
   policy_uri: ${policy_uri}
+
+cmd: analyze 

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -8,7 +8,6 @@ dist_cfg_path: null
 data_dir: ./train_dir
 run_dir: ${data_dir}/${run}
 policy_uri: file://${run_dir}/checkpoints
-policy_class: null
 
 torch_deterministic: true
 vectorization: multiprocessing

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -8,6 +8,7 @@ dist_cfg_path: null
 data_dir: ./train_dir
 run_dir: ${data_dir}/${run}
 policy_uri: file://${run_dir}/checkpoints
+policy_class: null
 
 torch_deterministic: true
 vectorization: multiprocessing

--- a/configs/sim/simple.yaml
+++ b/configs/sim/simple.yaml
@@ -1,9 +1,5 @@
 defaults:
-  - sim_suite
+  - sim_single
   - _self_
 
-name: simple 
-
-simulations:
-  simple/simple:
-    env: /env/mettagrid/simple
+env: /env/mettagrid/simple

--- a/configs/sim/simple.yaml
+++ b/configs/sim/simple.yaml
@@ -1,5 +1,9 @@
 defaults:
-  - sim_single
+  - sim_suite
   - _self_
 
-env: /env/mettagrid/simple
+name: simple 
+
+simulations:
+  simple/simple:
+    env: /env/mettagrid/simple

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -7,28 +7,23 @@ defaults:
   # - override /agent: non_robust_puffer
   - _self_
 
-    #policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
-policy_uri: puffer://deps/devpl/experiments/metta-cc749e4d/model_019074.pt
-policy_class: metta.agent.external.example.Recurrent
+    #policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
+policy_uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
+policy_class: metta.agent.external.wombo.Recurrent
 npc_policy_uri: null
 
 trainer:
   checkpoint_interval: 10
   evaluate_interval: 10
-  env: /env/mettagrid/navigation/training/multienv
+    #env: /env/mettagrid/navigation/training/multienv
   initial_policy:
-    #uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
-    uri: puffer://deps/devpl/experiments/metta-cc749e4d/model_019074.pt
+    #uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
+    uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
 
 eval:
   policy_uri: ${..policy_uri}
   npc_policy_uri: ${..npc_policy_uri}
   #eval_db_uri: train_dir/richard.dummy.1/
 
-wandb:
-  enabled: true
-  track: true
-  checkpoint_interval: 1
-
 run: ${oc.env:USER}.local.${run_id}
-  #trained_policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
+  #trained_policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -9,8 +9,10 @@ defaults:
 
     #policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
 policy_uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
-policy_class: metta.agent.external.lstm_transformer.Recurrent
 npc_policy_uri: null
+
+agent:
+  policy_class: metta.agent.external.lstm_transformer.Recurrent
 
 trainer:
   checkpoint_interval: 10

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -7,19 +7,20 @@ defaults:
   # - override /agent: non_robust_puffer
   - _self_
 
-policy_uri: puffer://checkpoints/metta-example/model_019074.pt
+policy_uri: puffer://checkpoints/metta-wombo/model_019074.pt
 npc_policy_uri: null
 
-agent:
-  #policy_class: null
-  policy_class: metta.agent.external.example.Recurrent
+puffer:
+  _target_: metta.agent.external.lstm_transformer.Recurrent
+  hidden_size: 384 
+  cnn_channels: 128
 
 trainer:
   checkpoint_interval: 10
   evaluate_interval: 10
     #env: /env/mettagrid/navigation/training/multienv
   initial_policy:
-     uri: puffer://checkpoints/metta-example/model_019074.pt
+     uri: puffer://checkpoints/metta-wombo/model_019074.pt
      #uri: puffer://checkpoints/metta-wombo/model_019074.pt
 
 eval:
@@ -28,4 +29,4 @@ eval:
   #eval_db_uri: train_dir/richard.dummy.1/
 
 run: ${oc.env:USER}.local.${run_id}
-trained_policy_uri: puffer://checkpoints/metta-example/model_019074.pt
+trained_policy_uri: puffer://checkpoints/metta-wombo/model_019074.pt

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -7,20 +7,20 @@ defaults:
   # - override /agent: non_robust_puffer
   - _self_
 
-    #policy_uri: puffer://checkpoints/metta-example/model_019074.pt
-policy_uri: puffer://checkpoints/metta-wombo/model_019074.pt
+policy_uri: puffer://checkpoints/metta-example/model_019074.pt
 npc_policy_uri: null
 
 agent:
-  policy_class: metta.agent.external.lstm_transformer.Recurrent
+  #policy_class: null
+  policy_class: metta.agent.external.example.Recurrent
 
 trainer:
   checkpoint_interval: 10
   evaluate_interval: 10
     #env: /env/mettagrid/navigation/training/multienv
   initial_policy:
-    #uri: puffer://checkpoints/metta-example/model_019074.pt
-    uri: puffer://checkpoints/metta-wombo/model_019074.pt
+     uri: puffer://checkpoints/metta-example/model_019074.pt
+     #uri: puffer://checkpoints/metta-wombo/model_019074.pt
 
 eval:
   policy_uri: ${..policy_uri}
@@ -28,4 +28,4 @@ eval:
   #eval_db_uri: train_dir/richard.dummy.1/
 
 run: ${oc.env:USER}.local.${run_id}
-  #trained_policy_uri: puffer://checkpoints/metta-example/model_019074.pt
+trained_policy_uri: puffer://checkpoints/metta-example/model_019074.pt

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -7,8 +7,8 @@ defaults:
   # - override /agent: non_robust_puffer
   - _self_
 
-    #policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
-policy_uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
+    #policy_uri: puffer://checkpoints/metta-example/model_019074.pt
+policy_uri: puffer://checkpoints/metta-wombo/model_019074.pt
 npc_policy_uri: null
 
 agent:
@@ -19,8 +19,8 @@ trainer:
   evaluate_interval: 10
     #env: /env/mettagrid/navigation/training/multienv
   initial_policy:
-    #uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
-    uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
+    #uri: puffer://checkpoints/metta-example/model_019074.pt
+    uri: puffer://checkpoints/metta-wombo/model_019074.pt
 
 eval:
   policy_uri: ${..policy_uri}
@@ -28,4 +28,4 @@ eval:
   #eval_db_uri: train_dir/richard.dummy.1/
 
 run: ${oc.env:USER}.local.${run_id}
-  #trained_policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
+  #trained_policy_uri: puffer://checkpoints/metta-example/model_019074.pt

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -9,7 +9,7 @@ defaults:
 
     #policy_uri: puffer://puffer_checkpoints/metta-example/model_019074.pt
 policy_uri: puffer://puffer_checkpoints/metta-wombo/model_019074.pt
-policy_class: metta.agent.external.wombo.Recurrent
+policy_class: metta.agent.external.lstm_transformer.Recurrent
 npc_policy_uri: null
 
 trainer:

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -1,0 +1,25 @@
+# @package __global__
+
+seed: null
+
+defaults:
+  # - override /env/mettagrid@env: simple
+  # - override /agent: non_robust_puffer
+  - _self_
+
+policy_uri: puffer://deps/devpl/experiments/metta-cc749e4d/model_019074.pt
+policy_class: metta.agent.external.example.Recurrent
+npc_policy_uri: null
+
+eval:
+  policy_uri: ${..policy_uri}
+  npc_policy_uri: ${..npc_policy_uri}
+  #eval_db_uri: train_dir/richard.dummy.1/
+
+wandb:
+  enabled: true
+  track: true
+  checkpoint_interval: 1
+
+run: ${oc.env:USER}.local.${run_id}
+trained_policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt

--- a/configs/user/richard.yaml
+++ b/configs/user/richard.yaml
@@ -7,9 +7,18 @@ defaults:
   # - override /agent: non_robust_puffer
   - _self_
 
+    #policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
 policy_uri: puffer://deps/devpl/experiments/metta-cc749e4d/model_019074.pt
 policy_class: metta.agent.external.example.Recurrent
 npc_policy_uri: null
+
+trainer:
+  checkpoint_interval: 10
+  evaluate_interval: 10
+  env: /env/mettagrid/navigation/training/multienv
+  initial_policy:
+    #uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
+    uri: puffer://deps/devpl/experiments/metta-cc749e4d/model_019074.pt
 
 eval:
   policy_uri: ${..policy_uri}
@@ -22,4 +31,4 @@ wandb:
   checkpoint_interval: 1
 
 run: ${oc.env:USER}.local.${run_id}
-trained_policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt
+  #trained_policy_uri: puffer://deps/devpl/experiments/metta-bc817736/model_019074.pt

--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -10,28 +10,189 @@ set -e
 # - NUM_GPUS: Number of GPUs per node
 # - NUM_WORKERS: Number of workers for training
 # - TASK_ARGS: Additional arguments to pass to the training command
+# - JOB_TIMEOUT_MINUTES: Optional timeout in minutes for auto-termination
 #
 # AWS Batch environment variables used:
+# - AWS_BATCH_JOB_ID: The ID of the current job
 # - AWS_BATCH_JOB_NODE_INDEX: Index of this node in the job
 # - AWS_BATCH_JOB_MAIN_NODE_INDEX: Index of the main node
 # - AWS_BATCH_JOB_NUM_NODES: Total number of nodes in the job
 
-# Link training directory
-ln -s /mnt/efs/train_dir train_dir 2> /dev/null || true
-# Create dist directory
-mkdir -p train_dir/dist/$RUN_ID
 
 # Source environment variables
 source ./devops/env.sh
 
-# Setup log directory and file
+# Link training directory
+ln -s /mnt/efs/train_dir train_dir
+
+# Create dist directory
+mkdir -p train_dir/dist/$RUN_ID
+
+# Setup log directory and file early
 export NODE_INDEX=${AWS_BATCH_JOB_NODE_INDEX:-0}
 export LOG_FILE="train_dir/logs/${JOB_NAME}.${NODE_INDEX}.log"
+
+# Create log directory - fail if this doesn't work
 mkdir -p $(dirname $LOG_FILE)
 
 # Start logging everything to the log file and stdout
 exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=== Logging to $LOG_FILE ==="
+
+# Function to log timeout-related messages to both stdout and our timeout log
+function timeout_log() {
+    local message="$1"
+    local timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+    # Fail if we can't write to the timeout log
+    echo "[$timestamp] TIMEOUT: $message" | tee -a "train_dir/logs/${JOB_NAME}.timeout.log"
+}
+
+# Set up the auto-termination feature if JOB_TIMEOUT_MINUTES is set
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ] && [ "$NODE_INDEX" = "0" -o "$AWS_BATCH_JOB_NODE_INDEX" = "0" ]; then
+    # Create timeout log file - fail if this doesn't work
+    mkdir -p "train_dir/logs"
+    TIMEOUT_LOG="train_dir/logs/${JOB_NAME}.timeout.log"
+    touch $TIMEOUT_LOG
+    
+    # Only set up timeout on the main node
+    TIMEOUT_SECONDS=$((JOB_TIMEOUT_MINUTES * 60))
+    
+    # Format timeout for display
+    if [ $JOB_TIMEOUT_MINUTES -ge 60 ]; then
+        HOURS=$((JOB_TIMEOUT_MINUTES / 60))
+        MINS=$((JOB_TIMEOUT_MINUTES % 60))
+        if [ $MINS -eq 0 ]; then
+            TIMEOUT_DISPLAY="${HOURS}h"
+        else
+            TIMEOUT_DISPLAY="${HOURS}h ${MINS}m"
+        fi
+    else
+        TIMEOUT_DISPLAY="${JOB_TIMEOUT_MINUTES}m"
+    fi
+    
+    timeout_log "Setting up auto-termination after ${TIMEOUT_DISPLAY} (${TIMEOUT_SECONDS} seconds)"
+    timeout_log "AWS_BATCH_JOB_ID=${AWS_BATCH_JOB_ID}"
+    timeout_log "AWS credentials check: $(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || echo 'NOT AVAILABLE')"
+    
+    # Start the timeout monitor in the background
+    (
+        timeout_log "Timeout monitor started. Will wake up after ${TIMEOUT_DISPLAY}"
+        
+        # Record the start time
+        START_TIME=$(date +%s)
+        
+        # Sleep for the specified timeout duration
+        sleep $TIMEOUT_SECONDS
+        
+        # Calculate how long we actually slept
+        END_TIME=$(date +%s)
+        ELAPSED_SECONDS=$((END_TIME - START_TIME))
+        ELAPSED_MINUTES=$((ELAPSED_SECONDS / 60))
+        
+        timeout_log "Waking up after ${ELAPSED_MINUTES}m (${ELAPSED_SECONDS}s). Should have been ${JOB_TIMEOUT_MINUTES}m (${TIMEOUT_SECONDS}s)"
+        timeout_log "JOB_TIMEOUT_MINUTES (${TIMEOUT_DISPLAY}) reached. Initiating job termination..."
+        
+        # Try to get the main training process to allow it to save checkpoints
+        timeout_log "Finding main process to terminate gracefully..."
+        PS_OUTPUT=$(ps -eo pid,%cpu,command --sort=-%cpu)
+        echo "$PS_OUTPUT" | head -n 10 >> $TIMEOUT_LOG
+        MAIN_PID=$(echo "$PS_OUTPUT" | awk 'NR==2 {print $1}')
+        
+        if [ ! -z "$MAIN_PID" ]; then
+            timeout_log "Sending SIGTERM to main process $MAIN_PID to allow checkpoint saving"
+            kill -15 $MAIN_PID 2>> $TIMEOUT_LOG || timeout_log "Failed to send SIGTERM to $MAIN_PID"
+            
+            # Give it some time to save checkpoints
+            timeout_log "Waiting 30 seconds for graceful termination and checkpoint saving..."
+            sleep 30
+            
+            # Check if the process is still running
+            if kill -0 $MAIN_PID 2>/dev/null; then
+                timeout_log "Process $MAIN_PID is still running, sending SIGKILL"
+                kill -9 $MAIN_PID 2>> $TIMEOUT_LOG || timeout_log "Failed to send SIGKILL to $MAIN_PID"
+            else
+                timeout_log "Process $MAIN_PID has terminated successfully"
+            fi
+        else
+            timeout_log "Could not identify main process"
+            
+            # If we can't find the main process, try to find any Python processes
+            timeout_log "Attempting to terminate all Python processes"
+            pkill -15 python 2>> $TIMEOUT_LOG || timeout_log "No Python processes found to terminate"
+            pkill -15 python3 2>> $TIMEOUT_LOG || timeout_log "No Python3 processes found to terminate"
+            sleep 5
+            pkill -9 python 2>> $TIMEOUT_LOG || true
+            pkill -9 python3 2>> $TIMEOUT_LOG || true
+        fi
+        
+        # AWS Batch API call is now a fallback only if process termination fails
+        if kill -0 $MAIN_PID 2>/dev/null || pgrep -f python > /dev/null; then
+            timeout_log "Process termination failed or other Python processes still running. Trying AWS Batch API as fallback."
+            
+            # Terminate the job via AWS Batch API
+            if [ ! -z "$AWS_BATCH_JOB_ID" ] && command -v aws &> /dev/null && [ ! -z "$AWS_ACCESS_KEY_ID" ]; then
+                timeout_log "Terminating AWS Batch job $AWS_BATCH_JOB_ID via AWS API"
+                
+                # Call AWS Batch API to terminate the job
+                aws batch terminate-job \
+                    --job-id $AWS_BATCH_JOB_ID \
+                    --reason "Timeout of ${TIMEOUT_DISPLAY} reached" \
+                    --region us-east-1 2>&1 >> $TIMEOUT_LOG
+                
+                timeout_log "Termination request sent to AWS Batch API"
+            else
+                timeout_log "AWS Batch API call not possible (missing AWS_BATCH_JOB_ID, AWS CLI, or credentials)"
+            fi
+        fi
+        
+        # Exit the timeout process
+        timeout_log "Timeout process complete"
+        exit 0
+    ) &
+    
+    # Store the timeout process ID
+    TIMEOUT_PID=$!
+    timeout_log "Timeout monitor process ID: $TIMEOUT_PID"
+    
+    # Create a trap to clean up the timeout process if the script exits normally
+    trap 'timeout_log "Job completed normally, canceling timeout monitor."; kill $TIMEOUT_PID 2>/dev/null || true' EXIT
+    
+    # Immediately exit the timeout process if testing
+    if [ "$JOB_TIMEOUT_MINUTES" = "test" ]; then
+        timeout_log "TEST MODE: Triggering immediate termination"
+        kill -9 $TIMEOUT_PID
+        aws batch terminate-job \
+            --job-id $AWS_BATCH_JOB_ID \
+            --reason "Test termination" \
+            --region us-east-1
+        exit 0
+    fi
+fi
+
+# Log timeout information if set
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then
+    if [ $JOB_TIMEOUT_MINUTES -ge 60 ]; then
+        HOURS=$((JOB_TIMEOUT_MINUTES / 60))
+        MINS=$((JOB_TIMEOUT_MINUTES % 60))
+        if [ $MINS -eq 0 ]; then
+            TIMEOUT_DISPLAY="${HOURS}h"
+        else
+            TIMEOUT_DISPLAY="${HOURS}h ${MINS}m"
+        fi
+    else
+        TIMEOUT_DISPLAY="${JOB_TIMEOUT_MINUTES}m"
+    fi
+    
+    echo "=== AUTO-TERMINATION: Job will terminate after ${TIMEOUT_DISPLAY} ==="
+    echo "=== Timeout process ID: $TIMEOUT_PID ==="
+    
+    # Print AWS identity if available (to verify credentials)
+    if command -v aws &> /dev/null; then
+        echo "=== AWS Identity: $(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || echo 'NOT AVAILABLE') ==="
+    else
+        echo "=== AWS CLI not available ==="
+    fi
+fi
 
 echo "=== Setting up environment ==="
 # Handle git reference if specified
@@ -64,7 +225,13 @@ echo "Node index: $NODE_INDEX of $NUM_NODES nodes"
 echo "Master address: $MASTER_ADDR:$MASTER_PORT"
 echo "Workers: $NUM_WORKERS"
 echo "Hardware: $HARDWARE"
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then
+    echo "Auto-termination: After ${TIMEOUT_DISPLAY}"
+else
+    echo "Auto-termination: Not set"
+fi
 echo "Additional args: $TASK_ARGS"
+echo "AWS_BATCH_JOB_ID: $AWS_BATCH_JOB_ID"
 
 # Run the training command
 ./devops/$CMD.sh run=$RUN_ID +hardware=$HARDWARE trainer.num_workers=$NUM_WORKERS $TASK_ARGS

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -10,7 +10,7 @@ import pufferlib.pytorch
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from einops import rearrange 
+from einops import rearrange
 from pufferlib.cleanrl import sample_logits
 from torch import nn
 from torch.nn import functional as F

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -15,14 +15,14 @@ from torch import nn
 from torch.nn import functional as F
 
 
-class Policy(pufferlib.models.LSTMWrapper):
+class Recurrent(pufferlib.models.LSTMWrapper):
     def __init__(self, env, policy=None, input_size=512, hidden_size=512):
         if policy is None:
-            policy = SubPolicy(env)
+            policy = Policy(env)
         super().__init__(env, policy, input_size, hidden_size)
 
 
-class SubPolicy(nn.Module):
+class Policy(nn.Module):
     def __init__(self, env, cnn_channels=128, hidden_size=512, **kwargs):
         super().__init__()
         self.hidden_size = hidden_size

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -1,19 +1,9 @@
-import importlib.util
-import math
-import types
-from types import SimpleNamespace
-from typing import List
 
-import numpy as np
 import pufferlib.models
 import pufferlib.pytorch
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from einops import rearrange
-from pufferlib.cleanrl import sample_logits
-from torch import nn
-from torch.nn import functional as F
 
 
 class Recurrent(pufferlib.models.LSTMWrapper):

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -73,7 +73,7 @@ class Policy(nn.Module):
 
     def encode_observations(self, observations, state=None):
         if len(observations.shape) == 5:
-            observations = rearrange(observations, 'b t h w c -> (b t) h w c')
+            observations = rearrange(observations, "b t h w c -> (b t) h w c")
         features = observations.permute(0, 3, 1, 2).float() / self.max_vec
         self_features = self.self_encoder(features[:, :, 5, 5])
         cnn_features = self.network(features)

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -1,4 +1,3 @@
-
 import pufferlib.models
 import pufferlib.pytorch
 import torch

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -10,6 +10,7 @@ import pufferlib.pytorch
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from einops import rearrange 
 from pufferlib.cleanrl import sample_logits
 from torch import nn
 from torch.nn import functional as F
@@ -71,6 +72,8 @@ class Policy(nn.Module):
         return (actions, value), hidden
 
     def encode_observations(self, observations, state=None):
+        if len(observations.shape) == 5:
+            observations = rearrange(observations, 'b t h w c -> (b t) h w c')
         features = observations.permute(0, 3, 1, 2).float() / self.max_vec
         self_features = self.self_encoder(features[:, :, 5, 5])
         cnn_features = self.network(features)

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -25,8 +25,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
 
         # TODO: Don't break compile
         if h is not None:
-            if len(h.shape) == 3: h = h.squeeze()
-            if len(c.shape) == 3: c = c.squeeze()
+            if len(h.shape) == 3:
+                h = h.squeeze()
+            if len(c.shape) == 3:
+                c = c.squeeze()
             assert h.shape[0] == c.shape[0] == observations.shape[0], "LSTM state must be (h, c)"
             lstm_state = (h, c)
         else:
@@ -40,6 +42,7 @@ class Recurrent(pufferlib.models.LSTMWrapper):
         state.lstm_c = c
         logits, values = self.policy.decode_actions(hidden)
         return logits, values
+
 
 class Policy(nn.Module):
     def __init__(self, env, cnn_channels=128, hidden_size=512, **kwargs):
@@ -90,7 +93,7 @@ class Policy(nn.Module):
         return (actions, value), hidden
 
     def encode_observations(self, observations, state=None):
-        #features = observations.permute(0, 3, 1, 2).float() / self.max_vec
+        # features = observations.permute(0, 3, 1, 2).float() / self.max_vec
         x = observations
         features = x.clone().permute(0, 2, 3, 1)
         self_features = self.self_encoder(features[:, :, 5, 5])

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -16,7 +16,7 @@ class Recurrent(pufferlib.models.LSTMWrapper):
         # Either B, T, H, W, C or B, H, W, C
         if len(observations.shape) == 5:
             x = observations.permute(0, 1, 4, 2, 3).float()
-            x[:] /= self.policy.max_vec  # [B, C, H, W]
+            x[:] /= self.policy.max_vec  # [B, T, C, H, W]
             return self.forward_train(x, state)
         else:
             x = observations.permute(0, 3, 1, 2).float() / self.policy.max_vec  # [B, C, H, W]

--- a/metta/agent/external/example.py
+++ b/metta/agent/external/example.py
@@ -6,20 +6,21 @@ from einops import rearrange
 
 
 class Recurrent(pufferlib.models.LSTMWrapper):
-    def __init__(self, env, policy=None, input_size=512, hidden_size=512):
+    def __init__(self, env, policy=None, cnn_channels=128, input_size=512, hidden_size=512):
         if policy is None:
-            policy = Policy(env)
+            policy = Policy(env, cnn_channels=cnn_channels, hidden_size=hidden_size)
         super().__init__(env, policy, input_size, hidden_size)
 
     def forward(self, observations, state):
         """Forward function for inference. 3x faster than using LSTM directly"""
+        # Either B, T, H, W, C or B, H, W, C
         if len(observations.shape) == 5:
             x = observations.permute(0, 1, 4, 2, 3).float()
             x[:] /= self.policy.max_vec  # [B, C, H, W]
             return self.forward_train(x, state)
         else:
             x = observations.permute(0, 3, 1, 2).float() / self.policy.max_vec  # [B, C, H, W]
-        hidden = self.policy.encode_observations(observations, state=state)
+        hidden = self.policy.encode_observations(x, state=state)
         h = state.lstm_h
         c = state.lstm_c
 
@@ -93,9 +94,7 @@ class Policy(nn.Module):
         return (actions, value), hidden
 
     def encode_observations(self, observations, state=None):
-        # features = observations.permute(0, 3, 1, 2).float() / self.max_vec
-        x = observations
-        features = x.clone().permute(0, 2, 3, 1)
+        features = observations.float()  # .permute(0, 3, 1, 2).float() / self.max_vec
         self_features = self.self_encoder(features[:, :, 5, 5])
         cnn_features = self.network(features)
         return torch.cat([self_features, cnn_features], dim=1)

--- a/metta/agent/external/lstm_transformer.py
+++ b/metta/agent/external/lstm_transformer.py
@@ -13,6 +13,35 @@ class Recurrent(pufferlib.models.LSTMWrapper):
             policy = Policy(env)
         super().__init__(env, policy, input_size, hidden_size)
 
+    def forward(self, observations, state):
+        """Forward function for inference. 3x faster than using LSTM directly"""
+        if len(observations.shape) == 5:
+            x = observations.permute(0, 1, 4, 2, 3).float()
+            x[:] /= self.policy.max_vec  # [B, C, H, W]
+            return self.forward_train(x, state)
+        else:
+            x = observations.permute(0, 3, 1, 2).float() / self.policy.max_vec  # [B, C, H, W]
+        hidden = self.policy.encode_observations(x, state=state)
+        h = state.lstm_h
+        c = state.lstm_c
+
+        # TODO: Don't break compile
+        if h is not None:
+            if len(h.shape) == 3: h = h.squeeze()
+            if len(c.shape) == 3: c = c.squeeze()
+            assert h.shape[0] == c.shape[0] == observations.shape[0], "LSTM state must be (h, c)"
+            lstm_state = (h, c)
+        else:
+            lstm_state = None
+
+        # hidden = self.pre_layernorm(hidden)
+        hidden, c = self.cell(hidden, lstm_state)
+        # hidden = self.post_layernorm(hidden)
+        state.hidden = hidden
+        state.lstm_h = hidden
+        state.lstm_c = c
+        logits, values = self.policy.decode_actions(hidden)
+        return logits, values
 
 class Policy(nn.Module):
     """Stronger drop‑in replacement for the original CNN+MLP policy.
@@ -100,48 +129,17 @@ class Policy(nn.Module):
         self.value = pufferlib.pytorch.layer_init(nn.Linear(hidden_size, 1), std=1)
 
         # Keep the original scaling vector so normalisation remains identical
-        max_vec = (
-            torch.tensor(
-                [
-                    1,
-                    10,
-                    30,
-                    1,
-                    1,
-                    255,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    1,
-                    1,
-                    1,
-                    10,
-                    1,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    100,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                ]
-            )
-            .float()
-            .view(1, 34, 1, 1)
-        )
+        # TODO - fix magic numbers!
+        # fmt: off
+        max_vec = torch.tensor([
+            1, 10, 30, 1, 1, 255,
+            100, 100, 100, 100, 100, 100, 100, 100,
+            1, 1, 1, 10, 1,
+            100, 100, 100, 100, 100, 100, 100, 100,
+            1, 1, 1, 1, 1, 1, 1
+        ], dtype=torch.float).reshape(1, 34, 1, 1)
+        # fmt: on
+
         self.register_buffer("max_vec", max_vec)
 
     # =====================================================================
@@ -150,9 +148,9 @@ class Policy(nn.Module):
     def encode_observations(self, observations: torch.Tensor, state=None) -> torch.Tensor:
         """Maps raw env observations → latent *hidden_size* vector."""
         self.max_vec = self.max_vec.to(observations.device)
-        if len(observations.shape) == 5:
-            observations = rearrange(observations, "b t h w c -> (b t) h w c")
-        x = observations.permute(0, 3, 1, 2).float() / self.max_vec  # [B, C, H, W]
+        #x = observations.permute(0, 3, 1, 2).float() / self.max_vec  # [B, C, H, W]
+        x = observations
+        observations = x.clone().permute(0, 2, 3, 1)
         B = x.size(0)
 
         # 1) Conv stem -----------------------------------------------------------------------

--- a/metta/agent/external/lstm_transformer.py
+++ b/metta/agent/external/lstm_transformer.py
@@ -27,8 +27,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
 
         # TODO: Don't break compile
         if h is not None:
-            if len(h.shape) == 3: h = h.squeeze()
-            if len(c.shape) == 3: c = c.squeeze()
+            if len(h.shape) == 3:
+                h = h.squeeze()
+            if len(c.shape) == 3:
+                c = c.squeeze()
             assert h.shape[0] == c.shape[0] == observations.shape[0], "LSTM state must be (h, c)"
             lstm_state = (h, c)
         else:
@@ -42,6 +44,7 @@ class Recurrent(pufferlib.models.LSTMWrapper):
         state.lstm_c = c
         logits, values = self.policy.decode_actions(hidden)
         return logits, values
+
 
 class Policy(nn.Module):
     """Stronger drop‑in replacement for the original CNN+MLP policy.
@@ -148,7 +151,7 @@ class Policy(nn.Module):
     def encode_observations(self, observations: torch.Tensor, state=None) -> torch.Tensor:
         """Maps raw env observations → latent *hidden_size* vector."""
         self.max_vec = self.max_vec.to(observations.device)
-        #x = observations.permute(0, 3, 1, 2).float() / self.max_vec  # [B, C, H, W]
+        # x = observations.permute(0, 3, 1, 2).float() / self.max_vec  # [B, C, H, W]
         x = observations
         observations = x.clone().permute(0, 2, 3, 1)
         B = x.size(0)

--- a/metta/agent/external/lstm_transformer.py
+++ b/metta/agent/external/lstm_transformer.py
@@ -1,0 +1,161 @@
+import importlib.util
+import math
+import types
+from typing import List
+
+import numpy as np
+import pufferlib.models
+import pufferlib.pytorch
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from torch import nn
+from torch.nn import functional as F
+
+
+class Recurrent(pufferlib.models.LSTMWrapper):
+    def __init__(self, env, policy=None, input_size=384, hidden_size=384):
+        if policy is None:
+            policy = Policy(env)
+        super().__init__(env, policy, input_size, hidden_size)
+
+class Policy(nn.Module):
+    """Stronger drop‑in replacement for the original CNN+MLP policy.
+
+    **Key ideas**
+    -------------
+    1. **Richer spatial features.**  A small Conv‑Stem extracts low‑level texture
+       information before patchification.
+    2. **Lightweight ViT encoder.**  A class token summarises the visual scene
+       through multi‑head self‑attention.  Depth/width are modest so it still
+       runs in real time on a single 4090.
+    3. **Separate proprioceptive stream.**  The 34‑dim agent‑centric vector is
+       encoded with a two‑layer MLP, mirroring the original design.
+    4. **Late fusion & projection.**  Visual CLS + self vector → linear project
+       to a unified embedding that matches *hidden_size* expected by the LSTM
+       wrapper.
+    5. **Actor‑Critic heads unchanged.**  Keeping the interface identical means
+       you can swap the old policy for this one with **no other code changes**.
+    """
+
+    def __init__(
+        self,
+        env,
+        patch_size: int = 2,
+        cnn_channels: int = 128,
+        hidden_size: int = 384,
+        depth: int = 3,
+        num_heads: int = 6,
+        mlp_ratio: float = 3.0,
+        **kw
+    ):
+        super().__init__()
+        self.is_continuous = False
+        self.hidden_size = hidden_size
+
+        # ------------------------------------------------------------------
+        #  Image → local features → patches → Transformer
+        # ------------------------------------------------------------------
+        in_channels = 34  # observation feature planes
+        self.conv_stem = nn.Sequential(
+            pufferlib.pytorch.layer_init(nn.Conv2d(in_channels, cnn_channels, 5, stride=2, padding=2)),
+            nn.ReLU(),
+            pufferlib.pytorch.layer_init(nn.Conv2d(cnn_channels, cnn_channels, 3, stride=1, padding=1)),
+            nn.ReLU(),
+        )
+
+        self.patch_size = patch_size
+        self.proj = pufferlib.pytorch.layer_init(
+            nn.Conv2d(cnn_channels, hidden_size, kernel_size=patch_size, stride=patch_size)
+        )
+
+        # class token & positional embeddings -------------------------------------------------
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.pos_emb = nn.Parameter(torch.zeros(1, 1000, hidden_size))  # 1000 >> max patch count
+        nn.init.trunc_normal_(self.pos_emb, std=0.02)
+
+        # Transformer encoder ----------------------------------------------------------------
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden_size,
+            nhead=num_heads,
+            dim_feedforward=int(hidden_size * mlp_ratio),
+            activation="gelu",
+            batch_first=True,
+            norm_first=True,
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=depth)
+
+        # ------------------------------------------------------------------
+        #  Proprioceptive / self features
+        # ------------------------------------------------------------------
+        self.self_encoder = nn.Sequential(
+            pufferlib.pytorch.layer_init(nn.Linear(34, hidden_size)),
+            nn.GELU(),
+        )
+
+        # ------------------------------------------------------------------
+        #  Fusion + heads
+        # ------------------------------------------------------------------
+        self.fuse_proj = pufferlib.pytorch.layer_init(nn.Linear(hidden_size * 2, hidden_size))
+
+        action_nvec = env.single_action_space.nvec
+        self.actor: List[nn.Linear] = nn.ModuleList(
+            [pufferlib.pytorch.layer_init(nn.Linear(hidden_size, n), std=0.01) for n in action_nvec]
+        )
+        self.value = pufferlib.pytorch.layer_init(nn.Linear(hidden_size, 1), std=1)
+
+        # Keep the original scaling vector so normalisation remains identical
+        max_vec = torch.tensor([
+            1, 10, 30, 1, 1, 255, 100, 100, 100, 100, 100, 100, 100, 100,
+            1, 1, 1, 10, 1, 100, 100, 100, 100, 100, 100, 100, 100,
+            1, 1, 1, 1, 1, 1, 1,
+        ]).float().view(1, 34, 1, 1)
+        self.register_buffer("max_vec", max_vec)
+
+    # =====================================================================
+    #  Public interface expected by wrapper
+    # =====================================================================
+    def encode_observations(self, observations: torch.Tensor, state=None) -> torch.Tensor:
+        """Maps raw env observations → latent *hidden_size* vector."""
+        self.max_vec = self.max_vec.to(observations.device)
+        if len(observations.shape) == 5:
+            observations = rearrange(observations, 'b t h w c -> (b t) h w c')
+        x = observations.permute(0, 3, 1, 2).float() / self.max_vec  # [B, C, H, W]
+        B = x.size(0)
+
+        # 1) Conv stem -----------------------------------------------------------------------
+        x = self.conv_stem(x)                                  # [B, C', H', W']
+
+        # 2) Patchify ------------------------------------------------------------------------
+        x = self.proj(x)                                       # [B, D, h, w]
+        x = x.flatten(2).transpose(1, 2)                       # [B, N, D]
+
+        # 3) Add CLS & positional encoding ---------------------------------------------------
+        cls = self.cls_token.expand(B, -1, -1)                 # [B, 1, D]
+        tokens = torch.cat([cls, x], dim=1)                    # [B, 1+N, D]
+        tokens = tokens + self.pos_emb[:, : tokens.size(1)]    # broadcast
+
+        # 4) Transformer ---------------------------------------------------------------------
+        tokens = self.transformer(tokens)                      # [B, 1+N, D]
+        vis_feat = tokens[:, 0]                                # CLS token
+
+        # 5) Self vector ---------------------------------------------------------------------
+        self_vec = observations[:, 5, 5, :].float() / self.max_vec[0, :, 0, 0]  # [B, 34]
+        self_feat = self.self_encoder(self_vec)
+
+        # 6) Fuse & project ------------------------------------------------------------------
+        fused = torch.cat([vis_feat, self_feat], dim=1)        # [B, 2D]
+        fused = self.fuse_proj(fused)                          # [B, D]
+        return fused
+
+    def decode_actions(self, hidden: torch.Tensor):
+        logits = [dec(hidden) for dec in self.actor]
+        value = self.value(hidden)
+        return logits, value
+
+    # Convenience entry point if you want to use the policy *without* a wrapper
+    def forward(self, observations, state=None):
+        hidden = self.encode_observations(observations, state)
+        logits, value = self.decode_actions(hidden)
+        return (logits, value), hidden

--- a/metta/agent/external/lstm_transformer.py
+++ b/metta/agent/external/lstm_transformer.py
@@ -1,17 +1,10 @@
-import importlib.util
-import math
-import types
 from typing import List
 
-import numpy as np
 import pufferlib.models
 import pufferlib.pytorch
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from einops import rearrange
-from torch import nn
-from torch.nn import functional as F
 
 
 class Recurrent(pufferlib.models.LSTMWrapper):

--- a/metta/agent/lib/actor.py
+++ b/metta/agent/lib/actor.py
@@ -113,9 +113,6 @@ class MettaActorSingleHead(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self.hidden = self._in_tensor_shapes[0][0]  # input_1 dim
         self.embed_dim = self._in_tensor_shapes[1][1]  # input_2 dim (_action_embeds_)

--- a/metta/agent/lib/metta_layer.py
+++ b/metta/agent/lib/metta_layer.py
@@ -41,17 +41,36 @@ class LayerBase(nn.Module):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, name, sources=None, nn_params=None, **cfg):
+    def __init__(self, name=None, sources=None, nn_params=None, **cfg):
         super().__init__()
+
+        # Extract name from cfg if not provided directly
+        if name is None and "name" in cfg:
+            name = cfg.pop("name")  # Using pop to remove it from cfg
         self._name = name
+
+        # Extract sources from cfg if not provided directly
+        if sources is None and "sources" in cfg:
+            sources = cfg.pop("sources")
         self._sources = sources
         if self._sources is not None:
             # convert from omegaconf's list class
             self._sources = list(self._sources)
-        self._net = None
-        self._ready = False
+
+        # Extract nn_params from cfg if not provided directly
+        if nn_params is None and "_nn_params" in cfg:
+            nn_params = cfg.pop("_nn_params")
+
+        # Initialize _nn_params
         if not hasattr(self, "_nn_params"):
             self._nn_params = nn_params if nn_params is not None else {}
+        else:
+            # If _nn_params already exists, update it with new values if provided
+            if nn_params is not None:
+                self._nn_params.update(nn_params)
+
+        self._net = None
+        self._ready = False
 
     @property
     def ready(self):

--- a/metta/agent/lib/nn_layer_library.py
+++ b/metta/agent/lib/nn_layer_library.py
@@ -33,9 +33,6 @@ class Linear(ParamLayer):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = [self._nn_params.out_features]
         assert len(self._in_tensor_shapes[0]) == 1, (
@@ -52,9 +49,6 @@ class ReLU(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.ReLU()
@@ -68,9 +62,6 @@ class LayerNorm(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.LayerNorm(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -83,9 +74,6 @@ class Bilinear(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = [self._nn_params.out_features]
@@ -120,9 +108,6 @@ class Embedding(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         # output shape [0] is the number of indices used in the forward pass which can change
         # no child layer should be sensitive to this dimension
@@ -149,9 +134,6 @@ class Conv2d(ParamLayer):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._set_conv_dims()
@@ -190,9 +172,6 @@ class MaxPool1d(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.MaxPool1d(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -205,9 +184,6 @@ class MaxPool2d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -222,9 +198,6 @@ class AdaptiveAvgPool1d(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.AdaptiveAvgPool1d(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -237,9 +210,6 @@ class AdaptiveAvgPool2d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -254,9 +224,6 @@ class AdaptiveMaxPool1d(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.AdaptiveMaxPool1d(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -269,9 +236,6 @@ class AdaptiveMaxPool2d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -286,9 +250,6 @@ class AvgPool1d(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.AvgPool1d(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -301,9 +262,6 @@ class AvgPool2d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -318,9 +276,6 @@ class Dropout(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.Dropout(**self._nn_params)
@@ -333,9 +288,6 @@ class Dropout2d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -350,9 +302,6 @@ class AlphaDropout(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.AlphaDropout(**self._nn_params)
@@ -365,9 +314,6 @@ class BatchNorm1d(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
@@ -382,9 +328,6 @@ class BatchNorm2d(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()
         return nn.BatchNorm2d(self._in_tensor_shapes[0][0], **self._nn_params)
@@ -398,9 +341,6 @@ class Flatten(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
-
     def _make_net(self):
         self._out_tensor_shape = [prod(self._in_tensor_shapes[0])]
         return nn.Flatten()
@@ -413,9 +353,6 @@ class Identity(LayerBase):
     Note that the __init__ of any layer class and the MettaAgent are only called when the agent
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
-
-    def __init__(self, **cfg):
-        super().__init__(**cfg)
 
     def _make_net(self):
         self._out_tensor_shape = self._in_tensor_shapes[0].copy()

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -485,15 +485,12 @@ class PolicyStore:
                     modules_queue.append(submodule_name)
 
     def _load_from_puffer(self, path: str, metadata_only: bool = False) -> PolicyRecord:
-        if self._cfg.agent.policy_class is not None:
-            policy_class = None
-            try:
-                policy_module = self._cfg.agent.policy_class.rsplit(".", 1)[0]
-                module = importlib.import_module(policy_module)
-                policy_class = getattr(module, self._cfg.agent.policy_class.rsplit(".", 1)[1])
-                print(f"Successfully imported: {policy_class}")
-            except (ModuleNotFoundError, AttributeError) as e:
-                print(f"Error importing Policy class: {e}")
+        if self._cfg.agent.policy_class is None:
+            self._cfg.agent.policy_class = "metta.agent.external.example.Recurrent"
+
+        policy_module = self._cfg.agent.policy_class.rsplit(".", 1)[0]
+        module = importlib.import_module(policy_module)
+        policy_class = getattr(module, self._cfg.agent.policy_class.rsplit(".", 1)[1])
 
         policy = load_policy(path, self._device, policy_class=policy_class)
         name = os.path.basename(path)

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -485,11 +485,12 @@ class PolicyStore:
                     modules_queue.append(submodule_name)
 
     def _load_from_puffer(self, path: str, metadata_only: bool = False) -> PolicyRecord:
-        if self._cfg.policy_module is not None:
+        if self._cfg.policy_class is not None:
             policy_class = None
             try:
-                module = importlib.import_module(self._cfg.policy_module)
-                policy_class = getattr(module, 'Policy')
+                policy_module = self._cfg.policy_class.rsplit(".", 1)[0]
+                module = importlib.import_module(policy_module)
+                policy_class = getattr(module, self._cfg.policy_class.rsplit(".", 1)[1])
                 print(f"Successfully imported: {policy_class}")
             except (ModuleNotFoundError, AttributeError) as e:
                 print(f"Error importing Policy class: {e}")

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -10,7 +10,6 @@ The PolicyStore is used by the training system to manage opponent policies and c
 """
 
 import collections
-import importlib
 import logging
 import os
 import random
@@ -485,18 +484,7 @@ class PolicyStore:
                     modules_queue.append(submodule_name)
 
     def _load_from_puffer(self, path: str, metadata_only: bool = False) -> PolicyRecord:
-<<<<<<< HEAD
         policy = load_policy(path, self._device, puffer=self._cfg.puffer)
-=======
-        if self._cfg.agent.policy_class is None:
-            self._cfg.agent.policy_class = "metta.agent.external.example.Recurrent"
-
-        policy_module = self._cfg.agent.policy_class.rsplit(".", 1)[0]
-        module = importlib.import_module(policy_module)
-        policy_class = getattr(module, self._cfg.agent.policy_class.rsplit(".", 1)[1])
-
-        policy = load_policy(path, self._device, policy_class=policy_class)
->>>>>>> 4b8e6eafd69122bacfa815bdd8678e43b5134d2a
         name = os.path.basename(path)
         pr = PolicyRecord(
             self,

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -485,12 +485,12 @@ class PolicyStore:
                     modules_queue.append(submodule_name)
 
     def _load_from_puffer(self, path: str, metadata_only: bool = False) -> PolicyRecord:
-        if self._cfg.policy_class is not None:
+        if self._cfg.agent.policy_class is not None:
             policy_class = None
             try:
-                policy_module = self._cfg.policy_class.rsplit(".", 1)[0]
+                policy_module = self._cfg.agent.policy_class.rsplit(".", 1)[0]
                 module = importlib.import_module(policy_module)
-                policy_class = getattr(module, self._cfg.policy_class.rsplit(".", 1)[1])
+                policy_class = getattr(module, self._cfg.agent.policy_class.rsplit(".", 1)[1])
                 print(f"Successfully imported: {policy_class}")
             except (ModuleNotFoundError, AttributeError) as e:
                 print(f"Error importing Policy class: {e}")

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -10,7 +10,6 @@ The PolicyStore is used by the training system to manage opponent policies and c
 """
 
 import collections
-import importlib
 import logging
 import os
 import random
@@ -485,14 +484,7 @@ class PolicyStore:
                     modules_queue.append(submodule_name)
 
     def _load_from_puffer(self, path: str, metadata_only: bool = False) -> PolicyRecord:
-        if self._cfg.agent.policy_class is None:
-            self._cfg.agent.policy_class = "metta.agent.external.example.Recurrent"
-
-        policy_module = self._cfg.agent.policy_class.rsplit(".", 1)[0]
-        module = importlib.import_module(policy_module)
-        policy_class = getattr(module, self._cfg.agent.policy_class.rsplit(".", 1)[1])
-
-        policy = load_policy(path, self._device, policy_class=policy_class)
+        policy = load_policy(path, self._device, puffer=self._cfg.puffer)
         name = os.path.basename(path)
         pr = PolicyRecord(
             self,

--- a/metta/eval/analysis_config.py
+++ b/metta/eval/analysis_config.py
@@ -3,6 +3,7 @@ from metta.util.config import Config
 
 
 class AnalysisConfig(Config):
+    __init__ = Config.__init__
     # Policy URI to analyze
     policy_uri: str | None = None
     policy_selector: PolicySelectorConfig = PolicySelectorConfig()

--- a/metta/eval/dashboard/dashboard_config.py
+++ b/metta/eval/dashboard/dashboard_config.py
@@ -4,6 +4,7 @@ from metta.util.config import Config
 
 
 class DashboardConfig(Config):
+    __init__ = Config.__init__
     # Output options
     num_output_policies: int | Literal["all"] = 20
     metric: str = "reward"

--- a/metta/rl/pufferlib/policy.py
+++ b/metta/rl/pufferlib/policy.py
@@ -116,13 +116,6 @@ class PufferAgentWrapper(nn.Module):
         logprob -> logprob_act
         hidden -> logits then, after sample_logits(), log_sftmx_logits
         """
-        if state.lstm_h is not None and state.lstm_c is not None:
-            state = SimpleNamespace(
-                lstm_h=state.lstm_h.squeeze(),
-                lstm_c=state.lstm_c.squeeze(),
-            )
-        else:
-            state = SimpleNamespace(lstm_h=None, lstm_c=None)
         hidden, critic = self.policy(obs, state)  # using variable names from LSTMWrapper
         action, logprob, logits_entropy = sample_logits(hidden, action)
         # explanation of var names in the docstring above

--- a/metta/rl/pufferlib/policy.py
+++ b/metta/rl/pufferlib/policy.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
-from hydra.utils import instantiate
 
 import torch
+from hydra.utils import instantiate
+from omegaconf import DictConfig
 from pufferlib.cleanrl import sample_logits
 from torch import nn
-from omegaconf import DictConfig
 
 
 def load_policy(path: str, device: str = "cpu", puffer: DictConfig = None):
@@ -13,12 +13,12 @@ def load_policy(path: str, device: str = "cpu", puffer: DictConfig = None):
     try:
         num_actions, hidden_size = weights["policy.actor.0.weight"].shape
         num_action_args, _ = weights["policy.actor.1.weight"].shape
-        cnn_channels, obs_channels, _, _ = weights["policy.network.0.weight"].shape
+        _, obs_channels, _, _ = weights["policy.network.0.weight"].shape
     except Exception as e:
         print(f"Failed automatic parse from weights: {e}")
         # TODO -- fix all magic numbers
         num_actions, num_action_args = 9, 10
-        cnn_channels, obs_channels = 128, 34
+        _, obs_channels = 128, 34
 
     # Create environment namespace
     env = SimpleNamespace(

--- a/metta/rl/pufferlib/policy.py
+++ b/metta/rl/pufferlib/policy.py
@@ -118,11 +118,11 @@ class PufferAgentWrapper(nn.Module):
         """
         if state.lstm_h is not None and state.lstm_c is not None:
             state = SimpleNamespace(
-                        lstm_h = state.lstm_h.squeeze(),
-                        lstm_c = state.lstm_c.squeeze(),
-                    )
+                lstm_h=state.lstm_h.squeeze(),
+                lstm_c=state.lstm_c.squeeze(),
+            )
         else:
-            state = SimpleNamespace(lstm_h = None, lstm_c = None)
+            state = SimpleNamespace(lstm_h=None, lstm_c=None)
         hidden, critic = self.policy(obs, state)  # using variable names from LSTMWrapper
         action, logprob, logits_entropy = sample_logits(hidden, action)
         # explanation of var names in the docstring above

--- a/metta/rl/pufferlib/policy.py
+++ b/metta/rl/pufferlib/policy.py
@@ -107,6 +107,8 @@ class PufferAgentWrapper(nn.Module):
     def __init__(self, policy: nn.Module):
         super().__init__()
         self.policy = policy
+        self.hidden_size = policy.hidden_size
+        self.lstm = policy
 
     def forward(self, obs: torch.Tensor, state, action=None):
         """Uses variable names from LSTMWrapper. Translating for Metta:
@@ -114,6 +116,13 @@ class PufferAgentWrapper(nn.Module):
         logprob -> logprob_act
         hidden -> logits then, after sample_logits(), log_sftmx_logits
         """
+        if state.lstm_h is not None and state.lstm_c is not None:
+            state = SimpleNamespace(
+                        lstm_h = state.lstm_h.squeeze(),
+                        lstm_c = state.lstm_c.squeeze(),
+                    )
+        else:
+            state = SimpleNamespace(lstm_h = None, lstm_c = None)
         hidden, critic = self.policy(obs, state)  # using variable names from LSTMWrapper
         action, logprob, logits_entropy = sample_logits(hidden, action)
         # explanation of var names in the docstring above

--- a/metta/rl/pufferlib/policy.py
+++ b/metta/rl/pufferlib/policy.py
@@ -1,89 +1,23 @@
 from types import SimpleNamespace
 
-import pufferlib.models
-import pufferlib.pytorch
 import torch
 from pufferlib.cleanrl import sample_logits
 from torch import nn
 
 
-class Recurrent(pufferlib.models.LSTMWrapper):
-    def __init__(self, env, policy, input_size=512, hidden_size=512):
-        super().__init__(env, policy, input_size, hidden_size)
-
-
-class Policy(nn.Module):
-    def __init__(self, env, cnn_channels=128, hidden_size=512, **kwargs):
-        super().__init__()
-        self.hidden_size = hidden_size
-        self.is_continuous = False
-
-        self.network = nn.Sequential(
-            pufferlib.pytorch.layer_init(nn.Conv2d(34, cnn_channels, 5, stride=3)),
-            nn.ReLU(),
-            pufferlib.pytorch.layer_init(nn.Conv2d(cnn_channels, cnn_channels, 3, stride=1)),
-            nn.ReLU(),
-            nn.Flatten(),
-            pufferlib.pytorch.layer_init(nn.Linear(cnn_channels, hidden_size // 2)),
-            nn.ReLU(),
-        )
-
-        self.self_encoder = nn.Sequential(
-            pufferlib.pytorch.layer_init(nn.Linear(34, hidden_size // 2)),
-            nn.ReLU(),
-        )
-
-        # TODO - fix magic numbers!
-        # fmt: off
-        max_vec = torch.tensor([
-            1, 10, 30, 1, 1, 255,
-            100, 100, 100, 100, 100, 100, 100, 100,
-            1, 1, 1, 10, 1,
-            100, 100, 100, 100, 100, 100, 100, 100,
-            1, 1, 1, 1, 1, 1, 1
-        ], dtype=torch.float).reshape(1, 34, 1, 1)
-        # fmt: on
-
-        self.register_buffer("max_vec", max_vec)
-
-        action_nvec = env.single_action_space.nvec
-        self.actor = nn.ModuleList(
-            [pufferlib.pytorch.layer_init(nn.Linear(hidden_size, n), std=0.01) for n in action_nvec]
-        )
-
-        self.value = pufferlib.pytorch.layer_init(nn.Linear(hidden_size, 1), std=1)
-
-        # self.layer_norm = nn.LayerNorm(hidden_size)
-
-    def forward(self, observations, state=None):
-        hidden, lookup = self.encode_observations(observations)
-        actions, value = self.decode_actions(hidden, lookup)
-        return (actions, value), hidden
-
-    def encode_observations(self, observations, state=None):
-        features = observations.permute(0, 3, 1, 2).float() / self.max_vec
-        self_features = self.self_encoder(features[:, :, 5, 5])
-        cnn_features = self.network(features)
-        return torch.cat([self_features, cnn_features], dim=1)
-
-    def decode_actions(self, hidden):
-        # hidden = self.layer_norm(hidden)
-        logits = [dec(hidden) for dec in self.actor]
-        value = self.value(hidden)
-        return logits, value
-
-
 def load_policy(path: str, device: str = "cpu", policy_class: type = None):
     weights = torch.load(path, map_location=device, weights_only=True)
 
-    # TODO -- fix all magic numbers
-    if policy_class is None:
+    try:
         num_actions, hidden_size = weights["policy.actor.0.weight"].shape
         num_action_args, _ = weights["policy.actor.1.weight"].shape
         cnn_channels, obs_channels, _, _ = weights["policy.network.0.weight"].shape
-    else:
+    except Exception as e:
+        print(f"Failed automatic parse from weights: {e}")
+        # TODO -- fix all magic numbers
         num_actions, num_action_args = 9, 10
-        obs_channels = 34
+        hidden_size = 384
+        cnn_channels, obs_channels = 128, 34
 
     # Create environment namespace
     env = SimpleNamespace(
@@ -91,19 +25,13 @@ def load_policy(path: str, device: str = "cpu", policy_class: type = None):
         single_observation_space=SimpleNamespace(shape=[obs_channels, 11, 11]),
     )
 
-    if policy_class is None:
-        policy = Policy(env, cnn_channels=cnn_channels, hidden_size=hidden_size)
-        policy = Recurrent(env, policy)
-    else:
-        policy = policy_class(env)
-        policy.to(device)
-
+    policy = policy_class(env, cnn_channels=cnn_channels, hidden_size=hidden_size)
     policy.load_state_dict(weights)
-    policy = PufferAgentWrapper(policy)
+    policy = PufferAgent(policy).to(device)
     return policy
 
 
-class PufferAgentWrapper(nn.Module):
+class PufferAgent(nn.Module):
     def __init__(self, policy: nn.Module):
         super().__init__()
         self.policy = policy

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -20,7 +20,7 @@ from metta.eval.eval_stats_db import EvalStatsDB
 from metta.rl.fast_gae import compute_gae
 from metta.rl.pufferlib.experience import Experience
 from metta.rl.pufferlib.kickstarter import Kickstarter
-from metta.rl.pufferlib.policy import PufferAgentWrapper 
+from metta.rl.pufferlib.policy import PufferAgentWrapper
 from metta.rl.pufferlib.profile import Profile
 from metta.rl.pufferlib.torch_profiler import TorchProfiler
 from metta.rl.pufferlib.trainer_checkpoint import TrainerCheckpoint

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -20,7 +20,7 @@ from metta.eval.eval_stats_db import EvalStatsDB
 from metta.rl.fast_gae import compute_gae
 from metta.rl.pufferlib.experience import Experience
 from metta.rl.pufferlib.kickstarter import Kickstarter
-from metta.rl.pufferlib.policy import PufferAgentWrapper
+from metta.rl.pufferlib.policy import PufferAgent
 from metta.rl.pufferlib.profile import Profile
 from metta.rl.pufferlib.torch_profiler import TorchProfiler
 from metta.rl.pufferlib.trainer_checkpoint import TrainerCheckpoint
@@ -155,7 +155,7 @@ class PufferTrainer:
 
         # validate that policy matches environment
         self.metta_agent: MettaAgent | DistributedMettaAgent = self.policy  # type: ignore
-        assert isinstance(self.metta_agent, (MettaAgent, DistributedMettaAgent, PufferAgentWrapper)), self.metta_agent
+        assert isinstance(self.metta_agent, (MettaAgent, DistributedMettaAgent, PufferAgent)), self.metta_agent
         _env_shape = metta_grid_env.single_observation_space.shape
         environment_shape = tuple(_env_shape) if isinstance(_env_shape, list) else _env_shape
 

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -348,7 +348,6 @@ class PufferTrainer:
                 self.agent_step += num_steps * self._world_size
 
                 o = torch.as_tensor(o)
-                o_device = o.to(self.device, non_blocking=True)
                 r = torch.as_tensor(r)
                 d = torch.as_tensor(d)
 
@@ -360,6 +359,8 @@ class PufferTrainer:
                 assert training_env_id.min() >= 0, "Negative index in training_env_id"
 
                 state = PolicyState(lstm_h=lstm_h[:, training_env_id], lstm_c=lstm_c[:, training_env_id])
+
+                o_device = o.to(self.device, non_blocking=True)
                 actions, logprob, _, value, _ = policy(o_device, state)
 
                 lstm_h[:, training_env_id] = (
@@ -374,7 +375,6 @@ class PufferTrainer:
 
             with profile.eval_misc:
                 value = value.flatten()
-                actions = actions.cpu().numpy()
                 mask = torch.as_tensor(mask)  # * policy.mask)
                 o = o if self.trainer_cfg.cpu_offload else o_device
                 self.experience.store(o, value, actions, logprob, r, d, training_env_id, mask)
@@ -384,6 +384,7 @@ class PufferTrainer:
                         infos[k].append(v)
 
             with profile.env:
+                actions = actions.cpu().numpy()
                 self.vecenv.send(actions)
 
         with profile.eval_misc:

--- a/metta/sim/simulation_config.py
+++ b/metta/sim/simulation_config.py
@@ -10,6 +10,8 @@ from metta.util.config import Config
 class SimulationConfig(Config):
     """Configuration for a single simulation run."""
 
+    __init__ = Config.__init__
+
     # Core simulation config
     num_episodes: int
     max_time_s: int = 120
@@ -20,6 +22,8 @@ class SimulationConfig(Config):
 
 class SingleEnvSimulationConfig(SimulationConfig):
     """Configuration for a single simulation run."""
+
+    __init__ = SimulationConfig.__init__
 
     env: str
     env_overrides: Optional[dict] = None

--- a/metta/util/config.py
+++ b/metta/util/config.py
@@ -25,6 +25,9 @@ class Config(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    # Sub-classes of Config class should use the `__init__ = Config.__init__` trick to satisfy Pylance.
+    # Without this, Pylance will complain about 0 positional arguments, because it looks up Pydantic's
+    # __init__ method, which takes no positional arguments.
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if len(args) == 1 and not kwargs and isinstance(args[0], (DictConfig, dict)):
             super().__init__(**self.prepare_dict(args[0]))

--- a/mettagrid/benchmarks/grid_object_benchmark.cpp
+++ b/mettagrid/benchmarks/grid_object_benchmark.cpp
@@ -14,7 +14,7 @@ public:
     init(type_id, r, c, layer);
   }
 
-  void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     // Simple implementation for benchmarking
     for (size_t i = 0; i < offsets.size(); ++i) {
       obs[offsets[i]] = i % 255;
@@ -75,7 +75,7 @@ static void BM_GridObjectObs(benchmark::State& state) {
   TestGridObject obj(1, 5, 10, 0);
 
   // Create offsets vector and observation buffer
-  std::vector<unsigned int> offsets(numOffsets);
+  std::vector<uint8_t> offsets(numOffsets);
   for (int i = 0; i < numOffsets; ++i) {
     offsets[i] = i;
   }

--- a/mettagrid/mettagrid/config.py
+++ b/mettagrid/mettagrid/config.py
@@ -62,10 +62,14 @@ class MettaGridConfig:
 
         This allows using the config directly as: config_dict, map_array = metta_grid_config.to_c_args()
         """
+        if self._map_builder is None:
+            self.generate_map()
 
-        env_map = self.generate_map() if self.env_map is None else self.env_map
+        if self.env_map is None:
+            raise ValueError("generate_map failed to create a valid env_map")
+
         # Convert string array to list of strings for C++ compatibility
-        env_map_list = env_map.tolist()
+        env_map_list = self.env_map.tolist()
         env_map = np.array(env_map_list)
 
         # Convert to container for C++ code with explicit casting to Dict[str, Any]
@@ -75,5 +79,7 @@ class MettaGridConfig:
 
     def map_labels(self) -> list[str]:
         if self._map_builder is None:
-            return []
+            self.generate_map()
+        if self._map_builder is None:
+            raise ValueError("generate_map failed to create a valid _map_builder")
         return self._map_builder.labels or []

--- a/mettagrid/mettagrid/grid_object.hpp
+++ b/mettagrid/mettagrid/grid_object.hpp
@@ -1,6 +1,7 @@
 #ifndef GRID_OBJECT_HPP
 #define GRID_OBJECT_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -52,7 +53,7 @@ public:
     init(type_id, GridLocation(r, c, layer));
   }
 
-  virtual void obs(ObsType* obs, const vector<unsigned int>& offsets) const = 0;
+  virtual void obs(ObsType* obs, const vector<uint8_t>& offsets) const = 0;
 };
 
 #endif  // GRID_OBJECT_HPP

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -454,8 +454,6 @@ py::tuple MettaGrid::step(py::array_t<int> actions) {
 
 py::dict MettaGrid::grid_objects() {
   py::dict objects;
-  auto obj_data = py::array_t<unsigned char>(_grid_features.size());
-  auto obj_data_view = obj_data.mutable_unchecked<1>();
 
   for (unsigned int obj_id = 1; obj_id < _grid->objects.size(); obj_id++) {
     auto obj = _grid->object(obj_id);
@@ -474,13 +472,14 @@ py::dict MettaGrid::grid_objects() {
     for (size_t i = 0; i < offsets.size(); i++) {
       offsets[i] = i;
     }
+    unsigned char obj_data[type_features.size()];
 
     // Encode object features
-    _obs_encoder->encode(obj, obj_data_view.mutable_data(0), offsets);
+    _obs_encoder->encode(obj, obj_data, offsets);
 
     // Add features to object dict
     for (size_t i = 0; i < type_features.size(); i++) {
-      obj_dict[py::str(type_features[i])] = obj_data_view(i);
+      obj_dict[py::str(type_features[i])] = obj_data[i];
     }
 
     objects[py::int_(obj_id)] = obj_dict;

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -468,8 +468,11 @@ py::dict MettaGrid::grid_objects() {
 
     // Get feature offsets for this object type
     auto type_features = _obs_encoder->type_feature_names()[obj->_type_id];
-    std::vector<unsigned int> offsets(type_features.size());
-    for (size_t i = 0; i < offsets.size(); i++) {
+    std::vector<uint8_t> offsets(type_features.size());
+    // We shouldn't have more than 256 features, since we're storing the feature_ids
+    // as uint_8ts.
+    assert(offsets.size() < 256);
+    for (uint8_t i = 0; i < offsets.size(); i++) {
       offsets[i] = i;
     }
     unsigned char obj_data[type_features.size()];

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -106,7 +106,7 @@ public:
     return this->frozen;
   }
 
-  virtual void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = group;
     obs[offsets[2]] = hp;

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -133,7 +133,7 @@ public:
     this->maybe_start_converting();
   }
 
-  void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = this->hp;
     obs[offsets[2]] = this->color;

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -18,7 +18,7 @@ public:
     this->_swappable = cfg["swappable"];
   }
 
-  virtual void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = this->hp;
     obs[offsets[2]] = this->_swappable;

--- a/mettagrid/mettagrid/observation_encoder.hpp
+++ b/mettagrid/mettagrid/observation_encoder.hpp
@@ -36,13 +36,16 @@ public:
     }
 
     // Generate an offset for each unique feature name.
-    std::map<std::string, size_t> features;
+    std::map<std::string, uint8_t> features;
 
     for (size_t type_id = 0; type_id < ObjectType::Count; ++type_id) {
       for (size_t i = 0; i < _type_feature_names[type_id].size(); ++i) {
         std::string feature_name = _type_feature_names[type_id][i];
         if (features.count(feature_name) == 0) {
           size_t index = features.size();
+          // We want to keep the index within the range of a byte since we plan to
+          // use this as a feature_id.
+          assert(index < 256);
           features.insert({feature_name, index});
           _feature_names.push_back(feature_name);
         }
@@ -61,7 +64,7 @@ public:
     encode(obj, obs, _offsets[obj->_type_id]);
   }
 
-  void encode(const GridObject* obj, ObsType* obs, const std::vector<unsigned int>& offsets) {
+  void encode(const GridObject* obj, ObsType* obs, const std::vector<uint8_t>& offsets) {
     obj->obs(obs, offsets);
   }
 
@@ -74,7 +77,7 @@ public:
   }
 
 private:
-  std::vector<std::vector<unsigned int>> _offsets;
+  std::vector<std::vector<uint8_t>> _offsets;
   std::vector<std::vector<std::string>> _type_feature_names;
   std::vector<std::string> _feature_names;
 };

--- a/mettagrid/tests/grid_object_test.cpp
+++ b/mettagrid/tests/grid_object_test.cpp
@@ -41,7 +41,7 @@ TEST_F(GridLocationTest, ThreeParamConstructor) {
 // Concrete implementation of GridObject for testing
 class TestGridObject : public GridObject {
 public:
-  void obs(ObsType* obs, const vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const vector<uint8_t>& offsets) const override {
     // Simple implementation for testing
     obs[offsets[0]] = 1;
   }
@@ -91,7 +91,7 @@ TEST_F(GridObjectTest, InitWithCoordinatesAndLayer) {
 // Test obs method
 TEST_F(GridObjectTest, ObsMethod) {
   ObsType observations[1] = {0};
-  vector<unsigned int> offsets = {0};
+  vector<uint8_t> offsets = {0};
 
   obj.obs(observations, offsets);
 

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -9,7 +9,7 @@ hydra-core==1.4.0dev1
 imageio==2.37.0
 jmespath==1.0.1
 matplotlib==3.10.3
-numpy==2.2.5
+numpy==2.2.6
 omegaconf==2.4.0.dev3
 pandas==2.2.3
 pettingzoo==1.25.0

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -30,7 +30,7 @@ setuptools==80.7.1
 shimmy==2.0.0
 sympy==1.13.3
 tabulate==0.9.0
-tensordict==0.8.2
+tensordict==0.8.3
 termcolor==2.4.0
 torchrl==0.8.0
 tqdm==4.67.1

--- a/tests/agent/lib/test_lstm.py
+++ b/tests/agent/lib/test_lstm.py
@@ -1,0 +1,309 @@
+import pytest
+import torch
+
+from metta.agent.lib.lstm import LSTM
+from metta.agent.policy_state import PolicyState
+
+
+@pytest.fixture
+def simple_lstm_environment():
+    """Create a minimal environment for testing the LSTM layer."""
+    # Define the dimensions
+    batch_size = 4
+    seq_length = 3
+    input_size = 10
+    hidden_size = 20
+    num_layers = 2
+
+    # Create input data
+    sample_input = {
+        "x": torch.rand(batch_size * seq_length, input_size),
+        "hidden": torch.rand(batch_size * seq_length, input_size),
+    }
+
+    obs_shape = [input_size]
+    hidden_size = hidden_size
+    cfg = {
+        "name": "_lstm_test_",
+        "_nn_params": {"num_layers": num_layers},
+        "sources": [{"name": "hidden"}],
+    }
+    # Create LSTM layer
+    lstm_layer = LSTM(obs_shape, hidden_size, **cfg)
+
+    # Set up in_tensor_shapes manually
+    lstm_layer._in_tensor_shapes = [[input_size]]
+
+    # Initialize the network
+    if not hasattr(lstm_layer, "_out_tensor_shape"):
+        lstm_layer._out_tensor_shape = [hidden_size]
+
+    # Set up the network manually
+    lstm_layer._initialize()
+
+    # Return all components needed for testing
+    return {
+        "lstm_layer": lstm_layer,
+        "sample_input": sample_input,
+        "params": {
+            "batch_size": batch_size,
+            "seq_length": seq_length,
+            "input_size": input_size,
+            "hidden_size": hidden_size,
+            "num_layers": num_layers,
+        },
+    }
+
+
+class TestLSTMLayer:
+    """Tests for the LSTM layer with focus on state handling behavior."""
+
+    def test_lstm_with_none_state(self, simple_lstm_environment):
+        """Test LSTM layer behavior with None state."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+        params = simple_lstm_environment["params"]
+
+        # Create dict with None state
+        td = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": None}
+
+        # Forward pass with None state
+        result = lstm_layer._forward(td)
+
+        # Verify output shape
+        assert result[lstm_layer._name].shape == (params["batch_size"] * params["seq_length"], params["hidden_size"])
+
+        # Verify state is created
+        assert result["state"] is not None
+        assert result["state"].shape[0] == 2 * params["num_layers"]
+
+    def test_lstm_with_zero_state(self, simple_lstm_environment):
+        """Test LSTM layer behavior with zero-initialized state."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+        params = simple_lstm_environment["params"]
+
+        # The key issue: we need to reshape the state to match what the LSTM expects
+        # PyTorch LSTM expects hidden/cell states with shape: (num_layers, batch_size, hidden_size)
+        # But our input x is (batch_size * seq_length, input_size)
+
+        # First, determine B (what the LSTM extracts as batch size from the input)
+        x_shape = sample_input["x"].shape
+        B = x_shape[0]  # batch_size * seq_length
+
+        # Create zero state with the proper dimensions
+        h_zeros = torch.zeros(params["num_layers"], B, params["hidden_size"])
+        c_zeros = torch.zeros(params["num_layers"], B, params["hidden_size"])
+        zero_state = torch.cat([h_zeros, c_zeros], dim=0)
+
+        # Create dict with zero state
+        td = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": zero_state}
+
+        # Forward pass with zero state
+        result = lstm_layer._forward(td)
+
+        # Verify output shape
+        assert result[lstm_layer._name].shape == (params["batch_size"] * params["seq_length"], params["hidden_size"])
+
+        # Verify state is updated
+        assert result["state"] is not None
+        assert result["state"].shape[0] == 2 * params["num_layers"]
+
+    def test_training_impact_simulation(self, simple_lstm_environment):
+        """Simulate how the PR change affects outputs over multiple training steps."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+        params = simple_lstm_environment["params"]
+
+        num_steps = 10  # Number of simulated training steps
+        differences = []
+
+        # Get the actual batch size from input x shape - this is critical
+        B = sample_input["x"].shape[0]  # batch_size * seq_length
+
+        # Initialize states with the correct shapes
+        h_orig = torch.zeros(params["num_layers"], B, params["hidden_size"])
+        c_orig = torch.zeros(params["num_layers"], B, params["hidden_size"])
+        h_new = h_orig.clone()
+        c_new = c_orig.clone()
+
+        # Environment IDs that will be affected by the PR change
+        # Note: We need to adjust how we access env_ids if B != params["batch_size"]
+        # For simplicity, we'll use half of B
+        env_ids = torch.arange(B // 2)
+
+        # Simulate multiple training steps
+        for step in range(num_steps):
+            # Create new random input for each step
+            x = torch.rand_like(sample_input["x"])
+            hidden = torch.rand_like(sample_input["hidden"])
+
+            # Original behavior
+            state_orig = torch.cat([h_orig, c_orig], dim=0)
+            td_orig = {"x": x, "hidden": hidden, "state": state_orig}
+
+            result_orig = lstm_layer._forward(td_orig)
+
+            # Update states for next step
+            state_out = result_orig["state"]
+            split_point = params["num_layers"]
+            h_orig = state_out[:split_point].clone()
+            c_orig = state_out[split_point:].clone()
+
+            # New behavior (PR)
+            # First, use the same state update
+            h_new = h_orig.clone()
+            c_new = c_orig.clone()
+
+            # Then simulate the PR fix: reset states for some env IDs
+            for i in env_ids:
+                h_new[:, i, :] = 0
+                c_new[:, i, :] = 0
+
+            state_new = torch.cat([h_new, c_new], dim=0)
+            td_new = {"x": x, "hidden": hidden, "state": state_new}
+
+            result_new = lstm_layer._forward(td_new)
+
+            # Calculate output difference for this step
+            output_diff = torch.abs(result_orig[lstm_layer._name] - result_new[lstm_layer._name]).mean().item()
+
+            differences.append(output_diff)
+
+            print(f"Step {step + 1} output difference: {output_diff}")
+
+        # Calculate increasing/decreasing trend
+        if differences[-1] > differences[0]:
+            print("Impact of PR change increases over time")
+        else:
+            print("Impact of PR change stabilizes or decreases over time")
+
+        # The average difference over all steps should be significant
+        avg_diff = sum(differences) / len(differences)
+        assert avg_diff > 1e-6, "PR change should have measurable impact over training"
+
+    def test_lstm_continual_state(self, simple_lstm_environment):
+        """Test LSTM layer with state continuity across calls."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+
+        # First pass with None state
+        td1 = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": None}
+
+        result1 = lstm_layer._forward(td1)
+        state1 = result1["state"]
+        output1 = result1[lstm_layer._name]
+
+        # Second pass with state from first pass
+        td2 = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": state1}
+
+        result2 = lstm_layer._forward(td2)
+        output2 = result2[lstm_layer._name]
+
+        # Outputs should be different when using state continuation
+        diff = torch.abs(output1 - output2).mean().item()
+        print(f"Output difference with continued state: {diff}")
+
+        # The difference should be significant when continuing state vs starting fresh
+        assert diff > 1e-6, "Continued state should produce different outputs"
+
+    def test_lstm_reset_behavior(self, simple_lstm_environment):
+        """Test how resetting state affects LSTM output."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+        params = simple_lstm_environment["params"]
+
+        # First pass to establish non-zero state
+        td1 = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": None}
+
+        result1 = lstm_layer._forward(td1)
+        state1 = result1["state"].clone()
+
+        # Create a state with some values reset to zero (simulating PR behavior)
+        reset_state = state1.clone()
+        split_point = params["num_layers"]
+
+        # Zero out state for half the batch
+        half_batch = params["batch_size"] // 2
+        for i in range(half_batch):
+            reset_state[:split_point, i, :] = 0.0  # Reset h state
+            reset_state[split_point:, i, :] = 0.0  # Reset c state
+
+        # Second pass with partially reset state
+        td2 = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": reset_state}
+
+        result2 = lstm_layer._forward(td2)
+
+        # Run another pass with original state for comparison
+        td3 = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": state1}
+
+        result3 = lstm_layer._forward(td3)
+
+        # Compare outputs
+        output_diff = torch.abs(result2[lstm_layer._name] - result3[lstm_layer._name]).mean().item()
+        print(f"Output difference due to partial state reset: {output_diff}")
+
+        # The difference should be significant when some states are reset
+        assert output_diff > 1e-6, "Partial state reset should affect outputs"
+
+    def test_pr_change_simulation(self, simple_lstm_environment):
+        """Simulate the specific change in your PR: replacing None states with zeros."""
+        lstm_layer = simple_lstm_environment["lstm_layer"]
+        sample_input = simple_lstm_environment["sample_input"]
+        params = simple_lstm_environment["params"]
+
+        # Build up some non-zero state first
+        td_init = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": None}
+
+        result_init = lstm_layer._forward(td_init)
+        state = result_init["state"].clone()
+
+        # Split into h and c states
+        split_point = params["num_layers"]
+        h_state = state[:split_point].clone()
+        c_state = state[split_point:].clone()
+
+        # Create policy states to simulate the different behaviors
+        # Original behavior: Use the state directly (which would crash if None)
+        policy_state_orig = PolicyState(lstm_h=h_state, lstm_c=c_state)
+
+        # Simulate state being None for some environment IDs
+        env_ids = torch.arange(params["batch_size"] // 2)
+
+        # New behavior (PR fix): Replace None with zeros
+        h_new = h_state.clone()
+        c_new = c_state.clone()
+
+        # Zero out for selected environment IDs
+        for i in env_ids:
+            h_new[:, i, :] = 0
+            c_new[:, i, :] = 0
+
+        policy_state_new = PolicyState(lstm_h=h_new, lstm_c=c_new)
+
+        # Create states in the format expected by the LSTM layer
+        assert policy_state_orig.lstm_h is not None
+        assert policy_state_orig.lstm_c is not None
+        assert policy_state_new.lstm_h is not None
+        assert policy_state_new.lstm_c is not None
+        state_orig = torch.cat([policy_state_orig.lstm_h, policy_state_orig.lstm_c], dim=0)
+        state_new = torch.cat([policy_state_new.lstm_h, policy_state_new.lstm_c], dim=0)
+
+        # Forward pass with original state
+        td_orig = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": state_orig}
+
+        result_orig = lstm_layer._forward(td_orig)
+
+        # Forward pass with new state (PR behavior)
+        td_new = {"x": sample_input["x"], "hidden": sample_input["hidden"], "state": state_new}
+
+        result_new = lstm_layer._forward(td_new)
+
+        # Compare outputs
+        output_diff = torch.abs(result_orig[lstm_layer._name] - result_new[lstm_layer._name]).mean().item()
+
+        print(f"Output difference due to PR change: {output_diff}")
+
+        # Differences should be significant for the affected environments
+        # but we're calculating average over all outputs
+        assert output_diff > 1e-6, "PR change should affect LSTM outputs"

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -18,6 +18,7 @@ from mettagrid.util.file import http_url
 
 # TODO: This job can be replaced with sim now that Simulations create replays
 class ReplayJob(Config):
+    __init__ = Config.__init__
     sim: SingleEnvSimulationConfig
     policy_uri: str
     selector_type: str

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -26,12 +26,14 @@ from metta.util.runtime_configuration import setup_mettagrid_environment
 SMOKE_TEST_NUM_SIMS = 1
 SMOKE_TEST_MIN_SCORE = 0.9
 
+
 # --------------------------------------------------------------------------- #
 # Config objects                                                              #
 # --------------------------------------------------------------------------- #
 
 
 class SimJob(Config):
+    __init__ = Config.__init__
     simulation_suite: SimulationSuiteConfig
     policy_uris: List[str]
     selector_type: str = "top"
@@ -110,7 +112,6 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Sim job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
 
     sim_job = SimJob(cfg.sim_job)
-    assert isinstance(sim_job, SimJob), f"Expected SimJob instance, got {type(sim_job).__name__}"
 
     if sim_job.smoke_test:
         logger.info("Limiting simulations to %d", SMOKE_TEST_NUM_SIMS)

--- a/tools/train.py
+++ b/tools/train.py
@@ -19,6 +19,7 @@ from metta.util.wandb.wandb_context import WandbContext
 
 # TODO: populate this more
 class TrainJob(Config):
+    __init__ = Config.__init__
     evals: SimulationSuiteConfig
     map_preview_uri: Optional[str] = None
 


### PR DESCRIPTION
This PR adds simple support for external python classes used as policies, demo-ing with PufferAgentWrapper.

We add a top-level parameter to the `common.yaml` config called "policy_class", e.g.:
`policy_class: metta.agent.external.example.Recurrent`

We added two external models, one is the PufferLib default model in `agent/external/example.py` the other is a custom lstm_transformer in `agent/external/lstm_transformer.py`

`policy_store.py` now checks for `policy_class` being not null, and if it's set it tries to import the class and use it. 

There are still magic numbers in the `rl/pufferlib/policy.py` file for now.

`rl/pufferlib/trainer.py` is modified to accept MettaAgent/DistributedMettaAgent OR PufferAgentWrapper, though next step will be to try to roll PufferAgentWrapper into MettaAgent, where experiments either use a MettaAgentBuilder or the PufferAgentWrapper.