### PR TITLE
Add sweep_eval config and update sweep parameters

### DIFF
--- a/configs/sim/sweep_eval.yaml
+++ b/configs/sim/sweep_eval.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - sim_suite
+  - _self_
+
+name: sweep_eval
+
+simulations:
+  navigation/emptyspace_withinsight:
+    env: env/mettagrid/navigation/evals/emptyspace_withinsight
+  simple:
+    env: env/mettagrid/simple
+# selector_type: "latest"

--- a/configs/sweep/cogeval_sweep.yaml
+++ b/configs/sweep/cogeval_sweep.yaml
@@ -6,7 +6,6 @@ num_random_samples: 10
 resume: true
 
 eval:
-  num_envs: 100
   num_episodes: 100
   max_time_s: 600
   policy_agents_pct: 1.0

--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -11,7 +11,7 @@ trainer:
   minibatch_size: ${ss:pow2, 1024, 131072}
   forward_pass_minibatch_target_size: $pow2(1024, 32768)
   bptt_horizon: ${ss:pow2, 1, 128}
-  total_timesteps: ${ss:log, 1e7, 4e7, 3e8}
+  total_timesteps: ${ss:log, 1e7, 1e8, 2e7}
   # compile: ${ss:int, 0, 1}
 
   optimizer:

--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -11,7 +11,7 @@ trainer:
   minibatch_size: ${ss:pow2, 1024, 131072}
   forward_pass_minibatch_target_size: $pow2(1024, 32768)
   bptt_horizon: ${ss:pow2, 1, 128}
-  total_timesteps: ${ss:log, 1e8, 4e8, 3e8}
+  total_timesteps: ${ss:log, 1e7, 4e7, 3e8}
   # compile: ${ss:int, 0, 1}
 
   optimizer:

--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -11,7 +11,7 @@ trainer:
   minibatch_size: ${ss:pow2, 1024, 131072}
   forward_pass_minibatch_target_size: $pow2(1024, 32768)
   bptt_horizon: ${ss:pow2, 1, 128}
-  total_timesteps: ${ss:log, 2e9, 4e9, 3e9}
+  total_timesteps: ${ss:log, 1e8, 4e8, 3e8}
   # compile: ${ss:int, 0, 1}
 
   optimizer:

--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -1,7 +1,7 @@
 trainer:
   gamma: ${ss:logit, 0.0, 1.0}
   gae_lambda: ${ss:logit, 0.0, 1.0}
-  update_epochs: ${ss:int, 1, 3}
+  update_epochs: ${ss:int, 1, 16}
   # clip_coef: ${ss:logit, 0.0, 1.0}
   vf_coef: ${ss:logit, 0.0, 1.0}
   # vf_clip_coef: ${ss:logit, 0.0, 1.0}

--- a/configs/sweep/pong.yaml
+++ b/configs/sweep/pong.yaml
@@ -4,7 +4,6 @@ num_random_samples: 10
 resume: true
 
 eval:
-  num_envs: 100
   num_episodes: 100
   max_time_s: 600
   policy_agents_pct: 0.5

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -2,7 +2,7 @@ defaults:
   - common
   - wandb: metta_research
   - agent: simple
-  - sim: navigation
+  - sim: simple
   - trainer: puffer
   - _self_
 

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -1,7 +1,7 @@
 defaults:
   - common
   - wandb: metta_research
-  - agent: simple
+  - agent: robust_cross
   - sim: navigation
   - trainer: puffer
   - _self_
@@ -17,6 +17,9 @@ num_random_samples: 10
 
 trainer:
   evaluate_interval: 300
+  env_overrides:
+    game:
+      use_observation_tokens: true
 
 sim:
   num_episodes: 5

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -2,7 +2,7 @@ defaults:
   - common
   - wandb: metta_research
   - agent: simple
-  - sim: simple
+  - sim: navigation
   - trainer: puffer
   - _self_
 

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -2,7 +2,7 @@ defaults:
   - common
   - wandb: metta_research
   - agent: robust_cross
-  - sim: navigation
+  - sim: sweep_eval
   - trainer: puffer
   - _self_
 

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -19,7 +19,6 @@ trainer:
   evaluate_interval: 300
 
 sim:
-  num_envs: 5
   num_episodes: 5
 
 sweep_job:

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -23,7 +23,6 @@ eval:
   npc_policy_uri: ${..npc_policy_uri}
   # eval_db_uri: ${..eval_db_uri}
   # env: /env/mettagrid/prog_3.yaml
-  # num_envs: 10
   # num_episodes: 10
   # max_time_s: 60
 

--- a/configs/user/berekuk.yaml
+++ b/configs/user/berekuk.yaml
@@ -11,7 +11,6 @@ run: ${oc.env:USER}.local.${run_id}
 policy_uri: wandb://run/${run}
 
 eval:
-  num_envs: 10
   num_episodes: 16
   max_time_s: 600
   policy_uri: ${..policy_uri}

--- a/configs/user/georgedeane.yaml
+++ b/configs/user/georgedeane.yaml
@@ -22,7 +22,6 @@ policy_uri: wandb://run/b.georgedeane.terrain_extra_hard
 # policy_uri: wandb://run/terrain_training_multienv_april18
 # policy_uri: wandb://run/b.daphne.terrain_multienv_april18
 
