### PR TITLE
Create stairs and add TallBridge

### DIFF
--- a/configs/env/mettagrid/mettagrid_zlevels.yaml
+++ b/configs/env/mettagrid/mettagrid_zlevels.yaml
@@ -1,0 +1,22 @@
+# Configuration for Mettagrid with Z-levels, stairs, and tall bridges
+defaults:
+  - mettagrid
+
+game:
+  objects:
+    stairs:
+      hp: 100
+      swappable: false
+
+    tallbridge:
+      hp: 100
+      swappable: false
+
+  actions:
+    climb:
+      enabled: true
+
+# Sample map with stairs and tall bridges
+# 'S' = stairs, 'B' = tallbridge, 'W' = wall, 'A' = agent, '.' = empty
+# The walls will act as floors at the upper Z-level
+# TallBridges allow agents to walk on top while agents below can walk underneath

--- a/mettagrid/mettagrid/actions/climb.hpp
+++ b/mettagrid/mettagrid/actions/climb.hpp
@@ -1,0 +1,51 @@
+#ifndef METTAGRID_METTAGRID_ACTIONS_CLIMB_HPP_
+#define METTAGRID_METTAGRID_ACTIONS_CLIMB_HPP_
+
+#include <string>
+
+#include "action_handler.hpp"
+#include "grid_object.hpp"
+#include "objects/agent.hpp"
+#include "objects/stairs.hpp"
+
+class Climb : public ActionHandler {
+public:
+  explicit Climb(const ActionConfig& cfg) : ActionHandler(cfg, "climb") {}
+
+  unsigned char max_arg() const override {
+    return 1;  // 0 = up, 1 = down
+  }
+
+protected:
+  bool _handle_action(Agent* actor, ActionArg arg) override {
+    bool going_up = (arg == 0);
+
+    // Check current Z-level
+    if (going_up && actor->z_level > 0) {
+      return false;  // Already at top level
+    }
+    if (!going_up && actor->z_level == 0) {
+      return false;  // Already at ground level
+    }
+
+    // Check if there are stairs at the current location
+    GridLocation stairs_loc = actor->location;
+    stairs_loc.layer = GridLayer::Object_Layer;
+
+    GridObject* obj = _grid->object_at(stairs_loc);
+    if (!obj || obj->_type_id != ObjectType::StairsT) {
+      return false;  // No stairs here
+    }
+
+    // Change Z-level
+    if (going_up) {
+      actor->z_level = 1;
+    } else {
+      actor->z_level = 0;
+    }
+
+    return true;
+  }
+};
+
+#endif  // METTAGRID_METTAGRID_ACTIONS_CLIMB_HPP_

--- a/mettagrid/mettagrid/actions/move.hpp
+++ b/mettagrid/mettagrid/actions/move.hpp
@@ -6,6 +6,7 @@
 #include "action_handler.hpp"
 #include "grid_object.hpp"
 #include "objects/agent.hpp"
+#include "objects/constants.hpp"
 
 class Move : public ActionHandler {
 public:
@@ -34,9 +35,37 @@ protected:
 
     GridLocation old_loc = actor->location;
     GridLocation new_loc = _grid->relative_location(old_loc, orientation);
-    if (!_grid->is_empty(new_loc.r, new_loc.c)) {
-      return false;
+
+    // Check if the new location is walkable based on Z-level
+    if (actor->z_level == 0) {
+      // Ground level - check for walls and other objects normally
+      if (!_grid->is_empty(new_loc.r, new_loc.c)) {
+        // Check if there's a TallBridge - we can walk under it
+        GridLocation obj_loc(new_loc.r, new_loc.c, GridLayer::Object_Layer);
+        GridObject* obj = _grid->object_at(obj_loc);
+        if (!obj || obj->_type_id != ObjectType::TallBridgeT) {
+          return false;  // Blocked by something that's not a TallBridge
+        }
+      }
+    } else {
+      // Upper Z-level - walls act as floors, only check agent layer
+      GridLocation agent_loc(new_loc.r, new_loc.c, GridLayer::Agent_Layer);
+      if (_grid->object_at(agent_loc) != nullptr) {
+        // Check if the other agent is at the same Z-level
+        Agent* other_agent = static_cast<Agent*>(_grid->object_at(agent_loc));
+        if (other_agent && other_agent->z_level == actor->z_level) {
+          return false;  // Blocked by agent at same Z-level
+        }
+      }
+
+      // Check if there's a wall below us (acts as floor) or a TallBridge
+      GridLocation obj_loc(new_loc.r, new_loc.c, GridLayer::Object_Layer);
+      GridObject* obj = _grid->object_at(obj_loc);
+      if (!obj || (obj->_type_id != ObjectType::WallT && obj->_type_id != ObjectType::TallBridgeT)) {
+        return false;  // No floor to walk on at upper level
+      }
     }
+
     return _grid->move_object(actor->id, new_loc);
   }
 };

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -16,6 +16,7 @@ public:
   unsigned char frozen;
   unsigned char freeze_duration;
   unsigned char orientation;
