### PR TITLE
Add checks for Skypilot git refs

### DIFF
--- a/devops/skypilot/config/sandbox.yaml
+++ b/devops/skypilot/config/sandbox.yaml
@@ -19,6 +19,7 @@ file_mounts:
     mode: MOUNT_CACHED
 
 setup: |
+  set -e
   cd /workspace/metta
   git fetch
   git checkout $METTA_GIT_REF

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -18,6 +18,7 @@ resources:
   image_id: docker:metta:latest
 
 setup: |
+  set -e
   cd /workspace/metta
   git fetch
   git checkout $METTA_GIT_REF


### PR DESCRIPTION
## Summary
- check that git ref is pushed before launching a Skypilot run
- fail Skypilot setup steps on first error
- verify commits exist on origin before launching

## Testing
- `ruff check devops/skypilot/launch.py`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6838df329264832e8ac782c51111f705