### PR TITLE
hotfix: fix bad map with new ascii map test

### DIFF
--- a/configs/env/mettagrid/maps/object_use/swap_out.map
+++ b/configs/env/mettagrid/maps/object_use/swap_out.map
@@ -5,7 +5,7 @@ W      s      s       W
 W      s A    s       W
 W      s      s       W
 W      s      s       W
-W      ssssssss      W
+W      ssssssss       W
 W                     W
 W         a           W
 W                     W

--- a/tests/map/test_validate_all_ascii_maps.py
+++ b/tests/map/test_validate_all_ascii_maps.py
@@ -206,7 +206,7 @@ class TestAsciiMaps:
                 if lines:
                     # This is the exact operation that causes InstantiationException
                     level_array = np.array([list(line) for line in lines], dtype="U6")
-                    mapped_array = np.vectorize(SYMBOLS.get)(level_array)
+                    _mapped_array = np.vectorize(SYMBOLS.get)(level_array)
 
                     # Basic structure validation
                     assert level_array.ndim == 2, "Should be 2D array"

--- a/tests/map/test_validate_all_ascii_maps.py
+++ b/tests/map/test_validate_all_ascii_maps.py
@@ -1,28 +1,75 @@
+"""
+Test suite for validating ASCII map files.
+
+This module validates .map files used by the mettagrid system to ensure they:
+1. Have consistent line lengths (required for NumPy array creation)
+2. Only contain symbols defined in the SYMBOLS mapping
+3. Can be successfully loaded as 2D NumPy arrays
+
+The validation prevents InstantiationException errors that occur when
+malformed maps are loaded at runtime.
+"""
+
 from pathlib import Path
 from typing import List, Tuple
 
 import numpy as np
 import pytest
 
-# Import SYMBOLS from the actual source file
 from mettagrid.room.ascii import SYMBOLS
 
 
 def find_map_files(root_dir: str = ".") -> List[Path]:
-    """Find all .map files in the repository."""
-    root_path = Path(root_dir)
-    return sorted(root_path.rglob("*.map"))
+    """
+    Find all .map files in the repository, excluding development directories.
+
+    Args:
+        root_dir: Root directory to search from
+
+    Returns:
+        Sorted list of Path objects for .map files
+    """
+    root_path = Path(root_dir).resolve()
+
+    # Exclude common development directories that might contain non-game .map files
+    exclude_patterns = {
+        ".venv",
+        "venv",
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+    }
+
+    map_files = []
+    for map_file in root_path.rglob("*.map"):
+        try:
+            relative_path = map_file.relative_to(root_path)
+            if not any(part in exclude_patterns for part in relative_path.parts):
+                map_files.append(map_file)
+        except ValueError:
+            # Include files we can't make relative
+            map_files.append(map_file)
+
+    return sorted(map_files)
 
 
 def validate_map_structure(file_path: Path) -> Tuple[bool, List[str]]:
     """
-    Validate a .map file structure.
+    Validate the structure and content of an ASCII map file.
+
+    Args:
+        file_path: Path to the .map file to validate
 
     Returns:
-        Tuple of (is_valid, list_of_errors)
+        Tuple of (is_valid, list_of_error_messages)
     """
     errors = []
 
+    # Read file content
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
@@ -32,36 +79,35 @@ def validate_map_structure(file_path: Path) -> Tuple[bool, List[str]]:
 
     lines = content.strip().splitlines()
 
-    # Check if file is empty
+    # Check for empty files
     if not lines:
         errors.append("File is empty")
         return False, errors
 
-    # Check line length consistency
+    # Validate line length consistency
     line_lengths = [len(line) for line in lines]
     if len(set(line_lengths)) > 1:
         min_len, max_len = min(line_lengths), max(line_lengths)
         errors.append(f"Inconsistent line lengths: min={min_len}, max={max_len}")
 
-        # Show which lines are problematic
+        # Report specific problematic lines
         expected_length = max(line_lengths)
         for i, line in enumerate(lines):
             if len(line) != expected_length:
                 errors.append(f"Line {i + 1} has length {len(line)}, expected {expected_length}")
 
