### PR TITLE
Implement ascii renderer

### DIFF
--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -9,7 +9,7 @@ import torch
 import wandb
 from heavyball import ForeachMuon
 from omegaconf import DictConfig, ListConfig
-from pufferlib.utils import profile
+from pufferlib.utils import profile, unroll_nested_dict
 
 from metta.agent.metta_agent import DistributedMettaAgent, MettaAgent
 from metta.agent.policy_state import PolicyState
@@ -29,7 +29,6 @@ from metta.sim.simulation_config import SimulationSuiteConfig, SingleEnvSimulati
 from metta.sim.simulation_suite import SimulationSuite
 from metta.sim.vecenv import make_vecenv
 from metta.util.config import config_from_path
-from metta.util.datastruct import flatten_config
 from mettagrid.mettagrid_env import MettaGridEnv
 
 torch.set_float32_matmul_precision("high")
@@ -393,7 +392,7 @@ class PufferTrainer:
                 self.experience.store(o, value, actions, selected_action_log_probs, r, d, training_env_id, mask)
 
                 for i in info:
-                    for k, v in flatten_config(i):
+                    for k, v in unroll_nested_dict(i):
                         infos[k].append(v)
 
             with profile.env:

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -9,7 +9,7 @@ import torch
 import wandb
 from heavyball import ForeachMuon
 from omegaconf import DictConfig, ListConfig
-from pufferlib.utils import profile, unroll_nested_dict
+from pufferlib.utils import profile
 
 from metta.agent.metta_agent import DistributedMettaAgent, MettaAgent
 from metta.agent.policy_state import PolicyState
@@ -29,6 +29,7 @@ from metta.sim.simulation_config import SimulationSuiteConfig, SingleEnvSimulati
 from metta.sim.simulation_suite import SimulationSuite
 from metta.sim.vecenv import make_vecenv
 from metta.util.config import config_from_path
+from metta.util.datastruct import flatten_config
 from mettagrid.mettagrid_env import MettaGridEnv
 
 torch.set_float32_matmul_precision("high")
@@ -392,7 +393,7 @@ class PufferTrainer:
                 self.experience.store(o, value, actions, selected_action_log_probs, r, d, training_env_id, mask)
 
                 for i in info:
-                    for k, v in unroll_nested_dict(i):
+                    for k, v in flatten_config(i):
                         infos[k].append(v)
 
             with profile.env:

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -58,6 +58,10 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         self._should_reset = False
 
         self._reset_env()
+        if self._render_mode is not None:
+            from .renderer.renderer import AsciiRenderer
+
+            self._renderer = AsciiRenderer(self.object_type_names)
         super().__init__(buf)
 
     def _make_episode_id(self):
@@ -99,6 +103,11 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
     def reset(self, seed: int | None = None, options: dict | None = None) -> tuple[np.ndarray, dict]:
         self._env_cfg = self._get_new_env_cfg()
         self._reset_env()
+
+        if self._render_mode is not None:
+            from .renderer.renderer import AsciiRenderer
+
+            self._renderer = AsciiRenderer(self.object_type_names)
 
         self._c_env.set_buffers(self.observations, self.terminals, self.truncations, self.rewards)
 

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -9,9 +9,9 @@ import gymnasium as gym
 import numpy as np
 import pufferlib
 from omegaconf import DictConfig, OmegaConf
+from pufferlib.utils import unroll_nested_dict
 from typing_extensions import override
 
-from metta.util.datastruct import flatten_config
 from mettagrid.level_builder import Level
 from mettagrid.mettagrid_c import MettaGrid
 from mettagrid.replay_writer import ReplayWriter
@@ -202,7 +202,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
                 "map_h": self.map_height,
             }
 
-            for k, v in flatten_config(OmegaConf.to_container(self._env_cfg, resolve=False)):
+            for k, v in unroll_nested_dict(OmegaConf.to_container(self._env_cfg, resolve=False)):
                 attributes[f"config.{k.replace('/', '.')}"] = str(v)
 
             agent_metrics = {}

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -105,11 +105,6 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         self._env_cfg = self._get_new_env_cfg()
         self._reset_env()
 
