### PR TITLE
Move normalization values to the mettagrid environment

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250524.1
+run_id: 20250603.3
 run: ${oc.env:USER}.local.${run_id}

--- a/metta/agent/lib/observation_normalizer.py
+++ b/metta/agent/lib/observation_normalizer.py
@@ -3,40 +3,6 @@ from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
 
-# ##ObservationNormalization
-# These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
-# but here we are. If you add / remove a feature, you should add / remove the corresponding normalization.
-OBS_NORMALIZATIONS = {
-    "agent": 1,
-    "agent:group": 10,
-    "agent:hp": 30,
-    "agent:frozen": 1,
-    "agent:energy": 255,
-    "agent:orientation": 1,
-    "agent:shield": 1,
-    "agent:color": 255,
-    "converter": 1,
-    "inv:ore.red": 100,
-    "inv:ore.blue": 100,
-    "inv:ore.green": 100,
-    "inv:battery.red": 100,
-    "inv:battery.blue": 100,
-    "inv:battery.green": 100,
-    "inv:heart": 100,
-    "inv:laser": 100,
-    "inv:armor": 100,
-    "inv:blueprint": 100,
-    "last_action": 10,
-    "last_action_argument": 10,
-    "agent:kinship": 10,
-    "hp": 30,
-    "converting": 1,
-    "color": 10,
-    "swappable": 1,
-    "type_id": 10,
-}
-
-
 class ObservationNormalizer(LayerBase):
     """
     Normalizes observation features by dividing each feature by its approximate maximum value.
@@ -50,15 +16,13 @@ class ObservationNormalizer(LayerBase):
     is instantiated and never again. I.e., not when it is reloaded from a saved policy.
     """
 
-    def __init__(self, grid_features, **cfg):
-        self._grid_features = grid_features
+    def __init__(self, feature_normalizations, **cfg):
+        self._feature_normalizations = feature_normalizations
         super().__init__(**cfg)
 
     def _initialize(self):
-        num_objects = len(self._grid_features)
-
-        obs_norm = torch.tensor([OBS_NORMALIZATIONS[k] for k in self._grid_features], dtype=torch.float32)
-        obs_norm = obs_norm.view(1, num_objects, 1, 1)
+        obs_norm = torch.tensor(self._feature_normalizations, dtype=torch.float32)
+        obs_norm = obs_norm.view(1, len(self._feature_normalizations), 1, 1)
 
         self.register_buffer("obs_norm", obs_norm)
 

--- a/metta/agent/lib/observation_normalizer.py
+++ b/metta/agent/lib/observation_normalizer.py
@@ -3,6 +3,7 @@ from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
 
