### PR TITLE
Fix noisy curriculum log

### DIFF
--- a/mettagrid/mettagrid/curriculum.py
+++ b/mettagrid/mettagrid/curriculum.py
@@ -15,8 +15,8 @@ class Curriculum:
     def get_task(self) -> "Task":
         raise NotImplementedError("Subclasses must implement this method")
 
-    def complete_task(self, id: str, score: float):
-        logger.info(f"Task completed: {id} -> {score:.5f}")
+    def complete_task(self, id: str, score: float) -> None:
+        logger.debug(f"Task completed: {id} -> {score:.5f}")
 
     @staticmethod
     def from_config_path(config_path: str, env_overrides: Optional[DictConfig] = None) -> "Curriculum":


### PR DESCRIPTION
## Summary
- downgrade info log in `Curriculum.complete_task`

## Testing
- `ruff format mettagrid/mettagrid/curriculum.py`
- `ruff check mettagrid/mettagrid/curriculum.py`
- `mypy mettagrid/mettagrid/curriculum.py` *(fails: missing dependencies)*
- `uv run pytest` *(fails: no network access to set up environment)*

------
https://chatgpt.com/codex/tasks/task_b_683e27820d048329af41842722b2a9c3