### PR TITLE
Switch grid to use unique pointers

### DIFF
--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -94,7 +94,7 @@ protected:
       actor->stats.incr("damage", ObjectTypeNames[object_target->_type_id]);
       if (object_target->hp <= 0) {
         actor->stats.incr("destroyed", ObjectTypeNames[object_target->_type_id]);
-        _grid->remove_object(object_target);
+        _grid->remove_object(object_target); // This will invalidate the pointer
       }
       return true;
     }

--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -94,7 +94,7 @@ protected:
       actor->stats.incr("damage", ObjectTypeNames[object_target->_type_id]);
       if (object_target->hp <= 0) {
         actor->stats.incr("destroyed", ObjectTypeNames[object_target->_type_id]);
-        _grid->remove_object(object_target); // This will invalidate the pointer
+        _grid->remove_object(object_target);  // This will invalidate the pointer
       }
       return true;
     }

--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -93,8 +93,8 @@ protected:
       object_target->hp -= 1;
       actor->stats.incr("damage", ObjectTypeNames[object_target->_type_id]);
       if (object_target->hp <= 0) {
-        _grid->remove_object(object_target);
         actor->stats.incr("destroyed", ObjectTypeNames[object_target->_type_id]);
+        _grid->remove_object(object_target);
       }
       return true;
     }

--- a/mettagrid/mettagrid/grid.hpp
+++ b/mettagrid/mettagrid/grid.hpp
@@ -2,12 +2,13 @@
 #define GRID_HPP
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 
 #include "grid_object.hpp"
 
 using namespace std;
-typedef vector<vector<vector<GridObjectId> > > GridType;
+typedef vector<vector<vector<GridObjectId>>> GridType;
 
 class Grid {
 public:
@@ -17,24 +18,18 @@ public:
   Layer num_layers;
 
   GridType grid;
-  vector<GridObject*> objects;
+  vector<std::unique_ptr<GridObject>> objects;
 
   inline Grid(unsigned int width, unsigned int height, vector<Layer> layer_for_type_id)
       : width(width), height(height), layer_for_type_id(layer_for_type_id) {
     num_layers = *max_element(layer_for_type_id.begin(), layer_for_type_id.end()) + 1;
-    grid.resize(height, vector<vector<GridObjectId> >(width, vector<GridObjectId>(this->num_layers, 0)));
+    grid.resize(height, vector<vector<GridObjectId>>(width, vector<GridObjectId>(this->num_layers, 0)));
 
     // 0 is reserved for empty space
     objects.push_back(nullptr);
   }
 
-  inline ~Grid() {
-    for (unsigned long id = 1; id < objects.size(); ++id) {
-      if (objects[id] != nullptr) {
-        delete objects[id];
-      }
-    }
-  }
+  virtual ~Grid() = default;
 
   inline char add_object(GridObject* obj) {
     if (obj->location.r >= height or obj->location.c >= width or obj->location.layer >= num_layers) {
@@ -45,20 +40,14 @@ public:
     }
 
     obj->id = this->objects.size();
-    this->objects.push_back(obj);
+    this->objects.push_back(std::unique_ptr<GridObject>(obj));
     this->grid[obj->location.r][obj->location.c][obj->location.layer] = obj->id;
     return true;
   }
 
   inline void remove_object(GridObject* obj) {
     this->grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
-    // delete obj;
     this->objects[obj->id] = nullptr;
-  }
-
-  inline void remove_object(GridObjectId id) {
-    GridObject* obj = this->objects[id];
-    this->remove_object(obj);
   }
 
   inline char move_object(GridObjectId id, const GridLocation& loc) {
@@ -70,7 +59,7 @@ public:
       return false;
     }
 
-    GridObject* obj = objects[id];
+    GridObject* obj = object(id);
     grid[loc.r][loc.c][loc.layer] = id;
     grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
     obj->location = loc;
@@ -78,12 +67,12 @@ public:
   }
 
   inline void swap_objects(GridObjectId id1, GridObjectId id2) {
-    GridObject* obj1 = objects[id1];
+    GridObject* obj1 = object(id1);
     GridLocation loc1 = obj1->location;
     Layer layer1 = loc1.layer;
     grid[loc1.r][loc1.c][loc1.layer] = 0;
 
-    GridObject* obj2 = objects[id2];
+    GridObject* obj2 = object(id2);
     GridLocation loc2 = obj2->location;
     Layer layer2 = loc2.layer;
     grid[loc2.r][loc2.c][loc2.layer] = 0;
@@ -99,7 +88,7 @@ public:
   }
 
   inline GridObject* object(GridObjectId obj_id) {
-    return objects[obj_id];
+    return objects[obj_id].get();
   }
 
   inline GridObject* object_at(const GridLocation& loc) {
@@ -109,7 +98,7 @@ public:
     if (grid[loc.r][loc.c][loc.layer] == 0) {
       return nullptr;
     }
-    return objects[grid[loc.r][loc.c][loc.layer]];
+    return object(grid[loc.r][loc.c][loc.layer]);
   }
 
   inline GridObject* object_at(const GridLocation& loc, TypeId type_id) {
@@ -130,7 +119,7 @@ public:
   }
 
   inline const GridLocation location(GridObjectId id) {
-    return objects[id]->location;
+    return object(id)->location;
   }
 
   inline const GridLocation relative_location(const GridLocation& loc,

--- a/mettagrid/mettagrid/grid.hpp
+++ b/mettagrid/mettagrid/grid.hpp
@@ -45,9 +45,14 @@ public:
     return true;
   }
 
-  inline void remove_object(GridObject* obj) {
+  // Removes and object from the grid and gives ownership of the object to the caller.
+  // Since the caller is now the owner, this can make the raw pointer invalid, if the
+  // returned unique_ptr is destroyed.
+  inline unique_ptr<GridObject> remove_object(GridObject* obj) {
     this->grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
+    auto obj_ptr = this->objects[obj->id].release();
     this->objects[obj->id] = nullptr;
+    return std::unique_ptr<GridObject>(obj_ptr);
   }
 
   inline char move_object(GridObjectId id, const GridLocation& loc) {


### PR DESCRIPTION
### TL;DR

Refactored Grid class to use `std::unique_ptr` for memory management of grid objects.

### What changed?

- Changed `vector<GridObject*>` to `vector<std::unique_ptr<GridObject>>` to automatically manage object lifetimes
- Removed manual destructor in favor of default virtual destructor
- Removed redundant `remove_object(GridObjectId id)` method
- Updated all object access methods to use `object(id)` or `.get()` to properly handle the unique pointers

### Why make this change?

This change improves memory safety by using C++ smart pointers to automatically manage the lifetime of grid objects. It eliminates the risk of memory leaks and dangling pointers that could occur with manual memory management. The code is now more robust and follows modern C++ best practices.