-
 # Infinite_cooldown models:
 # navigation_infinite_cooldown_sweep_2g_.r.0 - ok
 # navigation_infinite_cooldown_sweep_2g.r.1 - 9 reward after 400 timesteps
@@ -35,14 +34,12 @@ dashboard:
   output_path: evalresults/memory_db.html
 
 sim:
-  num_envs: 2
   num_episodes: 2
   max_time_s: 600
 
   # policy_uri: ${..policy_uri}
   # npc_policy_uri: ${..npc_policy_uri}
   env: /env/mettagrid/navigation/training/empty_world
-
 
 run_id: 103
 run: ${oc.env:USER}.local.${run_id}

--- a/configs/user/rwalters.yaml
+++ b/configs/user/rwalters.yaml
@@ -5,9 +5,6 @@ seed: null
 defaults:
   - _self_
 
-
-num_envs: 1
-
 trainer:
   env: /env/mettagrid/simple
   evaluate_interval: 200

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -72,7 +72,7 @@ def main():
     else:
         for i in range(1, args.copies + 1):
             copy_task = copy.deepcopy(task)
-            run_id = f"{args.run}_{i}"
+            run_id = args.run
             copy_task = copy_task.update_envs({"METTA_RUN_ID": run_id})
             copy_task.name = run_id
             copy_task.validate_name()

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -46,6 +46,7 @@ def main():
     parser.add_argument("--nodes", type=int, default=None)
     parser.add_argument("--cpus", type=int, default=None)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--copies", type=int, default=1, help="Number of identical job copies to launch")
     (args, cmd_args) = parser.parse_known_args()
 
     git_ref = args.git_ref
@@ -66,7 +67,16 @@ def main():
 
     task = patch_task(task, cpus=args.cpus, gpus=args.gpus, nodes=args.nodes)
 
-    launch_task(task, dry_run=args.dry_run)
+    if args.copies == 1:
+        launch_task(task, dry_run=args.dry_run)
+    else:
+        for i in range(1, args.copies + 1):
+            copy_task = copy.deepcopy(task)
+            run_id = f"{args.run}_{i}"
+            copy_task = copy_task.update_envs({"METTA_RUN_ID": run_id})
+            copy_task.name = run_id
+            copy_task.validate_name()
+            launch_task(copy_task, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -70,7 +70,7 @@ def main():
     if args.copies == 1:
         launch_task(task, dry_run=args.dry_run)
     else:
-        for i in range(1, args.copies + 1):
+        for _ in range(1, args.copies + 1):
             copy_task = copy.deepcopy(task)
             run_id = args.run
             copy_task = copy_task.update_envs({"METTA_RUN_ID": run_id})

--- a/mettagrid/mettagrid/curriculum.py
+++ b/mettagrid/mettagrid/curriculum.py
@@ -16,7 +16,8 @@ class Curriculum:
         raise NotImplementedError("Subclasses must implement this method")
 
     def complete_task(self, id: str, score: float):
-        logger.info(f"Task completed: {id} -> {score:.5f}")
+        # logger.info(f"Task completed: {id} -> {score:.5f}")
+        pass
 
     @staticmethod
     def from_config_path(config_path: str, env_overrides: Optional[DictConfig] = None) -> "Curriculum":
@@ -43,7 +44,7 @@ class Task:
         for curriculum, id in self._curriculums:
             curriculum.complete_task(id, score)
         self._is_complete = True
-        logger.info(f"Task completed: {self.name()} -> {score:.5f}")
+        # logger.info(f"Task completed: {self.name()} -> {score:.5f}")
 
     def is_complete(self):
         return self._is_complete

--- a/tools/sweep_init.py
+++ b/tools/sweep_init.py
@@ -12,6 +12,7 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 import wandb_carbs
 from metta.rl.carbs.metta_carbs import MettaCarbs, carbs_params_from_cfg
+from metta.sim.simulation_config import SimulationSuiteConfig
 from metta.util.config import config_from_path
 from metta.util.logging import setup_mettagrid_logger
 from metta.util.wandb.sweep import generate_run_id_for_sweep, sweep_id_from_name
@@ -71,6 +72,9 @@ def create_run(sweep_name: str, cfg: DictConfig | ListConfig, logger: Logger) ->
     """
 
     sweep_cfg = OmegaConf.load(os.path.join(cfg.sweep_dir, "config.yaml"))
+
+    # Create the simulation suite config to make sure it's valid
+    SimulationSuiteConfig(**cfg.sweep_job.evals)
 
     logger.info(f"Creating new run for sweep: {sweep_name} ({sweep_cfg.wandb_path})")
     run_name = generate_run_id_for_sweep(sweep_cfg.wandb_path, cfg.runs_dir)


### PR DESCRIPTION
# Add sweep_eval.yaml for simulation configuration

This PR introduces several changes to improve the sweep evaluation process:

- Added a new `sweep_eval.yaml` configuration file for simulations
- Expanded the range of `update_epochs` from 1-3 to 1-16 in the full sweep configuration
- Reduced `total_timesteps` range from 2e9-4e9 to 1e7-1e8 in the full sweep configuration
- Removed redundant `num_envs` parameters from various configuration files
- Added `use_observation_tokens: true` to the game environment overrides
- Added a `--copies` parameter to the SkyPilot launch script to run multiple identical jobs
- Reduced logging verbosity in the curriculum module by commenting out task completion logs

These changes streamline the sweep evaluation process and provide more flexibility in configuration options.