### PR TITLE
Deploy observatory to github pages

### DIFF
--- a/.github/workflows/deploy-mettascope.yml
+++ b/.github/workflows/deploy-mettascope.yml
@@ -1,12 +1,13 @@
-name: "Deploy Mettascope to GitHub Pages"
+name: "Deploy to GitHub Pages"
 on:
   push:
     branches:
       - main
     paths:
-      - "mettascope/**" # Run when any file in player directory changes
-      - ".github/workflows/**" # Run when workflow files change
-  workflow_dispatch: {} # Allow manual triggers
+      - "mettascope/**"
+      - "observatory/**"
+      - ".github/workflows/**"
+  workflow_dispatch: {}
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -20,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy-mettascope:
+  deploy-pages:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -36,13 +37,21 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          cache-dependency-path: "mettascope/package-lock.json"
+          cache-dependency-path: |
+            mettascope/package-lock.json
+            observatory/package-lock.json
 
-      - name: Install and build TypeScript
+      - name: Build Mettascope
         run: |
           cd mettascope
           npm ci
           npx tsc
+
+      - name: Build Observatory
+        run: |
+          cd observatory
+          npm ci
+          npm run build
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -80,10 +89,16 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Create deployment directory
+        run: |
+          mkdir -p deploy/observatory
+          cp -r mettascope/* deploy/
+          cp -r observatory/dist/* deploy/observatory/
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "./mettascope"
+          path: "./deploy"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/observatory/package.json
+++ b/observatory/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --base=./",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/tools/dashboard.py
+++ b/tools/dashboard.py
@@ -8,7 +8,7 @@ from metta.util.logging import setup_mettagrid_logger
 from metta.util.runtime_configuration import setup_mettagrid_environment
 from mettagrid.util.file import http_url
 
-DASHBOARD_URL = "https://softmax-public.s3.us-east-1.amazonaws.com/observatory/index.html"
+DASHBOARD_URL = "https://metta-ai.github.io/metta/observatory/"
 
 
 @hydra.main(version_base=None, config_path="../configs", config_name="dashboard_job")


### PR DESCRIPTION
# Update GitHub Pages Deployment to Include Observatory

### TL;DR

Modified the GitHub Pages deployment workflow to include both Mettascope and Observatory applications, and updated the dashboard URL to point to GitHub Pages.

### What changed?

- Renamed the workflow from "Deploy Mettascope to GitHub Pages" to "Deploy to GitHub Pages"
- Added `observatory/**` to the paths that trigger the workflow
- Updated the job name from `deploy-mettascope` to `deploy-pages`
- Added build steps for Observatory alongside Mettascope
- Created a combined deployment directory structure that includes both applications
- Updated the Observatory build command to use relative paths with `--base=./`
- Changed the dashboard URL in `tools/dashboard.py` from S3 to GitHub Pages (`https://metta-ai.github.io/metta/observatory/`)

### How this was tested

Created a fork of the repo where I ran the combined workflow and verified that it works correctly