### PR TITLE
Add README review to CI

### DIFF
--- a/.github/workflows/review-readme.yml
+++ b/.github/workflows/review-readme.yml
@@ -1,0 +1,28 @@
+name: README Accuracy Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  review-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check README files
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_model: "claude-3-7-sonnet-20250219"
+          allowed_tools: "Edit,Replace,Bash(git diff HEAD~1)"
+          direct_prompt: |
+            Review the diff for this pull request and compare it to all README.md files in the repository.
+            If code or configuration changes require updates to any README, create GitHub suggested edits.
+            Focus on commands, instructions, or dependencies that may have changed.
+            Summarize your recommendations in a short TLDR section.


### PR DESCRIPTION
## Summary
- add `review-readme.yml` to call Claude for README accuracy checks

## Testing
- `ruff format --check .`
- `ruff check --exit-non-zero-on-fix .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'torch')*