### PR TITLE
feat: add workflow for launching AWS training jobs

### DIFF
--- a/.github/workflows/aws-train.yml
+++ b/.github/workflows/aws-train.yml
@@ -1,0 +1,99 @@
+name: Launch AWS Training Job
+
+# This workflow can be manually triggered from the GitHub UI
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_minutes:
+        description: 'Job timeout in minutes (auto-termination)'
+        required: true
+        default: '60'
+        type: number
+      trainer_env:
+        description: 'Training environment configuration'
+        required: true
+        default: 'env/mettagrid/simple'
+        type: string
+      pr_number:
+        description: 'PR number (if applicable, leave empty otherwise)'
+        required: false
+        type: string
+
+
+jobs:
+  launch-batch-job:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for AWS credentials
+      contents: read # This is required to checkout the repository
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python and uv
+        id: setup-python-uv
+        uses: ./.github/actions/setup-python-uv
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Get current commit hash
+        id: get_commit_hash
+        run: |
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "Commit hash: $COMMIT_HASH"
+
+      - name: Generate run name
+        id: generate_run_name
+        run: |
+          # Get short commit hash
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          
+          # Get current timestamp in a format suitable for filenames
+          TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
+          
+          # Get branch name
+          BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9]/_/g')
+          
+          # Generate the run name
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            # Include PR number in run name if provided
+            RUN_NAME="github.pr${{ github.event.inputs.pr_number }}.$COMMIT_HASH.$TIMESTAMP"
+            echo "Using PR #${{ github.event.inputs.pr_number }} in run name"
+          else
+            # Use branch name if no PR number provided
+            RUN_NAME="github.$BRANCH.$COMMIT_HASH.$TIMESTAMP"
+            echo "Using branch name '$BRANCH' in run name"
+          fi
+          
+          echo "Generated run name: $RUN_NAME"
+          echo "run_name=$RUN_NAME" >> $GITHUB_OUTPUT
+
+      - name: Launch AWS Batch job
+        run: |
+          python -m devops.aws.batch.launch_task \
+            --cmd=train \
+            --run=${{ steps.generate_run_name.outputs.run_name }} \
+            --git-commit=${{ steps.get_commit_hash.outputs.commit_hash }} \
+            --timeout-minutes=${{ github.event.inputs.timeout_minutes }} \
+            --skip-validation \
+            --skip-push-check \
+            trainer.env=${{ github.event.inputs.trainer_env }}
+
+      - name: Output job details
+        run: |
+          echo "Training job launched with the following details:"
+          echo "Run name: ${{ steps.generate_run_name.outputs.run_name }}"
+          echo "Commit hash: ${{ steps.get_commit_hash.outputs.commit_hash }}"
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            echo "Pull Request: #${{ github.event.inputs.pr_number }}"
+          else
+            echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+          fi
+          echo "Auto-termination: After ${{ github.event.inputs.timeout_minutes }} minutes"
+          echo "Environment: ${{ github.event.inputs.trainer_env }}"

--- a/configs/sim_job.yaml
+++ b/configs/sim_job.yaml
@@ -13,6 +13,6 @@ sim_job:
   simulation_suite: ${sim}
   stats_dir: ${run_dir}/stats
   stats_db_uri: ${run_dir}/stats.db
-  replay_dir: s3://softmax-public/replays/evals
+  replay_dir: ${run_dir}/replays/evals
 
 cmd: sim

--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -18,8 +18,28 @@ set -e
 # - AWS_BATCH_JOB_MAIN_NODE_INDEX: Index of the main node
 # - AWS_BATCH_JOB_NUM_NODES: Total number of nodes in the job
 
