### PR TITLE
Fill with 0xff

### DIFF
--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -296,7 +296,13 @@ void MettaGrid::_step(py::array_t<int> actions) {
 
   auto obs_ptr = static_cast<uint8_t*>(_observations.request().ptr);
   auto obs_size = _observations.size();
-  std::fill(obs_ptr, obs_ptr + obs_size, 0);
+  if (_use_observation_tokens) {
+    // We want empty tokens to be 0xff, since 0s are very natural numbers to have in the observations, and we want
+    // empty to be obviously different.
+    std::fill(obs_ptr, obs_ptr + obs_size, 0xff);
+  } else {
+    std::fill(obs_ptr, obs_ptr + obs_size, 0);
+  }
 
   std::fill(_action_success.begin(), _action_success.end(), false);
 

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -297,9 +297,7 @@ void MettaGrid::_step(py::array_t<int> actions) {
   auto obs_ptr = static_cast<uint8_t*>(_observations.request().ptr);
   auto obs_size = _observations.size();
   if (_use_observation_tokens) {
-    // We want empty tokens to be 0xff, since 0s are very natural numbers to have in the observations, and we want
-    // empty to be obviously different.
-    std::fill(obs_ptr, obs_ptr + obs_size, 0xff);
+    std::fill(obs_ptr, obs_ptr + obs_size, EmptyTokenByte);
   } else {
     std::fill(obs_ptr, obs_ptr + obs_size, 0);
   }

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -19,6 +19,10 @@ enum GridLayer {
   GridLayerCount
 };
 
+// We want empty tokens to be 0xff, since 0s are very natural numbers to have in the observations, and we want
+// empty to be obviously different.
+const uint8_t EmptyTokenByte = 0xff;
+
 // Changing observation feature ids will break models that have
 // been trained on the old feature ids.
 // In the future, the string -> id mapping should be stored on a


### PR DESCRIPTION
# Fill empty observation tokens with 0xff

Adds a new constant `EmptyTokenByte` set to 0xff for empty tokens in observations. This makes empty tokens more distinguishable from natural zeros that might appear in observations.

When `_use_observation_tokens` is enabled, the code now fills observations with this empty token value instead of zeros.