### PR TITLE
fix: wandb_context test

### DIFF
--- a/metta/util/wandb/wandb_context.py
+++ b/metta/util/wandb/wandb_context.py
@@ -2,9 +2,9 @@ import copy
 import logging
 import os
 import socket
+from importlib.metadata import PackageNotFoundError, version
 from typing import Annotated, Literal, Union, cast
 
-import pkg_resources
 import requests
 import wandb
 import wandb.errors
@@ -43,7 +43,7 @@ WandbConfig = Annotated[Union[WandbConfigOff, WandbConfigOn], Field(discriminato
 def check_wandb_version() -> bool:
     try:
         # Get the installed wandb version
-        installed_version = pkg_resources.get_distribution("wandb").version
+        installed_version = version("wandb")
         installed_minor = int(installed_version.split(".")[1])
 
         # Fetch latest version from GitHub API
@@ -63,7 +63,7 @@ def check_wandb_version() -> bool:
             else:
                 return True
 
-    except pkg_resources.DistributionNotFound:
+    except PackageNotFoundError:
         logger.error("wandb package is not installed.")
         logger.error("Please install wandb using: pip install wandb")
         return False


### PR DESCRIPTION
This PR replaces the deprecated `pkg_resources` library with the standard `importlib.metadata` in the wandb context module, and fixes test isolation issues that were creating an unwanted config.yaml file during test runs.

**Changes:**
- Replace deprecated `pkg_resources` with `importlib.metadata` (eliminates deprecation warnings)
- Add file operation mocking to prevent tests from creating `config.yaml` files in the working directory