-    # Check for unknown symbols
+    # Validate symbols
     all_chars = set("".join(lines))
     unknown_chars = all_chars - set(SYMBOLS.keys())
     if unknown_chars:
-        # Filter out common whitespace/control characters
+        # Filter out acceptable whitespace characters
         truly_unknown = unknown_chars - {"\t", "\r", "\n"}
         if truly_unknown:
             errors.append(f"Unknown symbols found: {sorted(truly_unknown)}")
 
-    # Test NumPy array creation (the actual failure point in the original code)
+    # Test NumPy array creation (the critical operation that was failing)
     try:
         level_array = np.array([list(line) for line in lines], dtype="U6")
-        # Test symbol mapping
         np.vectorize(SYMBOLS.get)(level_array)
     except Exception as e:
         errors.append(f"Failed to create NumPy array: {e}")
@@ -74,30 +120,30 @@ class TestAsciiMaps:
 
     @pytest.fixture(scope="class")
     def map_files(self):
-        """Fixture to find all .map files."""
+        """Fixture providing all .map files found in the repository."""
         files = find_map_files()
         if not files:
             pytest.skip("No .map files found in repository")
         return files
 
-    def test_map_files_found(self, map_files):
-        """Test that we can find .map files in the repository."""
-        assert len(map_files) > 0, "Should find at least one .map file"
+    def test_map_files_discovered(self, map_files):
+        """Verify that map files are found in the repository."""
+        assert len(map_files) > 0, "Should discover at least one .map file"
 
     @pytest.mark.parametrize("map_file", find_map_files())
-    def test_map_file_structure(self, map_file):
-        """Test that each .map file has valid structure."""
+    def test_individual_map_structure(self, map_file):
+        """Test that each map file has valid structure and content."""
         is_valid, errors = validate_map_structure(map_file)
 
         if not is_valid:
-            error_msg = f"Map file validation failed for {map_file}:\n"
-            for error in errors:
-                error_msg += f"  - {error}\n"
-            pytest.fail(error_msg)
+            # Create detailed error message for failed validation
+            relative_path = map_file.relative_to(Path.cwd()) if Path.cwd() in map_file.parents else map_file
+            error_details = "\n".join(f"  • {error}" for error in errors)
+            pytest.fail(f"Map validation failed for {relative_path}:\n{error_details}")
 
     def test_all_maps_use_known_symbols(self, map_files):
-        """Test that all maps only use symbols defined in SYMBOLS."""
-        unknown_symbols_by_file = {}
+        """Verify all maps only use symbols defined in SYMBOLS mapping."""
+        files_with_unknown_symbols = {}
 
         for map_file in map_files:
             try:
@@ -108,152 +154,114 @@ class TestAsciiMaps:
                 unknown_chars = all_chars - set(SYMBOLS.keys()) - {"\t", "\r", "\n"}
 
                 if unknown_chars:
-                    unknown_symbols_by_file[map_file] = sorted(unknown_chars)
+                    files_with_unknown_symbols[map_file] = sorted(unknown_chars)
             except Exception:
-                # Individual file errors will be caught by test_map_file_structure
+                # Individual file read errors will be caught by test_individual_map_structure
                 continue
 
-        if unknown_symbols_by_file:
-            error_msg = "Unknown symbols found in map files:\n"
-            for file_path, symbols in unknown_symbols_by_file.items():
-                error_msg += f"  {file_path}: {symbols}\n"
-            pytest.fail(error_msg)
+        if files_with_unknown_symbols:
+            error_lines = []
+            for file_path, symbols in files_with_unknown_symbols.items():
+                relative_path = file_path.relative_to(Path.cwd()) if Path.cwd() in file_path.parents else file_path
+                error_lines.append(f"  • {relative_path}: {symbols}")
+
+            pytest.fail("Maps contain unknown symbols:\n" + "\n".join(error_lines))
 
     def test_all_maps_have_consistent_line_lengths(self, map_files):
-        """Test that all maps have consistent line lengths."""
-        inconsistent_files = {}
+        """Verify all maps have consistent line lengths within each file."""
+        files_with_inconsistent_lengths = {}
 
         for map_file in map_files:
             try:
                 with open(map_file, "r", encoding="utf-8") as f:
                     lines = f.read().strip().splitlines()
 
