### PR TITLE
Fix bug with replay urls

### DIFF
--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -638,11 +638,11 @@ class PufferTrainer:
             results = replay_simulator.simulate()
 
             if self.wandb_run is not None:
-                replay_url = results.stats_db.get_replay_urls(
+                replay_urls = results.stats_db.get_replay_urls(
                     policy_key=self.last_pr.key(), policy_version=self.last_pr.version()
                 )
-                if len(replay_url) > 0:
-                    replay_url = replay_url[0]
+                if len(replay_urls) > 0:
+                    replay_url = replay_urls[0]
                     player_url = "https://metta-ai.github.io/metta/?replayUrl=" + replay_url
                     link_summary = {
                         "replays/link": wandb.Html(f'<a href="{player_url}">MetaScope Replay (Epoch {self.epoch})</a>')

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -640,12 +640,14 @@ class PufferTrainer:
             if self.wandb_run is not None:
                 replay_url = results.stats_db.get_replay_urls(
                     policy_key=self.last_pr.key(), policy_version=self.last_pr.version()
-                )[0]
-                player_url = "https://metta-ai.github.io/metta/?replayUrl=" + replay_url
-                link_summary = {
-                    "replays/link": wandb.Html(f'<a href="{player_url}">MetaScope Replay (Epoch {self.epoch})</a>')
-                }
-                self.wandb_run.log(link_summary)
+                )
+                if len(replay_url) > 0:
+                    replay_url = replay_url[0]
+                    player_url = "https://metta-ai.github.io/metta/?replayUrl=" + replay_url
+                    link_summary = {
+                        "replays/link": wandb.Html(f'<a href="{player_url}">MetaScope Replay (Epoch {self.epoch})</a>')
+                    }
+                    self.wandb_run.log(link_summary)
 
     def _process_stats(self):
         for k in list(self.stats.keys()):


### PR DESCRIPTION
If the length of replay URLs is zero, training crashes, so we now check for that. 