### PR TITLE
Fix S3 save_to_uri bug and add tests

### DIFF
--- a/metta/map/utils/storage.py
+++ b/metta/map/utils/storage.py
@@ -18,6 +18,7 @@ def save_to_uri(text: str, uri: str):
         bucket, key = parse_s3_uri(uri)
         s3 = get_s3_client()
         s3.put_object(Bucket=bucket, Key=key, Body=text)
+        return
 
     filename = parse_file_uri(uri)
 

--- a/tests/map/utils/test_storage.py
+++ b/tests/map/utils/test_storage.py
@@ -1,0 +1,32 @@
+import builtins
+
+from metta.map.utils import storage
+
+
+def test_save_to_uri_local(tmp_path):
+    file_path = tmp_path / "file.txt"
+    storage.save_to_uri("hello", str(file_path))
+    assert file_path.read_text() == "hello"
+
+
+def test_save_to_uri_s3(monkeypatch):
+    calls = []
+
+    class DummyS3:
+        def put_object(self, Bucket, Key, Body):
+            calls.append((Bucket, Key, Body))
+
+    monkeypatch.setattr(storage, "get_s3_client", lambda: DummyS3())
+    monkeypatch.setattr(
+        storage,
+        "parse_file_uri",
+        lambda uri: (_ for _ in ()).throw(AssertionError("parse_file_uri should not be called")),
+    )
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("open should not be called")),
+    )
+
+    storage.save_to_uri("data", "s3://bucket/key")
+    assert calls == [("bucket", "key", "data")]


### PR DESCRIPTION
## Summary
- fix `save_to_uri` to skip writing a local file when saving to S3
- add tests verifying local and S3 save behaviors

## Testing
- `pytest tests/map/utils/test_storage.py -q`