### PR TITLE
added some useful defaults to inform cursor

### DIFF
--- a/.cursor/commands.md
+++ b/.cursor/commands.md
@@ -1,0 +1,104 @@
+# Metta Testing Commands
+
+This file contains simple commands for testing the metta codebase. These commands are designed to run quickly and provide useful feedback about whether the system is working correctly.
+
+## Prerequisites
+Make sure you have activated the virtual environment:
+```bash
+source .venv/bin/activate
+```
+
+## Quick Test Commands (30-60 seconds total)
+
+### Set Test ID First
+```bash
+# Set a unique test ID for this testing session
+export TEST_ID=$(date +%Y%m%d_%H%M%S)
+echo "Test ID: $TEST_ID"
+```
+
+### 1. Train for 30 seconds
+```bash
+# Basic training (will run indefinitely, terminate with Ctrl+C after ~30 seconds)
+python -m tools.train run=test_$TEST_ID +hardware=macbook trainer.num_workers=2
+
+# Smoke test training (runs with deterministic settings for CI/CD)
+python -m tools.train run=smoke_$TEST_ID +hardware=macbook trainer.num_workers=2 +smoke_test=true
+
+# Using cursor config (limited to 100k steps)
+python -m tools.train +user=cursor run=cursor_$TEST_ID trainer.num_workers=2
+```
+
+### 2. Run simulations on trained model
+```bash
+# Run evaluations on the checkpoint from step 1
+python -m tools.sim run=eval_$TEST_ID policy_uri=file://./train_dir/test_$TEST_ID/checkpoints device=cpu
+
+# Run smoke test simulation (limited simulations, deterministic)
+python -m tools.sim run=smoke_eval_$TEST_ID policy_uri=file://./train_dir/smoke_$TEST_ID/checkpoints device=cpu +sim_job.smoke_test=true
+
+# Using cursor config
+python -m tools.sim run=cursor_eval_$TEST_ID policy_uri=file://./train_dir/cursor_$TEST_ID/checkpoints +user=cursor
+```
+
+### 3. Analyze results
+```bash
+# Analyze the simulation results from step 2
+python -m tools.analyze run=analysis_$TEST_ID analysis.policy_uri=file://./train_dir/test_$TEST_ID/checkpoints analysis.eval_db_uri=./train_dir/eval_$TEST_ID/stats.db
+
+# Using cursor config
+python -m tools.analyze run=cursor_analysis_$TEST_ID +user=cursor analysis.eval_db_uri=./train_dir/cursor_eval_$TEST_ID/stats.db
+```
+
+## One-Line Test Commands
+
+### Basic 30-second test (copy-paste friendly)
+```bash
+export TEST_ID=$(date +%Y%m%d_%H%M%S) && echo "Test ID: $TEST_ID" && python -m tools.train run=test_$TEST_ID +hardware=macbook trainer.total_timesteps=10000 trainer.num_workers=2
+# After training completes or you Ctrl+C:
+python -m tools.sim run=eval_$TEST_ID policy_uri=file://./train_dir/test_$TEST_ID/checkpoints device=cpu sim=navigation
+python -m tools.analyze run=analysis_$TEST_ID analysis.policy_uri=file://./train_dir/test_$TEST_ID/checkpoints analysis.eval_db_uri=./train_dir/eval_$TEST_ID/stats.db
+```
+
+### Using cursor config (auto-limited training)
+```bash
+export TEST_ID=$(date +%Y%m%d_%H%M%S) && echo "Test ID: $TEST_ID"
+python -m tools.train +user=cursor run=cursor_$TEST_ID
+python -m tools.sim run=cursor_eval_$TEST_ID policy_uri=file://./train_dir/cursor_$TEST_ID/checkpoints +user=cursor sim=navigation
+python -m tools.analyze run=cursor_analysis_$TEST_ID +user=cursor analysis.eval_db_uri=./train_dir/cursor_eval_$TEST_ID/stats.db
+```
+
+## Full Integration Test (2-3 minutes)
+
+```bash
+# Set test ID
+export TEST_ID=$(date +%Y%m%d_%H%M%S)
+echo "Running full integration test with ID: $TEST_ID"
+
+# 1. Train for 100k steps (~1 minute on GPU)
+python -m tools.train run=test_$TEST_ID trainer.total_timesteps=100000 trainer.checkpoint_interval=50 trainer.evaluate_interval=0 trainer.num_workers=2
+
+# 2. Run limited simulations (~30 seconds)
+python -m tools.sim run=eval_$TEST_ID policy_uri=file://./train_dir/test_$TEST_ID/checkpoints sim=navigation device=cpu
+
+# 3. Analyze results
+python -m tools.analyze run=analysis_$TEST_ID analysis.policy_uri=file://./train_dir/test_$TEST_ID/checkpoints analysis.eval_db_uri=./train_dir/eval_$TEST_ID/stats.db
+
+# 4. Check for wandb metrics filtering (if wandb is enabled)
+grep -r "agent_raw" train_dir/test_$TEST_ID/wandb || echo "✓ No agent_raw metrics in wandb logs"
+```
+
+## Common Issues and Solutions
+
+1. **CUDA not available on Mac**: Always use `device=cpu` on macOS
+2. **Training runs forever**: Use `trainer.total_timesteps=X` to limit training
+3. **Simulations take too long**: Use `sim=navigation` to run only navigation tasks
+4. **Smoke test failures**: Check that agent_raw metrics are filtered from wandb
+5. **Wrong directory picked up**: Always use the same TEST_ID across all commands
+
+## Smoke Test Mode
+
+When `+smoke_test=true` is added:
+- Training: Verifies wandb metrics structure
+- Simulation: Runs limited sims and verifies stats DB structure
+- Both use deterministic seeds and settings for reproducibility

