### PR TITLE
Fix the offset of inventory for converters

### DIFF
--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -154,7 +154,7 @@ public:
     obs[offsets[2]] = this->color;
     obs[offsets[3]] = this->converting || this->cooling_down;
     for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      obs[offsets[4] + i] = this->inventory[i];
+      obs[offsets[4 + i]] = this->inventory[i];
     }
   }
 


### PR DESCRIPTION
### TL;DR

Fixed array indexing bug in Converter's observation method.

### What changed?

Fixed a bug in the `Converter` class where inventory items were being incorrectly indexed in the observation array. Changed `obs[offsets[4] + i]` to `obs[offsets[4 + i]]` to correctly access the offset values rather than adding the index to a single offset value.

This should make no difference in practice, since the inventory items should be sequential in the offset space. But the fix makes things more robust in case this changes.