### PR TITLE
fix: report delta steps per sec

### DIFF
--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -231,6 +231,8 @@ class PufferTrainer:
 
         logger.info(f"Training on {self.device}")
         while self.agent_step < self.trainer_cfg.total_timesteps:
+            steps_before = self.agent_step
+
             with self.torch_profiler:
                 with self.timer("_rollout"):
                     self._rollout()
@@ -245,7 +247,8 @@ class PufferTrainer:
             rollout_time = self.timer.get_last_elapsed("_rollout")
             train_time = self.timer.get_last_elapsed("_train")
             stats_time = self.timer.get_last_elapsed("_process_stats")
-            steps_per_sec = self.agent_step / (train_time + rollout_time)
+            steps_calculated = self.agent_step - steps_before
+            steps_per_sec = steps_calculated / (train_time + rollout_time)
 
             logger.info(
                 f"Epoch {self.epoch} - "


### PR DESCRIPTION
## Fix steps per second calculation to show delta instead of cumulative

### Problem
The current steps per second calculation reported in trainer logs uses the total `agent_step` count divided by the current epoch's timing, which produces misleading metrics that grow larger over time rather than showing the actual performance of each training epoch.

### Solution
- Track steps at the beginning of each epoch (`steps_before`)
- Calculate delta steps for the current epoch (`steps_calculated = self.agent_step - steps_before`)
- Use delta steps in the steps per second calculation instead of cumulative total

### Result
The reported steps per second now accurately reflects the training performance for each individual epoch, making it easier to monitor training efficiency and identify performance regressions.
