### PR TITLE
1k attempts in wfc by default

### DIFF
--- a/metta/map/scenes/wfc.py
+++ b/metta/map/scenes/wfc.py
@@ -51,7 +51,7 @@ class WFCParams(Config):
     next_node_heuristic: NextNodeHeuristic = "entropy"
     periodic_input: bool = True
     symmetry: Symmetry = "all"
-    attempts: int = 3
+    attempts: int = 1000
 
 
 class WFC(Scene[WFCParams]):


### PR DESCRIPTION
Fixes https://app.asana.com/1/1209016784099267/project/1210131926580024/task/1210157174994155?focus=true

David initially suggested fallbacks to other patterns on failure, but that's difficult with the current mapgen architecture - `RandomScene` works by delegating rendering to another scene, so there's no clear place where to make a fallback. `get_children()` can't try/catch because nothing is rendered yet.

I could call `render()` for another scene directly from `RandomScene`, and wrap that in try/catch, but that would make the scene tree less introspectable (I want to log the full scene tree and show it in web viewer, store it for further analysis, etc.).

This PR takes a simpler approach - it relies on WFC converging eventually. All WFC patterns that we have are guaranteed to converge (DCSS patterns are tested on import), so it should be fine.