### PR TITLE
wandb tests cleanup

### DIFF
--- a/tests/util/wandb/test_wandb_context.py
+++ b/tests/util/wandb/test_wandb_context.py
@@ -1,4 +1,3 @@
-import os
 import socket
 from dataclasses import dataclass
 
@@ -14,9 +13,6 @@ logger = setup_mettagrid_logger("Test")
 
 @pytest.fixture(autouse=True)
 def patch_dependencies(monkeypatch):
-    # Bypass version check
-    monkeypatch.setattr("metta.util.wandb.wandb_context.check_wandb_version", lambda: True)
-
     # Patch wandb.save to no-op
     monkeypatch.setattr(wandb, "save", lambda *args, **kwargs: None)
 
@@ -120,7 +116,7 @@ def test_run_fields(monkeypatch, dummy_init, tmp_path):
     assert run.save_code is True
 
 
-def test_exit_finishes_run(monkeypatch, dummy_init):
+def test_exit_finishes_run(monkeypatch, dummy_init, tmp_path):
     # Prepare enabled config
     cfg_on = WandbConfigOn(
         enabled=True,
@@ -129,7 +125,7 @@ def test_exit_finishes_run(monkeypatch, dummy_init):
         group="g",
         name="n",
         run_id="r",
-        data_dir=os.getcwd(),
+        data_dir=str(tmp_path),
         job_type="j",
     )
 


### PR DESCRIPTION
### TL;DR

Removed the `check_wandb_version()` function and its usage from the WandbContext class.

### What changed?

- Removed the `check_wandb_version()` function that was checking if the installed wandb version was up-to-date
- Removed the call to this function in the `WandbContext.__init__` method
- Removed unused imports (`pkg_resources` and `requests`) that were only needed for the version check
- Updated the test file to remove the monkeypatch for the now-deleted function
- Fixed a test by using `tmp_path` instead of `os.getcwd()` for the data directory

### How to test?

- Run the existing tests for the WandbContext class to ensure they pass
- Verify that WandbContext initialization works correctly without the version check
- Confirm that wandb functionality continues to work as expected in the application

### Why make this change?

The version check was likely causing unnecessary API calls to GitHub and adding complexity to the codebase. Removing it simplifies the code and eliminates potential network-related issues during initialization. The application can still function properly with the installed version of wandb without needing to verify it's the latest.