### PR TITLE
Update terrain styles in YAML configurations from sparse-altars-dense to dense

### DIFF
--- a/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
@@ -17,7 +17,7 @@ game:
       height: ${sampling:75,120,60}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: balanced # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: balanced # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         altar: ${sampling:30,75,50}
   objects:

--- a/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
@@ -17,7 +17,7 @@ game:
       height: ${sampling:75,120,60}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: sparse-altars-dense-objects # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: dense # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         altar: ${sampling:30,75,50}
   objects:

--- a/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
@@ -17,7 +17,7 @@ game:
       height: ${sampling:75,120,60}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: maze # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: maze # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         altar: ${sampling:30,75,50}
   objects:

--- a/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
@@ -17,7 +17,7 @@ game:
       height: ${sampling:75,120,60}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: all-sparse # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: all-sparse # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         altar: ${sampling:30,75,50}
   objects:

--- a/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
+++ b/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
@@ -31,7 +31,7 @@ game:
       height: ${sampling:20,50,30}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: all-sparse # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: all-sparse # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         mine: ${sampling:1,20,10}
         generator: ${sampling:1,10,2}

--- a/configs/env/mettagrid/object_use/training/varied_terrain.yaml
+++ b/configs/env/mettagrid/object_use/training/varied_terrain.yaml
@@ -27,7 +27,7 @@ game:
       height: ${sampling:20,120,80}
       border_width: ${sampling:1,6,3}
       agents: 1
-      style: ??? # ${choose:"sparse-altars-dense-objects","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
+      style: ??? # ${choose:"dense","all-sparse","all-dense","balanced","dense-altars-sparse-objects"}
       objects:
         mine.red: ${sampling:1,20,10}
         mine.blue: ${sampling:1,20,10}


### PR DESCRIPTION
Simple update for all YAML files that used the deprecated `sparse-altars-dense`.

- Modified `varied_terrain_balanced.yaml`, `varied_terrain_dense.yaml`, `varied_terrain_maze.yaml`, `varied_terrain_sparse.yaml`, `easy_all_objects.yaml`, and `varied_terrain.yaml` to replace the style options with updated choices in the object selection comments. This change ensures consistency across the terrain configurations.