### PR TITLE
spotted a potential bug in lists of nodes

### DIFF
--- a/metta/map/node.py
+++ b/metta/map/node.py
@@ -93,7 +93,7 @@ class Node:
             if order_by == "random":
                 assert offset is None, "offset is not supported for random order"
                 rng = np.random.default_rng(query.get("order_by_seed"))
-                selected_areas = rng.choice(selected_areas, size=int(limit), replace=False)  # type: ignore
+                selected_areas = list(rng.choice(selected_areas, size=int(limit), replace=False))  # type: ignore
             elif order_by == "first":
                 offset = offset or 0
                 selected_areas = selected_areas[offset : offset + limit]

--- a/tests/map/test_node.py
+++ b/tests/map/test_node.py
@@ -121,22 +121,22 @@ def test_select_areas_returns_list_type(node):
     # Test with no query
     selected_areas = node.select_areas({})
     assert isinstance(selected_areas, list), "select_areas should return a list"
-    
+
     # Test with random ordering (which uses numpy internally)
     query = {"limit": 2, "order_by": "random", "order_by_seed": 42}
     selected_areas = node.select_areas(query)
     assert isinstance(selected_areas, list), "select_areas with random ordering should return a list"
-    
+
     # Test with first ordering
     query = {"limit": 2, "order_by": "first"}
     selected_areas = node.select_areas(query)
     assert isinstance(selected_areas, list), "select_areas with first ordering should return a list"
-    
+
     # Test with last ordering
     query = {"limit": 2, "order_by": "last"}
     selected_areas = node.select_areas(query)
     assert isinstance(selected_areas, list), "select_areas with last ordering should return a list"
-    
+
     # Verify list operations work
     query = {"limit": 1, "order_by": "random", "order_by_seed": 42}
     selected_areas = node.select_areas(query)

--- a/tests/map/test_node.py
+++ b/tests/map/test_node.py
@@ -114,3 +114,32 @@ def test_select_areas_with_offset(node):
     assert len(selected_areas) == 2
     assert selected_areas[0].id == 0
     assert selected_areas[1].id == 1
+
+
+def test_select_areas_returns_list_type(node):
+    """Test that select_areas always returns a list, not a numpy array"""
+    # Test with no query
+    selected_areas = node.select_areas({})
+    assert isinstance(selected_areas, list), "select_areas should return a list"
+    
+    # Test with random ordering (which uses numpy internally)
+    query = {"limit": 2, "order_by": "random", "order_by_seed": 42}
+    selected_areas = node.select_areas(query)
+    assert isinstance(selected_areas, list), "select_areas with random ordering should return a list"
+    
+    # Test with first ordering
+    query = {"limit": 2, "order_by": "first"}
+    selected_areas = node.select_areas(query)
+    assert isinstance(selected_areas, list), "select_areas with first ordering should return a list"
+    
+    # Test with last ordering
+    query = {"limit": 2, "order_by": "last"}
+    selected_areas = node.select_areas(query)
+    assert isinstance(selected_areas, list), "select_areas with last ordering should return a list"
+    
+    # Verify list operations work
+    query = {"limit": 1, "order_by": "random", "order_by_seed": 42}
+    selected_areas = node.select_areas(query)
+    # This should not raise AttributeError if it's a proper list
+    selected_areas_copy = selected_areas.copy()
+    assert len(selected_areas_copy) == 1


### PR DESCRIPTION
The Bug:
The select_areas method in node.py was supposed to always return a regular Python list. But when you asked it to randomly pick some areas (like "give me 2 random areas"), it was secretly returning a NumPy array instead.

Why it mattered:
The method promised to return a list (that's what the type hint said)
NumPy arrays look similar to lists but they're different - you can't use methods like .append() on them
This inconsistency could break code that expected a real list

The Fix:
Super simple - we just wrapped the NumPy result with list() to convert it back to a regular Python list:

So basically, NumPy was being helpful by giving us a way to randomly select items, but it was giving us back its own special array type. We just needed to convert it back to what Python normally uses - a regular list. Now the method always returns the same type no matter how you ask for the areas (random, first, or last).