### PR TITLE
Remove storage helpers and rely on file_utils

### DIFF
--- a/metta/map/load_random_from_index.py
+++ b/metta/map/load_random_from_index.py
@@ -1,7 +1,7 @@
 import random
 
 from metta.map.load import Load
-from metta.map.utils import storage
+from mettagrid.util import file as file_utils
 
 from .scene import SceneCfg
 
@@ -21,7 +21,7 @@ class LoadRandomFromIndex(Load):
 
         # For 10k maps in a directory we'd have to fetch 100Kb of index data.
         # (Can we optimize this further by caching?)
-        index = storage.load_from_uri(self._index_uri)
+        index = file_utils.read(self._index_uri).decode()
         index = index.split("\n")
         random_map_uri = random.choice(index)
 

--- a/metta/map/utils/storable_map.py
+++ b/metta/map/utils/storable_map.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from metta.map.mapgen import MapGrid
 
-from . import storage
+from mettagrid.util import file as file_utils
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class StorableMap:
     @staticmethod
     def from_uri(uri: str) -> "StorableMap":
         logger.info(f"Loading map from {uri}")
-        content = storage.load_from_uri(uri)
+        content = file_utils.read(uri).decode()
 
         # TODO - validate content in a more principled way
         (frontmatter, content) = content.split("---\n", 1)
@@ -124,5 +124,5 @@ class StorableMap:
         return StorableMap(ascii_to_grid(lines), metadata=metadata, config=config)
 
     def save(self, uri: str):
-        storage.save_to_uri(str(self), uri)
+        file_utils.write_data(uri, str(self), content_type="text/plain")
         logger.info(f"Saved map to {uri}")

--- a/metta/map/utils/storage.py
+++ b/metta/map/utils/storage.py
@@ -1,4 +1,4 @@
-from metta.map.utils.s3utils import get_s3_client, is_s3_uri, parse_s3_uri
+
 
 
 def parse_file_uri(uri: str) -> str:
@@ -13,26 +13,3 @@ def parse_file_uri(uri: str) -> str:
     return uri
 
 
-def save_to_uri(text: str, uri: str):
-    if is_s3_uri(uri):
-        bucket, key = parse_s3_uri(uri)
-        s3 = get_s3_client()
-        s3.put_object(Bucket=bucket, Key=key, Body=text)
-
-    filename = parse_file_uri(uri)
-
-    with open(filename, "w") as f:
-        f.write(text)
-
-
-def load_from_uri(uri: str) -> str:
-    if is_s3_uri(uri):
-        bucket, key = parse_s3_uri(uri)
-        s3 = get_s3_client()
-        response = s3.get_object(Bucket=bucket, Key=key)
-        return response["Body"].read().decode("utf-8")
-
-    filename = parse_file_uri(uri)
-
-    with open(filename, "r") as f:
-        return f.read()

--- a/tests/map/utils/test_storable_map_io.py
+++ b/tests/map/utils/test_storable_map_io.py
@@ -1,0 +1,33 @@
+import numpy as np
+from omegaconf import DictConfig
+
+from metta.map.utils.storable_map import StorableMap
+from mettagrid.util import file as file_utils
+
+
+def simple_map():
+    grid = np.array([["empty", "wall"], ["wall", "empty"]], dtype="<U50")
+    return StorableMap(grid, metadata={}, config=DictConfig({}))
+
+
+def test_save_and_load_local(tmp_path):
+    path = tmp_path / "map.yaml"
+    m = simple_map()
+    m.save(str(path))
+
+    loaded = StorableMap.from_uri(str(path))
+    assert np.array_equal(loaded.grid, m.grid)
+
+
+def test_save_s3_uses_file_utils(monkeypatch):
+    calls = []
+
+    def fake_write_data(uri, data, content_type="application/octet-stream"):
+        calls.append((uri, data, content_type))
+
+    monkeypatch.setattr(file_utils, "write_data", fake_write_data)
+
+    m = simple_map()
+    m.save("s3://bucket/key")
+
+    assert calls == [("s3://bucket/key", str(m), "text/plain")]


### PR DESCRIPTION
## Summary
- remove obsolete `save_to_uri` and `load_from_uri`
- switch storable map I/O to use `mettagrid.util.file`
- read random-map index with `file_utils`
- add new `test_storable_map_io` to cover save/load logic

## Testing
- `pytest tests/map/utils/test_storable_map_io.py -q`
