### PR TITLE
hotfix: update launch aws workflow for uv.lock

### DIFF
--- a/devops/aws/batch/launch_task.py
+++ b/devops/aws/batch/launch_task.py
@@ -113,8 +113,8 @@ def validate_batch_job(args, task_args, job_name, job_queue, job_definition, req
     critical_files = [
         "./devops/aws/batch/entrypoint.sh",
         f"./devops/{args.cmd}.sh",
-        "requirements.txt",
-        "requirements_pinned.txt",
+        "uv.lock",
+        "pyproject.toml",
     ]
 
     if args.cmd == "train":


### PR DESCRIPTION

The AWS training job validation was failing because it was still checking for the old `requirements.txt` and `requirements_pinned.txt` files that were removed in PR #805 when we switched to using `uv.lock` for dependency management.

### Context
PR #805 migrated our dependency management from pip requirements files to uv's lockfile format. This change updates the AWS batch job launcher to be compatible with the new system.

### Note
This is an interim fix while we work on replacing this system with Skypilot. The entrypoint.sh script was already updated in PR #805 to remove the `uv pip install -r requirements.txt` line, so only the validation logic needed updating.