### PR TITLE
Stream console output to wandb

### DIFF
--- a/devops/setup.env
+++ b/devops/setup.env
@@ -2,5 +2,4 @@ export PYTHONUNBUFFERED=1
 export PYTHONPATH=$PYTHONPATH:$(pwd)
 export PYTHONOPTIMIZE=1
 export HYDRA_FULL_ERROR=1
-export WANDB_CONSOLE=off
 export WANDB_DIR="./wandb"


### PR DESCRIPTION
Wandb logging of console output (just called 'Logs' in the UI) was deactivated by accident in PR #93.
This PR reverts the change.