### PR TITLE
Preview any env or scene through mapgen and mapgen-scene scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ license = "MIT"
 [project.scripts]
 skypilot = "devops.skypilot.launch:main"
 skypilot-sandbox = "devops.skypilot.sandbox:main"
+mapgen = "tools.map.gen:main"
+mapgen-scene = "tools.map.gen_scene:main"
 
 [tool.coverage.run]
 source = ["mettagrid", "metta"]

--- a/tests/tools/map/test_gen.py
+++ b/tests/tools/map/test_gen.py
@@ -19,6 +19,19 @@ def test_gen_basic():
     )
 
 
+def test_hydra():
+    subprocess.check_call(
+        [
+            "python",
+            "-m",
+            f"{MAP_MODULE}.gen",
+            "--show-mode",
+            "ascii",
+            "./configs/env/mettagrid/puffer.yaml",
+        ]
+    )
+
+
 def test_gen_missing_config():
     exit_status = subprocess.call(
         [

--- a/tools/map/gen.py
+++ b/tools/map/gen.py
@@ -13,6 +13,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from metta.map.utils.show import ShowMode, show_map
 from metta.map.utils.storable_map import StorableMap
+from metta.util.config import config_from_path
 from metta.util.resolvers import register_resolvers
 
 # Aggressively exit on ctrl+c
@@ -22,27 +23,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
-def make_map(cfg_path: str, overrides: DictConfig | None = None):
-    # since we are not using hydra here we can't rely on the callback that normally sets up our custom resolvers
-    register_resolvers()
-
-    cfg: DictConfig = cast(DictConfig, OmegaConf.merge(OmegaConf.load(cfg_path), overrides))
-    if not OmegaConf.is_dict(cfg):
-        raise ValueError(f"Invalid config type: {type(cfg)}")
-
-    recursive = False
-    if cfg.get("game") and cfg.game.get("map_builder"):
-        # safe default for old room maps
-        recursive = cfg.game.get("recursive_map_builder", True)
-        # Looks like env config, unwrapping the map config from it. This won't
-        # work for all configs because they could rely on Hydra-specific
-        # features, but it has a decent chance of working.
-        cfg = cfg.game.map_builder
-
-    if "mapgen" in cfg.get("_target_"):
-        # mapgen works better with recursive=False
-        recursive = False
-
+def map_builder_cfg_to_storable_map(cfg: DictConfig, recursive: bool = False) -> StorableMap:
     # Generate and measure time taken
     start = time.time()
     map_builder = hydra.utils.instantiate(cfg, _recursive_=recursive)
@@ -61,6 +42,36 @@ def make_map(cfg_path: str, overrides: DictConfig | None = None):
     return storable_map
 
 
+def make_map(cfg_path: str, overrides: DictConfig | None = None):
+    # since we are not using hydra here we can't rely on the callback that normally sets up our custom resolvers
+    register_resolvers()
+
+    with hydra.initialize(config_path="../../configs", version_base=None):
+        hydra_cfg_path = os.path.relpath(cfg_path, "./configs")
+        cfg = config_from_path(hydra_cfg_path, overrides)
+
+    if not OmegaConf.is_dict(cfg):
+        raise ValueError(f"Invalid config type: {type(cfg)}")
+
+    cfg = cast(DictConfig, cfg)
+
+    recursive = False
+
+    if cfg.get("game") and cfg.game.get("map_builder"):
+        # safe default for old room maps
+        recursive = cfg.game.get("recursive_map_builder", True)
+        # Looks like env config, unwrapping the map config from it. This won't
+        # work for all configs because they could rely on Hydra-specific
+        # features, but it has a decent chance of working.
+        cfg = cfg.game.map_builder
+
+    if "mapgen" in cfg.get("_target_"):
+        # mapgen works better with recursive=False
+        recursive = False
+
+    return map_builder_cfg_to_storable_map(cfg, recursive=recursive)
+
+
 # Based on heuristics, see https://github.com/Metta-AI/mettagrid/pull/108#discussion_r2054699842
 def uri_is_file(uri: str) -> bool:
     last_part = uri.split("/")[-1]
@@ -72,7 +83,7 @@ def main():
     parser.add_argument("--output-uri", type=str, help="Output URI")
     parser.add_argument("--show-mode", choices=get_args(ShowMode), help="Show the map in the specified mode")
     parser.add_argument("--count", type=int, default=1, help="Number of maps to generate")
-    parser.add_argument("--overrides", type=str, default="", help="OmniConf overrides for the map config")
+    parser.add_argument("--overrides", type=str, default="", help="OmegaConf overrides for the map config")
     parser.add_argument("cfg_path", type=str, help="Path to the map config file")
     args = parser.parse_args()
 

--- a/tools/map/gen.py
+++ b/tools/map/gen.py
@@ -48,7 +48,12 @@ def make_map(cfg_path: str, overrides: DictConfig | None = None):
 
     with hydra.initialize(config_path="../../configs", version_base=None):
         hydra_cfg_path = os.path.relpath(cfg_path, "./configs")
-        cfg = config_from_path(hydra_cfg_path, overrides)
+        if "../" in hydra_cfg_path:
+            logger.info("Config is not in the configs directory, loading with OmegaConf")
+            cfg = OmegaConf.load(cfg_path)
+        else:
+            logger.info(f"Loading hydra config from {hydra_cfg_path}")
+            cfg = config_from_path(hydra_cfg_path, overrides)
 
     if not OmegaConf.is_dict(cfg):
         raise ValueError(f"Invalid config type: {type(cfg)}")

--- a/tools/map/gen_scene.py
+++ b/tools/map/gen_scene.py
@@ -1,0 +1,65 @@
+import argparse
+import logging
+import os
+import signal
+from typing import cast, get_args
+
+from omegaconf import DictConfig, OmegaConf
+
+from metta.map.utils.show import ShowMode, show_map
+from metta.util.resolvers import register_resolvers
+from tools.map.gen import map_builder_cfg_to_storable_map
+
+# Aggressively exit on ctrl+c
+signal.signal(signal.SIGINT, lambda sig, frame: os._exit(0))
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def make_map(cfg_path: str, width: int, height: int, overrides: DictConfig | None = None):
+    register_resolvers()
+
+    cfg: DictConfig = cast(DictConfig, OmegaConf.merge(OmegaConf.load(cfg_path), overrides))
+
+    if not OmegaConf.is_dict(cfg):
+        raise ValueError(f"Invalid config type: {type(cfg)}")
+
+    cfg = cast(DictConfig, cfg)
+
+    mapgen_cfg = OmegaConf.create(
+        {
+            "_target_": "metta.map.mapgen.MapGen",
+            "width": width,
+            "height": height,
+            "root": cfg,
+        }
+    )
+
+    return map_builder_cfg_to_storable_map(mapgen_cfg, recursive=False)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--show-mode", choices=get_args(ShowMode), default="mettascope", help="Show the map in the specified mode"
+    )
+    parser.add_argument("--overrides", type=str, default="", help="OmegaConf overrides for the scene config")
+    parser.add_argument("cfg_path", type=str, help="Path to the scene config file")
+    parser.add_argument("width", type=int, help="Width of the map")
+    parser.add_argument("height", type=int, help="Height of the map")
+    args = parser.parse_args()
+
+    show_mode = args.show_mode
+    cfg_path = args.cfg_path
+    overrides = args.overrides
+
+    overrides_cfg = OmegaConf.from_cli([override for override in overrides.split(" ") if override])
+
+    storable_map = make_map(cfg_path, args.width, args.height, overrides_cfg)
+
+    show_map(storable_map, show_mode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added two new command-line tools for map generation: `mapgen` and `mapgen-scene`.

`mapgen` script is an alias for `python -m tools.map.gen`; `mapgen-scene` is new.

`mapgen` script now supports any environment file, not just mapgen-based maps.

After this PR, I expect `mapgen` (script, not map class system) to become the most convenient way to preview env maps and finally get some adoption.

Upd: I've just realized that it doesn't work for maps that can'be expressed in ascii, so it fails on `simple.yaml` env because it has `block` object types. But it does work for almost all other configs. I'll address the ascii problem in another PR.

### How to test?

1. Generate a map from an environment config:
   ```
   mapgen configs/env/mettagrid/school.yaml
   ```


2. Generate a map from a scene config with specific dimensions:
   ```
   mapgen-scene scenes/test/maze.yaml 20 15
   ```
