### PR TITLE
Add help modal with scroll prevention and keyboard controls

### DIFF
--- a/mettascope/index.html
+++ b/mettascope/index.html
@@ -25,6 +25,9 @@
       <div class="filter-wrapper">
         <input id="main-filter" type="text" placeholder="Filter/Search Field">
       </div>
+      <div class="help-wrapper">
+        <button id="help-button">Help & Controls</button>
+      </div>
       <div class="share-wrapper">
         <img id="share-button" src="data/ui/share.png" alt="Share">
       </div>
@@ -68,6 +71,53 @@
     <div class="modal-content">
       <h2>Welcome to MettaScope</h2>
       <p>Please drop a replay file here to see the replay.</p>
+    </div>
+  </div>
+
+  <!-- Help Modal -->
+  <div id="help-modal" class="modal help-modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>MettaScope Help & Controls</h2>
+        <span class="close-button">&times;</span>
+      </div>
+      <div class="modal-body">
+        <div class="help-section about-metta">
+          <h3>About Metta</h3>
+          <p>Metta is an AI research platform for developing and testing AI agents in simulated environments. It provides tools for training, evaluating, and analyzing AI behavior.</p>
+        </div>
+        <div class="help-section about-mettascope">
+          <h3>About MettaScope</h3>
+          <p>MettaScope is a visualization tool that allows you to analyze and understand AI agent behavior in Metta environments. It provides detailed insights into agent actions, decisions, and performance.</p>
+        </div>
+        <div class="help-section">
+          <h3>Playback Controls</h3>
+          <ul>
+            <li>Use the play/pause button to control playback</li>
+            <li>Step forward/backward to move frame by frame</li>
+            <li>Use the speed controls to adjust playback speed</li>
+            <li>Drag the scrubber to jump to any point in the replay</li>
+          </ul>
+        </div>
+        <div class="help-section">
+          <h3>Visualization Controls</h3>
+          <ul>
+            <li>Toggle grid visibility with the grid button</li>
+            <li>Show/hide resources with the heart icon</li>
+            <li>Toggle fog of war with the cloud icon</li>
+            <li>Change view modes with the eye icon</li>
+          </ul>
+        </div>
+        <div class="help-section">
+          <h3>Navigation</h3>
+          <ul>
+            <li>Click and drag to pan the view</li>
+            <li>Use mouse wheel to zoom in/out</li>
+            <li>Click on units to select them</li>
+            <li>Use the filter field to search for specific units</li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -121,7 +121,12 @@ export const html = {
   // Utility
   modal: find('#modal') as HTMLDivElement,
   toast: find('#toast') as HTMLDivElement,
-}
+
+  // Help modal elements
+  helpButton: find('#help-button') as HTMLButtonElement,
+  helpModal: find('#help-modal') as HTMLDivElement,
+  helpModalClose: find('#help-modal .close-button') as HTMLSpanElement,
+};
 
 // Set the follow selection state, you can pass null to leave a state unchanged.
 export function setFollowSelection(map: boolean | null) {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -504,3 +504,43 @@ window.addEventListener('load', async () => {
 
   requestFrame();
 });
+
+// Initialize help modal with event listeners for opening, closing, and scroll prevention.
+function initHelpModal(): void {
+  if (!html.helpButton || !html.helpModal || !html.helpModalClose) {
+    console.error('Help modal elements not found');
+    return;
+  }
+
+  html.helpButton.addEventListener('click', () => {
+    html.helpModal.style.display = 'block';
+    document.body.classList.add('modal-open');
+  });
+
+  html.helpModalClose.addEventListener('click', () => {
+    html.helpModal.style.display = 'none';
+    document.body.classList.remove('modal-open');
+  });
+
+  html.helpModal.addEventListener('click', (event: MouseEvent) => {
+    if (event.target === html.helpModal) {
+      html.helpModal.style.display = 'none';
+      document.body.classList.remove('modal-open');
+    }
+  });
+
+  document.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && html.helpModal.style.display === 'block') {
+      html.helpModal.style.display = 'none';
+      document.body.classList.remove('modal-open');
+    }
+  });
+
+  html.helpModal.addEventListener('wheel', (event: WheelEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, { passive: false });
+}
+
+// Call initHelpModal when the page loads
+document.addEventListener('DOMContentLoaded', initHelpModal);

