### PR TITLE
_episode_rewards was not being initialized correctly and all indices …

### DIFF
--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -15,7 +15,8 @@
 		"ruff.enable": true,
 		"ruff.nativeServer": "on",
 		"files.associations": {
-			"*.pxd": "cython"
+			"*.pxd": "cython",
+			"array": "cpp"
 		},
 		"files.excludeGitIgnored": true,
 		"terminal.integrated.profiles.osx": {

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -15,8 +15,7 @@
 		"ruff.enable": true,
 		"ruff.nativeServer": "on",
 		"files.associations": {
-			"*.pxd": "cython",
-			"array": "cpp"
+			"*.pxd": "cython"
 		},
 		"files.excludeGitIgnored": true,
 		"terminal.integrated.profiles.osx": {

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -386,7 +386,7 @@ void MettaGrid::set_buffers(py::array_t<uint8_t, py::array::c_style>& observatio
   _terminals = terminals;
   _truncations = truncations;
   _rewards = rewards;
-  _episode_rewards = py::array_t<float>(_rewards.shape(0));
+  _episode_rewards = py::array_t<float>({static_cast<ssize_t>(_rewards.shape(0))}, {sizeof(float)});
   for (size_t i = 0; i < _agents.size(); i++) {
     _agents[i]->init(&_rewards.mutable_unchecked<1>()(i));
   }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -2,6 +2,7 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <iostream>
 
 #include "action_handler.hpp"
 #include "actions/attack.hpp"
@@ -161,9 +162,9 @@ MettaGrid::MettaGrid(py::dict env_cfg, py::list map) {
                                 static_cast<ssize_t>(_obs_width),
                                 static_cast<ssize_t>(_grid_features.size())};
   auto observations = py::array_t<uint8_t, py::array::c_style>(shape);
-  auto terminals = py::array_t<bool, py::array::c_style>(static_cast<ssize_t>(num_agents));
-  auto truncations = py::array_t<bool, py::array::c_style>(static_cast<ssize_t>(num_agents));
-  auto rewards = py::array_t<float, py::array::c_style>(static_cast<ssize_t>(num_agents));
+  auto terminals = py::array_t<bool, py::array::c_style>({static_cast<ssize_t>(num_agents)}, {sizeof(bool)});
+  auto truncations = py::array_t<bool, py::array::c_style>({static_cast<ssize_t>(num_agents)}, {sizeof(bool)});
+  auto rewards = py::array_t<float, py::array::c_style>({static_cast<ssize_t>(num_agents)}, {sizeof(float)});
 
   set_buffers(observations, terminals, truncations, rewards);
 }
@@ -376,6 +377,7 @@ void MettaGrid::validate_buffers() {
       throw std::runtime_error("rewards has the wrong shape");
     }
   }
+  assert(_episode_rewards.nbytes() == _rewards.nbytes());
 }
 
 void MettaGrid::set_buffers(py::array_t<uint8_t, py::array::c_style>& observations,
@@ -386,7 +388,7 @@ void MettaGrid::set_buffers(py::array_t<uint8_t, py::array::c_style>& observatio
   _terminals = terminals;
   _truncations = truncations;
   _rewards = rewards;
-  _episode_rewards = py::array_t<float>({static_cast<ssize_t>(_rewards.shape(0))}, {sizeof(float)});
+  _episode_rewards = py::array_t<float, py::array::c_style>({static_cast<ssize_t>(_rewards.shape(0))}, {sizeof(float)});
   for (size_t i = 0; i < _agents.size(); i++) {
     _agents[i]->init(&_rewards.mutable_unchecked<1>()(i));
   }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -376,7 +376,6 @@ void MettaGrid::validate_buffers() {
       throw std::runtime_error("rewards has the wrong shape");
     }
   }
-  assert(_episode_rewards.nbytes() == _rewards.nbytes());
 }
 
 void MettaGrid::set_buffers(py::array_t<uint8_t, py::array::c_style>& observations,

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -2,7 +2,6 @@
 
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
-#include <iostream>
 
 #include "action_handler.hpp"
 #include "actions/attack.hpp"

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -89,6 +89,48 @@ def test_observation():
 
 
 class TestSetBuffers:
+    def test_default_buffers(self):
+        env = create_minimal_mettagrid_env()
+        env.reset()
+
+        # check obs after we write something
+        noop_action_idx = env.action_names().index("noop")
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+        episode_rewards = env.get_episode_rewards()
+
+        # Check strides. We've had issues where we've not correctly initialized the buffers, and have had
+        # strides of zero.
+        assert rewards.strides == (4,)  # float32
+        assert terminals.strides == (1,)  # bool, tracked as a byte
+        assert truncations.strides == (1,)  # bool, tracked as a byte
+        assert episode_rewards.strides == (4,)  # float32
+        assert obs.strides[-1] == 1  # uint8
+
+        # This is a more brute force way to check that the buffers are behaving correctly by changing a single
+        # element and making sure the correct update is reflected. Given that the strides are correct, these tests
+        # are probably superfluous; but we've been surprised by what can fail in the past, so we're aiming for
+        # overkill.
+        assert (rewards == [0, 0]).all()
+        assert (terminals == [False, False]).all()
+        assert (truncations == [False, False]).all()
+        assert (episode_rewards == [0, 0]).all()
+
+        rewards[0] = 1
+        terminals[0] = True
+        truncations[0] = True
+        episode_rewards[0] = 1
+
+        assert (rewards == [1, 0]).all()
+        assert (terminals == [True, False]).all()
+        assert (truncations == [True, False]).all()
+        assert (episode_rewards == [1, 0]).all()
+
+        # Obs is non-empty, so we treat it differently than the others.
+        initial_obs_sum = obs.sum()
+        obs[0, 0, 0, 0] += 1
+        assert obs.sum() == initial_obs_sum + 1
+
     def test_set_buffers_wrong_shape(self):
         env = create_minimal_mettagrid_env()
         num_features = len(env.grid_features())

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -93,7 +93,6 @@ class TestSetBuffers:
         env = create_minimal_mettagrid_env()
         env.reset()
 
-        # check obs after we write something
         noop_action_idx = env.action_names().index("noop")
         actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
         obs, rewards, terminals, truncations, info = env.step(actions)


### PR DESCRIPTION
…in the numpy array shared a view.

Here is what was happening before in metttagrid_env.py:

```
-> obs, infos = self._c_env.reset()
(Pdb) ep_rew
array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.], dtype=float32)
(Pdb) abc[3] = 2
(Pdb) abc
array([0.,  0.,  0.,  2.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
(Pdb) ep_rew[3] = 2
(Pdb) ep_rew
array([2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2., 2.], dtype=float32)
```

Here's what's happening now:

```
-> obs, infos = self._c_env.reset()
(Pdb) ep_rew
array([1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0.], dtype=float32)
(Pdb) ep_rew[3] = 2
(Pdb) ep_rew
array([1., 0., 0., 2., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0.], dtype=float32)
```

Code is a one-line change:

`_episode_rewards = py::array_t<float>(_rewards.shape(0));`

becomes

`_episode_rewards = py::array_t<float>({static_cast<ssize_t>(_rewards.shape(0))}, {sizeof(float)});`