### PR TITLE
make feature_ids dense

### DIFF
--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -34,19 +34,19 @@ const uint8_t EmptyTokenByte = 0xff;
 // The namespace allows us to use these descriptive names without conflicts.
 namespace ObservationFeature {
 enum ObservationFeatureEnum : uint8_t {
-  TypeId = 1,
-  Group = 2,
-  Hp = 3,
-  Frozen = 4,
-  Orientation = 5,
-  Color = 6,
-  ConvertingOrCoolingDown = 7,
-  Swappable = 8,
+  TypeId = 0,
+  Group = 1,
+  Hp = 2,
+  Frozen = 3,
+  Orientation = 4,
+  Color = 5,
+  ConvertingOrCoolingDown = 6,
+  Swappable = 7,
   ObservationFeatureCount
 };
 }  // namespace ObservationFeature
 
-const uint8_t InventoryFeatureOffset = 100;
+const uint8_t InventoryFeatureOffset = ObservationFeature::ObservationFeatureCount;
 
 // There should be a one-to-one mapping between ObjectType and ObjectTypeNames.
 // ObjectTypeName is mostly used for human-readability, but may be used as a key

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -88,7 +88,7 @@ class TestObservations:
         """Test observation token format and content."""
         c_env = create_minimal_mettagrid_c_env()
         # These come from constants in the C++ code, and are fragile.
-        TYPE_ID_FEATURE = 1
+        TYPE_ID_FEATURE = 0
         WALL_TYPE_ID = 1
         obs, info = c_env.reset()
         # Agent 0 starts at (1,1) and should see walls above and to the left


### PR DESCRIPTION
This is a silently-breaking change to make feature_ids dense.

This should fix normalization, and make it easier for token_to_box to work.