### PR TITLE
Fix map labels

### DIFF
--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -57,9 +57,9 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
     def _reset_env(self):
         mettagrid_config = MettaGridConfig(self._env_cfg, self._env_map)
 
+        config_dict, env_map = mettagrid_config.to_c_args()
         self._map_labels = mettagrid_config.map_labels()
 
-        config_dict, env_map = mettagrid_config.to_c_args()
         self._c_env = MettaGrid(config_dict, env_map)
         self._grid_env = self._c_env
         self._num_agents = self._c_env.num_agents()


### PR DESCRIPTION
Map labels are being loaded before map_builder, so the plots for reward per label over time are not showing up on wandb