### PR TITLE
remove mettagrid make call in setup_build.sh

### DIFF
--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -128,7 +128,6 @@ uv pip install -e .
 
 # The following will build mettagrid, cmake and all, but in isolated environment.
 # This is according to scikit-build-core and PEP-517 conventions.
-# So we do another build in the next step, for testing and development.
 echo -e "\nInstalling MettaGrid..."
 uv pip --directory mettagrid install -e .
 

--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -132,9 +132,6 @@ uv pip install -e .
 echo -e "\nInstalling MettaGrid..."
 uv pip --directory mettagrid install -e .
 
-echo -e "\nBuilding MettaGrid..."
-(cd mettagrid && make)
-
 # ========== SANITY CHECK ==========
 echo -e "\nSanity check: verifying all local deps are importable..."
 


### PR DESCRIPTION
Earlier versions of #630 included `make` call in `setup_build.sh`, so that devs could run tests.

Then I removed makefile but forgot to update it.

Instead of running cmake commands, I decided to skip it entirely - which means that to run mettagrid C++ tests or benchmarks locally we'll have to run `cmake` manually (as explained in mettagrid README).