### PR TITLE
Add runtime arg type validation

### DIFF
--- a/metta/util/__init__.py
+++ b/metta/util/__init__.py
@@ -1,0 +1,3 @@
+from .validate import validate_arg_types
+
+__all__ = ["validate_arg_types"]

--- a/metta/util/validate.py
+++ b/metta/util/validate.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from functools import wraps
+from inspect import signature
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+
+def _is_instance(value: Any, expected_type: Any) -> bool:
+    origin = get_origin(expected_type)
+    if origin is Union:
+        return any(_is_instance(value, arg) for arg in get_args(expected_type))
+
+    if origin is not None:
+        expected_type = origin
+
+    try:
+        return isinstance(value, expected_type)
+    except TypeError:
+        return False
+
+
+def validate_arg_types(func):
+    """Assert argument types based on annotations."""
+
+    hints = get_type_hints(func)
+    sig = signature(func)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        for name, value in bound.arguments.items():
+            expected = hints.get(name)
+            if expected is not None:
+                assert _is_instance(value, expected), f"Argument '{name}' expected {expected} but got {type(value)}"
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/util/test_validate_arg_types.py
+++ b/tests/util/test_validate_arg_types.py
@@ -1,0 +1,17 @@
+import pytest
+
+from metta.util import validate_arg_types
+
+
+@validate_arg_types
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def test_validate_correct_types():
+    assert add(1, 2) == 3
+
+
+def test_validate_incorrect_types():
+    with pytest.raises(AssertionError):
+        add("1", 2)


### PR DESCRIPTION
## Summary
- validate arg types at runtime with `validate_arg_types` decorator
- export decorator from `metta.util`
- test the decorator

## Testing
- `ruff check metta/util/validate.py tests/util/test_validate_arg_types.py metta/util/__init__.py`
- `uv run pytest -q`
