### PR TITLE
hotfix: Set missing CUBLAS_WORKSPACE_CONFIG

### DIFF
--- a/metta/util/runtime_configuration.py
+++ b/metta/util/runtime_configuration.py
@@ -23,7 +23,16 @@ def seed_everything(seed, torch_deterministic):
         torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = torch_deterministic
     torch.backends.cudnn.benchmark = not torch_deterministic
-    torch.use_deterministic_algorithms(torch_deterministic)
+
+    if torch_deterministic:
+        torch.use_deterministic_algorithms(True)
+        # Set CuBLAS workspace config for deterministic behavior on CUDA >= 10.2
+        # https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
+        import os
+
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    else:
+        torch.use_deterministic_algorithms(False)
 
 
 def setup_mettagrid_environment(cfg):

--- a/metta/util/runtime_configuration.py
+++ b/metta/util/runtime_configuration.py
@@ -23,16 +23,14 @@ def seed_everything(seed, torch_deterministic):
         torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = torch_deterministic
     torch.backends.cudnn.benchmark = not torch_deterministic
+    torch.use_deterministic_algorithms(torch_deterministic)
 
     if torch_deterministic:
-        torch.use_deterministic_algorithms(True)
         # Set CuBLAS workspace config for deterministic behavior on CUDA >= 10.2
         # https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
         import os
 
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-    else:
-        torch.use_deterministic_algorithms(False)
 
 
 def setup_mettagrid_environment(cfg):


### PR DESCRIPTION

Training is failing with a `RuntimeError` when deterministic behavior was enabled on CUDA >= 10.2 systems:

```
RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` 
or `at::Context::setDeterministicAlgorithms(true)`, but this operation is not deterministic because 
it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must 
set an environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 
or CUBLAS_WORKSPACE_CONFIG=:16:8.
```

## Solution
Updated the `seed_everything` function in `metta/util/runtime_configuration.py` to:

- Conditionally call `torch.use_deterministic_algorithms()` based on the `torch_deterministic` flag
- Set the required `CUBLAS_WORKSPACE_CONFIG` environment variable when deterministic mode is enabled
- Use the `:4096:8` configuration as recommended by NVIDIA documentation

## Changes
- Modified `seed_everything()` to properly handle deterministic algorithm configuration
- Added environment variable setup for CuBLAS workspace configuration
- Improved code structure with conditional logic for deterministic vs non-deterministic modes


## References
- [[NVIDIA CuBLAS Documentation - Results Reproducibility](https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility)](https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility)
- [[PyTorch Reproducibility Documentation](https://pytorch.org/docs/stable/notes/randomness.html)](https://pytorch.org/docs/stable/notes/randomness.html)