### PR TITLE
Stop passing agent_idx to actions

### DIFF
--- a/mettagrid/mettagrid/action_handler.hpp
+++ b/mettagrid/mettagrid/action_handler.hpp
@@ -45,10 +45,7 @@ public:
     this->_grid = grid;
   }
 
-  bool handle_action(unsigned int actor_id,
-                     GridObjectId actor_object_id,
-                     ActionArg arg,
-                     unsigned int current_timestep) {
+  bool handle_action(GridObjectId actor_object_id, ActionArg arg, unsigned int current_timestep) {
     Agent* actor = static_cast<Agent*>(_grid->object(actor_object_id));
 
     if (actor->frozen > 0) {
@@ -58,7 +55,7 @@ public:
       return false;
     }
 
-    bool result = _handle_action(actor_id, actor, arg);
+    bool result = _handle_action(actor, arg);
 
     if (result) {
       actor->stats.incr(_stats.success);
@@ -81,7 +78,7 @@ public:
   }
 
 protected:
-  virtual bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) = 0;
+  virtual bool _handle_action(Agent* actor, ActionArg arg) = 0;
 
   StatNames _stats;
   std::string _action_name;

--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -20,7 +20,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     if (arg > 9 || arg < 1) {
       return false;
     }
@@ -37,10 +37,10 @@ protected:
     GridLocation target_loc =
         _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation), distance, offset);
 
-    return _handle_target(actor_id, actor, target_loc);
+    return _handle_target(actor, target_loc);
   }
 
-  bool _handle_target(unsigned int actor_id, Agent* actor, GridLocation target_loc) {
+  bool _handle_target(Agent* actor, GridLocation target_loc) {
     target_loc.layer = GridLayer::Agent_Layer;
     Agent* agent_target = static_cast<Agent*>(_grid->object_at(target_loc));
 

--- a/mettagrid/mettagrid/actions/attack_nearest.hpp
+++ b/mettagrid/mettagrid/actions/attack_nearest.hpp
@@ -17,7 +17,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     if (actor->inventory[InventoryItem::laser] == 0) {
       return false;
     }
@@ -38,7 +38,7 @@ protected:
         target_loc.layer = GridLayer::Agent_Layer;
         Agent* agent_target = static_cast<Agent*>(_grid->object_at(target_loc));
         if (agent_target) {
-          return _handle_target(actor_id, actor, target_loc);
+          return _handle_target(actor, target_loc);
         }
       }
     }

--- a/mettagrid/mettagrid/actions/change_color.hpp
+++ b/mettagrid/mettagrid/actions/change_color.hpp
@@ -15,7 +15,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     if (arg == 0) {  // Increment
       if (actor->color < 255) {
         actor->color += 1;

--- a/mettagrid/mettagrid/actions/get_output.hpp
+++ b/mettagrid/mettagrid/actions/get_output.hpp
@@ -18,7 +18,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     target_loc.layer = GridLayer::Object_Layer;
     // get_output only works on Converters, since only Converters have an output.

--- a/mettagrid/mettagrid/actions/move.hpp
+++ b/mettagrid/mettagrid/actions/move.hpp
@@ -16,7 +16,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     unsigned short direction = arg;
 
     Orientation orientation = static_cast<Orientation>(actor->orientation);

--- a/mettagrid/mettagrid/actions/noop.hpp
+++ b/mettagrid/mettagrid/actions/noop.hpp
@@ -15,7 +15,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     return true;
   }
 };

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -18,7 +18,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     target_loc.layer = GridLayer::Object_Layer;
     // put_recipe_items only works on Converters, since only Converters have a recipe.

--- a/mettagrid/mettagrid/actions/rotate.hpp
+++ b/mettagrid/mettagrid/actions/rotate.hpp
@@ -15,7 +15,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     unsigned short orientation = arg;
     actor->orientation = orientation;
     return true;

--- a/mettagrid/mettagrid/actions/swap.hpp
+++ b/mettagrid/mettagrid/actions/swap.hpp
@@ -17,7 +17,7 @@ public:
   }
 
 protected:
-  bool _handle_action(unsigned int actor_id, Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     MettaObject* target = static_cast<MettaObject*>(_grid->object_at(target_loc));
     if (target == nullptr) {

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -283,7 +283,7 @@ void MettaGrid::_step(py::array_t<int> actions) {
         continue;
       }
 
-      _action_success[idx] = handler->handle_action(idx, agent->id, arg, _current_timestep);
+      _action_success[idx] = handler->handle_action(agent->id, arg, _current_timestep);
     }
   }
 


### PR DESCRIPTION
This parameter isn't used. I believe we used to need it to update rewards, but this became unnecessary once rewards were moved to agent objects.

Tested by compiling.