### PR TITLE
Add env overrides to simulation suites

### DIFF
--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -158,3 +158,6 @@ simulations:
     env: env/mettagrid/memory/evals/tease_small
   memory/you_shall_not_pass:
     env: env/mettagrid/memory/evals/you_shall_not_pass
+# env_overrides:
+#   game:
+#     use_observation_tokens: true

--- a/configs/sim/sim.yaml
+++ b/configs/sim/sim.yaml
@@ -1,3 +1,3 @@
-
 num_episodes: 1
 max_time_s: 60
+env_overrides: {}

--- a/configs/sim/sim_single.yaml
+++ b/configs/sim/sim_single.yaml
@@ -3,4 +3,3 @@ defaults:
   - _self_
 
 env: ???
-env_overrides: {}

--- a/configs/user/daphne.yaml
+++ b/configs/user/daphne.yaml
@@ -10,16 +10,22 @@
 #navigation_poisson_sparser_pretrained.r.6
 
 defaults:
+  - override /agent: robust_cross
   - _self_
 
 trainer:
-  env: /env/mettagrid/object_use/training/multienv_nc
-  evaluate_interval: 10
-
+  env: /env/mettagrid/curriculum/navigation
+  evaluate_interval: 3
+  env_overrides:
+    game:
+      use_observation_tokens: true
+  evals:
+    env_overrides:
+      game:
+        use_observation_tokens: true
 
 policy_uri: wandb://run/b.georgedeane.george_sequence_no_increment
 
-
-run_id: 2
+run_id: 5
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -52,6 +52,11 @@ class PufferTrainer:
     ):
         self.cfg = cfg
         self.trainer_cfg = cfg.trainer
+
+        # Do we want to just put this check here?
+        if "obs_cross_attn" in cfg.agent.components:
+            sim_suite_config.env_overrides = {"game": {"use_observation_tokens": True}}
+
         self.sim_suite_config = sim_suite_config
 
         self._master = True
@@ -188,11 +193,6 @@ class PufferTrainer:
                             f"component_name: {component_name}\n"
                             f"component_shape: {component_shape}\n"
                             f"environment_shape: {environment_shape}\n"
-                        )
-                    # delete below after evaluate is tested with tokenized obs
-                    if len(environment_shape) == 2:
-                        assert self.trainer_cfg.evaluate_interval == 0, (
-                            "Tokenized obs agents aren't set up for evaluate yet (5-30-25)."
                         )
 
             if not found_match:
@@ -662,6 +662,7 @@ class PufferTrainer:
     def _generate_and_upload_replay(self):
         if self._master:
             logger.info("Generating and saving a replay to wandb and S3.")
+
             replay_simulator = Simulation(
                 name=f"replay_{self.epoch}",
                 config=self.replay_sim_config,

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -69,10 +69,7 @@ class Simulation:
         logger.info(f"config.env {config.env}")
         logger.info(f"config.env_overrides {config.env_overrides}")
 
-        if config.env_overrides is not None:
-            env_overrides = OmegaConf.create(config.env_overrides)
-        else:
-            env_overrides = None
+        env_overrides = OmegaConf.create(config.env_overrides)
 
         self._env_name = config.env
 

--- a/metta/sim/simulation_config.py
+++ b/metta/sim/simulation_config.py
@@ -15,6 +15,7 @@ class SimulationConfig(Config):
     # Core simulation config
     num_episodes: int
     max_time_s: int = 120
+    env_overrides: dict = {}
 
     npc_policy_uri: Optional[str] = None
     policy_agents_pct: float = 1.0
@@ -26,7 +27,7 @@ class SingleEnvSimulationConfig(SimulationConfig):
     __init__ = SimulationConfig.__init__
 
     env: str
-    env_overrides: Optional[dict] = None
+    env_overrides: dict = {}
 
 
 class SimulationSuiteConfig(SimulationConfig):

--- a/metta/sim/simulation_suite.py
+++ b/metta/sim/simulation_suite.py
@@ -45,6 +45,8 @@ class SimulationSuite:
 
         for name, sim_config in self._config.simulations.items():
             try:
+                # merge global simulation suite overrides with simulation-specific overrides
+                sim_config.env_overrides = {**self._config.env_overrides, **sim_config.env_overrides}
                 sim = Simulation(
                     name,
                     sim_config,


### PR DESCRIPTION
We want to be able to have global level overrides to our simulation suite so that we can train and evaluate on the robust cross architecture (which requires an environment override)