### PR TITLE
Remove some deprecated features

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -6,16 +6,11 @@ normalize_rewards: false
 
 sampling: 0
 
-hidden_features:
-  grid_obs: ["agent:energy", "agent:hp"]
-
 game:
   num_agents: ???
   obs_width: 11
   obs_height: 11
-  tile_size: 16
   max_steps: 1000
-  no_energy_steps: 500
 
   # default for the old map builder; new metta.map.mapgen requires false
   recursive_map_builder: true
@@ -24,7 +19,6 @@ game:
     max_inventory: ${sampling:0, 100, 50}
     freeze_duration: ${sampling:0, 200, 10}
     hp: 10
-    mortal: False
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0

--- a/configs/env/mettagrid/puffer.yaml
+++ b/configs/env/mettagrid/puffer.yaml
@@ -6,26 +6,17 @@ normalize_rewards: false
 
 sampling: 0
 
-hidden_features:
-  grid_obs: [
-    "agent:energy",
-    "agent:hp",
-  ]
-
 game:
   num_agents: 16
   obs_width: 11
   obs_height: 11
   max_steps: 1000
-  tile_size: 16
-  no_energy_steps: 500
   recursive_map_builder: true
 
   agent:
     max_inventory: 50
     freeze_duration: 0
     hp: 10
-    mortal: False
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -4,9 +4,6 @@ normalize_rewards: false
 
 sampling: 0
 
-hidden_features:
-  grid_obs: ["agent:energy", "agent:hp"]
-
 game:
   num_agents: 24
 
@@ -40,15 +37,12 @@ game:
 
   obs_width: 11
   obs_height: 11
-  tile_size: 16
   max_steps: 1000
-  no_energy_steps: 500
 
   agent:
     max_inventory: 50
     freeze_duration: 10
     hp: 10
-    mortal: False
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -4,9 +4,6 @@ normalize_rewards: false
 
 sampling: 0
 
-hidden_features:
-  grid_obs: ["agent:energy", "agent:hp"]
-
 game:
   map_builder:
     _target_: mettagrid.room.random.Random
@@ -26,8 +23,6 @@ game:
   obs_width: 11
   obs_height: 11
   max_steps: 5000
-  tile_size: 16
-  no_energy_steps: 500
 
   groups:
     agent:
@@ -40,7 +35,6 @@ game:
     freeze_duration: 10
     energy_reward: 0
     hp: 1
-    mortal: False
     use_cost: 0
     rewards:
       heart: 1

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -68,7 +68,6 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
 
         self._env = env
         # self._env = RewardTracker(self._env)
-        # self._env = FeatureMasker(self._env, self._cfg.hidden_features)
 
     def reset(self, seed=None, options=None):
         self._env_cfg = self._get_new_env_cfg()

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -3,25 +3,16 @@
   "report_stats_interval": 100,
   "normalize_rewards": false,
   "sampling": 0,
-  "hidden_features": {
-    "grid_obs": [
-      "agent:energy",
-      "agent:hp"
-    ]
-  },
   "game": {
     "num_agents": 24,
     "obs_width": 11,
     "obs_height": 11,
-    "tile_size": 16,
     "max_steps": 1000,
-    "no_energy_steps": 500,
     "recursive_map_builder": true,
     "agent": {
       "max_inventory": 50,
       "freeze_duration": 10,
       "hp": 10,
-      "mortal": false,
       "rewards": {
         "action_failure_penalty": 0,
         "ore.red": 0.005,


### PR DESCRIPTION
### TL;DR

Removed unused configuration parameters from MettaGrid environment configs.

### What changed?

- Removed `hidden_features` configuration section from all config files
- Removed unused parameters from game configuration:
  - `tile_size`
  - `no_energy_steps`
  - `mortal` flag from agent settings
- Removed commented out `FeatureMasker` code in `mettagrid_env.py`

### Why?

This started as me wanting to remove hp, but discovering that it's actually still used for object destruction. It's possible we should still remove it, but this goes outside of my intended simple cleanup.

### Testing

Grepped for usage of these strings across the codebase. Smoke tested training locally and saw no crashing.