### PR TITLE
Fix resource collection to prevent item loss and improve recipe handling

### DIFF
--- a/mettagrid/mettagrid/actions/get_output.hpp
+++ b/mettagrid/mettagrid/actions/get_output.hpp
@@ -46,13 +46,12 @@ protected:
         // collect resources from a converter that's in the middle of processing a queue.
         continue;
       }
-      // Only take resources if the converter has some.
-      if (converter->inventory[i] > 0) {
-        // The actor will destroy anything it can't hold. That's not intentional, so feel free
-        // to fix it.
-        actor->stats.add(InventoryItemNames[i], "get", converter->inventory[i]);
-        actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
-        converter->update_inventory(static_cast<InventoryItem>(i), -converter->inventory[i]);
+      unsigned char can_take = std::min<unsigned char>(actor->max_items - actor->inventory[i], converter->inventory[i]);
+
+      if (can_take > 0) {
+        actor->stats.add(InventoryItemNames[i], "get", can_take);
+        actor->update_inventory(static_cast<InventoryItem>(i), can_take);
+        converter->update_inventory(static_cast<InventoryItem>(i), -can_take);
         items_taken = true;
       }
     }

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -35,14 +35,19 @@ protected:
     //   }
     // }
 
+    bool success = false;
     for (size_t i = 0; i < converter->recipe_input.size(); i++) {
       unsigned int inv = std::min(converter->recipe_input[i], actor->inventory[i]);
+      if (inv == 0) {
+        continue;
+      }
       actor->update_inventory(static_cast<InventoryItem>(i), -inv);
       converter->update_inventory(static_cast<InventoryItem>(i), inv);
       actor->stats.add(InventoryItemNames[i], "put", inv);
+      success = true;
     }
 
-    return true;
+    return success;
   }
 };
 


### PR DESCRIPTION
### TL;DR

Fix resource collection to prevent unintentional item destruction when inventory is full.

### What changed?

- Modified the `GetOutput` action handler to limit the number of resources an actor can take from a converter based on the actor's available inventory space. Previously, actors would take all resources from a converter regardless of their inventory capacity, potentially destroying excess items.

- The change calculates the maximum amount an actor can take (`can_take`) as the minimum between the actor's remaining capacity and the converter's available inventory, ensuring actors only collect what they can hold.

- Updated the `PutRecipeItems` action handler to return `false` when no items are transferred, allowing the action to fail gracefully when there are no applicable items to put.