### PR TITLE
Update simulation compatibility exceptions

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250606.5
+run_id: 20250609.16
 run: ${oc.env:USER}.local.${run_id}

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -61,14 +61,6 @@ class PolicyRecord:
             raise TypeError(f"Expected MettaAgent or DistributedMettaAgent, got {type(policy).__name__}")
         return policy
 
-    def expected_observation_channels(self) -> Optional[int]:
-        policy = self.policy()
-        try:
-            cnn1_weight = policy.get_parameter("components.cnn1._net.0.weight")
-            return cnn1_weight.shape[1]
-        except AttributeError:
-            return None
-
     def num_params(self) -> int:
         return sum(p.numel() for p in self.policy().parameters() if p.requires_grad)
 

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -107,27 +107,6 @@ class Simulation:
         self._npc_pr = policy_store.policy(config.npc_policy_uri) if config.npc_policy_uri else None
         self._policy_agents_pct = config.policy_agents_pct if self._npc_pr is not None else 1.0
 
-        policy_expected_channels = self._policy_pr.expected_observation_channels()
-        npc_policy_expected_channels = self._npc_pr.expected_observation_channels() if self._npc_pr else None
-        env_expected_channels = self._vecenv.observation_space.shape[-1]
-
-        if policy_expected_channels is not None and policy_expected_channels != env_expected_channels:
-            error_msg = (
-                f"Main policy expects {policy_expected_channels} observation channels, "
-                f"but current environment provides {env_expected_channels}."
-            )
-            logger.error(error_msg)
-            raise SimulationCompatibilityError(error_msg)
-
-        # Check NPC policy compatibility (if it exists)
-        if npc_policy_expected_channels is not None and npc_policy_expected_channels != env_expected_channels:
-            error_msg = (
-                f"NPC policy expects {npc_policy_expected_channels} observation channels, "
-                f"but current environment provides {env_expected_channels}."
-            )
-            logger.error(error_msg)
-            raise SimulationCompatibilityError(error_msg)
-
         metta_grid_env: MettaGridEnv = self._vecenv.driver_env  # type: ignore
         assert isinstance(metta_grid_env, MettaGridEnv)
 
@@ -142,7 +121,11 @@ class Simulation:
         if self._npc_pr is not None:
             npc_agent: MettaAgent | DistributedMettaAgent = self._npc_pr.policy_as_metta_agent()
             assert isinstance(npc_agent, (MettaAgent, DistributedMettaAgent)), npc_agent
-            npc_agent.activate_actions(action_names, max_args, self._device)
+            try:
+                npc_agent.activate_actions(action_names, max_args, self._device)
+            except Exception as e:
+                logger.error(f"Error activating NPC actions: {e}")
+                raise SimulationCompatibilityError(f"[{self._name}] Error activating NPC actions for {self._npc_pr.name}: {e}")
 
         # ---------------- agent-index bookkeeping ---------------------- #
         idx_matrix = torch.arange(metta_grid_env.num_agents * self._num_envs, device=self._device).reshape(
@@ -230,7 +213,11 @@ class Simulation:
             if self._npc_pr is not None and len(self._npc_idxs):
                 npc_obs = obs_t[self._npc_idxs]
                 npc_policy = self._npc_pr.policy()
-                npc_actions, _, _, _, _ = npc_policy(npc_obs, self._npc_state)
+                try:
+                    npc_actions, _, _, _, _ = npc_policy(npc_obs, self._npc_state)
+                except Exception as e:
+                    logger.error(f"Error generating NPC actions: {e}")
+                    raise SimulationCompatibilityError(f"[{self._name}] Error generating NPC actions for {self._npc_pr.name}: {e}")
         # ---------------- action stitching ----------------------- #
         actions = policy_actions
         if self._npc_agents_per_env:

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -125,7 +125,9 @@ class Simulation:
                 npc_agent.activate_actions(action_names, max_args, self._device)
             except Exception as e:
                 logger.error(f"Error activating NPC actions: {e}")
-                raise SimulationCompatibilityError(f"[{self._name}] Error activating NPC actions for {self._npc_pr.name}: {e}")
+                raise SimulationCompatibilityError(
+                    f"[{self._name}] Error activating NPC actions for {self._npc_pr.name}: {e}"
+                )
 
         # ---------------- agent-index bookkeeping ---------------------- #
         idx_matrix = torch.arange(metta_grid_env.num_agents * self._num_envs, device=self._device).reshape(
@@ -217,7 +219,9 @@ class Simulation:
                     npc_actions, _, _, _, _ = npc_policy(npc_obs, self._npc_state)
                 except Exception as e:
                     logger.error(f"Error generating NPC actions: {e}")
-                    raise SimulationCompatibilityError(f"[{self._name}] Error generating NPC actions for {self._npc_pr.name}: {e}")
+                    raise SimulationCompatibilityError(
+                        f"[{self._name}] Error generating NPC actions for {self._npc_pr.name}: {e}"
+                    )
         # ---------------- action stitching ----------------------- #
         actions = policy_actions
         if self._npc_agents_per_env:


### PR DESCRIPTION
Remove observation channel compatibility checks and added better error handling for NPC policy actions.

### What changed?

- Removed the `expected_observation_channels()` method from `PolicyStore` class
- Removed the observation channel compatibility checks in the `Simulation` initialization
- Added try/except blocks around NPC action activation and generation with more descriptive error messages

### Why make this change?

The observation channel compatibility checks were fragile, and breaking in unhelpful ways as we switch to tokens. The new approach tries to capture the "don't crash on incompatible NPCs" that we had, while allowing more flexibility in policy design.