### PR TITLE
Fix problem with training script on MacOS

### DIFF
--- a/devops/train.sh
+++ b/devops/train.sh
@@ -17,7 +17,11 @@ export HEARTBEAT_FILE
 
 # System configuration
 if [ -z "$NUM_CPUS" ]; then
-  NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
+  if [ "$(uname)" == "Darwin" ]; then
+    NUM_CPUS=$(sysctl -n hw.ncpu)
+  else
+    NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
+  fi
   NUM_CPUS=$((NUM_CPUS / 2))
 fi
 


### PR DESCRIPTION
We are automatically determining the number of workers using `lscpu` and then setting the number of workers equal to the number of CPUs. However, `lscpu` is not installed on MacOS per default.

Changes:
Check whether the system runs MacOS and if true, use `sysctl -n hw.ncpu` to get the number of CPUs. 