+# Source environment variables first to set up any paths
+source ./devops/env.sh 2>/dev/null || true
+
+# Setup log directory and file early
+export NODE_INDEX=${AWS_BATCH_JOB_NODE_INDEX:-0}
+export LOG_FILE="train_dir/logs/${JOB_NAME}.${NODE_INDEX}.log"
+mkdir -p $(dirname $LOG_FILE) 2>/dev/null || true
+
+# Function to log timeout-related messages to both stdout and our timeout log
+function timeout_log() {
+    local message="$1"
+    local timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+    echo "[$timestamp] TIMEOUT: $message" | tee -a "train_dir/logs/${JOB_NAME}.timeout.log" 2>/dev/null || echo "[$timestamp] TIMEOUT: $message"
+}
+
 # Set up the auto-termination feature if JOB_TIMEOUT_MINUTES is set
 if [ ! -z "$JOB_TIMEOUT_MINUTES" ] && [ "$NODE_INDEX" = "0" -o "$AWS_BATCH_JOB_NODE_INDEX" = "0" ]; then
+    # Create timeout log file
+    mkdir -p "train_dir/logs" 2>/dev/null || true
+    TIMEOUT_LOG="train_dir/logs/${JOB_NAME}.timeout.log"
+    touch $TIMEOUT_LOG 2>/dev/null || TIMEOUT_LOG="/tmp/${JOB_NAME}.timeout.log"
+    
     # Only set up timeout on the main node
     TIMEOUT_SECONDS=$((JOB_TIMEOUT_MINUTES * 60))
     