+  unsigned char z_level;  // Track agent's Z-level (0 = ground, 1 = elevated)
   std::vector<unsigned char> inventory;
   std::vector<float> resource_rewards;
   std::vector<float> resource_reward_max;
@@ -43,6 +44,7 @@ public:
     this->frozen = 0;
     this->freeze_duration = cfg["freeze_duration"];
     this->orientation = 0;
+    this->z_level = 0;  // Initialize to ground level
     this->inventory.resize(InventoryItem::InventoryItemCount);
     unsigned char default_item_max = cfg["default_item_max"];
     this->max_items_per_type.resize(InventoryItem::InventoryItemCount);
@@ -119,6 +121,7 @@ public:
     features.push_back({ObservationFeature::Frozen, frozen});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});
+    features.push_back({ObservationFeature::ZLevel, z_level});
     for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
       if (inventory[i] > 0) {
         features.push_back({static_cast<uint8_t>(InventoryFeatureOffset + i), inventory[i]});
@@ -135,9 +138,10 @@ public:
     obs[offsets[4]] = frozen;
     obs[offsets[5]] = orientation;
     obs[offsets[6]] = color;
+    obs[offsets[7]] = z_level;
 
     for (int i = 0; i < InventoryItemCount; i++) {
-      obs[offsets[7 + i]] = inventory[i];
+      obs[offsets[8 + i]] = inventory[i];
     }
   }
 
@@ -150,6 +154,7 @@ public:
     names.push_back("agent:frozen");
     names.push_back("agent:orientation");
     names.push_back("agent:color");
+    names.push_back("agent:z_level");
 
     for (const auto& name : InventoryItemNames) {
       names.push_back("inv:" + name);

--- a/mettagrid/mettagrid/objects/constants.hpp
+++ b/mettagrid/mettagrid/objects/constants.hpp
@@ -42,6 +42,7 @@ enum ObservationFeatureEnum : uint8_t {
   Color = 5,
   ConvertingOrCoolingDown = 6,
   Swappable = 7,
+  ZLevel = 8,
   ObservationFeatureCount
 };
 }  // namespace ObservationFeature
@@ -67,11 +68,13 @@ enum ObjectType {
   FactoryT = 8,
   TempleT = 9,
   GenericConverterT = 10,
+  StairsT = 11,
+  TallBridgeT = 12,
   ObjectTypeCount
 };
 
 constexpr std::array<const char*, ObjectTypeCount> ObjectTypeNamesArray = {
-    {"agent", "wall", "mine", "generator", "altar", "armory", "lasery", "lab", "factory", "temple", "converter"}};
+    {"agent", "wall", "mine", "generator", "altar", "armory", "lasery", "lab", "factory", "temple", "converter", "stairs", "tallbridge"}};
 
 const std::vector<std::string> ObjectTypeNames(ObjectTypeNamesArray.begin(), ObjectTypeNamesArray.end());
 
