### PR TITLE
Add --force flag to bypass deprecated script warning

### DIFF
--- a/devops/aws/batch/launch_task.py
+++ b/devops/aws/batch/launch_task.py
@@ -345,6 +345,7 @@ def submit_batch_job(args, task_args):
 
 def main():
     parser = argparse.ArgumentParser(description="Launch an AWS Batch task with a wandb key.")
+    parser.add_argument("--force", action="store_true", help="Force use of deprecated script")
     parser.add_argument("--cluster", default="metta")
     parser.add_argument("--run", required=True)
     parser.add_argument("--job-name", help="The job name. If not specified, will use run id with random suffix.")
@@ -375,6 +376,11 @@ def main():
         help="Automatically terminate the job after this many minutes.",
     )
     args, task_args = parser.parse_known_args()
+
+    if not args.force:
+        print(red("This script is deprecated. Please use ./devops/skypilot/launch.py instead."))
+        print(yellow("Use --force to bypass this check if needed."))
+        sys.exit(1)
 
     use_colors(sys.stdout.isatty() and not args.no_color)
 

--- a/devops/tools/git-history-trainer.sh
+++ b/devops/tools/git-history-trainer.sh
@@ -404,6 +404,7 @@ for COMMIT in $COMMITS; do
     --timeout-minutes=30 \
     --skip-validation \
     --skip-push-check \
+    --force \
     trainer.env=env/mettagrid/simple
 
   # Log job details


### PR DESCRIPTION
### TL;DR

Added a deprecation warning to the AWS Batch launch script with a force flag to bypass it.

### What changed?

- Added a new `--force` command line argument to `launch_task.py`
- Added a deprecation warning that directs users to use `./devops/skypilot/launch.py` instead
- Added an early exit if the force flag is not provided
