### PR TITLE
Add laser_tag environment configuration

### DIFF
--- a/configs/env/mettagrid/laser_tag.yaml
+++ b/configs/env/mettagrid/laser_tag.yaml
@@ -1,0 +1,77 @@
+defaults:
+  - mettagrid
+  - _self_
+
+game:
+  group_reward_pct: 0
+  num_agents: 36
+  map_builder:
+    _target_: metta.map.mapgen.MapGen
+
+    width: ${sampling:20,50,25}
+    height: ${sampling:20,50,25}
+
+    border_width: 6
+
+    root:
+      _target_: metta.map.scenes.room_grid.RoomGrid
+
+      rows: 1
+      columns: 3
+
+      border_width: 0
+
+      children:
+        - where:
+            tags:
+              - room_0_0
+          scene:
+            _target_: metta.map.scenes.random.Random
+            objects:
+              lasery: 4
+              armory: 4
+            agents:
+              team_1: 18
+        - where:
+            tags:
+              - room_0_1
+          scene:
+            _target_: metta.map.scenes.random.Random
+            objects:
+              altar: 1
+        - where:
+            tags:
+              - room_0_2
+          scene:
+            _target_: metta.map.scenes.random.Random
+            objects:
+              lasery: 4
+              armory: 4
+            agents:
+              team_2: 18
+
+  agent:
+    default_item_max: ${sampling:1,10,5}
+    rewards:
+      heart: 1
+
+  objects:
+    altar:
+      initial_items: 1
+
+    lasery:
+      input_ore.red: 0
+      input_battery: 0
+      cooldown: ${sampling:1,10,5}
+      initial_items: 5
+
+    armory:
+      input_ore.red: 0
+      initial_items: 5
+      cooldown: ${sampling:1,10,5}
+
+  groups:
+    team_1:
+      group_reward_pct: ${...group_reward_pct}
+    team_2:
+      group_reward_pct: ${...group_reward_pct}

--- a/configs/env/mettagrid/laser_tag.yaml
+++ b/configs/env/mettagrid/laser_tag.yaml
@@ -39,6 +39,7 @@ game:
             _target_: metta.map.scenes.random.Random
             objects:
               altar: 1
+              mine.red: 10
         - where:
             tags:
               - room_0_2

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -16,7 +16,7 @@ trainer:
   #     max_steps: 1000
 
 # policy_uri: puffer:///tmp/puffer_metta.pt
-policy_uri: wandb://run/daveey.dist.2x4
+policy_uri: ${trained_policy_uri}
 # policy_uri: puffer://./train_dir/puffer/puffer_metta.pt
 
 npc_policy_uri: ${policy_uri}
@@ -34,10 +34,11 @@ analyzer:
 
 replay_job:
   sim:
-    env: /env/mettagrid/ants
+    env: /env/mettagrid/laser_tag
     env_overrides:
       game:
         max_steps: 300
+        group_reward_pct: 0.5
       sampling: 1
 
 sim_job:
@@ -55,7 +56,11 @@ sim_job:
   #       num_rooms: 4
 
 
+<<<<<<< HEAD
 run_id: 21
+=======
+run_id: 22
+>>>>>>> b8cb4627 (cp)
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -16,7 +16,7 @@ trainer:
   #     max_steps: 1000
 
 # policy_uri: puffer:///tmp/puffer_metta.pt
-policy_uri: ${trained_policy_uri}
+policy_uri: wandb://run/daveey.lasertag.r5.2x4:v12
 # policy_uri: puffer://./train_dir/puffer/puffer_metta.pt
 
 npc_policy_uri: ${policy_uri}
@@ -36,10 +36,10 @@ replay_job:
   sim:
     env: /env/mettagrid/laser_tag
     env_overrides:
+      sampling: 1
       game:
         max_steps: 300
         group_reward_pct: 0.5
-      sampling: 1
 
 sim_job:
   # policy_agents_pct: 1
@@ -56,11 +56,7 @@ sim_job:
   #       num_rooms: 4
 
 
-<<<<<<< HEAD
-run_id: 21
-=======
 run_id: 22
->>>>>>> b8cb4627 (cp)
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 


### PR DESCRIPTION
### TL;DR

Added a new laser tag environment configuration for MettagGrid with team-based gameplay.

### What changed?

- Added a new `laser_tag.yaml` configuration file for MettagGrid that:
  - Creates a 3-room layout with teams on opposite sides
  - Includes 36 agents split into two teams of 18
  - Configures lasery and armory objects for each team
  - Places an altar in the middle room
  - Sets up configurable parameters for item limits and cooldowns