@@ -117,6 +120,7 @@ const std::map<std::string, float> FeatureNormalizations = {
     {"agent:orientation", 1.0},
     {"agent:shield", 1.0},
     {"agent:color", 255.0},
+    {"agent:z_level", 1.0},
     {"converter", 1.0},
     {"inv:ore.red", 100.0},
     {"inv:ore.blue", 100.0},
@@ -136,6 +140,7 @@ const std::map<std::string, float> FeatureNormalizations = {
     {"color", 10.0},
     {"swappable", 1.0},
     {"type_id", 10.0},
+    {"z_level", 1.0},
 };
 
 const float DEFAULT_NORMALIZATION = 1.0;
@@ -149,6 +154,8 @@ const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer
                                                   {ObjectType::LaseryT, GridLayer::Object_Layer},
                                                   {ObjectType::LabT, GridLayer::Object_Layer},
                                                   {ObjectType::FactoryT, GridLayer::Object_Layer},
-                                                  {ObjectType::TempleT, GridLayer::Object_Layer}};
+                                                  {ObjectType::TempleT, GridLayer::Object_Layer},
+                                                  {ObjectType::StairsT, GridLayer::Object_Layer},
+                                                  {ObjectType::TallBridgeT, GridLayer::Object_Layer}};
 
 #endif  // METTAGRID_METTAGRID_OBJECTS_CONSTANTS_HPP_

--- a/mettagrid/mettagrid/objects/stairs.hpp
+++ b/mettagrid/mettagrid/objects/stairs.hpp
@@ -1,0 +1,42 @@
+#ifndef METTAGRID_METTAGRID_OBJECTS_STAIRS_HPP_
+#define METTAGRID_METTAGRID_OBJECTS_STAIRS_HPP_
+
+#include <string>
+#include <vector>
+
+#include "../grid_object.hpp"
+#include "constants.hpp"
+#include "metta_object.hpp"
+
+class Stairs : public MettaObject {
+public:
+  Stairs(GridCoord r, GridCoord c, ObjectConfig cfg) {
+    GridObject::init(ObjectType::StairsT, GridLocation(r, c, GridLayer::Object_Layer));
+    MettaObject::init_mo(cfg);
+  }
+
+  virtual vector<PartialObservationToken> obs_features() const override {
+    vector<PartialObservationToken> features;
+    features.push_back({ObservationFeature::TypeId, _type_id});
+    features.push_back({ObservationFeature::Hp, hp});
+    return features;
+  }
+
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
+    obs[offsets[0]] = _type_id;
+    obs[offsets[1]] = this->hp;
+  }
+
+  static std::vector<std::string> feature_names() {
+    std::vector<std::string> names;
+    names.push_back("type_id");
+    names.push_back("hp");
+    return names;
+  }
+
+  virtual bool swappable() const override {
+    return false;
+  }
+};
+
+#endif  // METTAGRID_METTAGRID_OBJECTS_STAIRS_HPP_

--- a/mettagrid/mettagrid/objects/tallbridge.hpp
+++ b/mettagrid/mettagrid/objects/tallbridge.hpp
@@ -1,0 +1,45 @@
+#ifndef METTAGRID_METTAGRID_OBJECTS_TALLBRIDGE_HPP_
+#define METTAGRID_METTAGRID_OBJECTS_TALLBRIDGE_HPP_
+
+#include <string>
+#include <vector>
+
+#include "../grid_object.hpp"
+#include "constants.hpp"
+#include "metta_object.hpp"
+
+class TallBridge : public MettaObject {
+public:
+  TallBridge(GridCoord r, GridCoord c, ObjectConfig cfg) {
+    GridObject::init(ObjectType::TallBridgeT, GridLocation(r, c, GridLayer::Object_Layer));
+    MettaObject::init_mo(cfg);
+  }
+
+  virtual vector<PartialObservationToken> obs_features() const override {
+    vector<PartialObservationToken> features;
+    features.push_back({ObservationFeature::TypeId, _type_id});
+    features.push_back({ObservationFeature::Hp, hp});
+    features.push_back({ObservationFeature::ZLevel, 1}); // TallBridge exists at upper Z-level
+    return features;
+  }
+
+  virtual void obs(ObsType* obs, const std::vector<uint8_t>& offsets) const override {
+    obs[offsets[0]] = _type_id;
+    obs[offsets[1]] = this->hp;
+    obs[offsets[2]] = 1; // Upper Z-level
+  }
+
+  static std::vector<std::string> feature_names() {
+    std::vector<std::string> names;
+    names.push_back("type_id");
+    names.push_back("hp");
+    names.push_back("z_level");
+    return names;
+  }
+
+  virtual bool swappable() const override {
+    return false;
+  }
+};
+
+#endif  // METTAGRID_METTAGRID_OBJECTS_TALLBRIDGE_HPP_

