### PR TITLE
Use einops.rearrange for tensor shaping

### DIFF
--- a/metta/agent/lib/actor.py
+++ b/metta/agent/lib/actor.py
@@ -69,9 +69,9 @@ class MettaActorBig(LayerBase):
 
         # input_1: [B*TT, hidden] -> [B*TT * num_actions, hidden]
         # input_2: [B*TT, num_actions, embed_dim] -> [B*TT * num_actions, embed_dim]
-        hidden_reshaped = repeat(hidden, "b h -> b a h", a=num_actions)  # shape: [B*TT, num_actions, hidden]
-        hidden_reshaped = rearrange(hidden_reshaped, "b a h -> (b a) h")  # shape: [N, H]
-        action_embeds_reshaped = rearrange(action_embeds, "b a e -> (b a) e")  # shape: [N, E]
+        hidden_reshaped = repeat(hidden, "b h -> b a h", a=num_actions)
+        hidden_reshaped = rearrange(hidden_reshaped, "b a h -> (b a) h")
+        action_embeds_reshaped = rearrange(action_embeds, "b a e -> (b a) e")
 
         # Perform bilinear operation  h W e -> k for each B * num_actions = N
         query = torch.einsum("n h, k h e -> n k e", hidden_reshaped, self.W)  # Shape: [N, K, E]
@@ -140,9 +140,9 @@ class MettaActorSingleHead(LayerBase):
         # Reshape inputs similar to Rev2 for bilinear calculation
         # input_1: [B*TT, hidden] -> [B*TT * num_actions, hidden]
         # input_2: [B*TT, num_actions, embed_dim] -> [B*TT * num_actions, embed_dim]
-        hidden_reshaped = repeat(hidden, "b h -> b a h", a=num_actions)  # shape: [B*TT, num_actions, hidden]
-        hidden_reshaped = rearrange(hidden_reshaped, "b a h -> (b a) h")  # shape: [N, H]
-        action_embeds_reshaped = rearrange(action_embeds, "b a e -> (b a) e")  # shape: [N, E]
+        hidden_reshaped = repeat(hidden, "b h -> b a h", a=num_actions)
+        hidden_reshaped = rearrange(hidden_reshaped, "b a h -> (b a) h")
+        action_embeds_reshaped = rearrange(action_embeds, "b a e -> (b a) e")
 
         # Perform bilinear operation using einsum
         # Perform bilinear operation  h W e -> k for each B * num_actions = N

--- a/metta/agent/lib/lstm.py
+++ b/metta/agent/lib/lstm.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from einops import rearrange
 from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
@@ -73,13 +74,11 @@ class LSTM(LayerBase):
             f"Hidden state shape {hidden.shape} does not match expected {(B * TT, self._in_tensor_shapes[0][0])}"
         )
 
-        hidden = hidden.reshape(B, TT, self._in_tensor_shapes[0][0])
-        hidden = hidden.transpose(0, 1)
+        hidden = rearrange(hidden, "(b t) h -> t b h", b=B, t=TT)
 
         hidden, state = self._net(hidden, state)
 
-        hidden = hidden.transpose(0, 1)
-        hidden = hidden.reshape(B * TT, self.hidden_size)
+        hidden = rearrange(hidden, "t b h -> (b t) h")
 
         if state is not None:
             state = tuple(s.detach() for s in state)

--- a/metta/agent/lib/obs_shaper.py
+++ b/metta/agent/lib/obs_shaper.py
@@ -1,3 +1,4 @@
+from einops import rearrange
 from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
@@ -54,7 +55,6 @@ class ObsShaper(LayerBase):
         x = x.reshape(B * TT, *space_shape)
         x = x.float()
 
-        # conv expects [batch, channel, w, h]. Below is hardcoded for [batch, w, h, channel]
         x = self._permute(x)
 
         td["_TT_"] = TT
@@ -67,7 +67,7 @@ class ObsShaper(LayerBase):
         if x.device.type == "mps":
             x = self._mps_permute(x)
         else:
-            x = x.permute(0, 3, 1, 2)
+            x = rearrange(x, "b h w c -> b c h w")
         return x
 
     def _mps_permute(self, x):


### PR DESCRIPTION
## Summary
- clean up tensor permutations in policy implementations
- remove outdated shape comments
- simplify LSTM reshaping logic with `rearrange`

## Testing
- `bash devops/setup_build.sh` *(fails: No route to host)*
- `ruff check metta/agent/external/example.py metta/agent/external/lstm_transformer.py metta/agent/lib/obs_shaper.py metta/agent/lib/lstm.py metta/agent/lib/actor.py` *(fails: pyenv: ruff: command not found)*
- `pytest -q` *(fails: pyenv: pytest: command not found)*