### PR TITLE
Fix env tests for curriculum

### DIFF
--- a/mettagrid/tests/test_basic.py
+++ b/mettagrid/tests/test_basic.py
@@ -1,6 +1,7 @@
 import pytest
 from omegaconf import OmegaConf
 
+from mettagrid.curriculum import SingleTaskCurriculum
 from mettagrid.mettagrid_env import MettaGridEnv
 from mettagrid.util.hydra import get_cfg
 
@@ -12,7 +13,8 @@ def environment():
     cfg = get_cfg("benchmark")
     print(OmegaConf.to_yaml(cfg))
 
-    env = MettaGridEnv(cfg, render_mode="human", _recursive_=False)
+    curriculum = SingleTaskCurriculum("benchmark", cfg)
+    env = MettaGridEnv(curriculum, render_mode="human")
     env.reset()
     yield env
     # Cleanup after test

--- a/mettagrid/tests/test_curriculum.py
+++ b/mettagrid/tests/test_curriculum.py
@@ -8,7 +8,7 @@ from mettagrid import curriculum
 
 @pytest.fixture
 def env_cfg():
-    return OmegaConf.create({"sampling": 0, "game": {"map": {"width": 10, "height": 10}}})
+    return OmegaConf.create({"sampling": 0, "game": {"num_agents": 1, "map": {"width": 10, "height": 10}}})
 
 
 def test_single_task_curriculum(env_cfg):

--- a/mettagrid/tests/test_env_map.py
+++ b/mettagrid/tests/test_env_map.py
@@ -1,6 +1,7 @@
 from omegaconf import OmegaConf
 
 import mettagrid.room.random
+from mettagrid.curriculum import SingleTaskCurriculum
 from mettagrid.mettagrid_env import MettaGridEnv
 from mettagrid.util.hydra import get_cfg
 
@@ -14,7 +15,8 @@ def test_env_map():
     level_builder = mettagrid.room.random.Random(width=3, height=4, objects=OmegaConf.create({}), border_width=1)
     level = level_builder.build()
 
-    env = MettaGridEnv(cfg, render_mode="human", level=level)
+    curriculum = SingleTaskCurriculum("benchmark", cfg)
+    env = MettaGridEnv(curriculum, render_mode="human", level=level)
 
     assert env.map_width == 3 + 2 * 1
     assert env.map_height == 4 + 2 * 1

--- a/mettagrid/tests/test_leaks.py
+++ b/mettagrid/tests/test_leaks.py
@@ -5,6 +5,7 @@ import psutil
 import pytest
 from hydra import compose, initialize
 
+from mettagrid.curriculum import SingleTaskCurriculum
 from mettagrid.mettagrid_env import MettaGridEnv
 
 
@@ -19,13 +20,15 @@ def cfg():
 
 def test_mettagrid_env_init(cfg):
     """Test that the MettaGridEnv can be initialized properly."""
-    env = MettaGridEnv(env_cfg=cfg, render_mode=None)
+    curriculum = SingleTaskCurriculum("test", cfg)
+    env = MettaGridEnv(curriculum, render_mode=None)
     assert env is not None, "Failed to initialize MettaGridEnv"
 
 
 def test_mettagrid_env_reset(cfg):
     """Test that the MettaGridEnv can be reset multiple times without memory leaks."""
-    env = MettaGridEnv(env_cfg=cfg, render_mode=None)
+    curriculum = SingleTaskCurriculum("test", cfg)
+    env = MettaGridEnv(curriculum, render_mode=None)
     # Reset the environment multiple times
     for _ in range(10):
         observation = env.reset()
@@ -58,7 +61,8 @@ def test_mettagrid_env_no_memory_leaks(cfg):
 
     for i in range(num_iterations):
         # Create the environment
-        env = MettaGridEnv(env_cfg=cfg, render_mode=None)
+        curriculum = SingleTaskCurriculum("test", cfg)
+        env = MettaGridEnv(curriculum, render_mode=None)
 
         # Reset the environment multiple times
         for _ in range(5):


### PR DESCRIPTION
## Summary
- update unit tests to pass curriculum objects to `MettaGridEnv`
- fix curriculum fixtures for new checks

## Testing
- `uv run python -m pytest -q mettagrid/tests`