### PR TITLE
Replace setup_build.sh with direct uv pip commands in batch entrypoint

### DIFF
--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -42,8 +42,13 @@ else
   echo "No git reference specified, using current branch"
 fi
 
+
 # Setup build (installs requirements)
-./devops/setup_build.sh
+uv pip install -r requirements.txt
+python setup.py build_ext --inplace
+uv pip install -e .
+
+uv run --active --directory mettagrid python setup.py build_ext --inplace
 
 export NUM_NODES=${AWS_BATCH_JOB_NUM_NODES:-1}
 export MASTER_ADDR=${AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS:-localhost}


### PR DESCRIPTION
### TL;DR

Replace `setup_build.sh` script with direct installation commands using `uv`.

### What changed?

- Removed the call to `./devops/setup_build.sh` in the AWS Batch entrypoint script
- Replaced it with explicit installation commands using `uv`:
  - `uv pip install -r requirements.txt`
  - `python setup.py build_ext --inplace`
  - `uv pip install -e .`
  - `uv run --active --directory mettagrid python setup.py build_ext --inplace`

### How to test?

1. Run the AWS Batch job with the updated entrypoint script
2. Verify that all dependencies are correctly installed
3. Confirm that the build process completes successfully
4. Check that the application runs as expected in the AWS Batch environment

### Why make this change?

Using `uv` directly instead of the setup script provides better control over the installation process and makes the entrypoint more transparent. This change also allows for more specific handling of the mettagrid directory build process, which may help with dependency resolution and build performance in the AWS Batch environment.