### PR TITLE
header

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -10,6 +10,8 @@ game:
   num_agents: ???
   obs_width: 11
   obs_height: 11
+  use_observation_tokens: true
+  num_observation_tokens: 100
   max_steps: 1000
 
   # default for the old map builder; new metta.map.mapgen requires false

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -384,7 +384,12 @@ void MettaGrid::validate_buffers() {
   if (_use_observation_tokens) {
     auto observation_info = _observations.request();
     auto shape = observation_info.shape;
-    if (observation_info.ndim != 3 || shape[0] != num_agents || shape[2] != 3) {
+    if (observation_info.ndim != 3) {
+      std::stringstream ss;
+      ss << "observations has " << observation_info.ndim << " dimensions but expected 3";
+      throw std::runtime_error(ss.str());
+    }
+    if (shape[0] != num_agents || shape[2] != 3) {
       std::stringstream ss;
       ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << "] but expected ["
          << num_agents << ", [something], 3]";
@@ -578,10 +583,19 @@ py::object MettaGrid::observation_space() {
   auto gym = py::module_::import("gymnasium");
   auto spaces = gym.attr("spaces");
 
-  return spaces.attr("Box")(0,
-                            255,
-                            py::make_tuple(_obs_height, _obs_width, _grid_features.size()),
-                            py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  if (_use_observation_tokens) {
+    // TODO: consider spaces other than "Box". They're more correctly descriptive, but I don't know if
+    // that matters to us.
+    return spaces.attr("Box")(0,
+                              255,
+                              py::make_tuple(_observations.shape(1), _observations.shape(2)),
+                              py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  } else {
+    return spaces.attr("Box")(0,
+                              255,
+                              py::make_tuple(_obs_height, _obs_width, _grid_features.size()),
+                              py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  }
 }
 
 py::list MettaGrid::action_success() {


### PR DESCRIPTION
# Add support for a fully robust agent

This PR affords the option to use an agent that accepts varied observation features and varied action spaces. Curriculum over actions and observations is now possible.

The default is to continue using a fixed set of channels and a not-robust-to-observations agent however we plan to deprecate this default after further testing.

The robust agent is under `robust.yaml` and it fully replaces the obs shaper, normalizer, and encoder layer stack.

The new observation format for MettaGrid uses tokens instead of a dense grid. This format is more efficient for sparse observations and allows for more flexibility in the observation space. Each token contains:
- Location (row/column packed into a single byte)
- Feature ID
- Feature value

To use:
- Under mettagrid.yaml, set `use_observation_tokens` to `true`
- Override agent default from simple to `robust` or build your own using `_target_: metta.agent.lib.obs_enc.ObsAttn`

Future work:
- The agent seems to train fast enough but there are some obvious speed optimizations that could be made
- Connecting the max number of tokens to agent tensor preallocation
- Connect global tokens such as last action
- Introduce two more encoder attention-style architectures for comparison