### PR TITLE
fix: simplify weights metrics logging

### DIFF
--- a/metta/agent/util/weights_analysis.py
+++ b/metta/agent/util/weights_analysis.py
@@ -78,29 +78,3 @@ def analyze_weights(weights: torch.Tensor, delta: float = 0.01) -> dict:
         metrics["effective_rank"] = effective_rank
 
     return metrics
-
-
-class WeightsMetricsHelper:
-    def __init__(self, cfg):
-        self.cfg = cfg
-        self._weight_metrics = []
-
-    def on_epoch_end(self, epoch, policy):
-        if self.cfg.agent.analyze_weights_interval != 0 and epoch % self.cfg.agent.analyze_weights_interval == 0:
-            self._weight_metrics = policy.compute_weight_metrics()
-        else:
-            # Ensure metrics are empty if not computed this epoch
-            self._weight_metrics = []
-
-    def stats(self):
-        formatted_metrics = {}
-        for metrics in self._weight_metrics:
-            name = metrics.get("name", "unknown")
-            for key, value in metrics.items():
-                if key != "name":
-                    metric_key = f"train/{key}/{name}"
-                    formatted_metrics[metric_key] = value
-        return formatted_metrics
-
-    def reset(self):
-        self._weight_metrics = []


### PR DESCRIPTION

Refactored weights metrics collection to remove the intermediate `WeightsMetricsHelper` class by ntegrating its functionality directly into the trainer's `_process_stats` method.

## Changes Made

### Removed Files
- **`WeightsMetricsHelper` class** from `metta/agent/util/weights_analysis.py`
  - Eliminated unnecessary abstraction layer
  - Removed 26 lines of boilerplate code

### Modified Files
- **`metta/rl/pufferlib/trainer.py`**
  - Integrated weights metrics collection directly into `_process_stats()`
  - Added inline weight metrics computation when `analyze_weights_interval` conditions are met
  - Changed metric key format from `train/{key}/{name}` to `weights/{key}/{name}` for better organization
  - Improved error handling in stats processing with more descriptive error messages

## Benefits
- **Reduced complexity**: Eliminated unnecessary helper class and its lifecycle management
- **Better locality**: Weights metrics logic is now co-located with other stats processing
- **Clearer naming**: Weights metrics now use the `weights/` prefix instead of `train/`
- **Improved error messages**: More descriptive error handling for stats processing failures
- **Less state management**: No need to track `_weight_metrics` state across epochs

## Behavior Changes
- Weights metrics are now prefixed with `weights/` instead of `train/` in logged data
- Metrics are computed on-demand during stats processing rather than being cached in a helper object

This change maintains the same functional behavior while simplifying the codebase and making the weights metrics logging more straightforward to understand and maintain.