--- a/.cursor/docs.md
+++ b/.cursor/docs.md
@@ -1,0 +1,36 @@
+## Testing the Codebase
+
+To quickly test that training, simulation, and analysis are working correctly, use these commands:
+
+### Quick 30-second test
+```bash
+# Set test ID for consistent file references
+export TEST_ID=$(date +%Y%m%d_%H%M%S) && echo "Test ID: $TEST_ID"
+
+# 1. Train for 30 seconds (terminate with Ctrl+C) or use cursor config for auto-stop
+python -m tools.train run=test_$TEST_ID +hardware=macbook
+# OR with cursor config (auto-stops after 100k steps):
+python -m tools.train +user=cursor run=cursor_$TEST_ID
+
+# 2. Run a few simulations
+python -m tools.sim run=eval_$TEST_ID policy_uri=file://./train_dir/test_$TEST_ID/checkpoints device=cpu sim=navigation
+
+# 3. Analyze results
+python -m tools.analyze run=analysis_$TEST_ID analysis.policy_uri=file://./train_dir/test_$TEST_ID/checkpoints analysis.eval_db_uri=./train_dir/eval_$TEST_ID/stats.db
+```
+
+For more testing commands and options, see `.cursor/commands.md`.
+
+### Smoke Tests
+
+The codebase includes smoke tests that verify:
+- WandB metrics are numeric (not string formatted)
+- No `agent_raw/*` entries are created (prevented in mettagrid_env.py to avoid thousands of metrics)
+- Stats database structure is correct
+
+Run smoke tests with:
+```bash
+export TEST_ID=$(date +%Y%m%d_%H%M%S)
+python -m tools.train run=smoke_$TEST_ID +smoke_test=true +hardware=macbook
+python -m tools.sim run=smoke_eval_$TEST_ID +sim_job.smoke_test=true policy_uri=file://./train_dir/smoke_$TEST_ID/checkpoints device=cpu
+```

--- a/configs/user/cursor.yaml
+++ b/configs/user/cursor.yaml
@@ -1,0 +1,22 @@
+# Cursor AI configuration for testing metta codebase
+# This config is used by the AI assistant when running test commands
+
+# Essential configuration
+policy_uri: puffer:///tmp/puffer_metta_cursor.pt
+
+# Analysis settings
+analysis:
+  policy_uri: ${..policy_uri}
+  eval_db_uri: ./train_dir/${run}/stats.db
+
+# Training settings optimized for quick testing
+trainer:
+  checkpoint_interval: 50      # Save frequently for testing
+  evaluate_interval: 0         # Skip evaluation during quick tests
+  total_timesteps: 100000     # Stop after 100k steps for quick tests
+
+# Hardware - assume CPU for compatibility
+device: cpu
+
+# Run naming for test tracking
+run: cursor_test_${now:%Y%m%d_%H%M%S}


### PR DESCRIPTION
I've been telling Cursor how to run things like tools.train/sim/analyze and pointing it to these docs. I don't know how useful having the docs is but it happily knows how to run everything