### PR TITLE
Add pre_test script for Codex

### DIFF
--- a/.codex/pre_test.sh
+++ b/.codex/pre_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script ensures that tests run inside the virtual environment created by `uv`.
+# It is executed automatically by Codex before running the test command.
+
+source .venv/bin/activate


### PR DESCRIPTION
## Summary
- create a `.codex` folder and `pre_test.sh` script
- the script activates `.venv` so Codex tests run inside the virtual env

## Testing
- `source .codex/pre_test.sh && pytest tests/util/test_resolvers.py::test_date_resolver_frozen_time -q`