### PR TITLE
Validate args in env init

### DIFF
--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -28,6 +28,16 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         replay_writer: Optional[ReplayWriter] = None,
         **kwargs,
     ):
+        if not isinstance(env_cfg, DictConfig):
+            raise TypeError(f"env_cfg must be an OmegaConf DictConfig, got {type(env_cfg)}")
+        if render_mode is not None and not isinstance(render_mode, str):
+            raise TypeError(f"render_mode must be str or None, got {type(render_mode)}")
+        if env_map is not None and not isinstance(env_map, np.ndarray):
+            raise TypeError(f"env_map must be a numpy.ndarray, got {type(env_map)}")
+        if stats_writer is not None and not isinstance(stats_writer, StatsWriter):
+            raise TypeError("stats_writer must be a StatsWriter instance or None")
+        if replay_writer is not None and not isinstance(replay_writer, ReplayWriter):
+            raise TypeError("replay_writer must be a ReplayWriter instance or None")
         self._render_mode = render_mode
         self._cfg_template = env_cfg
         self._env_cfg = self._get_new_env_cfg()

--- a/tests/mettagrid/test_env_input_validation.py
+++ b/tests/mettagrid/test_env_input_validation.py
@@ -1,0 +1,15 @@
+import pytest
+from omegaconf import OmegaConf
+
+from mettagrid.mettagrid_env import MettaGridEnv
+
+
+def test_invalid_env_map_type_raises():
+    cfg = OmegaConf.create({})
+    with pytest.raises(TypeError):
+        MettaGridEnv(cfg, render_mode=None, env_map={})
+
+
+def test_invalid_env_cfg_type_raises():
+    with pytest.raises(TypeError):
+        MettaGridEnv({}, render_mode=None)


### PR DESCRIPTION
## Summary
- validate MettaGridEnv constructor inputs
- test MettaGridEnv type validations

## Testing
- `ruff format mettagrid/mettagrid/mettagrid_env.py tests/mettagrid/test_env_input_validation.py`
- `ruff check mettagrid/mettagrid/mettagrid_env.py tests/mettagrid/test_env_input_validation.py`
- `pytest tests/mettagrid/test_env_input_validation.py -q` *(fails: ModuleNotFoundError: No module named 'omegaconf')*