### PR TITLE
prioritize central tokens

### DIFF
--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -115,7 +115,6 @@ public:
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Group, group});
-    features.push_back({ObservationFeature::Hp, hp});
     features.push_back({ObservationFeature::Frozen, frozen});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -157,7 +157,6 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
-    features.push_back({ObservationFeature::Hp, hp});
     features.push_back({ObservationFeature::Color, color});
     features.push_back({ObservationFeature::ConvertingOrCoolingDown, this->converting || this->cooling_down});
     for (uint8_t i = 0; i < InventoryItem::InventoryItemCount; i++) {

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -21,8 +21,10 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.push_back({ObservationFeature::TypeId, _type_id});
-    features.push_back({ObservationFeature::Hp, hp});
-    features.push_back({ObservationFeature::Swappable, _swappable});
+    if (_swappable) {
+      // Only emit the token if it's swappable, to reduce the number of tokens.
+      features.push_back({ObservationFeature::Swappable, 1});
+    }
     return features;
   }
 

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -102,6 +102,17 @@ class TestObservations:
             token_matches = obs[0, :, 0] == location
             assert not token_matches.any(), f"Expected no tokens at location {x}, {y}"
 
+    def test_observation_token_order(self):
+        """Test observation token order."""
+        c_env = create_minimal_mettagrid_c_env()
+        obs, info = c_env.reset()
+        distances = []
+        for location in obs[0, :, 0]:
+            # cast as ints to avoid numpy uint8 underflow
+            x = int(location >> 4)
+            y = int(location & 0xf)
+            distances.append(abs(x - 1) + abs(y - 1)) # 1,1 is the agent's location
+        assert distances == sorted(distances), f"Distances should be increasing: {distances}"
 
 def test_grid_objects():
     """Test grid object representation and properties."""

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -110,9 +110,10 @@ class TestObservations:
         for location in obs[0, :, 0]:
             # cast as ints to avoid numpy uint8 underflow
             x = int(location >> 4)
-            y = int(location & 0xf)
-            distances.append(abs(x - 1) + abs(y - 1)) # 1,1 is the agent's location
+            y = int(location & 0xF)
+            distances.append(abs(x - 1) + abs(y - 1))  # 1,1 is the agent's location
         assert distances == sorted(distances), f"Distances should be increasing: {distances}"
+
 
 def test_grid_objects():
     """Test grid object representation and properties."""


### PR DESCRIPTION
Orders observation tokens by distance from the agent, ensuring closer objects are prioritized when tokens need to be dropped.

Previously, objects were processed in row-column order, which meant that if token limits were reached, arbitrary objects would be dropped regardless of their relevance to the agent. The new implementation starts at distance zero and works outwards from there.

Added a test case in `test_mettagrid.py` to verify that observation tokens are indeed ordered by increasing distance from the agent.

### Why make this change?

This change implements a previously noted TODO in the code. When an agent has limited observation capacity, it's more important to be aware of nearby objects than distant ones. By ordering tokens by distance, we ensure that if tokens need to be dropped due to capacity constraints, the farthest (and likely least relevant) objects will be dropped first, improving the agent's situational awareness.