### PR TITLE
feat: run AWS training on each push to main

### DIFF
--- a/.github/workflows/aws-train.yml
+++ b/.github/workflows/aws-train.yml
@@ -1,24 +1,24 @@
 name: Launch AWS Training Job
 
-# This workflow can be manually triggered from the GitHub UI
 on:
   workflow_dispatch:
     inputs:
       timeout_minutes:
-        description: 'Job timeout in minutes (auto-termination)'
+        description: "Job timeout in minutes (auto-termination)"
         required: true
-        default: '60'
+        default: "60"
         type: number
       trainer_env:
-        description: 'Training environment configuration'
+        description: "Training environment configuration"
         required: true
-        default: 'env/mettagrid/simple'
+        default: "env/mettagrid/simple"
         type: string
       pr_number:
-        description: 'PR number (if applicable, leave empty otherwise)'
+        description: "PR number (if applicable, leave empty otherwise)"
         required: false
         type: string
-
+  push:
+    branches: [main]
 
 jobs:
   launch-batch-job:
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # Need at least 2 commits to detect merge commit messages
 
       - name: Setup Python and uv
         id: setup-python-uv
@@ -48,29 +50,48 @@ jobs:
           echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
           echo "Commit hash: $COMMIT_HASH"
 
+      - name: Extract PR number if available
+        id: extract_pr
+        if: github.event_name == 'push'
+        run: |
+          # Try to extract PR number from the merge commit message
+          PR_NUMBER=$(git log -1 --pretty=format:"%s" | grep -oP 'Merge pull request #\K\d+' || echo "")
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "Found PR #$PR_NUMBER from merge commit"
+          else
+            echo "pr_number=" >> $GITHUB_OUTPUT
+            echo "No PR number found in commit message"
+          fi
+
       - name: Generate run name
         id: generate_run_name
         run: |
           # Get short commit hash
           COMMIT_HASH=$(git rev-parse --short HEAD)
-          
+
           # Get current timestamp in a format suitable for filenames
           TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
-          
+
           # Get branch name
           BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9]/_/g')
-          
+
+          # Use PR number if available (either from manual input or extracted from merge commit)
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          if [ -z "$PR_NUMBER" ] && [ "${{ github.event_name }}" == "push" ]; then
+            PR_NUMBER="${{ steps.extract_pr.outputs.pr_number }}"
+          fi
+
           # Generate the run name
-          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
-            # Include PR number in run name if provided
-            RUN_NAME="github.pr${{ github.event.inputs.pr_number }}.$COMMIT_HASH.$TIMESTAMP"
-            echo "Using PR #${{ github.event.inputs.pr_number }} in run name"
+          if [ -n "$PR_NUMBER" ]; then
+            RUN_NAME="github.pr${PR_NUMBER}.$COMMIT_HASH.$TIMESTAMP"
+            echo "Using PR #$PR_NUMBER in run name"
           else
-            # Use branch name if no PR number provided
             RUN_NAME="github.$BRANCH.$COMMIT_HASH.$TIMESTAMP"
             echo "Using branch name '$BRANCH' in run name"
           fi
-          
+
           echo "Generated run name: $RUN_NAME"
           echo "run_name=$RUN_NAME" >> $GITHUB_OUTPUT
 
@@ -83,25 +104,51 @@ jobs:
 
       - name: Launch AWS Batch job
         run: |
+          # Set default values for push events or use workflow_dispatch inputs
+          if [ "${{ github.event_name }}" == "push" ]; then
+            # Use default values for push events
+            TIMEOUT="60"
+            ENV="env/mettagrid/simple"
+          else
+            # Use values from workflow_dispatch
+            TIMEOUT="${{ github.event.inputs.timeout_minutes }}"
+            ENV="${{ github.event.inputs.trainer_env }}"
+          fi
+
           python -m devops.aws.batch.launch_task \
             --cmd=train \
             --run=${{ steps.generate_run_name.outputs.run_name }} \
             --git-commit=${{ steps.get_commit_hash.outputs.commit_hash }} \
-            --timeout-minutes=${{ github.event.inputs.timeout_minutes }} \
+            --timeout-minutes=$TIMEOUT \
             --skip-validation \
             --skip-push-check \
             --profile="" \
-            trainer.env=${{ github.event.inputs.trainer_env }}
+            trainer.env=$ENV
 
       - name: Output job details
         run: |
+          # Determine PR number source for output
+          PR_NUMBER="${{ github.event.inputs.pr_number }}"
+          if [ -z "$PR_NUMBER" ] && [ "${{ github.event_name }}" == "push" ]; then
+            PR_NUMBER="${{ steps.extract_pr.outputs.pr_number }}"
+          fi
+
+          # Set environment and timeout based on event type
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TIMEOUT="60"
+            ENV="env/mettagrid/simple"
+          else
+            TIMEOUT="${{ github.event.inputs.timeout_minutes }}"
+            ENV="${{ github.event.inputs.trainer_env }}"
+          fi
+
           echo "Training job launched with the following details:"
           echo "Run name: ${{ steps.generate_run_name.outputs.run_name }}"
           echo "Commit hash: ${{ steps.get_commit_hash.outputs.commit_hash }}"
-          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
-            echo "Pull Request: #${{ github.event.inputs.pr_number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Pull Request: #$PR_NUMBER"
           else
             echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
           fi
-          echo "Auto-termination: After ${{ github.event.inputs.timeout_minutes }} minutes"
-          echo "Environment: ${{ github.event.inputs.trainer_env }}"
+          echo "Auto-termination: After $TIMEOUT minutes"
+          echo "Environment: $ENV"


### PR DESCRIPTION
This PR automatically launches a 60min AWS training job in the `simple` env whenever code is pushed to the main branch. 

## Changes

- Modified the AWS training workflow to trigger on pushes to the main branch
- Added automatic PR number extraction from merge commit messages
- Set up default parameters for automated runs
- Maintained the ability to manually trigger runs with custom parameters

Workflow has been successfully tested with manual launches from the GitHub UI and correctly launches AWS training jobs

example: 
[github.main.933bbce.20250520_221914](https://wandb.ai/metta-research/metta/runs/github.main.933bbce.20250520_221914)

