### PR TITLE
preallocate obs vectors

### DIFF
--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -113,6 +113,7 @@ public:
 
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
+    features.reserve(5 + InventoryItem::InventoryItemCount);
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Group, group});
     features.push_back({ObservationFeature::Frozen, frozen});

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -156,6 +156,7 @@ public:
 
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
+    features.reserve(5 + InventoryItem::InventoryItemCount);
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Color, color});
     features.push_back({ObservationFeature::ConvertingOrCoolingDown, this->converting || this->cooling_down});

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -20,6 +20,7 @@ public:
 
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
+    features.reserve(2);
     features.push_back({ObservationFeature::TypeId, _type_id});
     if (_swappable) {
       // Only emit the token if it's swappable, to reduce the number of tokens.


### PR DESCRIPTION
Presize observation vectors to reduce the number of times we need to allocate memory while using them.

This should be a no-brainer, but I'm running perf tests on this to see what the impact is.