### PR TITLE
Fix default values for object use.

### DIFF
--- a/configs/env/mettagrid/object_use/training/varied_terrain.yaml
+++ b/configs/env/mettagrid/object_use/training/varied_terrain.yaml
@@ -4,6 +4,8 @@ defaults:
 
 sampling: 1
 
+num_agents: 4
+
 game:
   num_agents: ${..num_agents}
   agent:


### PR DESCRIPTION
Minimal change that sets the number of agents in the `varied_terrain.yaml` file that defines the default parameters for the object-use training environment collection.