-                if not lines:
-                    continue
-
-                line_lengths = [len(line) for line in lines]
-                if len(set(line_lengths)) > 1:
-                    min_len, max_len = min(line_lengths), max(line_lengths)
-                    inconsistent_files[map_file] = (min_len, max_len, len(lines))
+                if lines:
+                    line_lengths = [len(line) for line in lines]
+                    if len(set(line_lengths)) > 1:
+                        min_len, max_len = min(line_lengths), max(line_lengths)
+                        files_with_inconsistent_lengths[map_file] = (min_len, max_len, len(lines))
 
             except Exception:
-                # Individual file errors will be caught by test_map_file_structure
+                # Individual file read errors will be caught by test_individual_map_structure
                 continue
 
-        if inconsistent_files:
-            error_msg = "Maps with inconsistent line lengths found:\n"
-            for file_path, (min_len, max_len, total_lines) in inconsistent_files.items():
-                error_msg += (
-                    f"  {file_path}: lines vary from {min_len} to {max_len} chars ({total_lines} lines total)\n"
-                )
-            pytest.fail(error_msg)
+        if files_with_inconsistent_lengths:
+            error_lines = []
+            for file_path, (min_len, max_len, total_lines) in files_with_inconsistent_lengths.items():
+                relative_path = file_path.relative_to(Path.cwd()) if Path.cwd() in file_path.parents else file_path
+                error_lines.append(f"  • {relative_path}: {min_len}-{max_len} chars ({total_lines} lines)")
 
-    def test_maps_can_be_loaded_as_numpy_arrays(self, map_files):
-        """Test that all maps can be successfully loaded as NumPy arrays."""
-        failed_files = {}
+            pytest.fail("Maps have inconsistent line lengths:\n" + "\n".join(error_lines))
+
+    def test_all_maps_load_as_numpy_arrays(self, map_files):
+        """Verify all maps can be loaded as NumPy arrays (critical for runtime)."""
+        files_that_failed_loading = {}
 
         for map_file in map_files:
             try:
                 with open(map_file, "r", encoding="utf-8") as f:
                     lines = f.read().strip().splitlines()
 
-                if not lines:
-                    continue
+                if lines:
+                    # This is the exact operation that causes InstantiationException
+                    level_array = np.array([list(line) for line in lines], dtype="U6")
+                    mapped_array = np.vectorize(SYMBOLS.get)(level_array)
 
-                # This is the exact operation that was failing in the original error
-                level_array = np.array([list(line) for line in lines], dtype="U6")
-                mapped_array = np.vectorize(SYMBOLS.get)(level_array)
-
-                # Basic sanity checks
-                assert level_array.ndim == 2, "Should be a 2D array"
-                assert level_array.shape[0] == len(lines), "Should have correct number of rows"
+                    # Basic structure validation
+                    assert level_array.ndim == 2, "Should be 2D array"
+                    assert level_array.shape[0] == len(lines), "Should have correct row count"
 
             except Exception as e:
-                failed_files[map_file] = str(e)
+                files_that_failed_loading[map_file] = str(e)
 
-        if failed_files:
-            error_msg = "Maps that failed to load as NumPy arrays:\n"
-            for file_path, error in failed_files.items():
-                error_msg += f"  {file_path}: {error}\n"
-            pytest.fail(error_msg)
+        if files_that_failed_loading:
+            error_lines = []
+            for file_path, error in files_that_failed_loading.items():
+                relative_path = file_path.relative_to(Path.cwd()) if Path.cwd() in file_path.parents else file_path
+                error_lines.append(f"  • {relative_path}: {error}")
+
+            pytest.fail("Maps failed to load as NumPy arrays:\n" + "\n".join(error_lines))
 
 
-# Utility functions for manual testing and debugging
-def print_map_summary():
-    """Print a summary of all maps found (useful for debugging)."""
+def print_validation_summary():
+    """Print a comprehensive validation summary (useful for manual inspection)."""
+    print("ASCII Map Validation Summary")
+    print("=" * 50)
+
     map_files = find_map_files()
+    print(f"Found {len(map_files)} .map files\n")
 
-    print(f"Found {len(map_files)} .map files:")
+    if not map_files:
+        print("No .map files found to validate.")
+        return
 
     valid_count = 0
