### PR TITLE
Remove grid layers

### DIFF
--- a/mettagrid/benchmarks/grid_object_benchmark.cpp
+++ b/mettagrid/benchmarks/grid_object_benchmark.cpp
@@ -10,8 +10,8 @@ class TestGridObject : public GridObject {
 public:
   TestGridObject() = default;
 
-  TestGridObject(TypeId type_id, GridCoord r, GridCoord c, Layer layer) {
-    init(type_id, r, c, layer);
+  TestGridObject(TypeId type_id, GridCoord r, GridCoord c) {
+    init(type_id, r, c);
   }
 
   virtual vector<PartialObservationToken> obs_features() const override {
@@ -33,7 +33,7 @@ public:
 // Benchmark initializing a GridLocation object
 static void BM_GridLocationCreation(benchmark::State& state) {
   for (auto _ : state) {
-    GridLocation loc(10, 20, 1);
+    GridLocation loc(10, 20);
     benchmark::DoNotOptimize(&loc);
     benchmark::ClobberMemory();
   }
@@ -44,7 +44,7 @@ BENCHMARK(BM_GridLocationCreation);
 static void BM_GridObjectInitWithLocation(benchmark::State& state) {
   for (auto _ : state) {
     TestGridObject obj;
-    GridLocation loc(10, 20, 1);
+    GridLocation loc(10, 20);
     obj.init(5, loc);
     benchmark::DoNotOptimize(&obj);
     benchmark::ClobberMemory();
@@ -63,24 +63,13 @@ static void BM_GridObjectInitWithCoordinates(benchmark::State& state) {
 }
 BENCHMARK(BM_GridObjectInitWithCoordinates);
 
-// Benchmark initializing a GridObject with coordinates and layer
-static void BM_GridObjectInitWithCoordinatesAndLayer(benchmark::State& state) {
-  for (auto _ : state) {
-    TestGridObject obj;
-    obj.init(5, 10, 20, 1);
-    benchmark::DoNotOptimize(&obj);
-    benchmark::ClobberMemory();
-  }
-}
-BENCHMARK(BM_GridObjectInitWithCoordinatesAndLayer);
-
 // Benchmark the performance of the obs method with varying number of offsets
 static void BM_GridObjectObs(benchmark::State& state) {
   // Use the loop iteration count to vary the size of the offsets vector
   const int numOffsets = state.range(0);
 
   // Set up the test object
-  TestGridObject obj(1, 5, 10, 0);
+  TestGridObject obj(1, 5, 10);
 
   // Create offsets vector and observation buffer
   std::vector<uint8_t> offsets(numOffsets);
@@ -108,7 +97,6 @@ static void BM_CreateManyObjects(benchmark::State& state) {
   std::mt19937 gen(rd());
   std::uniform_int_distribution<GridCoord> coordDist(0, 999);
   std::uniform_int_distribution<TypeId> typeDist(0, 10);
-  std::uniform_int_distribution<Layer> layerDist(0, 3);
 
   for (auto _ : state) {
     state.PauseTiming();  // Don't time the vector allocation
@@ -116,7 +104,7 @@ static void BM_CreateManyObjects(benchmark::State& state) {
     state.ResumeTiming();
 
     for (int i = 0; i < numObjects; ++i) {
-      objects[i].init(typeDist(gen), coordDist(gen), coordDist(gen), layerDist(gen));
+      objects[i].init(typeDist(gen), coordDist(gen), coordDist(gen));
     }
 
     benchmark::DoNotOptimize(objects.data());

--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -39,11 +39,13 @@ protected:
   }
 
   bool _handle_target(Agent* actor, GridLocation target_loc) {
-    target_loc.layer = GridLayer::Agent_Layer;
-    Agent* agent_target = static_cast<Agent*>(_grid->object_at(target_loc));
+    MettaObject* object_target = static_cast<MettaObject*>(_grid->object_at(target_loc));
+    if (object_target == nullptr) {
+      return false;
+    }
 
-    bool was_frozen = false;
-    if (agent_target) {
+    Agent* agent_target = dynamic_cast<Agent*>(object_target);
+    if (agent_target != nullptr) {
       actor->stats.incr(_stats.target[agent_target->_type_id]);
       actor->stats.incr(_stats.target[agent_target->_type_id], actor->group_name);
       actor->stats.incr(_stats.target[agent_target->_type_id], actor->group_name, agent_target->group_name);
@@ -54,7 +56,7 @@ protected:
         actor->stats.incr("attack.other_team", actor->group_name);
       }
 
-      was_frozen = agent_target->frozen > 0;
+      bool was_frozen = agent_target->frozen > 0;
 
       if (agent_target->update_inventory(InventoryItem::armor, -1)) {
         actor->stats.incr("attack.blocked", agent_target->group_name);
@@ -83,11 +85,7 @@ protected:
 
         return true;
       }
-    }
-
-    target_loc.layer = GridLayer::Object_Layer;
-    MettaObject* object_target = static_cast<MettaObject*>(_grid->object_at(target_loc));
-    if (object_target) {
+    } else {
       actor->stats.incr(_stats.target[object_target->_type_id]);
       actor->stats.incr(_stats.target[object_target->_type_id], actor->group_name);
       object_target->hp -= 1;

--- a/mettagrid/mettagrid/actions/attack_nearest.hpp
+++ b/mettagrid/mettagrid/actions/attack_nearest.hpp
@@ -33,9 +33,8 @@ protected:
         GridLocation target_loc =
             _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation), distance, offset);
 
-        target_loc.layer = GridLayer::Agent_Layer;
-        Agent* agent_target = static_cast<Agent*>(_grid->object_at(target_loc));
-        if (agent_target) {
+        Agent* agent_target = dynamic_cast<Agent*>(_grid->object_at(target_loc));
+        if (agent_target != nullptr) {
           return _handle_target(actor, target_loc);
         }
       }

--- a/mettagrid/mettagrid/actions/get_output.hpp
+++ b/mettagrid/mettagrid/actions/get_output.hpp
@@ -20,7 +20,6 @@ public:
 protected:
   bool _handle_action(Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
-    target_loc.layer = GridLayer::Object_Layer;
     // get_output only works on Converters, since only Converters have an output.
     // Once we generalize this to `get`, we should be able to get from any HasInventory object, which
     // should include agents. That's (e.g.) why we're checking inventory_is_accessible.

--- a/mettagrid/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/mettagrid/actions/put_recipe_items.hpp
@@ -20,7 +20,6 @@ public:
 protected:
   bool _handle_action(Agent* actor, ActionArg arg) override {
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
-    target_loc.layer = GridLayer::Object_Layer;
     // put_recipe_items only works on Converters, since only Converters have a recipe.
     // Once we generalize this to `put`, we should be able to put to any HasInventory object, which
     // should include agents.

--- a/mettagrid/mettagrid/actions/swap.hpp
+++ b/mettagrid/mettagrid/actions/swap.hpp
@@ -21,10 +21,6 @@ protected:
     GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
     MettaObject* target = static_cast<MettaObject*>(_grid->object_at(target_loc));
     if (target == nullptr) {
-      target_loc.layer = GridLayer::Object_Layer;
-      target = static_cast<MettaObject*>(_grid->object_at(target_loc));
-    }
-    if (target == nullptr) {
       return false;
     }
 

--- a/mettagrid/mettagrid/grid_object.hpp
+++ b/mettagrid/mettagrid/grid_object.hpp
@@ -8,7 +8,6 @@
 
 using namespace std;
 
-typedef unsigned short Layer;
 typedef uint8_t TypeId;
 typedef unsigned int GridCoord;
 using ObsType = uint8_t;
@@ -37,11 +36,9 @@ class GridLocation {
 public:
   GridCoord r;
   GridCoord c;
-  Layer layer;
 
-  inline GridLocation(GridCoord r, GridCoord c, Layer layer) : r(r), c(c), layer(layer) {}
-  inline GridLocation(GridCoord r, GridCoord c) : r(r), c(c), layer(0) {}
-  inline GridLocation() : r(0), c(0), layer(0) {}
+  inline GridLocation(GridCoord r, GridCoord c) : r(r), c(c) {}
+  inline GridLocation() : r(0), c(0) {}
 };
 
 enum Orientation {
@@ -67,11 +64,7 @@ public:
   }
 
   void init(TypeId type_id, GridCoord r, GridCoord c) {
-    init(type_id, GridLocation(r, c, 0));
-  }
-
-  void init(TypeId type_id, GridCoord r, GridCoord c, Layer layer) {
-    init(type_id, GridLocation(r, c, layer));
+    init(type_id, GridLocation(r, c));
   }
 
   virtual vector<PartialObservationToken> obs_features() const = 0;

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -35,7 +35,7 @@ public:
         // Configuration -- rewards that the agent will get for certain
         // actions or inventory changes.
         std::map<std::string, float> rewards) {
-    GridObject::init(ObjectType::AgentT, GridLocation(r, c, GridLayer::Agent_Layer));
+    GridObject::init(ObjectType::AgentT, GridLocation(r, c));
     MettaObject::init_mo(cfg);
 
     this->group_name = group_name;

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -12,11 +12,6 @@ enum class EventType {
   CoolDown = 1
 };
 
-enum GridLayer {
-  Agent_Layer = 0,
-  Object_Layer = 1
-};
-
 // Changing observation feature ids will break models that have
 // been trained on the old feature ids.
 // In the future, the string -> id mapping should be stored on a
@@ -77,16 +72,5 @@ enum InventoryItem {
 
 const std::vector<std::string> InventoryItemNames =
     {"ore.red", "ore.blue", "ore.green", "battery", "heart", "armor", "laser", "blueprint"};
-
-const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},
-                                                  {ObjectType::WallT, GridLayer::Object_Layer},
-                                                  {ObjectType::MineT, GridLayer::Object_Layer},
-                                                  {ObjectType::GeneratorT, GridLayer::Object_Layer},
-                                                  {ObjectType::AltarT, GridLayer::Object_Layer},
-                                                  {ObjectType::ArmoryT, GridLayer::Object_Layer},
-                                                  {ObjectType::LaseryT, GridLayer::Object_Layer},
-                                                  {ObjectType::LabT, GridLayer::Object_Layer},
-                                                  {ObjectType::FactoryT, GridLayer::Object_Layer},
-                                                  {ObjectType::TempleT, GridLayer::Object_Layer}};
 
 #endif

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -67,7 +67,7 @@ public:
   EventManager* event_manager;
 
   Converter(GridCoord r, GridCoord c, ObjectConfig cfg, TypeId type_id) {
-    GridObject::init(type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(type_id, GridLocation(r, c));
     MettaObject::init_mo(cfg);
     HasInventory::init_has_inventory(cfg);
     this->recipe_input.resize(InventoryItem::InventoryCount);

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -13,7 +13,7 @@ public:
   bool _swappable;
 
   Wall(GridCoord r, GridCoord c, ObjectConfig cfg) {
-    GridObject::init(ObjectType::WallT, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(ObjectType::WallT, GridLocation(r, c));
     MettaObject::init_mo(cfg);
     this->_swappable = cfg["swappable"];
   }

--- a/mettagrid/tests/grid_object_test.cpp
+++ b/mettagrid/tests/grid_object_test.cpp
@@ -19,7 +19,6 @@ TEST_F(GridLocationTest, DefaultConstructor) {
   GridLocation location;
   EXPECT_EQ(0, location.r);
   EXPECT_EQ(0, location.c);
-  EXPECT_EQ(0, location.layer);
 }
 
 // Test two-parameter constructor
@@ -27,15 +26,6 @@ TEST_F(GridLocationTest, TwoParamConstructor) {
   GridLocation location(5, 10);
   EXPECT_EQ(5, location.r);
   EXPECT_EQ(10, location.c);
-  EXPECT_EQ(0, location.layer);  // Default layer should be 0
-}
-
-// Test three-parameter constructor
-TEST_F(GridLocationTest, ThreeParamConstructor) {
-  GridLocation location(5, 10, 2);
-  EXPECT_EQ(5, location.r);
-  EXPECT_EQ(10, location.c);
-  EXPECT_EQ(2, location.layer);
 }
 
 // Concrete implementation of GridObject for testing
@@ -64,13 +54,12 @@ protected:
 
 // Test init with GridLocation
 TEST_F(GridObjectTest, InitWithLocation) {
-  GridLocation loc(5, 10, 2);
+  GridLocation loc(5, 10);
   obj.init(1, loc);
 
   EXPECT_EQ(1, obj._type_id);
   EXPECT_EQ(5, obj.location.r);
   EXPECT_EQ(10, obj.location.c);
-  EXPECT_EQ(2, obj.location.layer);
 }
 
 // Test init with coordinates
@@ -80,17 +69,6 @@ TEST_F(GridObjectTest, InitWithCoordinates) {
   EXPECT_EQ(2, obj._type_id);
   EXPECT_EQ(15, obj.location.r);
   EXPECT_EQ(20, obj.location.c);
-  EXPECT_EQ(0, obj.location.layer);  // Default layer
-}
-
-// Test init with coordinates and layer
-TEST_F(GridObjectTest, InitWithCoordinatesAndLayer) {
-  obj.init(3, 25, 30, 4);
-
-  EXPECT_EQ(3, obj._type_id);
-  EXPECT_EQ(25, obj.location.r);
-  EXPECT_EQ(30, obj.location.c);
-  EXPECT_EQ(4, obj.location.layer);
 }
 
 // Test obs method

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -134,11 +134,7 @@ TEST_F(MettaGridTest, AttackAction) {
   EXPECT_EQ(attacker->orientation, Orientation::Up);
 
   // Create a grid and add the agents to it. Then set up an attack action handler and call it.
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
   grid.add_object(attacker);
   grid.add_object(target);
 
@@ -176,11 +172,7 @@ TEST_F(MettaGridTest, PutRecipeItems) {
   agent->init(&reward);
 
   // Create a grid and add the agent
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
   grid.add_object(agent);
 
   // Create a generator that takes red ore and outputs batteries
@@ -237,11 +229,7 @@ TEST_F(MettaGridTest, GetOutput) {
   agent->init(&reward);
 
   // Create a grid and add the agent
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
   grid.add_object(agent);
 
   // Create a generator that takes red ore and outputs batteries

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -118,7 +118,7 @@ def test_grid_objects():
     expected_agents = 2
     assert len(objects) == expected_walls + expected_agents, "Wrong number of objects"
 
-    common_properties = {"r", "c", "layer", "type", "id"}
+    common_properties = {"r", "c", "type", "id"}
 
     for obj in objects.values():
         if obj.get("wall"):


### PR DESCRIPTION
I wanted to make GridLayer an `enum class`, but instead decided we don't need layers in the grid. My best guess is that they came from us not being able to use dynamic_cast (or equivalent) in Cython. Let me know if there's something I'm missing. Otherwise here's the auto-gen commit message:

This PR removes the concept of layers from the grid system, simplifying the codebase by having a single object per grid cell. Key changes:

- Remove `layer` field from `GridLocation` class
- Update `Grid` class to use a 2D grid instead of 3D
- Remove `layer_for_type_id` and related layer mapping
- Update all action handlers to work with the simplified grid structure
- Fix object targeting in attack actions to use dynamic_cast for type checking
- Update benchmarks and tests to work with the new grid structure

This change improves code clarity by removing the need to manage multiple layers at each grid position, while maintaining all existing functionality through proper object type checking.