### PR TITLE
Switch away from using a numpy array for maps

### DIFF
--- a/mettagrid/mettagrid/config.py
+++ b/mettagrid/mettagrid/config.py
@@ -68,13 +68,12 @@ class MettaGridConfig:
         if self.env_map is None:
             raise ValueError("generate_map failed to create a valid env_map")
 
-        env_map = self.generate_map() if self.env_map is None else self.env_map
         # Convert to container for C++ code with explicit casting to Dict[str, Any]
         config_dict = cast(Dict[str, Any], OmegaConf.to_container(self.env_cfg))
 
         # Convert string array to list of strings for C++ compatibility
         # TODO: push the not-numpy-array higher up the stack, and consider pushing not-a-sparse-list lower.
-        return config_dict, env_map.tolist()
+        return config_dict, self.env_map.tolist()
 
     def map_labels(self) -> list[str]:
         if self._map_builder is None:

--- a/mettagrid/mettagrid/config.py
+++ b/mettagrid/mettagrid/config.py
@@ -68,14 +68,13 @@ class MettaGridConfig:
         if self.env_map is None:
             raise ValueError("generate_map failed to create a valid env_map")
 
-        # Convert string array to list of strings for C++ compatibility
-        env_map_list = self.env_map.tolist()
-        env_map = np.array(env_map_list)
-
+        env_map = self.generate_map() if self.env_map is None else self.env_map
         # Convert to container for C++ code with explicit casting to Dict[str, Any]
         config_dict = cast(Dict[str, Any], OmegaConf.to_container(self.env_cfg))
 
-        return config_dict, env_map
+        # Convert string array to list of strings for C++ compatibility
+        # TODO: push the not-numpy-array higher up the stack, and consider pushing not-a-sparse-list lower.
+        return config_dict, env_map.tolist()
 
     def map_labels(self) -> list[str]:
         if self._map_builder is None:

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -29,7 +29,7 @@ namespace py = pybind11;
 
 class METTAGRID_API MettaGrid {
 public:
-  MettaGrid(py::dict env_cfg, py::array map);
+  MettaGrid(py::dict env_cfg, py::list map);
   ~MettaGrid();
 
   // Python API methods

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -53,7 +53,7 @@ def create_minimal_mettagrid_env(max_steps=10, width=5, height=5):
         }
     }
 
-    return MettaGrid(env_config, game_map)
+    return MettaGrid(env_config, game_map.tolist())
 
 
 def test_truncation_at_max_steps():


### PR DESCRIPTION
This moves us from using numpy arrays for maps at the cpp level to using python lists. I think there are better solutions -- ones where we reconsider using numpy arrays in Python as well, and maybe rethink using strings as values, but this is easier to apply surgically.

The main reason for this change is to be able to switch to using normal Python _strings_, so we can avoid needing to do utf32 -> utf8 conversion in cpp, and can get rid of a lot of warnings about the deprecated libraries we're using to do so.