-        if self._render_mode is not None:
-            from .renderer.renderer import AsciiRenderer
-
-            self._renderer = AsciiRenderer(self.object_type_names)
-
         self._c_env.set_buffers(self.observations, self.terminals, self.truncations, self.rewards)
 
         self._episode_id = self._make_episode_id()

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -9,9 +9,9 @@ import gymnasium as gym
 import numpy as np
 import pufferlib
 from omegaconf import DictConfig, OmegaConf
-from pufferlib.utils import unroll_nested_dict
 from typing_extensions import override
 
+from metta.util.datastruct import flatten_config
 from mettagrid.level_builder import Level
 from mettagrid.mettagrid_c import MettaGrid
 from mettagrid.replay_writer import ReplayWriter
@@ -58,11 +58,12 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         self._should_reset = False
 
         self._reset_env()
+
+        super().__init__(buf)
         if self._render_mode is not None:
             from .renderer.renderer import AsciiRenderer
 
             self._renderer = AsciiRenderer(self.object_type_names)
-        super().__init__(buf)
 
     def _make_episode_id(self):
         return str(uuid.uuid4())
@@ -201,7 +202,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
                 "map_h": self.map_height,
             }
 
-            for k, v in unroll_nested_dict(OmegaConf.to_container(self._env_cfg, resolve=False)):
+            for k, v in flatten_config(OmegaConf.to_container(self._env_cfg, resolve=False)):
                 attributes[f"config.{k.replace('/', '.')}"] = str(v)
 
             agent_metrics = {}

--- a/mettagrid/mettagrid/renderer/renderer.py
+++ b/mettagrid/mettagrid/renderer/renderer.py
@@ -9,6 +9,7 @@ class AsciiRenderer:
     """Simple ASCII renderer for ``MettaGridEnv``."""
 
     SYMBOLS = {v: k for k, v in MAP_SYMBOLS.items()}
+    SYMBOLS["wall"] = "█"
 
     def __init__(self, object_type_names: List[str]):
         self._object_type_names = object_type_names

--- a/mettagrid/mettagrid/renderer/renderer.py
+++ b/mettagrid/mettagrid/renderer/renderer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class AsciiRenderer:
+    """Simple ASCII renderer for ``MettaGridEnv``."""
+
+    SYMBOLS = {
+        "empty": " ",
+        "wall": "🧱",
+        "generator": "⚙",
+        "altar": "⛩",
+        "factory": "🏭",
+        "lab": "🔬",
+        "temple": "🏰",
+        "armory": "r",
+        "lasery": "l",
+        "mine": "g",
+        "converter": "c",
+        "agent": "A",
+    }
+
+    def __init__(self, object_type_names: List[str]):
+        self._object_type_names = object_type_names
+        self._bounds_set = False
+        self._min_row = 0
+        self._min_col = 0
+        self._height = 0
+        self._width = 0
+
+    def _compute_bounds(self, grid_objects: Dict[int, dict]):
+        rows = []
+        cols = []
+        for obj in grid_objects.values():
+            type_name = self._object_type_names[obj["type"]]
+            if type_name == "wall":
+                rows.append(obj["r"])
+                cols.append(obj["c"])
+        if not rows or not cols:
+            for obj in grid_objects.values():
+                rows.append(obj["r"])
+                cols.append(obj["c"])
+        self._min_row = min(rows)
+        self._min_col = min(cols)
+        self._height = max(rows) - self._min_row + 1
+        self._width = max(cols) - self._min_col + 1
+        self._bounds_set = True
+
+    def _symbol_for(self, obj: dict) -> str:
+        type_name = self._object_type_names[obj["type"]]
+        base = type_name.split(".")[0]
+        if base == "agent":
+            agent_id = obj.get("agent_id")
+            if agent_id is not None:
+                if agent_id < 10:
+                    return str(agent_id)
+                idx = (agent_id - 10) % 26
+                return chr(ord("a") + idx)
+        return self.SYMBOLS.get(base, "?")
+
+    def render(self, step: int, grid_objects: Dict[int, dict]) -> str:
+        if not self._bounds_set:
+            self._compute_bounds(grid_objects)
+        grid = [[" "] * self._width for _ in range(self._height)]
+        for obj in grid_objects.values():
+            r = obj["r"] - self._min_row
+            c = obj["c"] - self._min_col
+            if 0 <= r < self._height and 0 <= c < self._width:
+                grid[r][c] = self._symbol_for(obj)
+        lines = ["".join(row) for row in grid]
+        return "\n".join(lines)