+
 class ObservationNormalizer(LayerBase):
     """
     Normalizes observation features by dividing each feature by its approximate maximum value.

--- a/metta/agent/metta_agent.py
+++ b/metta/agent/metta_agent.py
@@ -27,11 +27,14 @@ def make_policy(env: MettaGridEnv, cfg: ListConfig | DictConfig):
         }
     )
 
+    # Here's where we create MettaAgent. We're including the term MettaAgent here for better
+    # searchability. Otherwise you might only find yaml files.
     return hydra.utils.instantiate(
         cfg.agent,
         obs_space=obs_space,
         action_space=env.single_action_space,
         grid_features=env.grid_features,
+        feature_normalizations=env.feature_normalizations,
         global_features=env.global_features,
         device=cfg.device,
         _recursive_=False,
@@ -58,10 +61,13 @@ class MettaAgent(nn.Module):
         obs_space: Union[gym.spaces.Space, gym.spaces.Dict],
         action_space: gym.spaces.Space,
         grid_features: list[str],
+        feature_normalizations: list[float],
         device: str,
         **cfg,
     ):
         super().__init__()
+        # Note that this doesn't instantiate the components -- that will happen later once
+        # we've built up the right parameters for them.
         cfg = OmegaConf.create(cfg)
 
         logger.info(f"obs_space: {obs_space} ")
@@ -81,6 +87,7 @@ class MettaAgent(nn.Module):
             "clip_range": self.clip_range,
             "action_space": action_space,
             "grid_features": grid_features,
+            "feature_normalizations": feature_normalizations,
             "obs_key": cfg.observations.obs_key,
             "obs_shape": obs_shape,
             "hidden_size": self.hidden_size,

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -51,6 +51,7 @@ MettaGrid::MettaGrid(py::dict env_cfg, py::list map) {
   _grid = std::make_unique<Grid>(width, height, layer_for_type_id);
   _obs_encoder = std::make_unique<ObservationEncoder>();
   _grid_features = _obs_encoder->feature_names();
+  _feature_normalizations = _obs_encoder->feature_normalizations();
 
   _event_manager = std::make_unique<EventManager>();
   _stats = std::make_unique<StatsTracker>();
@@ -549,6 +550,11 @@ py::list MettaGrid::grid_features() {
   return py::cast(_grid_features);
 }
 
+// These should correspond to the grid_features list.
+py::list MettaGrid::feature_normalizations() {
+  return py::cast(_feature_normalizations);
+}
+
 unsigned int MettaGrid::num_agents() {
   return _agents.size();
 }
@@ -717,6 +723,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def_property_readonly("map_width", &MettaGrid::map_width)
       .def_property_readonly("map_height", &MettaGrid::map_height)
       .def("grid_features", &MettaGrid::grid_features)
+      .def("feature_normalizations", &MettaGrid::feature_normalizations)
       .def_property_readonly("num_agents", &MettaGrid::num_agents)
       .def("get_episode_rewards", &MettaGrid::get_episode_rewards)
       .def("get_episode_stats", &MettaGrid::get_episode_stats)

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -52,6 +52,7 @@ public:
   unsigned int map_width();
   unsigned int map_height();
   py::list grid_features();
+  py::list feature_normalizations();
   unsigned int num_agents();
   py::array_t<float> get_episode_rewards();
   py::dict get_episode_stats();
@@ -101,6 +102,7 @@ private:
   py::array_t<float> _episode_rewards;
 
   std::vector<std::string> _grid_features;
+  std::vector<float> _feature_normalizations;
 
   std::vector<bool> _action_success;
 

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -277,6 +277,10 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         return self._c_env.grid_features()
 
     @property
+    def feature_normalizations(self):
+        return self._c_env.feature_normalizations()
+
+    @property
     def global_features(self):
         return []
 

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -134,6 +134,8 @@ const std::map<std::string, float> FeatureNormalizations = {
     {"type_id", 10.0},
 };
 
+const float DEFAULT_NORMALIZATION = 1.0;
+
 const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},
                                                   {ObjectType::WallT, GridLayer::Object_Layer},
                                                   {ObjectType::MineT, GridLayer::Object_Layer},

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -87,10 +87,52 @@ enum InventoryItem {
   InventoryItemCount
 };
 
-constexpr std::array<const char*, InventoryItemCount> InventoryItemNamesArray = {
-    {"ore.red", "ore.blue", "ore.green", "battery.red", "battery.blue", "battery.green", "heart", "armor", "laser", "blueprint"}};
+constexpr std::array<const char*, InventoryItemCount> InventoryItemNamesArray = {{"ore.red",
+                                                                                  "ore.blue",
+                                                                                  "ore.green",
+                                                                                  "battery.red",
+                                                                                  "battery.blue",
+                                                                                  "battery.green",
+                                                                                  "heart",
+                                                                                  "armor",
+                                                                                  "laser",
+                                                                                  "blueprint"}};
 
 const std::vector<std::string> InventoryItemNames(InventoryItemNamesArray.begin(), InventoryItemNamesArray.end());
+
+// ##ObservationNormalization
+// These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
+// but here we are. If you add / remove a feature, you should add / remove the corresponding normalization.
+// These should move to configuration "soon". E.g., by 2025-06-10.
+const std::map<std::string, float> FeatureNormalizations = {
+    {"agent", 1.0},
+    {"agent:group", 10.0},
+    {"agent:hp", 30.0},
+    {"agent:frozen", 1.0},
+    {"agent:energy", 255.0},
+    {"agent:orientation", 1.0},
+    {"agent:shield", 1.0},
+    {"agent:color", 255.0},
+    {"converter", 1.0},
+    {"inv:ore.red", 100.0},
+    {"inv:ore.blue", 100.0},
+    {"inv:ore.green", 100.0},
+    {"inv:battery.red", 100.0},
+    {"inv:battery.blue", 100.0},
+    {"inv:battery.green", 100.0},
+    {"inv:heart", 100.0},
+    {"inv:laser", 100.0},
+    {"inv:armor", 100.0},
+    {"inv:blueprint", 100.0},
+    {"last_action", 10.0},
+    {"last_action_argument", 10.0},
+    {"agent:kinship", 10.0},
+    {"hp", 30.0},
+    {"converting", 1.0},
+    {"color", 10.0},
+    {"swappable", 1.0},
+    {"type_id", 10.0},
+};
 
 const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},
                                                   {ObjectType::WallT, GridLayer::Object_Layer},

--- a/mettagrid/mettagrid/observation_encoder.hpp
+++ b/mettagrid/mettagrid/observation_encoder.hpp
@@ -47,6 +47,7 @@ public:
           assert(index < 256);
           features.insert({feature_name, index});
           _feature_names.push_back(feature_name);
+          _feature_normalizations.push_back(FeatureNormalizations.at(feature_name));
         }
       }
     }
@@ -75,6 +76,10 @@ public:
     return _feature_names;
   }
 
+  const std::vector<float>& feature_normalizations() const {
+    return _feature_normalizations;
+  }
+
   const std::vector<std::vector<std::string>>& type_feature_names() const {
     return _type_feature_names;
   }
@@ -83,6 +88,7 @@ private:
   std::vector<std::vector<uint8_t>> _offsets;
   std::vector<std::vector<std::string>> _type_feature_names;
   std::vector<std::string> _feature_names;
+  std::vector<float> _feature_normalizations;
 };
 
 #endif  // METTAGRID_METTAGRID_OBSERVATION_ENCODER_HPP_

--- a/mettagrid/mettagrid/observation_encoder.hpp
+++ b/mettagrid/mettagrid/observation_encoder.hpp
@@ -47,7 +47,11 @@ public:
           assert(index < 256);
           features.insert({feature_name, index});
           _feature_names.push_back(feature_name);
-          _feature_normalizations.push_back(FeatureNormalizations.at(feature_name));
+          if (FeatureNormalizations.count(feature_name) > 0) {
+            _feature_normalizations.push_back(FeatureNormalizations.at(feature_name));
+          } else {
+            _feature_normalizations.push_back(DEFAULT_NORMALIZATION);
+          }
         }
       }
     }

--- a/tests/agent/test_metta_agent.py
+++ b/tests/agent/test_metta_agent.py
@@ -25,6 +25,7 @@ def create_metta_agent():
 
     action_space = gym.spaces.MultiDiscrete([3, 2])
     grid_features = ["agent", "hp", "type_id"]
+    feature_normalizations = [1.0, 30.0, 10.0]
 
     config_dict = {
         "clip_range": 0.1,
@@ -86,7 +87,12 @@ def create_metta_agent():
 
     # Create the agent with minimal config needed for the tests
     agent = MettaAgent(
-        obs_space=obs_space, action_space=action_space, grid_features=grid_features, device="cpu", **config_dict
+        obs_space=obs_space,
+        action_space=action_space,
+        grid_features=grid_features,
+        device="cpu",
+        feature_normalizations=feature_normalizations,
+        **config_dict,
     )
 
     # Create test components that have clip_weights method for testing


### PR DESCRIPTION
This moves the source of truth for observation normalization values from the ObservationNormalizer to the cpp environment. This sets us up to have the normalization set in configuration.

We continue passing grid_features for now, although they're unused. We should talk about whether they're useful to ensure that the features remain stable (e.g., the order remains stable). This is a similar problem we have for tokens -- making sure the feature_ids remain appropriately stable.

Normalization values are also only passed on layer creation -- not when we save and restore. That will need to change if we want the agent to be able to deal with normalization values updating between environments.