### PR TITLE
Switch features to uint_8t

### DIFF
--- a/mettagrid/benchmarks/grid_object_benchmark.cpp
+++ b/mettagrid/benchmarks/grid_object_benchmark.cpp
@@ -14,7 +14,7 @@ public:
     init(type_id, r, c, layer);
   }
 
-  void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     // Simple implementation for benchmarking
     for (size_t i = 0; i < offsets.size(); ++i) {
       obs[offsets[i]] = i % 255;
@@ -75,7 +75,7 @@ static void BM_GridObjectObs(benchmark::State& state) {
   TestGridObject obj(1, 5, 10, 0);
 
   // Create offsets vector and observation buffer
-  std::vector<unsigned int> offsets(numOffsets);
+  std::vector<uint8_t> offsets(numOffsets);
   for (int i = 0; i < numOffsets; ++i) {
     offsets[i] = i;
   }

--- a/mettagrid/mettagrid/grid_object.hpp
+++ b/mettagrid/mettagrid/grid_object.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 using namespace std;
 

--- a/mettagrid/mettagrid/grid_object.hpp
+++ b/mettagrid/mettagrid/grid_object.hpp
@@ -52,7 +52,7 @@ public:
     init(type_id, GridLocation(r, c, layer));
   }
 
-  virtual void obs(ObsType* obs, const vector<unsigned int>& offsets) const = 0;
+  virtual void obs(ObsType* obs, const vector<uint8_t>& offsets) const = 0;
 };
 
 #endif  // GRID_OBJECT_HPP

--- a/mettagrid/mettagrid/grid_object.hpp
+++ b/mettagrid/mettagrid/grid_object.hpp
@@ -1,9 +1,9 @@
 #ifndef GRID_OBJECT_HPP
 #define GRID_OBJECT_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 using namespace std;
 

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -468,8 +468,11 @@ py::dict MettaGrid::grid_objects() {
 
     // Get feature offsets for this object type
     auto type_features = _obs_encoder->type_feature_names()[obj->_type_id];
-    std::vector<unsigned int> offsets(type_features.size());
-    for (size_t i = 0; i < offsets.size(); i++) {
+    std::vector<uint8_t> offsets(type_features.size());
+    // We shouldn't have more than 256 features, since we're storing the feature_ids
+    // as uint_8ts.
+    assert(offsets.size() < 256);
+    for (uint8_t i = 0; i < offsets.size(); i++) {
       offsets[i] = i;
     }
     unsigned char obj_data[type_features.size()];

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -106,7 +106,7 @@ public:
     return this->frozen;
   }
 
-  virtual void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = group;
     obs[offsets[2]] = hp;

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -133,7 +133,7 @@ public:
     this->maybe_start_converting();
   }
 
-  void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = this->hp;
     obs[offsets[2]] = this->color;

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -18,7 +18,7 @@ public:
     this->_swappable = cfg["swappable"];
   }
 
-  virtual void obs(ObsType* obs, const std::vector<unsigned int>& offsets) const override {
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
     obs[offsets[0]] = 1;
     obs[offsets[1]] = this->hp;
     obs[offsets[2]] = this->_swappable;

--- a/mettagrid/mettagrid/observation_encoder.hpp
+++ b/mettagrid/mettagrid/observation_encoder.hpp
@@ -36,13 +36,16 @@ public:
     }
 
     // Generate an offset for each unique feature name.
-    std::map<std::string, size_t> features;
+    std::map<std::string, uint8_t> features;
 
     for (size_t type_id = 0; type_id < ObjectType::Count; ++type_id) {
       for (size_t i = 0; i < _type_feature_names[type_id].size(); ++i) {
         std::string feature_name = _type_feature_names[type_id][i];
         if (features.count(feature_name) == 0) {
           size_t index = features.size();
+          // We want to keep the index within the range of a byte since we plan to
+          // use this as a feature_id.
+          assert(index < 256);
           features.insert({feature_name, index});
           _feature_names.push_back(feature_name);
         }
@@ -61,7 +64,7 @@ public:
     encode(obj, obs, _offsets[obj->_type_id]);
   }
 
-  void encode(const GridObject* obj, ObsType* obs, const std::vector<unsigned int>& offsets) {
+  void encode(const GridObject* obj, ObsType* obs, const std::vector<uint8_t>& offsets) {
     obj->obs(obs, offsets);
   }
 
@@ -74,7 +77,7 @@ public:
   }
 
 private:
-  std::vector<std::vector<unsigned int>> _offsets;
+  std::vector<std::vector<uint8_t>> _offsets;
   std::vector<std::vector<std::string>> _type_feature_names;
   std::vector<std::string> _feature_names;
 };

--- a/mettagrid/tests/grid_object_test.cpp
+++ b/mettagrid/tests/grid_object_test.cpp
@@ -91,7 +91,7 @@ TEST_F(GridObjectTest, InitWithCoordinatesAndLayer) {
 // Test obs method
 TEST_F(GridObjectTest, ObsMethod) {
   ObsType observations[1] = {0};
-  vector<unsigned int> offsets = {0};
+  vector<uint8_t> offsets = {0};
 
   obj.obs(observations, offsets);
 

--- a/mettagrid/tests/grid_object_test.cpp
+++ b/mettagrid/tests/grid_object_test.cpp
@@ -41,7 +41,7 @@ TEST_F(GridLocationTest, ThreeParamConstructor) {
 // Concrete implementation of GridObject for testing
 class TestGridObject : public GridObject {
 public:
-  void obs(ObsType* obs, const vector<unsigned int>& offsets) const override {
+  void obs(ObsType* obs, const vector<uint8_t>& offsets) const override {
     // Simple implementation for testing
     obs[offsets[0]] = 1;
   }


### PR DESCRIPTION
For initial token use, we're going to re-use feature offsets to be feature ids, so sizing these correctly for that purpose.