-    invalid_count = 0
+    invalid_files = []
 
     for map_file in map_files:
         is_valid, errors = validate_map_structure(map_file)
-        status = "✓" if is_valid else "✗"
-        print(f"  {status} {map_file}")
+        relative_path = map_file.relative_to(Path.cwd()) if Path.cwd() in map_file.parents else map_file
 
-        if not is_valid:
-            invalid_count += 1
-            for error in errors[:2]:  # Show first 2 errors
-                print(f"    - {error}")
-            if len(errors) > 2:
-                print(f"    ... and {len(errors) - 2} more errors")
-        else:
+        if is_valid:
+            print(f"✓ {relative_path}")
             valid_count += 1
-
-    print(f"\nSummary: {valid_count} valid, {invalid_count} invalid")
-
-
-def fix_line_lengths(file_path: Path, dry_run: bool = True) -> bool:
-    """
-    Fix inconsistent line lengths by padding shorter lines with spaces.
-
-    Args:
-        file_path: Path to the .map file
-        dry_run: If True, only print what would be changed
-
-    Returns:
-        True if file was (or would be) modified
-    """
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            content = f.read()
-    except Exception as e:
-        print(f"Error reading {file_path}: {e}")
-        return False
-
-    lines = content.strip().splitlines()
-    line_lengths = [len(line) for line in lines]
-
-    if len(set(line_lengths)) <= 1:
-        return False  # All lines same length
-
-    max_length = max(line_lengths)
-    fixed_lines = []
-    changes_made = False
-
-    for i, line in enumerate(lines):
-        if len(line) < max_length:
-            fixed_line = line.ljust(max_length)
-            fixed_lines.append(fixed_line)
-            changes_made = True
-            if dry_run:
-                print(f"  Line {i + 1}: would pad from {len(line)} to {max_length} chars")
         else:
-            fixed_lines.append(line)
+            print(f"✗ {relative_path}")
+            for error in errors:
+                print(f"    • {error}")
+            invalid_files.append(relative_path)
+            print()
 
-    if changes_made:
-        if dry_run:
-            print(f"Would fix {file_path} ({sum(1 for l in line_lengths if l < max_length)} lines need padding)")
-        else:
-            with open(file_path, "w", encoding="utf-8") as f:
-                f.write("\n".join(fixed_lines) + "\n")
-            print(f"Fixed {file_path}")
+    print("\nValidation Results:")
+    print(f"  Valid:   {valid_count}")
+    print(f"  Invalid: {len(invalid_files)}")
 
-    return changes_made
+    if invalid_files:
+        print("\nFiles requiring manual correction:")
+        for file_path in invalid_files:
+            print(f"  • {file_path}")
 
 
 if __name__ == "__main__":
-    # When run directly, show map summary
-    print_map_summary()
+    print_validation_summary()

