### PR TITLE
Remove unneeded stats initialization

### DIFF
--- a/mettagrid/mettagrid/stats_tracker.hpp
+++ b/mettagrid/mettagrid/stats_tracker.hpp
@@ -59,10 +59,6 @@ public:
   }
 
   void add(const std::string& key, float amount) {
-    if (_stats.find(key) == _stats.end()) {
-      _stats[key] = 0.0f;
-    }
-
     _stats[key] += amount;
     track_timing(key);
     track_bounds(key, _stats[key]);


### PR DESCRIPTION
Simplifies the `add` method in `StatsTracker` class by removing redundant initialization check.

Removed the conditional check that initializes a stat key to 0.0f if it doesn't exist in the `_stats` map. This check is unnecessary since C++ map's operator[] already creates a default-initialized value (0.0f for float) when accessing a non-existent key.

I'd meant to include this in the previous PR, but merged-vs-resubmitted in the wrong order.