### PR TITLE
Move wandb_carbs from external dependency to local package

### DIFF
--- a/devops/setup_build.sh
+++ b/devops/setup_build.sh
@@ -126,11 +126,6 @@ uv pip install -r requirements.txt
 echo -e "\nInstalling Metta..."
 uv pip install -e .
 
-# The following will build mettagrid, cmake and all, but in isolated environment.
-# This is according to scikit-build-core and PEP-517 conventions.
-echo -e "\nInstalling MettaGrid..."
-uv pip --directory mettagrid install -e .
-
 # ========== SANITY CHECK ==========
 echo -e "\nSanity check: verifying all local deps are importable..."
 

--- a/metta/rl/carbs/metta_carbs.py
+++ b/metta/rl/carbs/metta_carbs.py
@@ -13,6 +13,7 @@ from carbs import (
     Param,
 )
 from omegaconf import DictConfig, ListConfig, OmegaConf
+
 from wandb_carbs import Pow2WandbCarbs
 
 logger = logging.getLogger("sweep_rollout")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -c requirements_pinned.txt
 -r requirements_pinned.txt
 git+https://github.com/relh/PufferLib.git@3.0
-git+https://github.com/Metta-AI/wandb_carbs.git
 git+https://github.com/imbue-ai/carbs.git

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -1,3 +1,6 @@
+-e ./wandb_carbs
+-e ./mettagrid
+
 boto3==1.38.23
 colorama==0.4.6
 duckdb==1.2.0

--- a/tools/sweep_eval.py
+++ b/tools/sweep_eval.py
@@ -7,7 +7,6 @@ import time
 import hydra
 import yaml
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from wandb_carbs import WandbCarbs
 
 from metta.agent.policy_store import PolicyStore
 from metta.eval.eval_stats_db import EvalStatsDB
@@ -16,6 +15,7 @@ from metta.sim.simulation_suite import SimulationSuite
 from metta.util.logging import setup_mettagrid_logger
 from metta.util.runtime_configuration import setup_mettagrid_environment
 from metta.util.wandb.wandb_context import WandbContext
+from wandb_carbs import WandbCarbs
 
 
 def log_file(run_dir, name, data, wandb_run):

--- a/tools/sweep_init.py
+++ b/tools/sweep_init.py
@@ -7,10 +7,10 @@ from logging import Logger
 
 import hydra
 import wandb
-import wandb_carbs
 import yaml
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
+import wandb_carbs
 from metta.rl.carbs.metta_carbs import MettaCarbs, carbs_params_from_cfg
 from metta.util.config import config_from_path
 from metta.util.logging import setup_mettagrid_logger

