### PR TITLE
fix: Add `--reset` flag to AWS setup for sso migration

### DIFF
--- a/devops/aws/README.md
+++ b/devops/aws/README.md
@@ -1,4 +1,4 @@
-# AWS Setup and Job Management Guide 
+# AWS Setup and Job Management Guide
 
 ## Initial Setup
 

--- a/devops/aws/README.md
+++ b/devops/aws/README.md
@@ -1,4 +1,4 @@
-# AWS Setup and Job Management Guide
+# AWS Setup and Job Management Guide 
 
 ## Initial Setup
 
@@ -206,7 +206,7 @@ The `batch_setup.py` script creates all the necessary AWS Batch resources:
 
 #### Prerequisites
 
-- AWS CLI installed and configured with the `stem-root` profile
+- AWS CLI installed and configured with the `softmax-root` profile
 - Required IAM roles already created:
   - `AWSBatchServiceRole`: Service role for AWS Batch
   - `ecsInstanceRole`: Instance role for EC2 instances
@@ -267,7 +267,7 @@ aws batch submit-job \
   --job-name test-job \
   --job-queue metta-jq-prod \
   --job-definition metta-batch-dist-train \
-  --profile stem-root
+  --profile softmax-root
 ```
 
 ### Advanced Troubleshooting
@@ -281,12 +281,12 @@ If jobs get stuck in the RUNNABLE state, check:
 
 ```bash
 # Check job status
-aws batch describe-jobs --jobs YOUR_JOB_ID --profile stem-root
+aws batch describe-jobs --jobs YOUR_JOB_ID --profile softmax-root
 
 # Check compute environment status
-aws batch describe-compute-environments --compute-environments YOUR_COMPUTE_ENV --profile stem-root
+aws batch describe-compute-environments --compute-environments YOUR_COMPUTE_ENV --profile softmax-root
 
 # Check ECS container instances