@@ -36,71 +56,107 @@ if [ ! -z "$JOB_TIMEOUT_MINUTES" ] && [ "$NODE_INDEX" = "0" -o "$AWS_BATCH_JOB_N
         TIMEOUT_DISPLAY="${JOB_TIMEOUT_MINUTES}m"
     fi
     
-    echo "AUTO-TERMINATION: Job will terminate after ${TIMEOUT_DISPLAY}"
+    timeout_log "Setting up auto-termination after ${TIMEOUT_DISPLAY} (${TIMEOUT_SECONDS} seconds)"
+    timeout_log "AWS_BATCH_JOB_ID=${AWS_BATCH_JOB_ID}"
+    timeout_log "AWS credentials check: $(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || echo 'NOT AVAILABLE')"
     
     # Start the timeout monitor in the background
     (
+        timeout_log "Timeout monitor started. Will wake up after ${TIMEOUT_DISPLAY}"
+        
+        # Record the start time
+        START_TIME=$(date +%s)
+        
         # Sleep for the specified timeout duration
         sleep $TIMEOUT_SECONDS
         
-        echo "JOB_TIMEOUT_MINUTES (${TIMEOUT_DISPLAY}) reached. Initiating job termination..."
+        # Calculate how long we actually slept
+        END_TIME=$(date +%s)
+        ELAPSED_SECONDS=$((END_TIME - START_TIME))
+        ELAPSED_MINUTES=$((ELAPSED_SECONDS / 60))
         
-        # Record timeout in a specific log file
-        TIMEOUT_LOG="train_dir/logs/${JOB_NAME}.timeout.log"
-        echo "$(date): JOB TERMINATED DUE TO TIMEOUT AFTER ${TIMEOUT_DISPLAY}" > $TIMEOUT_LOG
+        timeout_log "Waking up after ${ELAPSED_MINUTES}m (${ELAPSED_SECONDS}s). Should have been ${JOB_TIMEOUT_MINUTES}m (${TIMEOUT_SECONDS}s)"
+        timeout_log "JOB_TIMEOUT_MINUTES (${TIMEOUT_DISPLAY}) reached. Initiating job termination..."
         
         # Try to get the main training process to allow it to save checkpoints
-        MAIN_PID=$(ps -eo pid,%cpu --sort=-%cpu | awk 'NR==2 {print $1}')
+        timeout_log "Finding main process to terminate gracefully..."
+        PS_OUTPUT=$(ps -eo pid,%cpu,command --sort=-%cpu)
+        echo "$PS_OUTPUT" | head -n 10 >> $TIMEOUT_LOG
+        MAIN_PID=$(echo "$PS_OUTPUT" | awk 'NR==2 {print $1}')
         
         if [ ! -z "$MAIN_PID" ]; then
-            echo "Sending SIGTERM to main process $MAIN_PID to allow checkpoint saving" | tee -a $TIMEOUT_LOG
-            kill -15 $MAIN_PID || true
+            timeout_log "Sending SIGTERM to main process $MAIN_PID to allow checkpoint saving"
+            kill -15 $MAIN_PID 2>> $TIMEOUT_LOG || timeout_log "Failed to send SIGTERM to $MAIN_PID"
             
             # Give it some time to save checkpoints
-            echo "Waiting 60 seconds for graceful termination and checkpoint saving..." | tee -a $TIMEOUT_LOG
-            sleep 60
+            timeout_log "Waiting 30 seconds for graceful termination and checkpoint saving..."
+            sleep 30
+        else
+            timeout_log "Could not identify main process"
         fi
         
         # Terminate the job via AWS Batch API
         if [ ! -z "$AWS_BATCH_JOB_ID" ]; then
-            echo "Terminating AWS Batch job $AWS_BATCH_JOB_ID via AWS API" | tee -a $TIMEOUT_LOG
-            aws batch terminate-job \
-                --job-id $AWS_BATCH_JOB_ID \
-                --reason "Timeout of ${TIMEOUT_DISPLAY} reached" \
-                --region us-east-1
-            echo "Termination request sent to AWS Batch API" | tee -a $TIMEOUT_LOG
+            timeout_log "Terminating AWS Batch job $AWS_BATCH_JOB_ID via AWS API"
+            
+            # Verify AWS CLI is available
+            if ! command -v aws &> /dev/null; then
+                timeout_log "ERROR: AWS CLI is not installed or not in PATH"
+            else
+                timeout_log "AWS CLI is available"
+                
+                # Verify AWS credentials
+                if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+                    timeout_log "ERROR: AWS credentials not set in environment"
+                else
+                    timeout_log "AWS credentials are set"
+                    
+                    # Call AWS Batch API to terminate the job
+                    TERMINATION_RESULT=$(aws batch terminate-job \
+                        --job-id $AWS_BATCH_JOB_ID \
+                        --reason "Timeout of ${TIMEOUT_DISPLAY} reached" \
+                        --region us-east-1 2>&1)
+                    
+                    TERMINATION_EXIT_CODE=$?
+                    if [ $TERMINATION_EXIT_CODE -eq 0 ]; then
+                        timeout_log "Successfully sent termination request to AWS Batch API"
+                    else
+                        timeout_log "ERROR: Failed to terminate job via API: $TERMINATION_EXIT_CODE"
+                        timeout_log "API response: $TERMINATION_RESULT"
+                    fi
+                fi
+            fi
         else
-            echo "ERROR: AWS_BATCH_JOB_ID not found. Cannot terminate job via API." | tee -a $TIMEOUT_LOG
+            timeout_log "ERROR: AWS_BATCH_JOB_ID not found. Cannot terminate job via API."
         fi
         
-        # Wait for AWS Batch to process the termination
-        echo "Waiting for AWS Batch to process the termination request..." | tee -a $TIMEOUT_LOG
+        # Wait a bit more, then try more aggressive termination
+        timeout_log "Waiting 30 more seconds for API termination to take effect..."
         sleep 30
         
-        # As a last resort, attempt to shut down the container
-        echo "Forcing exit of the entrypoint script" | tee -a $TIMEOUT_LOG
-        exit 1
+        # If we're still running, try killing all Python processes
+        timeout_log "Still running after API termination attempt. Trying to kill all Python processes..."
+        pkill -9 python 2>> $TIMEOUT_LOG || timeout_log "No Python processes found to kill"
+        pkill -9 python3 2>> $TIMEOUT_LOG || timeout_log "No Python3 processes found to kill"
+        
+        # As a last resort, exit the script with an error code
+        timeout_log "Forcing exit of the script with exit code 143 (SIGTERM)"
+        kill -9 -1 2>/dev/null || timeout_log "Failed to send SIGKILL to all processes in the group"
+        exit 143
     ) &
     
     # Store the timeout process ID
     TIMEOUT_PID=$!
+    timeout_log "Timeout monitor process ID: $TIMEOUT_PID"
     
     # Create a trap to clean up the timeout process if the script exits normally
-    trap 'echo "Job completed normally, canceling timeout monitor."; kill $TIMEOUT_PID 2>/dev/null || true' EXIT
+    trap 'timeout_log "Job completed normally, canceling timeout monitor."; kill $TIMEOUT_PID 2>/dev/null || true' EXIT
 fi
 
 # Link training directory
 ln -s /mnt/efs/train_dir train_dir 2> /dev/null || true
 # Create dist directory
-mkdir -p train_dir/dist/$RUN_ID
-
-# Source environment variables
-source ./devops/env.sh
-
-# Setup log directory and file
-export NODE_INDEX=${AWS_BATCH_JOB_NODE_INDEX:-0}
-export LOG_FILE="train_dir/logs/${JOB_NAME}.${NODE_INDEX}.log"
-mkdir -p $(dirname $LOG_FILE)
+mkdir -p train_dir/dist/$RUN_ID 2>/dev/null || true
 
 # Start logging everything to the log file and stdout
 exec > >(tee -a "$LOG_FILE") 2>&1
@@ -121,6 +177,14 @@ if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then
     fi
     
     echo "=== AUTO-TERMINATION: Job will terminate after ${TIMEOUT_DISPLAY} ==="
+    echo "=== Timeout process ID: $TIMEOUT_PID ==="
+    
+    # Print AWS identity if available (to verify credentials)
+    if command -v aws &> /dev/null; then
+        echo "=== AWS Identity: $(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null || echo 'NOT AVAILABLE') ==="
+    else
+        echo "=== AWS CLI not available ==="
+    fi
 fi
 
 echo "=== Setting up environment ==="
@@ -160,6 +224,7 @@ else
     echo "Auto-termination: Not set"
 fi
 echo "Additional args: $TASK_ARGS"
+echo "AWS_BATCH_JOB_ID: $AWS_BATCH_JOB_ID"
 
 # Run the training command
 ./devops/$CMD.sh run=$RUN_ID +hardware=$HARDWARE trainer.num_workers=$NUM_WORKERS $TASK_ARGS

--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -10,11 +10,84 @@ set -e
 # - NUM_GPUS: Number of GPUs per node
 # - NUM_WORKERS: Number of workers for training
 # - TASK_ARGS: Additional arguments to pass to the training command
+# - JOB_TIMEOUT_MINUTES: Optional timeout in minutes for auto-termination
 #
 # AWS Batch environment variables used:
+# - AWS_BATCH_JOB_ID: The ID of the current job
 # - AWS_BATCH_JOB_NODE_INDEX: Index of this node in the job
 # - AWS_BATCH_JOB_MAIN_NODE_INDEX: Index of the main node
 # - AWS_BATCH_JOB_NUM_NODES: Total number of nodes in the job
+
+# Set up the auto-termination feature if JOB_TIMEOUT_MINUTES is set
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ] && [ "$NODE_INDEX" = "0" -o "$AWS_BATCH_JOB_NODE_INDEX" = "0" ]; then
+    # Only set up timeout on the main node
+    TIMEOUT_SECONDS=$((JOB_TIMEOUT_MINUTES * 60))
+    
+    # Format timeout for display
+    if [ $JOB_TIMEOUT_MINUTES -ge 60 ]; then
+        HOURS=$((JOB_TIMEOUT_MINUTES / 60))
+        MINS=$((JOB_TIMEOUT_MINUTES % 60))
+        if [ $MINS -eq 0 ]; then
+            TIMEOUT_DISPLAY="${HOURS}h"
+        else
+            TIMEOUT_DISPLAY="${HOURS}h ${MINS}m"
+        fi
+    else
+        TIMEOUT_DISPLAY="${JOB_TIMEOUT_MINUTES}m"
+    fi
+    
+    echo "AUTO-TERMINATION: Job will terminate after ${TIMEOUT_DISPLAY}"
+    
+    # Start the timeout monitor in the background
+    (
+        # Sleep for the specified timeout duration
+        sleep $TIMEOUT_SECONDS
+        
+        echo "JOB_TIMEOUT_MINUTES (${TIMEOUT_DISPLAY}) reached. Initiating job termination..."
+        
+        # Record timeout in a specific log file
+        TIMEOUT_LOG="train_dir/logs/${JOB_NAME}.timeout.log"
+        echo "$(date): JOB TERMINATED DUE TO TIMEOUT AFTER ${TIMEOUT_DISPLAY}" > $TIMEOUT_LOG
+        
+        # Try to get the main training process to allow it to save checkpoints
+        MAIN_PID=$(ps -eo pid,%cpu --sort=-%cpu | awk 'NR==2 {print $1}')
+        
+        if [ ! -z "$MAIN_PID" ]; then
+            echo "Sending SIGTERM to main process $MAIN_PID to allow checkpoint saving" | tee -a $TIMEOUT_LOG
+            kill -15 $MAIN_PID || true
+            
+            # Give it some time to save checkpoints
+            echo "Waiting 60 seconds for graceful termination and checkpoint saving..." | tee -a $TIMEOUT_LOG
+            sleep 60
+        fi
+        
+        # Terminate the job via AWS Batch API
+        if [ ! -z "$AWS_BATCH_JOB_ID" ]; then
+            echo "Terminating AWS Batch job $AWS_BATCH_JOB_ID via AWS API" | tee -a $TIMEOUT_LOG
+            aws batch terminate-job \
+                --job-id $AWS_BATCH_JOB_ID \
+                --reason "Timeout of ${TIMEOUT_DISPLAY} reached" \
+                --region us-east-1
+            echo "Termination request sent to AWS Batch API" | tee -a $TIMEOUT_LOG
+        else
+            echo "ERROR: AWS_BATCH_JOB_ID not found. Cannot terminate job via API." | tee -a $TIMEOUT_LOG
+        fi
+        
+        # Wait for AWS Batch to process the termination
+        echo "Waiting for AWS Batch to process the termination request..." | tee -a $TIMEOUT_LOG
+        sleep 30
+        
+        # As a last resort, attempt to shut down the container
+        echo "Forcing exit of the entrypoint script" | tee -a $TIMEOUT_LOG
+        exit 1
+    ) &
+    
+    # Store the timeout process ID
+    TIMEOUT_PID=$!
+    
+    # Create a trap to clean up the timeout process if the script exits normally
+    trap 'echo "Job completed normally, canceling timeout monitor."; kill $TIMEOUT_PID 2>/dev/null || true' EXIT
+fi
 
 # Link training directory
 ln -s /mnt/efs/train_dir train_dir 2> /dev/null || true
