### PR TITLE
Update inventory management

### DIFF
--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -25,11 +25,9 @@ protected:
       return false;
     }
 
-    if (actor->inventory[InventoryItem::laser] == 0) {
+    if (actor->update_inventory(InventoryItem::laser, -1) == 0) {
       return false;
     }
-
-    actor->update_inventory(InventoryItem::laser, -1);
 
     short distance = 1 + (arg - 1) / 3;
     short offset = -((arg - 1) % 3 - 1);
@@ -58,8 +56,7 @@ protected:
 
       was_frozen = agent_target->frozen > 0;
 
-      if (agent_target->inventory[InventoryItem::armor] > 0) {
-        agent_target->update_inventory(InventoryItem::armor, -1);
+      if (agent_target->update_inventory(InventoryItem::armor, -1)) {
         actor->stats.incr("attack.blocked", agent_target->group_name);
         actor->stats.incr("attack.blocked", agent_target->group_name, actor->group_name);
       } else {
@@ -78,9 +75,9 @@ protected:
           }
 
           for (int item = 0; item < InventoryItem::InventoryCount; item++) {
-            actor->stats.add(InventoryItemNames[item], "stolen", actor->group_name, agent_target->inventory[item]);
-            actor->update_inventory(static_cast<InventoryItem>(item), agent_target->inventory[item]);
-            agent_target->update_inventory(static_cast<InventoryItem>(item), -agent_target->inventory[item]);
+            int stolen = actor->update_inventory(static_cast<InventoryItem>(item), agent_target->inventory[item]);
+            agent_target->update_inventory(static_cast<InventoryItem>(item), -stolen);
+            actor->stats.add(InventoryItemNames[item], "stolen", actor->group_name, stolen);
           }
         }
 

--- a/mettagrid/mettagrid/actions/attack_nearest.hpp
+++ b/mettagrid/mettagrid/actions/attack_nearest.hpp
@@ -18,11 +18,9 @@ public:
 
 protected:
   bool _handle_action(Agent* actor, ActionArg arg) override {
-    if (actor->inventory[InventoryItem::laser] == 0) {
+    if (actor->update_inventory(InventoryItem::laser, -1) == 0) {
       return false;
     }
-
-    actor->update_inventory(InventoryItem::laser, -1);
 
     // Scan the space to find the nearest agent. Prefer the middle (offset 0) before the edges (offset -1, 1).
     for (int distance = 1; distance < 4; distance++) {

--- a/mettagrid/mettagrid/actions/get_output.hpp
+++ b/mettagrid/mettagrid/actions/get_output.hpp
@@ -42,12 +42,12 @@ protected:
         // collect resources from a converter that's in the middle of processing a queue.
         continue;
       }
-      unsigned char can_take = std::min<unsigned char>(actor->max_items - actor->inventory[i], converter->inventory[i]);
 
-      if (can_take > 0) {
-        actor->stats.add(InventoryItemNames[i], "get", can_take);
-        actor->update_inventory(static_cast<InventoryItem>(i), can_take);
-        converter->update_inventory(static_cast<InventoryItem>(i), -can_take);
+      int taken = actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
+
+      if (taken > 0) {
+        actor->stats.add(InventoryItemNames[i], "get", taken);
+        converter->update_inventory(static_cast<InventoryItem>(i), -taken);
         items_taken = true;
       }
     }

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -31,14 +31,14 @@ protected:
 
     bool success = false;
     for (size_t i = 0; i < converter->recipe_input.size(); i++) {
-      unsigned int inv = std::min(converter->recipe_input[i], actor->inventory[i]);
-      if (inv == 0) {
-        continue;
+      int max_to_put = std::min(converter->recipe_input[i], actor->inventory[i]);
+      int put = converter->update_inventory(static_cast<InventoryItem>(i), max_to_put);
+      if (put > 0) {
+        // We should be able to put this many items into the converter. If not, something is wrong.
+        assert(actor->update_inventory(static_cast<InventoryItem>(i), -put) == -put, "Inconsistent inventory update");
+        actor->stats.add(InventoryItemNames[i], "put", put);
+        success = true;
       }
-      actor->update_inventory(static_cast<InventoryItem>(i), -inv);
-      converter->update_inventory(static_cast<InventoryItem>(i), inv);
-      actor->stats.add(InventoryItemNames[i], "put", inv);
-      success = true;
     }
 
     return success;

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -35,7 +35,7 @@ protected:
       int put = converter->update_inventory(static_cast<InventoryItem>(i), max_to_put);
       if (put > 0) {
         // We should be able to put this many items into the converter. If not, something is wrong.
-        assert(actor->update_inventory(static_cast<InventoryItem>(i), -put) == -put, "Inconsistent inventory update");
+        assert(actor->update_inventory(static_cast<InventoryItem>(i), -put) == -put);
         actor->stats.add(InventoryItemNames[i], "put", put);
         success = true;
       }

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -32,12 +32,14 @@ protected:
     bool success = false;
     for (size_t i = 0; i < converter->recipe_input.size(); i++) {
       int max_to_put = std::min(converter->recipe_input[i], actor->inventory[i]);
-      int put = converter->update_inventory(static_cast<InventoryItem>(i), max_to_put);
-      if (put > 0) {
-        // We should be able to put this many items into the converter. If not, something is wrong.
-        assert(actor->update_inventory(static_cast<InventoryItem>(i), -put) == -put);
-        actor->stats.add(InventoryItemNames[i], "put", put);
-        success = true;
+      if (max_to_put > 0) {
+        int put = converter->update_inventory(static_cast<InventoryItem>(i), max_to_put);
+        if (put > 0) {
+          // We should be able to put this many items into the converter. If not, something is wrong.
+          assert(actor->update_inventory(static_cast<InventoryItem>(i), -put) == -put);
+          actor->stats.add(InventoryItemNames[i], "put", put);
+          success = true;
+        }
       }
     }
 

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -137,8 +137,6 @@ public:
 
   private:
     unsigned char max_items;
-
-  friend class MettaGridTest;
 };
 
 #endif

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -63,7 +63,7 @@ public:
   }
 
   int update_inventory(InventoryItem item, short amount) {
-    int current_amount = this->inventory[static_cast<int>(item)];
+    int current_amount = this->inventory[item];
     int new_amount = current_amount + amount;
     if (new_amount > this->max_items) {
       new_amount = this->max_items;
@@ -73,7 +73,7 @@ public:
     }
 
     int delta = new_amount - current_amount;
-    this->inventory[static_cast<int>(item)] = new_amount;
+    this->inventory[item] = new_amount;
 
     if (delta > 0) {
       this->stats.add(InventoryItemNames[item], "gained", delta);

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -1,9 +1,9 @@
 #ifndef AGENT_HPP
 #define AGENT_HPP
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "../grid_object.hpp"
 #include "../stats_tracker.hpp"

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -135,8 +135,8 @@ public:
     return names;
   }
 
-  private:
-    unsigned char max_items;
+private:
+  unsigned char max_items;
 };
 
 #endif

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "../grid_object.hpp"
 #include "../stats_tracker.hpp"
@@ -65,12 +66,7 @@ public:
   int update_inventory(InventoryItem item, short amount) {
     int current_amount = this->inventory[item];
     int new_amount = current_amount + amount;
-    if (new_amount > this->max_items) {
-      new_amount = this->max_items;
-    }
-    if (new_amount < 0) {
-      new_amount = 0;
-    }
+    new_amount = std::clamp(new_amount, 0, static_cast<int>(this->max_items));
 
     int delta = new_amount - current_amount;
     this->inventory[item] = new_amount;

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -16,7 +16,6 @@ public:
   unsigned char freeze_duration;
   unsigned char orientation;
   std::vector<unsigned char> inventory;
-  unsigned char max_items;
   std::vector<float> resource_rewards;
   std::vector<float> resource_reward_max;
   float action_failure_penalty;
@@ -63,7 +62,7 @@ public:
     this->reward = reward;
   }
 
-  void update_inventory(InventoryItem item, short amount) {
+  int update_inventory(InventoryItem item, short amount) {
     int current_amount = this->inventory[static_cast<int>(item)];
     int new_amount = current_amount + amount;
     if (new_amount > this->max_items) {
@@ -83,6 +82,8 @@ public:
     }
 
     this->compute_resource_reward(item);
+
+    return delta;
   }
 
   inline void compute_resource_reward(InventoryItem item) {
@@ -133,6 +134,11 @@ public:
     }
     return names;
   }
+
+  private:
+    unsigned char max_items;
+
+  friend class MettaGridTest;
 };
 
 #endif

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -128,9 +128,10 @@ public:
     this->maybe_start_converting();
   }
 
-  void update_inventory(InventoryItem item, short amount) override {
-    HasInventory::update_inventory(item, amount);
+  int update_inventory(InventoryItem item, short amount) override {
+    int delta = HasInventory::update_inventory(item, amount);
     this->maybe_start_converting();
+    return delta;
   }
 
   void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <iostream>
 
 #include "constants.hpp"
 #include "metta_object.hpp"

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -1,9 +1,9 @@
 #ifndef HAS_INVENTORY_HPP
 #define HAS_INVENTORY_HPP
 
+#include <algorithm>
 #include <map>
 #include <string>
-#include <algorithm>
 
 #include "constants.hpp"
 #include "metta_object.hpp"

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <algorithm>
 
 #include "constants.hpp"
 #include "metta_object.hpp"
@@ -23,12 +24,7 @@ public:
   virtual int update_inventory(InventoryItem item, short amount) {
     int initial_amount = this->inventory[item];
     int new_amount = initial_amount + amount;
-    if (new_amount > 255) {
-      new_amount = 255;
-    }
-    if (new_amount < 0) {
-      new_amount = 0;
-    }
+    new_amount = std::clamp(new_amount, 0, 255);
     this->inventory[item] = new_amount;
     return new_amount - initial_amount;
   }

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -20,14 +20,17 @@ public:
     return true;
   }
 
-  virtual void update_inventory(InventoryItem item, short amount) {
-    if (amount + this->inventory[item] > 255) {
-      amount = 255 - this->inventory[item];
+  virtual int update_inventory(InventoryItem item, short amount) {
+    int initial_amount = this->inventory[item];
+    int new_amount = initial_amount + amount;
+    if (new_amount > 255) {
+      new_amount = 255;
     }
-    if (amount + this->inventory[item] < 0) {
-      amount = -this->inventory[item];
+    if (new_amount < 0) {
+      new_amount = 0;
     }
-    this->inventory[item] += amount;
+    this->inventory[item] = new_amount;
+    return new_amount - initial_amount;
   }
 };
 

--- a/mettagrid/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/mettagrid/objects/has_inventory.hpp
@@ -3,7 +3,6 @@
 
 #include <map>
 #include <string>
-#include <iostream>
 
 #include "constants.hpp"
 #include "metta_object.hpp"

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -268,7 +268,7 @@ TEST_F(MettaGridTest, GetOutput) {
   GetOutput get(get_cfg);
   get.init(&grid);
 
-  // Test putting matching items
+  // Test getting output
   bool success = get.handle_action(agent->id, 0, 0);
   EXPECT_TRUE(success);
   EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 1);      // Still have red ore

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -71,9 +71,12 @@ TEST_F(MettaGridTest, UpdateInventory) {
 
   Agent* agent = MettaGrid::create_agent(0, 0, "green", 1, group_cfg, agent_cfg);
   ASSERT_NE(agent, nullptr);
+  float reward = 0;
+  agent->init(&reward);
 
   // Test adding items
   int delta = agent->update_inventory(InventoryItem::heart, 5);
+
   EXPECT_EQ(delta, 5);
   EXPECT_EQ(agent->inventory[InventoryItem::heart], 5);
 
@@ -108,10 +111,14 @@ TEST_F(MettaGridTest, AttackAction) {
   auto group_cfg = configs["group_cfg"].cast<py::dict>();
 
   // Create two agents - one attacker and one target
-  Agent* attacker = MettaGrid::create_agent(0, 0, "red", 1, group_cfg, agent_cfg);
-  Agent* target = MettaGrid::create_agent(0, 2, "blue", 2, group_cfg, agent_cfg);
+  Agent* attacker = MettaGrid::create_agent(2, 0, "red", 1, group_cfg, agent_cfg);
+  Agent* target = MettaGrid::create_agent(0, 0, "blue", 2, group_cfg, agent_cfg);
   ASSERT_NE(attacker, nullptr);
   ASSERT_NE(target, nullptr);
+  float attacker_reward = 0;
+  attacker->init(&attacker_reward);
+  float target_reward = 0;
+  target->init(&target_reward);
 
   // Give attacker a laser
   attacker->update_inventory(InventoryItem::laser, 1);
@@ -123,12 +130,24 @@ TEST_F(MettaGridTest, AttackAction) {
   EXPECT_EQ(target->inventory[InventoryItem::heart], 2);
   EXPECT_EQ(target->inventory[InventoryItem::battery], 3);
 
-  // Create attack action handler
+  // Assert the attacker is facing the correct direction
+  EXPECT_EQ(attacker->orientation, Orientation::Up);
+
+  // Create a grid and add the agents to it. Then set up an attack action handler and call it.
+  std::vector<Layer> layer_for_type_id;
+  for (const auto& layer : ObjectLayers) {
+    layer_for_type_id.push_back(layer.second);
+  }
+  Grid grid(10, 10, layer_for_type_id);
+  grid.add_object(attacker);
+  grid.add_object(target);
+
   ActionConfig attack_cfg;
   Attack attack(attack_cfg);
+  attack.init(&grid);
 
   // Perform attack (arg 5 targets directly in front)
-  bool success = attack.handle_action(0, attacker->id, 5, 0);
+  bool success = attack.handle_action(attacker->id, 5, 0);
   EXPECT_TRUE(success);
 
   // Verify laser was consumed
@@ -143,6 +162,5 @@ TEST_F(MettaGridTest, AttackAction) {
   EXPECT_EQ(attacker->inventory[InventoryItem::heart], 2);
   EXPECT_EQ(attacker->inventory[InventoryItem::battery], 3);
 
-  delete attacker;
-  delete target;
+  // grid will delete the agents
 }

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -2,13 +2,13 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
-#include "mettagrid_c.hpp"
-#include "objects/agent.hpp"
-#include "objects/converter.hpp"
-#include "objects/constants.hpp"
 #include "actions/attack.hpp"
 #include "actions/get_output.hpp"
 #include "actions/put_recipe_items.hpp"
+#include "mettagrid_c.hpp"
+#include "objects/agent.hpp"
+#include "objects/constants.hpp"
+#include "objects/converter.hpp"
 
 namespace py = pybind11;
 
@@ -94,7 +94,7 @@ TEST_F(MettaGridTest, UpdateInventory) {
   // Test hitting max_items limit
   agent->update_inventory(InventoryItem::heart, 50);
   delta = agent->update_inventory(InventoryItem::heart, 200);  // max_items is 123
-  EXPECT_EQ(delta, 73);  // Should only add up to max_items
+  EXPECT_EQ(delta, 73);                                        // Should only add up to max_items
   EXPECT_EQ(agent->inventory[InventoryItem::heart], 123);
 
   // Test multiple items
@@ -212,14 +212,14 @@ TEST_F(MettaGridTest, PutRecipeItems) {
   // Test putting matching items
   bool success = put.handle_action(agent->id, 0, 0);
   EXPECT_TRUE(success);
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 0);  // One red ore consumed
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);  // Blue ore unchanged
+  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 0);      // One red ore consumed
+  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);     // Blue ore unchanged
   EXPECT_EQ(generator->inventory[InventoryItem::ore_red], 1);  // One red ore added to generator
 
   // Test putting non-matching items
   success = put.handle_action(agent->id, 0, 0);
-  EXPECT_FALSE(success);  // Should fail since we only have blue ore left
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);  // Blue ore unchanged
+  EXPECT_FALSE(success);                                        // Should fail since we only have blue ore left
+  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);      // Blue ore unchanged
   EXPECT_EQ(generator->inventory[InventoryItem::ore_blue], 0);  // No blue ore in generator
 
   // grid will delete the agent and generator
@@ -271,8 +271,8 @@ TEST_F(MettaGridTest, GetOutput) {
   // Test putting matching items
   bool success = get.handle_action(agent->id, 0, 0);
   EXPECT_TRUE(success);
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 1);  // Still have red ore
-  EXPECT_EQ(agent->inventory[InventoryItem::battery], 1);  // Also have a battery
+  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 1);      // Still have red ore
+  EXPECT_EQ(agent->inventory[InventoryItem::battery], 1);      // Also have a battery
   EXPECT_EQ(generator->inventory[InventoryItem::battery], 0);  // Generator gave away its battery
 
   // grid will delete the agent and generator


### PR DESCRIPTION
Refactors inventory management to make objects more in control of when they can and can't receive input.

This changes to make it so put and get return the actual delta of items, rather than having outside logic assume what the agent / converter can take. The main purpose of this is to make it so we can [later] have per-item inventory limits, and have the logic to manage those contained in the `update_inventory` function. As a side effect of this change, I fixed some places where items could get lost, like when you're stealing from a frozen agent.

This still makes some assumptions that entities will be able to _lose_ inventory if they have it. If we cared, we could also expose functions like "max_potential_update", rather than only exposing it through mutation.

Testing:
Added unit tests.