--- a/wandb_carbs/LICENSE
+++ b/wandb_carbs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Metta AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wandb_carbs/README.md
+++ b/wandb_carbs/README.md
@@ -1,0 +1,211 @@
+# Wandb Carbs
+
+[![PyPI version](https://badge.fury.io/py/wandb-carbs.svg)](https://badge.fury.io/py/wandb-carbs)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+Wandb Carbs is a Python package that integrates the [CARBS](https://github.com/imbue-ai/carbs) (Cost-Aware Bayesian Search) hyperparameter optimization library with [Weights & Biases](https://wandb.ai/) (W&B) sweeps. It enables cost-aware Bayesian parameter search using W&B's sweep functionality, allowing for efficient hyperparameter optimization across multiple parallel agents while storing all state within W&B.
+
+> **Note:** This project is now compatible with [uv](https://github.com/astral-sh/uv) for fast Python package management. You can install it in editable mode with:
+>
+> ```bash
+> uv pip install -e .
+> ```
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [How It Works](#how-it-works)
+  - [Creating a Sweep](#creating-a-sweep)
+  - [Running an Experiment](#running-an-experiment)
+- [Examples](#examples)
+- [Notes](#notes)
+- [References](#references)
+- [License](#license)
+
+## Features
+
+- **Cost-Aware Bayesian Optimization**: Optimize hyperparameters considering both performance and computational cost.
+- **Seamless W&B Integration**: Leverage W&B sweeps for distributed hyperparameter optimization with state stored in W&B.
+- **Parallel Execution**: Support multiple parallel agents running as part of the sweep.
+- **Automatic State Management**: Each agent initializes with observations from completed runs and generates suggestions for incomplete runs.
+- **Customizable Parameter Spaces**: Support for `LogSpace`, `LogitSpace`, and `LinearSpace` parameter spaces.
+
+## Installation
+
+You can install Wandb Carbs via pip:
+
+```bash
+pip install wandb_carbs
+```
+
+Or, for local development using [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv pip install -e .
+```
+
+## Usage
+
+### Prerequisites
+
+- An account on [Weights & Biases](https://wandb.ai/).
+- Basic understanding of [CARBS](https://github.com/imbue-ai/carbs) for Bayesian optimization.
+- Familiarity with W&B sweeps.
+
+### How It Works
+
+CARBS performs cost-aware Bayesian parameter search but doesn't natively integrate with W&B sweeps. Wandb Carbs bridges this gap by:
+
+- **Creating a W&B Sweep**: Converts CARBS parameter definitions into a W&B sweep configuration.
+- **Initializing Agents**: Each sweep agent run creates a new CARBS instance.
+- **State Initialization**: Agents initialize with observations from completed runs in the sweep and generate suggestions for incomplete runs.
+- **Parameter Suggestion**: Generates a suggestion for the current run and updates the run's configuration with the suggested parameters.
+- **Recording Results**: After the run completes, it stores the CARBS objective and cost in the run's metadata.
+
+This setup allows multiple parallel agents to run as part of the sweep while storing all the state in W&B.
+
+### Creating a Sweep
+
+First, define your parameter spaces using CARBS:
+
+```python
+from carbs import Param, LogSpace, LinearSpace
+
+# Define parameter spaces
+params = [
+    Param(name='learning_rate', space=LogSpace(min=1e-5, max=1e-1)),
+    Param(name='batch_size', space=LinearSpace(min=16, max=128, is_integer=True)),
+]
+```
+
+Use the `create_sweep` function from Wandb Carbs to create a W&B sweep:
+
+```python
+from wandb_carbs import create_sweep
+
+sweep_id = create_sweep(
+    sweep_name='My CARBS Sweep',
+    wandb_entity='your_wandb_entity',
+    wandb_project='your_wandb_project',
+    carbs_spaces=params
+)
+```
+
+This function converts the CARBS parameters into a W&B sweep configuration and returns a `sweep_id` that you can use to manage the sweep.
+
+### Running an Experiment
+
+In your training script, integrate Wandb Carbs:
+
+```python
+import wandb
+from wandb_carbs import WandbCarbs
+from carbs import CARBS
+
+def train():
+    # Initialize W&B run
+    wandb.init()
+
+    # Initialize CARBS
+    carbs = CARBS(params=params)
+
+    # Initialize Wandb Carbs
+    wandb_carbs = WandbCarbs(carbs=carbs)
+
+    # Get hyperparameters suggestion
+    suggestion = wandb_carbs.suggest()
+
+    # Your training code here
+    # The suggested parameters are in wandb.config
+    model = build_model(wandb.config)
+    performance = evaluate_model(model)
+
+    # Record observation
+    objective = performance['accuracy']  # The metric you aim to optimize
+    cost = performance['training_time']  # Computational cost measure
+    wandb_carbs.record_observation(objective=objective, cost=cost)
+
+    # Finish the run
+    wandb.finish()
+
+if __name__ == '__main__':
+    train()
+```
+
+**Note:** The suggested hyperparameters are automatically stored in `wandb.config` by the W&B agent; therefore, you don't need to manually update `wandb.config` with the suggestion.
+
+## Examples
+
+### Full Example
+
+```python
+import wandb
+from wandb_carbs import WandbCarbs, create_sweep
+from carbs import CARBS, Param, LogSpace, LinearSpace
+
+# Define parameter spaces
+params = [
+    Param(name='learning_rate', space=LogSpace(min=1e-5, max=1e-1)),
+    Param(name='batch_size', space=LinearSpace(min=16, max=128, is_integer=True)),
+]
+
+# Create a sweep
+sweep_id = create_sweep(
+    sweep_name='My CARBS Sweep',
+    wandb_entity='your_wandb_entity',
+    wandb_project='your_wandb_project',
+    carbs_spaces=params
+)
+
+def train():
+    # Initialize W&B run
+    wandb.init()
+
+    # Initialize CARBS
+    carbs = CARBS(params=params)
+
+    # Initialize Wandb Carbs
+    wandb_carbs = WandbCarbs(carbs=carbs)
+
+    # Get hyperparameters suggestion
+    suggestion = wandb_carbs.suggest()
+
+    # Your training code here
+    # The suggested parameters are in wandb.config
+    model = build_model(wandb.config)
+    performance = evaluate_model(model)
+
+    # Record observation
+    objective = performance['accuracy']
+    cost = performance['training_time']
+    wandb_carbs.record_observation(objective=objective, cost=cost)
+
+    # Finish the run
+    wandb.finish()
+
+if __name__ == '__main__':
+    train()
+```
+
+### Managing the Sweep
+
+- Use the `sweep_id` returned by `create_sweep` to monitor and manage your sweep in the W&B dashboard.
+- Ensure that all agents (parallel runs) are correctly configured to run the `train` function.
+
+## Notes
+
+- Replace `your_wandb_entity` and `your_wandb_project` with your actual W&B entity and project names.
+- The `objective` should be the metric you aim to optimize (e.g., accuracy, F1 score).
+- The `cost` can be any measure of computational cost, like training time, memory usage, or FLOPs.
+- Ensure that your `build_model` and `evaluate_model` functions use the parameters from `wandb.config`.
+
+## References
+
+- **CARBS**: For more detailed instructions on CARBS, visit the [CARBS GitHub repository](https://github.com/imbue-ai/carbs).
+- **Weights & Biases**: Learn more about W&B sweeps [here](https://docs.wandb.ai/guides/sweeps).
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/wandb_carbs/__init__.py
+++ b/wandb_carbs/__init__.py
@@ -1,0 +1,3 @@
+from .wandb_carbs import WandbCarbs, create_sweep
+
+__all__ = ["WandbCarbs", "create_sweep"]

--- a/wandb_carbs/pyproject.toml
+++ b/wandb_carbs/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wandb_carbs"
+version = "0.0.8"
+description = "Integrates Imbue's Cost Aware pareto-Region Bayesian Search (CARBS) with Weights and Biases (WanDB)"
+authors = [{ name = "David Bloomin", email = "daveey@gmail.com" }]
+license = { file = "LICENSE" }
+readme = "README.md"
+keywords = [
+    "bayesian-optimization",
+    "bayesian-search",
+    "cost-aware",
+    "pareto-region",
+    "carbs",
+    "wandb",
+    "weights-and-biases",
+]
+requires-python = ">=3.10,<4.0"
+dependencies = ["carbs>=0.0.1", "wandb>=0.16"]
+
+[project.optional-dependencies]
+test = ["pytest>=6.2.4"]
+
+[tool.setuptools]
+include-package-data = true

--- a/wandb_carbs/wandb_carbs.py
+++ b/wandb_carbs/wandb_carbs.py
@@ -1,0 +1,312 @@
+import json
+import logging
+import math
+import random
+import time
+import traceback
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import List, Set
+
+import wandb
+from carbs import (
+    CARBS,
+    LinearSpace,
+    LogitSpace,
+    LogSpace,
+    ObservationInParam,
+    Param,
+    SuggestionInBasic,
+)
+
+logger = logging.getLogger("wandb_carbs")
+# logger.setLevel(logging.DEBUG)
+
+
+class WandbCarbs:
+    def __init__(self, carbs: CARBS, wandb_run=None, sweep_id: str = None):
+        """
+        Initialize WandbCarbs with a CARBS instance and optionally a wandb run.
+
+        Args:
+            carbs (CARBS): The CARBS instance to use for suggestions.
+            wandb_run (wandb.Run, optional): The wandb run to use. If None, uses the current run.
+        """
+        self._wandb_run = wandb_run or wandb.run
+        self._sweep_id = self._wandb_run.sweep_id
+        self._api = wandb.Api()
+
+        self._carbs = carbs
+        self._carbs._set_seed(int(time.time()))
+        self._num_observations = 0
+        self._num_failures = 0
+        self._num_running = 0
+        self._defunct = 0
+        self._invalid = 0
+        self._observations = []
+
+        assert self._wandb_run.summary.get("carbs.state") is None, f"Run {self._wandb_run.name} already has carbs state"
+
+        self._wandb_run.summary.update({"carbs.state": "initializing"})
+        self._load_runs()
+        self._generate_carbs_suggestion()
+
+        wandb_config = self._transform_suggestion(deepcopy(self._suggestion))
+        del wandb_config["suggestion_uuid"]
+        self._wandb_run.config.__dict__["_locked"] = {}
+        self._wandb_run.config.update(wandb_config, allow_val_change=True)
+        self._wandb_run.summary.update({"carbs.state": "running"})
+
+    def record_observation(self, objective: float, cost: float, allow_update: bool = False):
+        self._record_observation(self._wandb_run, objective, cost, allow_update)
+
+    @staticmethod
+    def _record_observation(wandb_run, objective: float, cost: float, allow_update: bool = False):
+        """
+        Record an observation for the current run.
+
+        Args:
+            objective (float): The objective value to record.
+            cost (float): The cost value to record.
+            allow_update (bool, optional): If True, allows updating even if the run is not in "running" state.
+        """
+        if not allow_update:
+            assert wandb_run.summary["carbs.state"] == "running", (
+                f"Run is not running, cannot record observation {wandb_run.summary}"
+            )
+
+        wandb_run.summary.update({"carbs.objective": objective, "carbs.cost": cost, "carbs.state": "success"})
+        logger.info(f"Recording observation ({objective}, {cost}) for {wandb_run.name}")
+
+    def record_failure(self):
+        self._record_failure(self._wandb_run)
+
+    @staticmethod
+    def _record_failure(wandb_run):
+        """
+        Record a failure for the current run.
+        """
+        logger.info(f"Recording failure for {wandb_run.name}")
+        wandb_run.summary.update({"carbs.state": "failure"})
+
+    def suggest(self):
+        """
+        Get the current suggestion.
+
+        Returns:
+            dict: The current suggestion.
+        """
+        return self._transform_suggestion(deepcopy(self._suggestion))
+
+    def _transform_suggestion(self, suggestion):
+        return suggestion
+
+    def _load_runs(self):
+        logger.info(f"Loading previous runs from sweep {self._sweep_id}")
+
+        for run in self._get_runs_from_wandb():
+            self._update_carbs_from_run(run)
+
+        logger.info(
+            "Initialized CARBS with "
+            + json.dumps(
+                {
+                    "observations": self._num_observations,
+                    "failures": self._num_failures,
+                    "running": self._num_running,
+                    "defunct": self._defunct,
+                    "invalid": self._invalid,
+                }
+            )
+        )
+
+    def _get_runs_from_wandb(self):
+        runs = self._api.runs(
+            path=f"{self._wandb_run.entity}/{self._wandb_run.project}",
+            filters={
+                "sweep": self._sweep_id,
+                # "tags": {"$in": [f"sweep_id:{self._sweep_id}"]},
+                "summary_metrics.carbs.state": {"$exists": True},
+                "id": {"$ne": self._wandb_run.id},
+            },
+            order="+created_at",
+        )
+        return runs
+
+    def _update_carbs_from_run(self, run):
+        if run.summary["carbs.state"] == "initializing":
+            logger.debug(f"skipping run {run.name} because it is initializing")
+
+        if run.summary["carbs.state"] == "running":
+            last_hb = datetime.strptime(run._attrs["heartbeatAt"], "%Y-%m-%dT%H:%M:%S%fZ").replace(tzinfo=timezone.utc)
+            if (datetime.now(timezone.utc) - last_hb).total_seconds() > 5 * 60:
+                logger.debug(f"skipping run {run.name} because it has not heartbeated in the last 5 minutes")
+                self._defunct += 1
+                return
+
+        try:
+            suggestion = self._suggestion_from_run(run)
+        except Exception as e:
+            logger.warning(f"Failed to get suggestion from run {run.name}: {e}")
+            self._invalid += 1
+            return
+
+        self._carbs._remember_suggestion(
+            suggestion, SuggestionInBasic(self._carbs._param_space_real_to_basic_space_real(suggestion)), run.id
+        )
+
+        if run.summary["carbs.state"] == "running":
+            logger.debug(f"recording suggestion run {run.name} that is still running")
+            self._num_running += 1
+            return
+
+        objective = run.summary.get("carbs.objective", 0)
+        cost = run.summary.get("carbs.cost", 0)
+
+        if run.summary["carbs.state"] == "failure":
+            self._num_failures += 1
+        else:
+            self._num_observations += 1
+
+        logger.debug(
+            f"Observation {run.name} "
+            + f"{objective} / {cost} "
+            + f"failure: {run.summary['carbs.state'] == 'failure'} "
+            + json.dumps(suggestion, indent=2)
+        )
+        self._observations.append(
+            {
+                "suggestion": suggestion,
+                "objective": objective,
+                "cost": cost,
+                "is_failure": run.summary["carbs.state"] == "failure",
+                "run_id": run.id,
+                "run_name": run.name,
+            }
+        )
+        self._carbs.observe(
+            ObservationInParam(
+                input=suggestion, output=objective, cost=cost, is_failure=run.summary["carbs.state"] == "failure"
+            )
+        )
+
+    def _suggestion_from_run(self, run):
+        suggestion = {param.name: run.config.get(param.name, param.search_center) for param in self._carbs.params}
+        suggestion["suggestion_uuid"] = run.id
+        return suggestion
+
+    def _generate_carbs_suggestion(self):
+        while True:
+            try:
+                self._suggestion = self._carbs.suggest().suggestion
+                break
+            except Exception as e:
+                logger.warning(f"Failed to suggest: {e}")
+                logger.debug(traceback.format_exc())
+
+                if len(self._carbs.success_observations) == 0 and len(self._carbs.failure_observations) == 0:
+                    logger.error("Unable to recover from failed suggestion, no observations to remove")
+                    raise e
+
+                # Remove a random element from success and failure observations
+                if len(self._carbs.success_observations):
+                    logger.info("Removing random success observation")
+                    self._carbs.success_observations.pop(random.randint(0, len(self._carbs.success_observations) - 1))
+                elif len(self._carbs.failure_observations):
+                    logger.info("Removing random failure observation")
+                    self._carbs.failure_observations.pop(random.randint(0, len(self._carbs.failure_observations) - 1))
+
+
+class Pow2WandbCarbs(WandbCarbs):
+    """
+    A subclass of WandbCarbs that handles parameters that should be treated as powers of 2.
+
+    This class extends WandbCarbs to support parameters that are internally represented as
+    exponents but should be presented as powers of 2 externally.
+
+    Attributes:
+        pow2_params (Set[str]): A set of parameter names that should be treated as powers of 2.
+
+    """
+
+    def __init__(self, carbs: CARBS, pow2_params: Set[str], wandb_run=None):
+        """
+        Initialize the Pow2WandbCarbs instance.
+
+        Args:
+            carbs (CARBS): The CARBS instance to use for optimization.
+            pow2_params (Set[str]): A set of parameter names to be treated as powers of 2.
+            wandb_run: The Weights & Biases run object (optional).
+        """
+        self.pow2_params = pow2_params or set()
+        super().__init__(carbs, wandb_run)
+
+    def _transform_suggestion(self, suggestion):
+        for param in self._carbs.params:
+            if param.name in self.pow2_params:
+                suggestion[param.name] = 2 ** suggestion[param.name]
+        return suggestion
+
+    def _suggestion_from_run(self, run):
+        suggestion = super()._suggestion_from_run(run)
+        for param in self._carbs.params:
+            if param.name in self.pow2_params:
+                try:
+                    suggestion[param.name] = int(math.log2(suggestion[param.name]))
+                except ValueError as e:
+                    logger.warning(f"Failed to convert {run.name}:{param.name} to power of 2: {suggestion[param.name]}")
+                    raise e
+
+        return suggestion
+
+
+def create_sweep(sweep_name: str, wandb_entity: str, wandb_project: str, carb_params: List[Param]):
+    """
+    Create a new wandb sweep based on CARBS parameters.
+
+    Args:
+        sweep_name (str): The name of the sweep.
+        wandb_entity (str): The wandb entity (username or team name).
+        wandb_project (str): The wandb project name.
+        carb_params (List[Param]): The CARBS parameter spaces.
+
+    Returns:
+        str: The ID of the created sweep.
+    """
+    sweep_id = wandb.sweep(
+        sweep=_wandb_sweep_cfg_from_carbs_params(sweep_name, carb_params),
+        project=wandb_project,
+        entity=wandb_entity,
+    )
+    return sweep_id
+
+
+def _wandb_sweep_cfg_from_carbs_params(name, carb_params: List[Param]):
+    wandb_sweep_cfg = {
+        "method": "bayes",
+        "metric": {
+            "goal": "maximize",
+            "name": "carbs.objective",
+        },
+        "parameters": {},
+        "name": name,
+    }
+    for param in carb_params:
+        wandb_sweep_cfg["parameters"][param.name] = {
+            "min": param.space.min,
+            "max": param.space.max,
+            "distribution": _wandb_distribution(param),
+        }
+    return wandb_sweep_cfg
+
+
+def _wandb_distribution(param: Param):
+    if isinstance(param.space, LogSpace):
+        return "log_uniform_values"
+    elif isinstance(param.space, LogitSpace):
+        return "uniform"
+    elif isinstance(param.space, LinearSpace):
+        if param.space.is_integer:
+            return "int_uniform"
+        else:
+            return "uniform"


### PR DESCRIPTION
### TL;DR

Moved wandb_carbs from an external dependency to an internal package and updated the installation process.

### What changed?

- Moved wandb_carbs from an external GitHub dependency to an internal package within the repository
- Added wandb_carbs code, including LICENSE, README.md, and implementation files
- Updated requirements_pinned.txt to use the local wandb_carbs package as an editable install
- Modified setup_build.sh to remove MettaGrid installation step
- Updated import order in sweep_init.py to accommodate the local wandb_carbs package

### How to test?

1. Run the setup_build.sh script to verify it completes without errors
2. Import wandb_carbs in Python code to ensure it's properly installed
3. Run a sweep using the wandb_carbs integration to confirm functionality
4. Verify that tools/sweep_init.py executes correctly with the updated import order

### Why make this change?

This change internalizes the wandb_carbs package to reduce external dependencies and provide better control over the codebase. By moving the package into the repository, it simplifies the development process, makes it easier to maintain and modify the wandb_carbs code, and ensures version compatibility with the rest of the project.