@@ -32,6 +105,23 @@ mkdir -p $(dirname $LOG_FILE)
 # Start logging everything to the log file and stdout
 exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=== Logging to $LOG_FILE ==="
+
+# Log timeout information if set
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then
+    if [ $JOB_TIMEOUT_MINUTES -ge 60 ]; then
+        HOURS=$((JOB_TIMEOUT_MINUTES / 60))
+        MINS=$((JOB_TIMEOUT_MINUTES % 60))
+        if [ $MINS -eq 0 ]; then
+            TIMEOUT_DISPLAY="${HOURS}h"
+        else
+            TIMEOUT_DISPLAY="${HOURS}h ${MINS}m"
+        fi
+    else
+        TIMEOUT_DISPLAY="${JOB_TIMEOUT_MINUTES}m"
+    fi
+    
+    echo "=== AUTO-TERMINATION: Job will terminate after ${TIMEOUT_DISPLAY} ==="
+fi
 
 echo "=== Setting up environment ==="
 # Handle git reference if specified
@@ -64,6 +154,11 @@ echo "Node index: $NODE_INDEX of $NUM_NODES nodes"
 echo "Master address: $MASTER_ADDR:$MASTER_PORT"
 echo "Workers: $NUM_WORKERS"
 echo "Hardware: $HARDWARE"
