### PR TITLE
Remove hp and swappable tokens

### DIFF
--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -115,7 +115,6 @@ public:
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Group, group});
-    features.push_back({ObservationFeature::Hp, hp});
     features.push_back({ObservationFeature::Frozen, frozen});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -157,7 +157,6 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
-    features.push_back({ObservationFeature::Hp, hp});
     features.push_back({ObservationFeature::Color, color});
     features.push_back({ObservationFeature::ConvertingOrCoolingDown, this->converting || this->cooling_down});
     for (uint8_t i = 0; i < InventoryItem::InventoryItemCount; i++) {

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -21,8 +21,10 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
-    features.push_back({ObservationFeature::Hp, hp});
-    features.push_back({ObservationFeature::Swappable, _swappable});
+    if (_swappable) {
+      // Only emit the token if it's swappable, to reduce the number of tokens.
+      features.push_back({ObservationFeature::Swappable, 1});
+    }
     return features;
   }
 


### PR DESCRIPTION
This optimizes some token emission. The main point is to reduce walls from 3 tokens to 1.

- Remove `hp` observation feature. For Agent this shouldn't matter at all, since Agent hp don't matter. Converters and walls can technically be destroyed, but this should be an almost-never experience, and is something we should probably remove.
- Only emit the `Swappable` token for `Wall` objects when they are actually swappable