### PR TITLE
Retry eval smoke tests

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -321,9 +321,12 @@ jobs:
           AWS_ACCESS_KEY_ID: set_but_not_used
           AWS_SECRET_ACCESS_KEY: set_but_not_used
         # We retry evals a few times because they're not deterministic (despite our best efforts)
+        # Our smoke tests should pass at least 90% of the time if they're working, so this should have
+        # a spurious failure rate of less than 0.01%. We assume that spurious successes should be
+        # extremely rare.
         run: |
           source .github/scripts/benchmark.sh
-          for i in {1..5}; do
+          for i in {1..4}; do
             if benchmark "evals_try$i" "./run_evals.sh smoke_test"; then
               exit 0
             fi

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -320,9 +320,15 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           AWS_ACCESS_KEY_ID: set_but_not_used
           AWS_SECRET_ACCESS_KEY: set_but_not_used
+        # We retry evals a few times because they're not deterministic (despite our best efforts)
         run: |
           source .github/scripts/benchmark.sh
-          benchmark "evals" "./run_evals.sh smoke_test"
+          for i in {1..5}; do
+            if benchmark "evals_try$i" "./run_evals.sh smoke_test"; then
+              exit 0
+            fi
+          done
+          exit 1
 
       - name: Save evals benchmark
         id: save_evals_benchmark

--- a/metta/util/runtime_configuration.py
+++ b/metta/util/runtime_configuration.py
@@ -13,12 +13,17 @@ logger = logging.getLogger("runtime_configuration")
 
 
 def seed_everything(seed, torch_deterministic):
+    # Despite these efforts, we still don't get deterministic behavior. But presumably
+    # this is better than nothing.
+    # https://docs.pytorch.org/docs/stable/notes/randomness.html#reproducibility
     random.seed(seed)
     np.random.seed(seed)
     if seed is not None:
         torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = torch_deterministic
-    torch.backends.cudnn.benchmark = True
+    torch.backends.cudnn.benchmark = not torch_deterministic
+    torch.use_deterministic_algorithms(torch_deterministic)
 
 
 def setup_mettagrid_environment(cfg):

--- a/run_evals.sh
+++ b/run_evals.sh
@@ -53,11 +53,10 @@ if [ "$1" = "smoke_test" ]; then
   #   ... because you're adding a new eval family on which we can't score well, please add the new eval
   #       family after the smoke test terminates.
   POLICIES=("b.daphne.navigation0:v12")
-  # Use a fixed seed so tests are deterministic. It's okay to change this seed if you have
-  # a reason -- we just don't want tests to fail spuriously.
+  # We try to be as deterministic as possible, but this turns out to be less deterministic than we'd like.
   # Use device=cpu since we're probably on github. We should probably address this via
   # hardware=..., but for the most part this shouldn't matter for eval.
-  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415 device=cpu"
+  MAYBE_SMOKE_TEST="+sim_job.smoke_test=True seed=31415 torch_deterministic=True device=cpu"
   MESSAGE="Running smoke test eval"
 elif [ -n "$1" ]; then
   echo "Invalid argument: $1"


### PR DESCRIPTION
# Retry eval smoke tests to reduce spurious failures

This PR improves the reliability of our eval smoke tests by:

1. Retrying the eval smoke tests up to 4 times in the GitHub workflow to reduce spurious failures
2. Enhancing deterministic behavior in `seed_everything()` by:
   - Adding `torch.cuda.manual_seed_all(seed)`
   - Setting `torch.backends.cudnn.benchmark` to the opposite of `torch_deterministic`
   - Enabling `torch.use_deterministic_algorithms(torch_deterministic)`
3. Setting `torch_deterministic=True` in the smoke test configuration

Despite these improvements, we acknowledge in comments that perfect determinism is still challenging to achieve.