### PR TITLE
Revert a change to sim replay_dir that's breaking smoke tests

### DIFF
--- a/configs/sim_job.yaml
+++ b/configs/sim_job.yaml
@@ -13,6 +13,6 @@ sim_job:
   simulation_suite: ${sim}
   stats_dir: ${run_dir}/stats
   stats_db_uri: ${run_dir}/stats.db
-  replay_dir: s3://softmax-public/replays/evals
+  replay_dir: ${run_dir}/replays/evals
 
 cmd: sim


### PR DESCRIPTION
This reverts a change in https://github.com/Metta-AI/metta/pull/505 that causes smoke tests to fail, by requiring them to access s3.