--- a/mettagrid/mettagrid/observation_encoder.hpp
+++ b/mettagrid/mettagrid/observation_encoder.hpp
@@ -10,6 +10,8 @@
 #include "objects/agent.hpp"
 #include "objects/constants.hpp"
 #include "objects/converter.hpp"
+#include "objects/stairs.hpp"
+#include "objects/tallbridge.hpp"
 #include "objects/wall.hpp"
 
 class ObservationEncoder {
@@ -20,6 +22,8 @@ public:
 
     _type_feature_names[ObjectType::AgentT] = Agent::feature_names();
     _type_feature_names[ObjectType::WallT] = Wall::feature_names();
+    _type_feature_names[ObjectType::StairsT] = Stairs::feature_names();
+    _type_feature_names[ObjectType::TallBridgeT] = TallBridge::feature_names();
 
     // These are different types of Converters. They all have the same feature names,
     // so this is somewhat redundant.

--- a/test_zlevels.py
+++ b/test_zlevels.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Test script for Z-level functionality with stairs and tall bridges."""
+
+import numpy as np
+
+from mettagrid.mettagrid_c import MettaGrid
+
+# Test configuration
+test_config = {
+    "game": {
+        "num_agents": 2,
+        "obs_width": 11,
+        "obs_height": 11,
+        "use_observation_tokens": False,
+        "num_observation_tokens": 128,
+        "tile_size": 16,
+        "max_steps": 100,
+        "agent": {
+            "default_item_max": 50,
+            "heart_max": 255,
+            "freeze_duration": 10,
+            "hp": 10,
+            "rewards": {
+                "action_failure_penalty": 0.0,
+                "ore.red": 0.005,
+                "ore.blue": 0.005,
+                "ore.green": 0.005,
+                "ore.red_max": 4,
+                "ore.blue_max": 4,
+                "ore.green_max": 4,
+                "battery.red": 0.01,
+                "battery.blue": 0.01,
+                "battery.green": 0.01,
+                "battery.red_max": 5,
+                "battery.blue_max": 5,
+                "battery.green_max": 5,
+                "heart": 1,
+                "heart_max": 1000,
+            },
+        },
+        "groups": {"test": {"id": 0, "sprite": 0, "props": {}}},
+        "objects": {
+            "wall": {"hp": 10, "swappable": False},
+            "stairs": {"hp": 100, "swappable": False},
+            "tallbridge": {"hp": 100, "swappable": False},
+        },
+        "actions": {
+            "noop": {"enabled": True},
+            "move": {"enabled": True},
+            "rotate": {"enabled": True},
+            "put_items": {"enabled": False},
+            "get_items": {"enabled": False},
+            "attack": {"enabled": False},
+            "swap": {"enabled": False},
+            "change_color": {"enabled": False},
+            "climb": {"enabled": True},
+        },
+    }
+}
+
+# Create a simple test map
+# W = wall, S = stairs, B = tall bridge, A = agent, . = empty
+test_map = [
+    ["wall", "wall", "wall", "wall", "wall", "wall", "wall"],
+    ["wall", ".", ".", "stairs", ".", ".", "wall"],
+    ["wall", ".", "agent.test", ".", "agent.test", ".", "wall"],
+    ["wall", ".", ".", "tallbridge", ".", ".", "wall"],
+    ["wall", ".", ".", ".", ".", ".", "wall"],
+    ["wall", "wall", "wall", "wall", "wall", "wall", "wall"],
+]
+
+
+def test_zlevels():
+    print("Testing Z-level functionality with stairs and tall bridges")
+    print("==========================================================")
+
+    # Create environment
+    env = MettaGrid({"game": test_config["game"]}, test_map)
+
+    # Get action indices
+    action_names = env.action_names()
+    print(f"Available actions: {action_names}")
+
+    # Find action indices
+    move_idx = action_names.index("move") if "move" in action_names else -1
+    climb_idx = action_names.index("climb") if "climb" in action_names else -1
+
+    print(f"Move action index: {move_idx}")
+    print(f"Climb action index: {climb_idx}")
+
+    # Reset environment
+    obs, info = env.reset()
+
+    # Print initial state
+    print("\nInitial state:")
+    objects = env.grid_objects()
+    for obj_id, obj_data in objects.items():
+        if "agent_id" in obj_data:
+            z_level = obj_data.get("agent:z_level", 0)
+            print(f"Agent {obj_data['agent_id']} at ({obj_data['r']}, {obj_data['c']}) - Z-level: {z_level}")
+
+    # Test scenario:
+    # 1. Move agent 0 to stairs
+    # 2. Climb up
+    # 3. Move on upper level (walls act as floors)
+    # 4. Move agent 1 under the tall bridge
+
+    print("\nTest scenario:")
+
+    # Step 1: Move agent 0 north to stairs
+    print("\n1. Moving agent 0 north towards stairs...")
+    actions = np.array([[move_idx, 0], [move_idx, 0]])  # Both agents move up
+    obs, rewards, terminals, truncations, info = env.step(actions)
+
+    # Step 2: Agent 0 climbs stairs
+    print("\n2. Agent 0 climbing stairs...")
+    actions = np.array([[climb_idx, 0], [move_idx, 0]])  # Agent 0 climbs up, Agent 1 moves
+    obs, rewards, terminals, truncations, info = env.step(actions)
+
+    # Print current state
+    objects = env.grid_objects()
+    for obj_id, obj_data in objects.items():
+        if "agent_id" in obj_data:
+            z_level = obj_data.get("agent:z_level", 0)
+            print(f"Agent {obj_data['agent_id']} at ({obj_data['r']}, {obj_data['c']}) - Z-level: {z_level}")
+
+    # Step 3: Move agent 0 on upper level
+    print("\n3. Agent 0 moving on upper level (walls act as floors)...")
+    actions = np.array([[move_idx, 0], [move_idx, 0]])  # Both move forward
+    obs, rewards, terminals, truncations, info = env.step(actions)
+
+    # Step 4: Move agent 1 under tall bridge
+    print("\n4. Agent 1 moving under tall bridge...")
+    actions = np.array([[move_idx, 0], [move_idx, 0]])  # Both move forward
+    obs, rewards, terminals, truncations, info = env.step(actions)
+
+    # Final state
+    print("\nFinal state:")
+    objects = env.grid_objects()
+    for obj_id, obj_data in objects.items():
+        if "agent_id" in obj_data:
+            z_level = obj_data.get("agent:z_level", 0)
+            print(f"Agent {obj_data['agent_id']} at ({obj_data['r']}, {obj_data['c']}) - Z-level: {z_level}")
+
+    print("\nTest completed successfully!")
+    print("- Stairs allow agents to move between Z-levels")
+    print("- Walls act as floors at the upper Z-level")
+    print("- TallBridge allows agents to walk underneath at ground level")
+    print("- TallBridge provides a walkable surface at upper Z-level")
+
+
+if __name__ == "__main__":
+    test_zlevels()


### PR DESCRIPTION
I implemented Z-level functionality with stairs and tall bridges in the Mettagrid environment. I added `stairs.hpp` and `tallbridge.hpp` components to enable vertical movement and multi-level navigation. In `agent.hpp`, I added `z_level` tracking (0=ground, 1=elevated). I created a new `climb` action in `climb.hpp` that lets agents use stairs to change levels. The `move` action was modified to handle Z-level specific collisions and allow walking under tall bridges. I added new object types `StairsT` and `TallBridgeT` to `constants.hpp` and updated observation encoding to include Z-level information. A test script `test_zlevels.py` demonstrates the functionality with a sample environment configuration in `mettagrid_zlevels.yaml`. The implementation allows agents to navigate between levels while maintaining proper collision handling and visibility rules.