### PR TITLE
Add a unit test for grid_objects

### DIFF
--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -88,6 +88,62 @@ def test_observation():
     assert not obs[0, 1, 2, :].any(), "Expected empty space to right of agent 0"
 
 
+def test_grid_objects():
+    env = create_minimal_mettagrid_env()
+    objects = env.grid_objects()
+    
+    # Test that we have the expected number of objects
+    # 4 walls on each side (minus corners) + 2 agents
+    expected_walls = 2 * (env.map_width() + env.map_height() - 2)
+    expected_agents = 2
+    assert len(objects) == expected_walls + expected_agents, "Wrong number of objects"
+
+    common_properties = {"r", "c", "layer", "type", "id"}
+    
+    for obj_id, obj in objects.items():
+        print(obj)
+        if obj.get("wall"):
+            assert set(obj) == {"wall", "hp", "swappable"} | common_properties
+            # assert obj["hp"] == 100, "Wall should have 100 hp"
+            # assert "swappable" in obj, "Wall should have swappable property"
+    # # Test wall properties
+    # wall_id = None
+    # for obj_id, obj in objects.items():
+    #     if obj["wall"] == 1:  # Wall type
+    #         wall_id = obj_id
+    #         break
+    
+    # assert wall_id is not None, "No wall found"
+    # wall = objects[wall_id]
+    # assert wall["hp"] == 100, "Wall should have 100 hp"
+    # assert "swappable" in wall, "Wall should have swappable property"
+    
+    # # Test agent properties
+    # agent_ids = []
+    # for obj_id, obj in objects.items():
+    #     if obj["type"] == 0:  # Agent type
+    #         agent_ids.append(obj_id)
+    
+    # assert len(agent_ids) == 2, "Should have 2 agents"
+    
+    # # Test first agent (upper left)
+    # agent1 = objects[agent_ids[0]]
+    # assert agent1["r"] == 1, "First agent should be at row 1"
+    # assert agent1["c"] == 1, "First agent should be at column 1"
+    # assert agent1["group"] == 0, "Agent should be in group 0"
+    # assert agent1["agent_id"] in [0, 1], "Agent should have an agent_id"
+    
+    # # Test second agent (middle)
+    # agent2 = objects[agent_ids[1]]
+    # mid_y = env.map_height() // 2
+    # mid_x = env.map_width() // 2
+    # assert agent2["r"] == mid_y, "Second agent should be in middle row"
+    # assert agent2["c"] == mid_x, "Second agent should be in middle column"
+    # assert agent2["group"] == 0, "Agent should be in group 0"
+    # assert agent2["agent_id"] in [0, 1], "Agent should have an agent_id"
+    # assert agent2["agent_id"] != agent1["agent_id"], "Agents should have different agent_ids"
+
+
 class TestSetBuffers:
     def test_set_buffers_wrong_shape(self):
         env = create_minimal_mettagrid_env()

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -49,6 +49,7 @@ def create_minimal_mettagrid_env(max_steps=10, width=5, height=5):
             },
             "agent": {
                 "inventory_size": 0,
+                "hp": 100,
             },
         }
     }
@@ -100,18 +101,18 @@ def test_grid_objects():
 
     common_properties = {"r", "c", "layer", "type", "id"}
     
-    for obj_id, obj in objects.items():
-        print(obj)
+    for obj in objects.values():
         if obj.get("wall"):
             assert set(obj) == {"wall", "hp", "swappable"} | common_properties
             assert obj["wall"] == 1, "Wall should have type 1"
             assert obj["hp"] == 100, "Wall should have 100 hp"
         if obj.get("agent"):
-            assert set(obj) == {"agent", "group", "hp", "frozen", "orientation", "color"} | common_properties
+            # agents will also have various inventory, which we don't list here
+            assert set(obj).issuperset({"agent", "agent:group", "hp", "agent:frozen", "agent:orientation", "agent:color", "agent:inv:heart"} | common_properties)
             assert obj["agent"] == 1, "Agent should have type 1"
-            assert obj["group"] == 0, "Agent should be in group 0"
+            assert obj["agent:group"] == 0, "Agent should be in group 0"
             assert obj["hp"] == 100, "Agent should have 100 hp"
