### PR TITLE
Update cpp standard to be 20 across the board

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -15,7 +15,7 @@
             ],
             "compilerPath": "/usr/bin/clang++",
             "cStandard": "c23",
-            "cppStandard": "c++23",
+            "cppStandard": "c++20",
             "intelliSenseMode": "macos-clang-x64"
         }
     ],

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -9,7 +9,7 @@
 		}
 	],
 	"settings": {
-		"C_Cpp.default.cppStandard": "c++11",
+		"C_Cpp.default.cppStandard": "c++20",
 		"yaml.schemas": {
 			"envs/griddly/gdy-schema.json": "envs/griddly/power_grid/*.yaml"
 		},


### PR DESCRIPTION
We were being inconsistent in our standards. This brings some up and some down. AFAIK this should only impact intellisense.

I don't have a great reason to favor c++20 over c++23, but that's the standard we're using in compilation, so it seemed most straightforward to bring intellisense to that standard rather than try to push everything up to c++23.