+if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then
+    echo "Auto-termination: After ${TIMEOUT_DISPLAY}"
+else
+    echo "Auto-termination: Not set"
+fi
 echo "Additional args: $TASK_ARGS"
 
 # Run the training command

--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -21,6 +21,15 @@ set -e
 # Source environment variables first to set up any paths
 source ./devops/env.sh 2>/dev/null || true
 
+# Link training directory
+ln -s /mnt/efs/train_dir train_dir 2> /dev/null
+# Create dist directory
+mkdir -p train_dir/dist/$RUN_ID 2> /dev/null
+
+# Start logging everything to the log file and stdout
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== Logging to $LOG_FILE ==="
+
 # Setup log directory and file early
 export NODE_INDEX=${AWS_BATCH_JOB_NODE_INDEX:-0}
 export LOG_FILE="train_dir/logs/${JOB_NAME}.${NODE_INDEX}.log"
@@ -154,15 +163,6 @@ if [ ! -z "$JOB_TIMEOUT_MINUTES" ] && [ "$NODE_INDEX" = "0" -o "$AWS_BATCH_JOB_N
         exit 0
     fi
 fi
-
-# Link training directory
-ln -s /mnt/efs/train_dir train_dir 2> /dev/null || true
-# Create dist directory
-mkdir -p train_dir/dist/$RUN_ID 2>/dev/null || true
-
-# Start logging everything to the log file and stdout
-exec > >(tee -a "$LOG_FILE") 2>&1
-echo "=== Logging to $LOG_FILE ==="
 
 # Log timeout information if set
 if [ ! -z "$JOB_TIMEOUT_MINUTES" ]; then

--- a/devops/aws/batch/entrypoint.sh
+++ b/devops/aws/batch/entrypoint.sh
@@ -18,22 +18,24 @@ set -e
 # - AWS_BATCH_JOB_MAIN_NODE_INDEX: Index of the main node
 # - AWS_BATCH_JOB_NUM_NODES: Total number of nodes in the job
 
-# Source environment variables first to set up any paths
-source ./devops/env.sh 2>/dev/null || true
+
+# Source environment variables
+source ./devops/env.sh
 
 # Link training directory
-ln -s /mnt/efs/train_dir train_dir 2> /dev/null
-# Create dist directory
-mkdir -p train_dir/dist/$RUN_ID 2> /dev/null
+ln -s /mnt/efs/train_dir train_dir
 
-# Start logging everything to the log file and stdout
-exec > >(tee -a "$LOG_FILE") 2>&1
-echo "=== Logging to $LOG_FILE ==="
+# Create dist directory
+mkdir -p train_dir/dist/$RUN_ID
 
 # Setup log directory and file early
 export NODE_INDEX=${AWS_BATCH_JOB_NODE_INDEX:-0}
 export LOG_FILE="train_dir/logs/${JOB_NAME}.${NODE_INDEX}.log"
+
 mkdir -p $(dirname $LOG_FILE) 2>/dev/null || true
+# Start logging everything to the log file and stdout
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "=== Logging to $LOG_FILE ==="
 
 # Function to log timeout-related messages to both stdout and our timeout log
 function timeout_log() {

--- a/devops/aws/batch/launch_task.py
+++ b/devops/aws/batch/launch_task.py
@@ -327,7 +327,7 @@ def main():
     parser.add_argument(
         "--timeout-minutes",
         type=int,
-        help="Automatically terminate the job after this many minutes. The job will gracefully terminate the main process when the timeout is reached.",
+        help="Automatically terminate the job after this many minutes.",
     )
     args, task_args = parser.parse_known_args()
 


### PR DESCRIPTION
This PR adds a new flag to our AWS launch script that allows a job to self-terminate after a certain number of minutes. 

The intention is to use this in a new workflow that will train for ~30 min on env/simple for every push to main so that we can spot real world performance problems earlier.