--- a/mettascope/style.css
+++ b/mettascope/style.css
@@ -191,23 +191,14 @@ body {
 
 .modal {
   display: none;
-  /* Hidden by default */
   position: fixed;
-  /* Stay in place */
   z-index: 1000;
-  /* Sit on top */
   left: 0;
   top: 0;
   width: 100%;
-  /* Full width */
   height: 100%;
-  /* Full height */
-  overflow: auto;
-  /* Enable scroll if needed */
-  background-color: rgb(0, 0, 0);
-  /* Fallback color */
+  overflow: auto;  /* This allows scrolling within the modal */
   background-color: rgba(0, 0, 0, 0.4);
-  /* Black w/ opacity */
 }
 
 .modal-content {
@@ -341,6 +332,28 @@ body {
   cursor: pointer;
 }
 
+/* Help button styling */
+#header .help-wrapper {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+#header #help-button {
+  background-color: #273646;
+  color: #fff;
+  border: 1px solid #4a5c6b;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+#header #help-button:hover {
+  background-color: #4a5c6b;
+}
+
 /* Remove previous pseudo-element styles if they still exist */
 #header>#logo,
 #header>#file-name,
@@ -458,4 +471,113 @@ body {
 #control-bar .section img.active {
   background-color: rgba(255, 255, 255, 0.15);
   box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.3);
+}
+
+/* Help modal specific styles */
+.help-modal .modal-content {
+  max-width: 900px;
+  width: 90%;
+  padding: 20px;
+  line-height: 1.4;
+  text-align: left;
+  margin: 5vh auto;
+  background-color: #404040;
+  border-radius: 8px;
+}
+
+.help-modal .modal-header {
+  margin-bottom: 20px;
+  text-align: center;
+  position: relative;  /* Add this for absolute positioning of close button */
+}
+
+.help-modal .modal-header h2 {
+  color: #fff;
+  font-size: 20px;
+  margin: 0;
+}
+
+.help-modal .modal-body {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 15px;
+}
+
+.help-modal .help-section {
+  background: #2d2d2d;
+  padding: 15px;
+  border-radius: 6px;
+}
+
+.help-modal .help-section.about-metta {
+  grid-column: 1 / -1;  /* Span both columns */
+  margin-bottom: 5px;
+}
+
+.help-modal .help-section.about-mettascope {
+  grid-column: 1 / -1;  /* Span both columns */
+  margin-bottom: 5px;
+}
+
+.help-modal .help-section h3 {
+  color: #fff;
+  font-size: 16px;
+  margin: 0 0 10px 0;
+}
+
+.help-modal .help-section p {
+  color: #ccc;
+  font-size: 14px;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.help-modal .help-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.help-modal .help-section li {
+  color: #ccc;
+  margin-bottom: 8px;
+  padding-left: 20px;
+  position: relative;
+  font-size: 14px;
+}
+
+.help-modal .help-section li:before {
+  content: "•";
+  position: absolute;
+  left: 8px;
+  color: #4a5c6b;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.help-modal {
+  overflow-y: auto;
+}
+
+/* Add this new class */
+.modal-open {
+  overflow: hidden;
+}
+
+.help-modal .close-button {
+  position: absolute;
+  right: 0;
+  top: 0;
+  color: #aaa;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 0 5px;
+  line-height: 1;
+}
+
+.help-modal .close-button:hover {
+  color: #fff;
 }


### PR DESCRIPTION
# Add Help Modal with Scroll Prevention and Keyboard Controls

## Changes
- Added a help modal to the MettaScope interface
- Implemented scroll prevention when the modal is open
- Added keyboard controls (Escape key to close)
- Organized modal content into sections:
  - About Metta
  - About MettaScope
  - Playback Controls
  - Visualization Controls
  - Navigation

## Testing
- Verified modal opens/closes correctly
- Confirmed scroll prevention works
- Tested keyboard controls
- Checked responsive layout

<img width="1470" alt="Screenshot 2025-05-20 at 3 10 04 PM" src="https://github.com/user-attachments/assets/49e96d3c-8b7d-4d1b-aa42-f450342a002b" />
