### PR TITLE
Switch events to use enum class

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250523.1
+run_id: 20250523.2
 run: ${oc.env:USER}.local.${run_id}

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -15,9 +15,7 @@
 		"ruff.enable": true,
 		"ruff.nativeServer": "on",
 		"files.associations": {
-			"*.pxd": "cython",
-			"queue": "cpp",
-			"stack": "cpp"
+			"*.pxd": "cython"
 		},
 		"files.excludeGitIgnored": true,
 		"terminal.integrated.profiles.osx": {

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -15,7 +15,9 @@
 		"ruff.enable": true,
 		"ruff.nativeServer": "on",
 		"files.associations": {
-			"*.pxd": "cython"
+			"*.pxd": "cython",
+			"queue": "cpp",
+			"stack": "cpp"
 		},
 		"files.excludeGitIgnored": true,
 		"terminal.integrated.profiles.osx": {

--- a/mettagrid/mettagrid/event.hpp
+++ b/mettagrid/mettagrid/event.hpp
@@ -2,8 +2,8 @@
 #define EVENT_H
 
 #include <cassert>
-#include <queue>
 #include <map>
+#include <queue>
 using namespace std;
 
 #include "grid.hpp"

--- a/mettagrid/mettagrid/event.hpp
+++ b/mettagrid/mettagrid/event.hpp
@@ -3,17 +3,16 @@
 
 #include <cassert>
 #include <queue>
-#include <vector>
+#include <map>
 using namespace std;
 
 #include "grid.hpp"
 #include "grid_object.hpp"
 #include "stats_tracker.hpp"
-typedef unsigned short EventId;
 typedef int EventArg;
 struct Event {
   unsigned int timestamp;
-  EventId event_id;
+  EventType event_type;
   GridObjectId object_id;
   EventArg arg;
 
@@ -46,7 +45,7 @@ private:
 public:
   Grid* grid;
   StatsTracker* stats;
-  vector<EventHandler*> event_handlers;
+  map<EventType, unique_ptr<EventHandler>> event_handlers;
 
   EventManager() {
     this->grid = nullptr;
@@ -59,20 +58,14 @@ public:
     this->_current_timestep = 0;
   }
 
-  ~EventManager() {
-    for (auto handler : this->event_handlers) {
-      delete handler;
-    }
-  }
-
-  void schedule_event(EventId event_id, unsigned int delay, GridObjectId object_id, EventArg arg) {
+  void schedule_event(EventType event_type, unsigned int delay, GridObjectId object_id, EventArg arg) {
     Event event;
     // If the object id is 0, the object has probably not been added to the grid yet. Given
     // our current usage of events, this is an error, since we won't be able to find the object
     // later when the event resolves.
     assert(object_id != 0);
     event.timestamp = this->_current_timestep + delay;
-    event.event_id = event_id;
+    event.event_type = event_type;
     event.object_id = object_id;
     event.arg = arg;
     this->_event_queue.push(event);
@@ -87,7 +80,7 @@ public:
         break;
       }
       this->_event_queue.pop();
-      this->event_handlers[event.event_id]->handle_event(event.object_id, event.arg);
+      this->event_handlers[event.event_type]->handle_event(event.object_id, event.arg);
     }
   }
 };

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -53,7 +53,8 @@ MettaGrid::MettaGrid(py::dict env_cfg, py::list map) {
   _stats = std::make_unique<StatsTracker>();
 
   _event_manager->init(_grid.get(), _stats.get());
-  _event_manager->event_handlers.insert({EventType::FinishConverting, std::make_unique<ProductionHandler>(_event_manager.get())});
+  _event_manager->event_handlers.insert(
+      {EventType::FinishConverting, std::make_unique<ProductionHandler>(_event_manager.get())});
   _event_manager->event_handlers.insert({EventType::CoolDown, std::make_unique<CoolDownHandler>(_event_manager.get())});
 
   _action_success.resize(num_agents);

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -53,8 +53,8 @@ MettaGrid::MettaGrid(py::dict env_cfg, py::list map) {
   _stats = std::make_unique<StatsTracker>();
 
   _event_manager->init(_grid.get(), _stats.get());
-  _event_manager->event_handlers.push_back(new ProductionHandler(_event_manager.get()));
-  _event_manager->event_handlers.push_back(new CoolDownHandler(_event_manager.get()));
+  _event_manager->event_handlers.insert({EventType::FinishConverting, std::make_unique<ProductionHandler>(_event_manager.get())});
+  _event_manager->event_handlers.insert({EventType::CoolDown, std::make_unique<CoolDownHandler>(_event_manager.get())});
 
   _action_success.resize(num_agents);
 

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -7,7 +7,7 @@
 
 #include "../grid_object.hpp"
 
-enum Events {
+enum class EventType {
   FinishConverting = 0,
   CoolDown = 1
 };

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -49,7 +49,7 @@ private:
     // All the previous returns were "we don't start converting".
     // This one is us starting to convert.
     this->converting = true;
-    this->event_manager->schedule_event(Events::FinishConverting, this->conversion_ticks, this->id, 0);
+    this->event_manager->schedule_event(EventType::FinishConverting, this->conversion_ticks, this->id, 0);
   }
 
 public:
@@ -113,7 +113,7 @@ public:
     if (this->cooldown > 0) {
       // Start cooldown phase
       this->cooling_down = true;
-      this->event_manager->schedule_event(Events::CoolDown, this->cooldown, this->id, 0);
+      this->event_manager->schedule_event(EventType::CoolDown, this->cooldown, this->id, 0);
     } else if (this->cooldown == 0) {
       // No cooldown, try to start converting again immediately
       this->maybe_start_converting();


### PR DESCRIPTION
Refactored event handling system to use an enum class and a map for better type safety and organization.

In another diff I ran into issues with enums and namespacing, and learned that `enum class` exists seems to be generally better. This incrementally switches us to use that, and does some other hygiene around Events as well.

Tested with unit tests, and by running in `play` and seeing that mines periodically create new ore.