-            assert obj["frozen"] == 0, "Agent should not be frozen"
+            assert obj["agent:frozen"] == 0, "Agent should not be frozen"
 
 
 class TestSetBuffers:

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -104,44 +104,14 @@ def test_grid_objects():
         print(obj)
         if obj.get("wall"):
             assert set(obj) == {"wall", "hp", "swappable"} | common_properties
-            # assert obj["hp"] == 100, "Wall should have 100 hp"
-            # assert "swappable" in obj, "Wall should have swappable property"
-    # # Test wall properties
-    # wall_id = None
-    # for obj_id, obj in objects.items():
-    #     if obj["wall"] == 1:  # Wall type
-    #         wall_id = obj_id
-    #         break
-    
-    # assert wall_id is not None, "No wall found"
-    # wall = objects[wall_id]
-    # assert wall["hp"] == 100, "Wall should have 100 hp"
-    # assert "swappable" in wall, "Wall should have swappable property"
-    
-    # # Test agent properties
-    # agent_ids = []
-    # for obj_id, obj in objects.items():
-    #     if obj["type"] == 0:  # Agent type
-    #         agent_ids.append(obj_id)
-    
-    # assert len(agent_ids) == 2, "Should have 2 agents"
-    
-    # # Test first agent (upper left)
-    # agent1 = objects[agent_ids[0]]
-    # assert agent1["r"] == 1, "First agent should be at row 1"
-    # assert agent1["c"] == 1, "First agent should be at column 1"
-    # assert agent1["group"] == 0, "Agent should be in group 0"
-    # assert agent1["agent_id"] in [0, 1], "Agent should have an agent_id"
-    
-    # # Test second agent (middle)
-    # agent2 = objects[agent_ids[1]]
-    # mid_y = env.map_height() // 2
-    # mid_x = env.map_width() // 2
-    # assert agent2["r"] == mid_y, "Second agent should be in middle row"
-    # assert agent2["c"] == mid_x, "Second agent should be in middle column"
-    # assert agent2["group"] == 0, "Agent should be in group 0"
-    # assert agent2["agent_id"] in [0, 1], "Agent should have an agent_id"
-    # assert agent2["agent_id"] != agent1["agent_id"], "Agents should have different agent_ids"
+            assert obj["wall"] == 1, "Wall should have type 1"
+            assert obj["hp"] == 100, "Wall should have 100 hp"
+        if obj.get("agent"):
+            assert set(obj) == {"agent", "group", "hp", "frozen", "orientation", "color"} | common_properties
+            assert obj["agent"] == 1, "Agent should have type 1"
+            assert obj["group"] == 0, "Agent should be in group 0"
+            assert obj["hp"] == 100, "Agent should have 100 hp"
+            assert obj["frozen"] == 0, "Agent should not be frozen"
 
 
 class TestSetBuffers:

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -92,7 +92,7 @@ def test_observation():
 def test_grid_objects():
     env = create_minimal_mettagrid_env()
     objects = env.grid_objects()
-    
+
     # Test that we have the expected number of objects
     # 4 walls on each side (minus corners) + 2 agents
     expected_walls = 2 * (env.map_width() + env.map_height() - 2)
@@ -100,7 +100,7 @@ def test_grid_objects():
     assert len(objects) == expected_walls + expected_agents, "Wrong number of objects"
 
     common_properties = {"r", "c", "layer", "type", "id"}
-    
+
     for obj in objects.values():
         if obj.get("wall"):
             assert set(obj) == {"wall", "hp", "swappable"} | common_properties
@@ -108,7 +108,10 @@ def test_grid_objects():
             assert obj["hp"] == 100, "Wall should have 100 hp"
         if obj.get("agent"):
             # agents will also have various inventory, which we don't list here
-            assert set(obj).issuperset({"agent", "agent:group", "hp", "agent:frozen", "agent:orientation", "agent:color", "agent:inv:heart"} | common_properties)
+            assert set(obj).issuperset(
+                {"agent", "agent:group", "hp", "agent:frozen", "agent:orientation", "agent:color", "agent:inv:heart"}
+                | common_properties
+            )
             assert obj["agent"] == 1, "Agent should have type 1"
             assert obj["agent:group"] == 0, "Agent should be in group 0"
             assert obj["hp"] == 100, "Agent should have 100 hp"


### PR DESCRIPTION
Introduces a new test for the `grid_objects()` method. The test verifies that the correct number of objects are returned, and that they have expected properties and values.