-aws ecs list-container-instances --cluster YOUR_ECS_CLUSTER --profile stem-root
+aws ecs list-container-instances --cluster YOUR_ECS_CLUSTER --profile softmax-root
 ```
 

--- a/devops/aws/batch/register_job_definition.py
+++ b/devops/aws/batch/register_job_definition.py
@@ -10,8 +10,8 @@ import boto3
 def get_role_arn(role_name, profile=None):
     """Look up the ARN for a given IAM role name."""
     try:
-        # Use the specified profile or default to stem-root
-        session = boto3.Session(profile_name=profile or "stem-root", region_name="us-east-1")
+        # Use the specified profile or default to softmax-root
+        session = boto3.Session(profile_name=profile or "softmax-root", region_name="us-east-1")
         iam = session.client("iam")
         response = iam.get_role(RoleName=role_name)
         return response["Role"]["Arn"]
@@ -55,8 +55,8 @@ def get_efs_id(name_tag=None):
 
 def create_job_definition(args):
     """Create a job definition dictionary without registering it."""
-    # Use the stem-root profile for AWS operations
-    boto3.Session(profile_name="stem-root", region_name="us-east-1")
+    # Use the softmax-root profile for AWS operations
+    boto3.Session(profile_name="softmax-root", region_name="us-east-1")
 
     # Look up role ARNs if not provided
     job_role_arn = args.job_role_arn
@@ -147,8 +147,8 @@ def create_job_definition(args):
 
 def register_job_definition(args):
     """Register a new job definition or a new version of an existing one."""
-    # Use the stem-root profile for AWS operations
-    session = boto3.Session(profile_name="stem-root", region_name="us-east-1")
+    # Use the softmax-root profile for AWS operations
+    session = boto3.Session(profile_name="softmax-root", region_name="us-east-1")
     batch = session.client("batch")
 
     # Check if job definition already exists
@@ -179,13 +179,13 @@ def register_job_definition(args):
 
 
 def main():
-    # Use stem-root profile instead of unsetting AWS_PROFILE
-    if "AWS_PROFILE" in os.environ and os.environ["AWS_PROFILE"] != "stem-root":
-        print(f"Setting AWS_PROFILE environment variable to stem-root (was: {os.environ['AWS_PROFILE']})")
-        os.environ["AWS_PROFILE"] = "stem-root"
+    # Use softmax-root profile instead of unsetting AWS_PROFILE
+    if "AWS_PROFILE" in os.environ and os.environ["AWS_PROFILE"] != "softmax-root":
+        print(f"Setting AWS_PROFILE environment variable to softmax-root (was: {os.environ['AWS_PROFILE']})")
+        os.environ["AWS_PROFILE"] = "softmax-root"
     elif "AWS_PROFILE" not in os.environ:
-        print("Setting AWS_PROFILE environment variable to stem-root")
-        os.environ["AWS_PROFILE"] = "stem-root"
+        print("Setting AWS_PROFILE environment variable to softmax-root")
+        os.environ["AWS_PROFILE"] = "softmax-root"
 
     parser = argparse.ArgumentParser(description="Register a multi-node AWS Batch job definition")
     parser.add_argument("--job-definition-name", default="metta-batch-dist-train", help="Name of the job definition")

--- a/devops/aws/setup_aws_profiles.sh
+++ b/devops/aws/setup_aws_profiles.sh
@@ -1,14 +1,5 @@
 #!/bin/bash -e
 
-# Script usage function
-show_usage() {
-  echo "Usage: $0 [--reset]"
-  echo ""
-  echo "Options:"
-  echo "  --reset    Completely clear existing AWS configuration and cache before setup"
-  echo "  -h, --help Show this help message"
-}
-
 # Parse command line arguments
 RESET_CONFIG=false
 
@@ -18,13 +9,9 @@ while [[ $# -gt 0 ]]; do
       RESET_CONFIG=true
       shift
       ;;
-    -h|--help)
-      show_usage
-      exit 0
-      ;;
     *)
       echo "Unknown option: $1"
-      show_usage
+      echo "Usage: $0 [--reset]"
       exit 1
       ;;
   esac
@@ -33,17 +20,6 @@ done
 # Function to completely clear AWS configuration and cache
 clear_aws_completely() {
   echo "Completely clearing AWS configuration and cache..."
-  
-  # Create backup if config exists
-  if [ -f ~/.aws/config ]; then
-    echo "Creating backup of existing AWS config..."
-    cp ~/.aws/config ~/.aws/config.backup.$(date +%Y%m%d_%H%M%S)
-  fi
-  
-  if [ -f ~/.aws/credentials ]; then
-    echo "Creating backup of existing AWS credentials..."
-    cp ~/.aws/credentials ~/.aws/credentials.backup.$(date +%Y%m%d_%H%M%S)
-  fi
   
   # Remove entire AWS directory
   echo "Removing entire ~/.aws directory..."

--- a/devops/aws/setup_aws_profiles.sh
+++ b/devops/aws/setup_aws_profiles.sh
@@ -1,5 +1,60 @@
 #!/bin/bash -e
 
+# Script usage function
+show_usage() {
+  echo "Usage: $0 [--reset]"
+  echo ""
+  echo "Options:"
+  echo "  --reset    Completely clear existing AWS configuration and cache before setup"
+  echo "  -h, --help Show this help message"
+}
+
+# Parse command line arguments
+RESET_CONFIG=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --reset)
+      RESET_CONFIG=true
+      shift
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      show_usage
+      exit 1
+      ;;
+  esac
+done
+
+# Function to completely clear AWS configuration and cache
+clear_aws_completely() {
+  echo "Completely clearing AWS configuration and cache..."
+  
+  # Create backup if config exists
+  if [ -f ~/.aws/config ]; then
+    echo "Creating backup of existing AWS config..."
+    cp ~/.aws/config ~/.aws/config.backup.$(date +%Y%m%d_%H%M%S)
+  fi
+  
+  if [ -f ~/.aws/credentials ]; then
+    echo "Creating backup of existing AWS credentials..."
+    cp ~/.aws/credentials ~/.aws/credentials.backup.$(date +%Y%m%d_%H%M%S)
+  fi
+  
+  # Remove entire AWS directory
+  echo "Removing entire ~/.aws directory..."
+  rm -rf ~/.aws/
+  
+  # Recreate the directory
+  mkdir -p ~/.aws
+  
+  echo "AWS configuration completely cleared and reset."
+}
+
 # Function to check if a valid SSO token exists
 check_sso_token() {
   # Path to the SSO cache directory
@@ -39,7 +94,7 @@ initialize_aws_config() {
   echo "Initializing AWS configuration..."
 
   # Check if the SSO session already exists
-  if ! grep -q "\[sso-session softmax-sso\]" ~/.aws/config; then
+  if ! grep -q "\[sso-session softmax-sso\]" ~/.aws/config 2>/dev/null; then
     echo "Adding SSO session configuration..."
     mkdir -p ~/.aws
     # Create a temporary file with the new config
@@ -83,7 +138,7 @@ EOF
   aws configure set profile.softmax-admin.region us-east-1
 
   echo "AWS profiles have been configured successfully."
-  grep -q '^export AWS_PROFILE=' ~/.zshrc || echo -e '\nexport AWS_PROFILE=softmax' >> ~/.zshrc
+  grep -q '^export AWS_PROFILE=' ~/.zshrc 2>/dev/null || echo -e '\nexport AWS_PROFILE=softmax' >> ~/.zshrc
 }
 
 # Check if we're in CI or Docker
@@ -95,23 +150,33 @@ fi
 
 # Main execution logic
 if [ -z "$CI" ] && [ "$IS_DOCKER" = "false" ]; then
-  # Check if we already have a valid token
-  if check_sso_token; then
-    echo "Valid SSO token already exists for softmax-sso"
-    echo "Skip initialization as token is valid."
-  else
-    echo "No valid SSO token found, initializing AWS config..."
+  
+  # Handle reset if requested
+  if [ "$RESET_CONFIG" = true ]; then
+    clear_aws_completely
+    echo "Proceeding with fresh AWS SSO setup..."
     initialize_aws_config
-
-    echo "Running AWS SSO login..."
-    aws sso login --profile softmax
-
-    # Verify token was created successfully
+  else
+    # Check if we already have a valid token
     if check_sso_token; then
-      echo "SSO login successful! Token created for softmax-sso."
+      echo "Valid SSO token already exists for softmax-sso"
+      echo "Skip initialization as token is valid."
+      echo "Use --reset if you need to completely reset your AWS configuration."
+      exit 0
     else
-      echo "WARNING: SSO login completed but valid token not found. There might be an issue."
+      echo "No valid SSO token found, initializing AWS config..."
+      initialize_aws_config
     fi
+  fi
+
+  echo "Running AWS SSO login..."
+  aws sso login --profile softmax
+
+  # Verify token was created successfully
+  if check_sso_token; then
+    echo "SSO login successful! Token created for softmax-sso."
+  else
+    echo "WARNING: SSO login completed but valid token not found. There might be an issue."
   fi
 else
   # Always initialize in CI/Docker environments, but don't attempt login


### PR DESCRIPTION

Adds a `--reset` parameter to the AWS setup script to help users migrate from problematic AWS configurations or when switching between different setups.

## Changes Made

- **Added `--reset` flag**: Completely clears existing AWS configuration and cache before setup
- **Improved error handling**: Better handling of missing config files with `2>/dev/null` redirects
- Changed all references from `stem-root` profile to `softmax-root` profile
- Updated AWS CLI examples to use the correct profile names
- Changed default profile from `stem-root` to `softmax-root`
- Updated all boto3 session configurations to use the new profile

## Usage

### Normal operation (unchanged behavior):
```bash
./setup_aws_profiles.sh
```

### Complete reset for migration/troubleshooting:
```bash
./setup_aws_profiles.sh --reset
```

## Why This Change?

The `--reset` flag addresses common scenarios where users need to:
- Migrate from old/broken AWS configurations
- Switch between different AWS setups
- Troubleshoot authentication issues
- Start completely fresh after configuration corruption
