### PR TITLE
Temporary assert eval interval = 0 if using the tokenized environment

### DIFF
--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -4,7 +4,7 @@ seed: null
 
 defaults:
   # - override /env/mettagrid@env: simple
-  - override /agent: robust_LSTM_cross
+  - override /agent: robust_cross
   - _self_
 
 policy_uri: puffer:///tmp/puffer_metta.pt
@@ -34,7 +34,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 688
+run_id: 691
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -189,6 +189,9 @@ class PufferTrainer:
                             f"component_shape: {component_shape}\n"
                             f"environment_shape: {environment_shape}\n"
                         )
+                    # delete below after evaluate is tested with tokenized obs
+                    if len(environment_shape) == 2:
+                        assert self.trainer_cfg.evaluate_interval == 0, "Tokenized obs agents aren't set up for evaluate yet (5-30-25)."
 
             if not found_match:
                 raise ValueError(


### PR DESCRIPTION
This assertion needs to be deleted once we've updated eval (and sim) to work with tokenized obs. It's currently CNN-centric. 