### PR TITLE
Make sure seeds are deterministically different on different processes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(pytest:*)",
       "Bash(./devops/test_uv_setup.sh:*)",
       "Bash(rm:*)",
-      "WebFetch(domain:docs.astral.sh)"
+      "WebFetch(domain:docs.astral.sh)",
+      "Bash(ruff check:*)"
     ],
     "deny": []
   },

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -858,7 +858,11 @@ class PufferTrainer:
         if self.cfg.seed is None:
             self.cfg.seed = np.random.randint(0, 1000000)
 
-        self.vecenv.async_reset(self.cfg.seed)
+        # Use rank-specific seed for environment reset to ensure different 
+        # processes generate uncorrelated environments in distributed training
+        rank = int(os.environ.get("RANK", 0))
+        rank_specific_env_seed = self.cfg.seed + rank if self.cfg.seed is not None else rank
+        self.vecenv.async_reset(rank_specific_env_seed)
 
 
 class AbortingTrainer(PufferTrainer):

--- a/metta/util/runtime_configuration.py
+++ b/metta/util/runtime_configuration.py
@@ -12,15 +12,23 @@ from rich import traceback
 logger = logging.getLogger("runtime_configuration")
 
 
-def seed_everything(seed, torch_deterministic):
+def seed_everything(seed, torch_deterministic, rank: int = 0):
     # Despite these efforts, we still don't get deterministic behavior. But presumably
     # this is better than nothing.
     # https://docs.pytorch.org/docs/stable/notes/randomness.html#reproducibility
-    random.seed(seed)
-    np.random.seed(seed)
+    
+    # Add rank offset to base seed for distributed training to ensure different
+    # processes generate uncorrelated random sequences
     if seed is not None:
-        torch.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)
+        rank_specific_seed = seed + rank
+    else:
+        rank_specific_seed = rank
+    
+    random.seed(rank_specific_seed)
+    np.random.seed(rank_specific_seed)
+    if seed is not None:
+        torch.manual_seed(rank_specific_seed)
+        torch.cuda.manual_seed_all(rank_specific_seed)
     torch.backends.cudnn.deterministic = torch_deterministic
     torch.backends.cudnn.benchmark = not torch_deterministic
     torch.use_deterministic_algorithms(torch_deterministic)
@@ -56,6 +64,10 @@ def setup_mettagrid_environment(cfg):
 
     # print(OmegaConf.to_yaml(cfg))
     traceback.install(show_locals=False)
-    seed_everything(cfg.seed, cfg.torch_deterministic)
+    
+    # Get rank for distributed training seeding
+    rank = int(os.environ.get("RANK", 0))
+    seed_everything(cfg.seed, cfg.torch_deterministic, rank)
+    
     os.makedirs(cfg.run_dir, exist_ok=True)
     signal.signal(signal.SIGINT, lambda sig, frame: os._exit(0))


### PR DESCRIPTION
In order to make training reproducible, we manually set seeds for all random number generators; however, for distributed training, this has the effect of different processes generating the same experience.

Changes
We add the local rank to every seed. This way, we get different random numbers for every process but still keep them being reproducible.