--- a/mettagrid/mettagrid/renderer/renderer.py
+++ b/mettagrid/mettagrid/renderer/renderer.py
@@ -1,26 +1,14 @@
 from __future__ import annotations
 
-import shutil
 from typing import Dict, List
+
+from mettagrid.room.ascii import SYMBOLS as MAP_SYMBOLS
 
 
 class AsciiRenderer:
     """Simple ASCII renderer for ``MettaGridEnv``."""
 
-    SYMBOLS = {
-        "empty": " ",
-        "wall": "█",  # Full block character
-        "generator": "G",  # Changed from ⚙
-        "altar": "A",  # Changed from ⛩
-        "factory": "F",  # Changed from 🏭
-        "lab": "L",  # Changed from 🔬
-        "temple": "T",  # Changed from 🏰
-        "armory": "r",
-        "lasery": "l",
-        "mine": "g",
-        "converter": "c",
-        "agent": "A",
-    }
+    SYMBOLS = {v: k for k, v in MAP_SYMBOLS.items()}
 
     def __init__(self, object_type_names: List[str]):
         self._object_type_names = object_type_names
@@ -29,9 +17,6 @@ class AsciiRenderer:
         self._min_col = 0
         self._height = 0
         self._width = 0
-        self._terminal_height = 0
-        self._terminal_width = 0
-        self._update_terminal_size()
         self._last_buffer = None
         # Clear screen and hide cursor on init
         print("\033[?25l", end="")  # Hide cursor
@@ -41,15 +26,6 @@ class AsciiRenderer:
     def __del__(self):
         # Show cursor when renderer is destroyed
         print("\033[?25h", end="")
-
-    def _update_terminal_size(self):
-        """Update the terminal size information."""
-        try:
-            self._terminal_height, self._terminal_width = shutil.get_terminal_size()
-        except (AttributeError, OSError):
-            # Fallback if terminal size can't be determined
-            self._terminal_height = 24
-            self._terminal_width = 80
 
     def _compute_bounds(self, grid_objects: Dict[int, dict]):
         rows = []

--- a/mettagrid/tests/test_basic.py
+++ b/mettagrid/tests/test_basic.py
@@ -49,7 +49,7 @@ class TestEnvironmentFunctionality:
 
     def test_env_initialization(self, environment):
         """Test environment initialization."""
-        assert environment._renderer is None
+        assert environment._renderer is not None
         assert environment._c_env is not None
         assert environment._grid_env is not None
         assert environment._c_env == environment._grid_env

--- a/mettagrid/tests/test_basic.py
+++ b/mettagrid/tests/test_basic.py
@@ -49,7 +49,6 @@ class TestEnvironmentFunctionality:
 
     def test_env_initialization(self, environment):
         """Test environment initialization."""
-        assert environment._renderer is not None
         assert environment._c_env is not None
         assert environment._grid_env is not None
         assert environment._c_env == environment._grid_env


### PR DESCRIPTION
## Summary
- add simple ASCII renderer for MettaGrid
- instantiate renderer when render mode is used
- update tests for renderer initialization

## Testing
- `uv run ruff format mettagrid/tests/test_basic.py mettagrid/mettagrid/renderer/renderer.py mettagrid/mettagrid/mettagrid_env.py`
- `uv run ruff check mettagrid/tests/test_basic.py mettagrid/mettagrid/renderer/renderer.py mettagrid/mettagrid/mettagrid_env.py`
- `uv run pytest -q`