### PR TITLE
Remove has_inventory in favor of dynamic_casting

### DIFF
--- a/mettagrid/mettagrid/actions/get_output.hpp
+++ b/mettagrid/mettagrid/actions/get_output.hpp
@@ -21,18 +21,14 @@ protected:
   bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     target_loc.layer = GridLayer::Object_Layer;
-    MettaObject* target = static_cast<MettaObject*>(_grid->object_at(target_loc));
-    if (target == nullptr || !target->has_inventory()) {
+    // get_output only works on Converters, since only Converters have an output.
+    // Once we generalize this to `get`, we should be able to get from any HasInventory object, which
+    // should include agents. That's (e.g.) why we're checking inventory_is_accessible.
+    Converter* converter = dynamic_cast<Converter*>(_grid->object_at(target_loc));
+    if (converter == nullptr) {
       return false;
     }
 
-    // ##Converter_and_HasInventory_are_the_same_thing
-    // It's more correct to cast this as a HasInventory, but right now Converters are
-    // the only implementors of HasInventory, and we also need to call maybe_start_converting
-    // on them. We should later refactor this to we call .update_inventory on the target, and
-    // have this automatically call maybe_start_converting. That's hard because we need to
-    // let it maybe schedule events.
-    Converter* converter = static_cast<Converter*>(target);
     if (!converter->inventory_is_accessible()) {
       return false;
     }

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -21,19 +21,13 @@ protected:
   bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     target_loc.layer = GridLayer::Object_Layer;
-    MettaObject* target = static_cast<MettaObject*>(_grid->object_at(target_loc));
-    if (target == nullptr || !target->has_inventory()) {
+    // put_recipe_items only works on Converters, since only Converters have a recipe.
+    // Once we generalize this to `put`, we should be able to put to any HasInventory object, which
+    // should include agents.
+    Converter* converter = dynamic_cast<Converter*>(_grid->object_at(target_loc));
+    if (converter == nullptr) {
       return false;
     }
-
-    // #Converter_and_HasInventory_are_the_same_thing
-    Converter* converter = static_cast<Converter*>(target);
-
-    // for (size_t i = 0; i < converter->recipe_input.size(); i++) {
-    //   if (converter->recipe_input[i] > actor->inventory[i]) {
-    //     return false;
-    //   }
-    // }
 
     bool success = false;
     for (size_t i = 0; i < converter->recipe_input.size(); i++) {

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -15,10 +15,6 @@ public:
     this->inventory.resize(InventoryItem::InventoryCount);
   }
 
-  virtual bool has_inventory() {
-    return true;
-  }
-
   // Whether the inventory is accessible to an agent.
   virtual bool inventory_is_accessible() {
     return true;

--- a/mettagrid/mettagrid/objects/metta_object.hpp
+++ b/mettagrid/mettagrid/objects/metta_object.hpp
@@ -16,10 +16,6 @@ public:
     this->hp = cfg["hp"];
   }
 
-  virtual bool has_inventory() {  // TODO: make const
-    return false;
-  }
-
   virtual bool swappable() const {
     return false;
   }


### PR DESCRIPTION
### TL;DR

Refactored action handlers to use dynamic_cast for type checking instead of has_inventory() method

### What changed?

- Removed the `has_inventory()` virtual method from `MettaObject` and `HasInventory` classes
- Modified `GetOutput` and `PutRecipeItems` action handlers to use `dynamic_cast<Converter*>` instead of checking `has_inventory()` and then using `static_cast`
- Added clarifying comments about the intended behavior of these actions and future generalizations

### How to test?

- Verify that `get_output` action still works correctly with Converters
- Verify that `put_recipe_items` action still works correctly with Converters
- Confirm that attempting these actions on non-Converter objects fails as expected

### Why make this change?

This removes a function that shouldn't be needed. I _think_ the previous version of casting was done related to some cython issue, but don't remember specifically.