### PR TITLE
Fix typo in worldmap comment

### DIFF
--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -51,7 +51,7 @@ export function focusFullMap(panel: PanelInfo) {
   panel.focusPos(width / 2, height / 2, Math.min(panel.width / width, panel.height / height));
 }
 
-// Draw the the floor.
+// Draw the floor.
 function drawFloor() {
   const floorColor = parseHtmlColor("#CFA970");
   ctx.drawSolidRect(


### PR DESCRIPTION
## Summary
- correct comment near `drawFloor` in `mettascope/src/worldmap.ts`

## Testing
- `git status --short`