### PR TITLE
Update observation_space to work for observation_tokens

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -10,6 +10,8 @@ game:
   num_agents: ???
   obs_width: 11
   obs_height: 11
+  use_observation_tokens: true
+  num_observation_tokens: 100
   max_steps: 1000
 
   # default for the old map builder; new metta.map.mapgen requires false

--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -10,8 +10,6 @@ game:
   num_agents: ???
   obs_width: 11
   obs_height: 11
-  use_observation_tokens: true
-  num_observation_tokens: 100
   max_steps: 1000
 
   # default for the old map builder; new metta.map.mapgen requires false

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -384,7 +384,12 @@ void MettaGrid::validate_buffers() {
   if (_use_observation_tokens) {
     auto observation_info = _observations.request();
     auto shape = observation_info.shape;
-    if (observation_info.ndim != 3 || shape[0] != num_agents || shape[2] != 3) {
+    if (observation_info.ndim != 3) {
+      std::stringstream ss;
+      ss << "observations has " << observation_info.ndim << " dimensions but expected 3";
+      throw std::runtime_error(ss.str());
+    }
+    if (shape[0] != num_agents || shape[2] != 3) {
       std::stringstream ss;
       ss << "observations has shape [" << shape[0] << ", " << shape[1] << ", " << shape[2] << "] but expected ["
          << num_agents << ", [something], 3]";
@@ -578,10 +583,19 @@ py::object MettaGrid::observation_space() {
   auto gym = py::module_::import("gymnasium");
   auto spaces = gym.attr("spaces");
 
-  return spaces.attr("Box")(0,
-                            255,
-                            py::make_tuple(_obs_height, _obs_width, _grid_features.size()),
-                            py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  if (_use_observation_tokens) {
+    // TODO: consider spaces other than "Box". They're more correctly descriptive, but I don't know if
+    // that matters to us.
+    return spaces.attr("Box")(0,
+                              255,
+                              py::make_tuple(_observations.shape(1), _observations.shape(2)),
+                              py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  } else {
+    return spaces.attr("Box")(0,
+                              255,
+                              py::make_tuple(_obs_height, _obs_width, _grid_features.size()),
+                              py::arg("dtype") = py::module_::import("numpy").attr("uint8"));
+  }
 }
 
 py::list MettaGrid::action_success() {


### PR DESCRIPTION
This exposes a different observation shape if we're using tokens, so puffer will send us the right shaped observations.

Testing:

AlexV's been developing against this for a while.