### PR TITLE
Assert that we're not copying `actions` when receiving them in mettagrid

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250603.3
+run_id: 20250606.4
 run: ${oc.env:USER}.local.${run_id}

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -291,14 +291,14 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
   }
 }
 
-void MettaGrid::_compute_observations(py::array_t<int32_t, py::array::c_style> actions) {
+void MettaGrid::_compute_observations(py::array_t<ActionType, py::array::c_style> actions) {
   for (size_t idx = 0; idx < _agents.size(); idx++) {
     auto& agent = _agents[idx];
     _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx);
   }
 }
 
-void MettaGrid::_step(py::array_t<int32_t, py::array::c_style> actions) {
+void MettaGrid::_step(py::array_t<ActionType, py::array::c_style> actions) {
   auto actions_view = actions.unchecked<2>();
 
   // Reset rewards and observations
@@ -469,7 +469,7 @@ void MettaGrid::set_buffers(const py::array_t<uint8_t, py::array::c_style>& obse
   validate_buffers();
 }
 
-py::tuple MettaGrid::step(py::array_t<int32_t, py::array::c_style> actions) {
+py::tuple MettaGrid::step(py::array_t<ActionType, py::array::c_style> actions) {
   _step(actions);
 
   auto rewards_view = _rewards.mutable_unchecked<1>();

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -291,14 +291,14 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
   }
 }
 
-void MettaGrid::_compute_observations(py::array_t<int> actions) {
+void MettaGrid::_compute_observations(py::array_t<int32_t, py::array::c_style> actions) {
   for (size_t idx = 0; idx < _agents.size(); idx++) {
     auto& agent = _agents[idx];
     _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx);
   }
 }
 
-void MettaGrid::_step(py::array_t<int> actions) {
+void MettaGrid::_step(py::array_t<int32_t, py::array::c_style> actions) {
   auto actions_view = actions.unchecked<2>();
 
   // Reset rewards and observations
@@ -469,7 +469,7 @@ void MettaGrid::set_buffers(const py::array_t<uint8_t, py::array::c_style>& obse
   validate_buffers();
 }
 
-py::tuple MettaGrid::step(py::array_t<int> actions) {
+py::tuple MettaGrid::step(py::array_t<int32_t, py::array::c_style> actions) {
   _step(actions);
 
   auto rewards_view = _rewards.mutable_unchecked<1>();

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -739,7 +739,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
   py::class_<MettaGrid>(m, "MettaGrid")
       .def(py::init<py::dict, py::list>())
       .def("reset", &MettaGrid::reset)
-      .def("step", &MettaGrid::step)
+      .def("step", &MettaGrid::step, py::arg("actions").noconvert())
       .def("set_buffers",
            &MettaGrid::set_buffers,
            py::arg("observations").noconvert(),

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -40,7 +40,8 @@ public:
 
   // Python API methods
   py::tuple reset();
-  py::tuple step(py::array_t<int> actions);
+  // In general, these types need to match what puffer wants to use.
+  py::tuple step(py::array_t<int32_t, py::array::c_style> actions);
   void set_buffers(const py::array_t<unsigned char, py::array::c_style>& observations,
                    const py::array_t<bool, py::array::c_style>& terminals,
                    const py::array_t<bool, py::array::c_style>& truncations,
@@ -112,8 +113,8 @@ private:
                             unsigned short obs_width,
                             unsigned short obs_height,
                             size_t agent_idx);
-  void _compute_observations(py::array_t<int> actions);
-  void _step(py::array_t<int> actions);
+  void _compute_observations(py::array_t<int32_t, py::array::c_style> actions);
+  void _step(py::array_t<int32_t, py::array::c_style> actions);
 };
 
 #endif  // METTAGRID_METTAGRID_METTAGRID_C_HPP_

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -115,8 +115,8 @@ private:
                             unsigned short obs_width,
                             unsigned short obs_height,
                             size_t agent_idx);
-  void _compute_observations(py::array_t<int32_t, py::array::c_style> actions);
-  void _step(py::array_t<int32_t, py::array::c_style> actions);
+  void _compute_observations(py::array_t<ActionType, py::array::c_style> actions);
+  void _step(py::array_t<ActionType, py::array::c_style> actions);
 };
 
 #endif  // METTAGRID_METTAGRID_METTAGRID_C_HPP_

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "types.hpp"
+
 // Forward declarations of existing C++ classes
 class Grid;
 class EventManager;
@@ -41,11 +43,11 @@ public:
   // Python API methods
   py::tuple reset();
   // In general, these types need to match what puffer wants to use.
-  py::tuple step(py::array_t<int32_t, py::array::c_style> actions);
-  void set_buffers(const py::array_t<unsigned char, py::array::c_style>& observations,
-                   const py::array_t<bool, py::array::c_style>& terminals,
-                   const py::array_t<bool, py::array::c_style>& truncations,
-                   const py::array_t<float, py::array::c_style>& rewards);
+  py::tuple step(py::array_t<ActionType, py::array::c_style> actions);
+  void set_buffers(const py::array_t<ObservationType, py::array::c_style>& observations,
+                   const py::array_t<TerminalType, py::array::c_style>& terminals,
+                   const py::array_t<TruncationType, py::array::c_style>& truncations,
+                   const py::array_t<RewardType, py::array::c_style>& rewards);
   void validate_buffers();
   py::dict grid_objects();
   py::list action_names();

--- a/mettagrid/tests/test_basic.py
+++ b/mettagrid/tests/test_basic.py
@@ -1,9 +1,10 @@
+import numpy as np
 import pytest
 from gymnasium.spaces import Box, MultiDiscrete
 from omegaconf import OmegaConf
 
 from mettagrid.curriculum import SingleTaskCurriculum
-from mettagrid.mettagrid_env import MettaGridEnv
+from mettagrid.mettagrid_env import MettaGridEnv, dtype_actions
 from mettagrid.util.hydra import get_cfg
 
 
@@ -79,7 +80,8 @@ class TestEnvironmentFunctionality:
 
         num_agents = environment._c_env.num_agents
         # Take a step with NoOp actions for all agents
-        (obs, rewards, terminated, truncated, infos) = environment.step([[0, 0]] * num_agents)
+        actions = np.array([[0, 0]] * num_agents, dtype=dtype_actions)
+        (obs, rewards, terminated, truncated, infos) = environment.step(actions)
 
         # Check timestep increased
         assert environment._c_env.current_step == 1

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -89,7 +89,7 @@ class TestBuffers:
         c_env.reset()
 
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
         obs, rewards, terminals, truncations, info = c_env.step(actions)
         episode_rewards = c_env.get_episode_rewards()
 
@@ -255,7 +255,7 @@ class TestBuffers:
 
         # Take a step - this should overwrite our manual values
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         obs_returned, rewards_returned, terminals_returned, truncations_returned, info = c_env.step(actions)
 
@@ -294,7 +294,7 @@ class TestBuffers:
 
         # Take one step to reach max_steps
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
         c_env.step(actions)  # current_step = 1, should trigger truncations
 
         # Now truncations should all be True
@@ -314,7 +314,7 @@ class TestBuffers:
 
         # Take a step to get valid baseline values
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
         c_env.step(actions)
 
         # Store initial values
@@ -435,7 +435,7 @@ class TestBuffers:
         gym_obs, gym_info = gym_env.reset()
 
         noop_action_idx = gym_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         gym_obs_step, gym_rewards, gym_terminals, gym_truncations, gym_info_step = gym_env.step(actions)
         gym_episode_rewards = gym_env.get_episode_rewards()

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -405,7 +405,7 @@ class TestBuffers:
 
         # Take first step
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         obs, step_rewards_1, terminals_ret, truncations_ret, _info = c_env.step(actions)
         episode_rewards_1 = c_env.get_episode_rewards()

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from mettagrid.mettagrid_c import MettaGrid
+from mettagrid.mettagrid_env import dtype_actions, dtype_observations, dtype_rewards, dtype_terminals, dtype_truncations
 
 NUM_AGENTS = 2
 OBS_HEIGHT = 3
@@ -89,7 +90,7 @@ class TestBuffers:
         c_env.reset()
 
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
         obs, rewards, terminals, truncations, info = c_env.step(actions)
         episode_rewards = c_env.get_episode_rewards()
 
@@ -161,28 +162,32 @@ class TestBuffers:
         c_env = create_minimal_mettagrid_c_env()
 
         # Correct buffers for comparison
-        observations = np.zeros((NUM_AGENTS, NUM_OBS_TOKENS, OBS_TOKEN_SIZE), dtype=np.uint8)
-        terminals = np.zeros(NUM_AGENTS, dtype=bool)
-        truncations = np.zeros(NUM_AGENTS, dtype=bool)
-        rewards = np.zeros(NUM_AGENTS, dtype=np.float32)
+        observations = np.zeros((NUM_AGENTS, NUM_OBS_TOKENS, OBS_TOKEN_SIZE), dtype=dtype_observations)
+        terminals = np.zeros(NUM_AGENTS, dtype=dtype_terminals)
+        truncations = np.zeros(NUM_AGENTS, dtype=dtype_truncations)
+        rewards = np.zeros(NUM_AGENTS, dtype=dtype_rewards)
 
         # Wrong observation dtype
         wrong_obs = np.zeros((NUM_AGENTS, NUM_OBS_TOKENS, OBS_TOKEN_SIZE), dtype=np.float32)
+        assert wrong_obs.dtype != dtype_observations
         with pytest.raises(TypeError):
             c_env.set_buffers(wrong_obs, terminals, truncations, rewards)
 
         # Wrong terminals dtype
         wrong_terminals = np.zeros(NUM_AGENTS, dtype=np.int32)
+        assert wrong_terminals.dtype != dtype_terminals
         with pytest.raises(TypeError):
             c_env.set_buffers(observations, wrong_terminals, truncations, rewards)
 
         # Wrong truncations dtype
         wrong_truncations = np.zeros(NUM_AGENTS, dtype=np.int32)
+        assert wrong_truncations.dtype != dtype_truncations
         with pytest.raises(TypeError):
             c_env.set_buffers(observations, terminals, wrong_truncations, rewards)
 
         # Wrong rewards dtype
         wrong_rewards = np.zeros(NUM_AGENTS, dtype=np.float64)
+        assert wrong_rewards.dtype != dtype_rewards
         with pytest.raises(TypeError):
             c_env.set_buffers(observations, terminals, truncations, wrong_rewards)
 
@@ -255,7 +260,7 @@ class TestBuffers:
 
         # Take a step - this should overwrite our manual values
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         obs_returned, rewards_returned, terminals_returned, truncations_returned, info = c_env.step(actions)
 
@@ -294,7 +299,7 @@ class TestBuffers:
 
         # Take one step to reach max_steps
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
         c_env.step(actions)  # current_step = 1, should trigger truncations
 
         # Now truncations should all be True
@@ -314,7 +319,7 @@ class TestBuffers:
 
         # Take a step to get valid baseline values
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
         c_env.step(actions)
 
         # Store initial values
@@ -405,7 +410,7 @@ class TestBuffers:
 
         # Take first step
         noop_action_idx = c_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         obs, step_rewards_1, terminals_ret, truncations_ret, _info = c_env.step(actions)
         episode_rewards_1 = c_env.get_episode_rewards()
@@ -435,7 +440,7 @@ class TestBuffers:
         gym_obs, gym_info = gym_env.reset()
 
         noop_action_idx = gym_env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         gym_obs_step, gym_rewards, gym_terminals, gym_truncations, gym_info_step = gym_env.step(actions)
         gym_episode_rewards = gym_env.get_episode_rewards()

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from mettagrid.mettagrid_c import MettaGrid
+from mettagrid.mettagrid_env import dtype_actions
 
 NUM_AGENTS = 2
 OBS_HEIGHT = 3
@@ -64,14 +65,14 @@ def test_truncation_at_max_steps():
     """Test that environments properly truncate at max_steps."""
     max_steps = 5
     c_env = create_minimal_mettagrid_c_env(max_steps=max_steps)
-    obs, info = c_env.reset()
+    _obs, _info = c_env.reset()
 
     # Noop until time runs out
     noop_action_idx = c_env.action_names().index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
     for step_num in range(1, max_steps + 1):
-        obs, rewards, terminals, truncations, info = c_env.step(actions)
+        _obs, _rewards, terminals, truncations, _info = c_env.step(actions)
         if step_num < max_steps:
             assert not np.any(truncations), f"Truncations should be False before max_steps at step {step_num}"
             assert not np.any(terminals), f"Terminals should be False before max_steps at step {step_num}"
@@ -90,7 +91,7 @@ class TestObservations:
         # These come from constants in the C++ code, and are fragile.
         TYPE_ID_FEATURE = 0
         WALL_TYPE_ID = 1
-        obs, info = c_env.reset()
+        obs, _info = c_env.reset()
         # Agent 0 starts at (1,1) and should see walls above and to the left
         # for now we treat the walls as "something non-empty"
         for x, y in [(0, 1), (1, 0)]:
@@ -105,7 +106,7 @@ class TestObservations:
     def test_observation_token_order(self):
         """Test observation token order."""
         c_env = create_minimal_mettagrid_c_env()
-        obs, info = c_env.reset()
+        obs, _info = c_env.reset()
         distances = []
         for location in obs[0, :, 0]:
             # cast as ints to avoid numpy uint8 underflow
@@ -176,7 +177,7 @@ def test_action_interface():
 
     # Test basic action execution
     noop_action_idx = action_names.index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
     obs, rewards, terminals, truncations, info = c_env.step(actions)
 
@@ -203,7 +204,7 @@ def test_environment_state_consistency():
 
     # Take a noop action (should not change world state significantly)
     noop_action_idx = c_env.action_names().index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
     _obs2, _rewards, _terminals, _truncations, _info2 = c_env.step(actions)
     post_step_objects = c_env.grid_objects()

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -68,7 +68,7 @@ def test_truncation_at_max_steps():
 
     # Noop until time runs out
     noop_action_idx = c_env.action_names().index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
     for step_num in range(1, max_steps + 1):
         obs, rewards, terminals, truncations, info = c_env.step(actions)
@@ -176,7 +176,7 @@ def test_action_interface():
 
     # Test basic action execution
     noop_action_idx = action_names.index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
     obs, rewards, terminals, truncations, info = c_env.step(actions)
 
@@ -203,7 +203,7 @@ def test_environment_state_consistency():
 
     # Take a noop action (should not change world state significantly)
     noop_action_idx = c_env.action_names().index("noop")
-    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+    actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
     _obs2, _rewards, _terminals, _truncations, _info2 = c_env.step(actions)
     post_step_objects = c_env.grid_objects()

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -182,7 +182,7 @@ class TestRewards:
 
         # Take a step with noop actions
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         obs, step_rewards, terminals, truncations, info = env.step(actions)
 
@@ -279,7 +279,7 @@ class TestRewards:
 
         # Take first step
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         obs, step_rewards_1, terminals, truncations, info = env.step(actions)
         episode_rewards_1 = env.get_episode_rewards()
@@ -312,7 +312,7 @@ class TestRewards:
 
         # Take steps
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int64)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
 
         obs, step_rewards_1, terminals, truncations, info = env.step(actions)
         episode_rewards_1 = env.get_episode_rewards()

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -182,7 +182,7 @@ class TestRewards:
 
         # Take a step with noop actions
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         obs, step_rewards, terminals, truncations, info = env.step(actions)
 
@@ -279,7 +279,7 @@ class TestRewards:
 
         # Take first step
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         obs, step_rewards_1, terminals, truncations, info = env.step(actions)
         episode_rewards_1 = env.get_episode_rewards()
@@ -312,7 +312,7 @@ class TestRewards:
 
         # Take steps
         noop_action_idx = env.action_names().index("noop")
-        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=np.int32)
+        actions = np.full((NUM_AGENTS, 2), [noop_action_idx, 0], dtype=dtype_actions)
 
         obs, step_rewards_1, terminals, truncations, info = env.step(actions)
         episode_rewards_1 = env.get_episode_rewards()


### PR DESCRIPTION
Update the MettaGrid C++ interface to explicitly use `int32_t` parameters instead of the generic `int` type, and assert that we're not making unexpected copies. This should _not_ be a correctness issue, since we only read from the actions array; but we've gotten burned by unexpected copying before, so it's nice to root out.

Tested by running `train`. If this were incompatible with what puffer was sending, I would expect to see an immediate crash.