### PR TITLE
Add macOS 13 tests

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -160,7 +160,10 @@ jobs:
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- run Python test job on macOS 13 in addition to Linux

## Testing
- `ruff format .` *(failed: Python 3.11.7 not installed)*
- `ruff check .` *(failed: Python 3.11.7 not installed)*
- `uv run pytest tests/agent/test_metta_agent.py::test_clip_weights_calls_components -q`