--- a/tests/map/test_validate_all_ascii_maps.py
+++ b/tests/map/test_validate_all_ascii_maps.py
@@ -1,0 +1,259 @@
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+# Import SYMBOLS from the actual source file
+from mettagrid.room.ascii import SYMBOLS
+
+
+def find_map_files(root_dir: str = ".") -> List[Path]:
+    """Find all .map files in the repository."""
+    root_path = Path(root_dir)
+    return sorted(root_path.rglob("*.map"))
+
+
+def validate_map_structure(file_path: Path) -> Tuple[bool, List[str]]:
+    """
+    Validate a .map file structure.
+
+    Returns:
+        Tuple of (is_valid, list_of_errors)
+    """
+    errors = []
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception as e:
+        errors.append(f"Failed to read file: {e}")
+        return False, errors
+
+    lines = content.strip().splitlines()
+
+    # Check if file is empty
+    if not lines:
+        errors.append("File is empty")
+        return False, errors
+
+    # Check line length consistency
+    line_lengths = [len(line) for line in lines]
+    if len(set(line_lengths)) > 1:
+        min_len, max_len = min(line_lengths), max(line_lengths)
+        errors.append(f"Inconsistent line lengths: min={min_len}, max={max_len}")
+
+        # Show which lines are problematic
+        expected_length = max(line_lengths)
+        for i, line in enumerate(lines):
+            if len(line) != expected_length:
+                errors.append(f"Line {i + 1} has length {len(line)}, expected {expected_length}")
+
+    # Check for unknown symbols
+    all_chars = set("".join(lines))
+    unknown_chars = all_chars - set(SYMBOLS.keys())
+    if unknown_chars:
+        # Filter out common whitespace/control characters
+        truly_unknown = unknown_chars - {"\t", "\r", "\n"}
+        if truly_unknown:
+            errors.append(f"Unknown symbols found: {sorted(truly_unknown)}")
+
+    # Test NumPy array creation (the actual failure point in the original code)
+    try:
+        level_array = np.array([list(line) for line in lines], dtype="U6")
+        # Test symbol mapping
+        np.vectorize(SYMBOLS.get)(level_array)
+    except Exception as e:
+        errors.append(f"Failed to create NumPy array: {e}")
+
+    return len(errors) == 0, errors
+
+
+class TestAsciiMaps:
+    """Test suite for ASCII map validation."""
+
+    @pytest.fixture(scope="class")
+    def map_files(self):
+        """Fixture to find all .map files."""
+        files = find_map_files()
+        if not files:
+            pytest.skip("No .map files found in repository")
+        return files
+
+    def test_map_files_found(self, map_files):
+        """Test that we can find .map files in the repository."""
+        assert len(map_files) > 0, "Should find at least one .map file"
+
+    @pytest.mark.parametrize("map_file", find_map_files())
+    def test_map_file_structure(self, map_file):
+        """Test that each .map file has valid structure."""
+        is_valid, errors = validate_map_structure(map_file)
+
+        if not is_valid:
+            error_msg = f"Map file validation failed for {map_file}:\n"
+            for error in errors:
+                error_msg += f"  - {error}\n"
+            pytest.fail(error_msg)
+
+    def test_all_maps_use_known_symbols(self, map_files):
+        """Test that all maps only use symbols defined in SYMBOLS."""
+        unknown_symbols_by_file = {}
+
+        for map_file in map_files:
+            try:
+                with open(map_file, "r", encoding="utf-8") as f:
+                    content = f.read()
+
+                all_chars = set(content)
+                unknown_chars = all_chars - set(SYMBOLS.keys()) - {"\t", "\r", "\n"}
+
+                if unknown_chars:
+                    unknown_symbols_by_file[map_file] = sorted(unknown_chars)
+            except Exception:
+                # Individual file errors will be caught by test_map_file_structure
+                continue
+
+        if unknown_symbols_by_file:
+            error_msg = "Unknown symbols found in map files:\n"
+            for file_path, symbols in unknown_symbols_by_file.items():
+                error_msg += f"  {file_path}: {symbols}\n"
+            pytest.fail(error_msg)
+
+    def test_all_maps_have_consistent_line_lengths(self, map_files):
+        """Test that all maps have consistent line lengths."""
+        inconsistent_files = {}
+
+        for map_file in map_files:
+            try:
+                with open(map_file, "r", encoding="utf-8") as f:
+                    lines = f.read().strip().splitlines()
+
+                if not lines:
+                    continue
+
+                line_lengths = [len(line) for line in lines]
+                if len(set(line_lengths)) > 1:
+                    min_len, max_len = min(line_lengths), max(line_lengths)
+                    inconsistent_files[map_file] = (min_len, max_len, len(lines))
+
+            except Exception:
+                # Individual file errors will be caught by test_map_file_structure
+                continue
+
+        if inconsistent_files:
+            error_msg = "Maps with inconsistent line lengths found:\n"
+            for file_path, (min_len, max_len, total_lines) in inconsistent_files.items():
+                error_msg += (
+                    f"  {file_path}: lines vary from {min_len} to {max_len} chars ({total_lines} lines total)\n"
+                )
+            pytest.fail(error_msg)
+
+    def test_maps_can_be_loaded_as_numpy_arrays(self, map_files):
+        """Test that all maps can be successfully loaded as NumPy arrays."""
+        failed_files = {}
+
+        for map_file in map_files:
+            try:
+                with open(map_file, "r", encoding="utf-8") as f:
+                    lines = f.read().strip().splitlines()
+
+                if not lines:
+                    continue
+
+                # This is the exact operation that was failing in the original error
+                level_array = np.array([list(line) for line in lines], dtype="U6")
+                mapped_array = np.vectorize(SYMBOLS.get)(level_array)
+
+                # Basic sanity checks
+                assert level_array.ndim == 2, "Should be a 2D array"
+                assert level_array.shape[0] == len(lines), "Should have correct number of rows"
+
+            except Exception as e:
+                failed_files[map_file] = str(e)
+
+        if failed_files:
+            error_msg = "Maps that failed to load as NumPy arrays:\n"
+            for file_path, error in failed_files.items():
+                error_msg += f"  {file_path}: {error}\n"
+            pytest.fail(error_msg)
+
+
+# Utility functions for manual testing and debugging
+def print_map_summary():
+    """Print a summary of all maps found (useful for debugging)."""
+    map_files = find_map_files()
+
+    print(f"Found {len(map_files)} .map files:")
+
+    valid_count = 0
+    invalid_count = 0
+
+    for map_file in map_files:
+        is_valid, errors = validate_map_structure(map_file)
+        status = "✓" if is_valid else "✗"
+        print(f"  {status} {map_file}")
+
+        if not is_valid:
+            invalid_count += 1
+            for error in errors[:2]:  # Show first 2 errors
+                print(f"    - {error}")
+            if len(errors) > 2:
+                print(f"    ... and {len(errors) - 2} more errors")
+        else:
+            valid_count += 1
+
+    print(f"\nSummary: {valid_count} valid, {invalid_count} invalid")
+
+
+def fix_line_lengths(file_path: Path, dry_run: bool = True) -> bool:
+    """
+    Fix inconsistent line lengths by padding shorter lines with spaces.
+
+    Args:
+        file_path: Path to the .map file
+        dry_run: If True, only print what would be changed
+
+    Returns:
+        True if file was (or would be) modified
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return False
+
+    lines = content.strip().splitlines()
+    line_lengths = [len(line) for line in lines]
+
+    if len(set(line_lengths)) <= 1:
+        return False  # All lines same length
+
+    max_length = max(line_lengths)
+    fixed_lines = []
+    changes_made = False
+
+    for i, line in enumerate(lines):
+        if len(line) < max_length:
+            fixed_line = line.ljust(max_length)
+            fixed_lines.append(fixed_line)
+            changes_made = True
+            if dry_run:
+                print(f"  Line {i + 1}: would pad from {len(line)} to {max_length} chars")
+        else:
+            fixed_lines.append(line)
+
+    if changes_made:
+        if dry_run:
+            print(f"Would fix {file_path} ({sum(1 for l in line_lengths if l < max_length)} lines need padding)")
+        else:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(fixed_lines) + "\n")
+            print(f"Fixed {file_path}")
+
+    return changes_made
+
+
+if __name__ == "__main__":
+    # When run directly, show map summary
+    print_map_summary()


### PR DESCRIPTION

Runs are failing early with an `InstantiationException` error when loading ASCII maps due to inconsistent line lengths in map files. The error occurred because NumPy cannot create arrays from sequences with inhomogeneous shapes:

```
ValueError('setting an array element with a sequence. The requested array has an 
inhomogeneous shape after 1 dimensions. The detected shape was (12,) + 
inhomogeneous part.')
```

### 1. Added Comprehensive ASCII Map Validation Test
Created `tests/map/test_validate_all_ascii_maps.py` that validates all `.map` files in the repository to ensure they:

- **Have consistent line lengths** (required for NumPy array creation)
- **Only contain known symbols** defined in `SYMBOLS` mapping
- **Can be successfully loaded as 2D NumPy arrays** (prevents runtime failures)

The test suite includes:
- Individual validation for each map file (28 parametrized tests)
- Bulk validation tests for common issues
- Clear error reporting with specific line numbers and file paths
- Automatic discovery of `.map` files while excluding development directories

### 2. Fixed Problematic Map File
Fixed `configs/env/mettagrid/maps/object_use/swap_out.map`:
- **Issue**: Line 8 had 22 characters while other lines had 23 characters
- **Fix**: Added missing space to make line 8 consistent with other lines

