### PR TITLE
Clean up stats to_dict

### DIFF
--- a/mettagrid/mettagrid/stats_tracker.hpp
+++ b/mettagrid/mettagrid/stats_tracker.hpp
@@ -141,13 +141,6 @@ public:
     // Add timing metadata and calculated stats
     for (const auto& [key, step] : _first_seen_at) {
       result[key + ".first_step"] = static_cast<float>(step);
-
-      // Calculate average value (total / updates)
-      if (_update_count.count(key) && _stats.count(key)) {
-        float total = result[key];
-        float updates = static_cast<float>(_update_count.at(key));
-        result[key + ".avg"] = total / updates;
-      }
     }
 
     for (const auto& [key, step] : _last_seen_at) {
@@ -157,6 +150,7 @@ public:
     for (const auto& [key, count] : _update_count) {
       result[key + ".updates"] = static_cast<float>(count);
       result[key + ".rate"] = rate(key);
+      result[key + ".avg"] = result[key] / updates;
 
       // Also calculate activity rate if there's a time span
       auto first_it = _first_seen_at.find(key);

--- a/mettagrid/mettagrid/stats_tracker.hpp
+++ b/mettagrid/mettagrid/stats_tracker.hpp
@@ -150,7 +150,7 @@ public:
     for (const auto& [key, count] : _update_count) {
       result[key + ".updates"] = static_cast<float>(count);
       result[key + ".rate"] = rate(key);
-      result[key + ".avg"] = result[key] / updates;
+      result[key + ".avg"] = result[key] / count;
 
       // Also calculate activity rate if there's a time span
       auto first_it = _first_seen_at.find(key);


### PR DESCRIPTION
Changes where we calculate `avg` in stats_tracker to be under "do we have a `count`?" instead of "do we have a `_first_seen_at`?". This makes more logical sense to me, and should be more robust if we stop having `_first_seen_at` always populated.

Tested via existing unit tests.