### PR TITLE
be consistent about using self._task

### DIFF
--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -81,7 +81,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         self.labels = self._task.env_cfg().get("labels", None)
         self._should_reset = False
 
-        self._initialize_c_env(self._task)
+        self._initialize_c_env()
         super().__init__(buf)
 
         if self._render_mode is not None:
@@ -97,8 +97,9 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
     def _make_episode_id(self):
         return str(uuid.uuid4())
 
-    def _initialize_c_env(self, task: Task) -> None:
+    def _initialize_c_env(self) -> None:
         """Initialize the C++ environment."""
+        task = self._task
         level = self._level
         if level is None:
             map_builder_config = task.env_cfg().game.map_builder
@@ -107,8 +108,8 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
 
         # Validate the level
         level_agents = np.count_nonzero(np.char.startswith(level.grid, "agent"))
-        assert self._task.env_cfg().game.num_agents == level_agents, (
-            f"Number of agents {self._task.env_cfg().game.num_agents} "
+        assert task.env_cfg().game.num_agents == level_agents, (
+            f"Number of agents {task.env_cfg().game.num_agents} "
             f"does not match number of agents in map {level_agents}"
         )
 
@@ -127,7 +128,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
     def reset(self, seed: int | None = None) -> tuple[np.ndarray, dict]:
         self._task = self._curriculum.get_task()
 
-        self._initialize_c_env(self._task)
+        self._initialize_c_env()
 
         assert self.observations.dtype == dtype_observations
         assert self.terminals.dtype == dtype_terminals

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -68,7 +68,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
     ):
         self._render_mode = render_mode
         self._curriculum = curriculum
-        self._task = self._curriculum.get_task()
+        self._task: Task = self._curriculum.get_task()
         self._level = level
         self._renderer = None
         self._map_labels = []
@@ -109,8 +109,7 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         # Validate the level
         level_agents = np.count_nonzero(np.char.startswith(level.grid, "agent"))
         assert task.env_cfg().game.num_agents == level_agents, (
-            f"Number of agents {task.env_cfg().game.num_agents} "
-            f"does not match number of agents in map {level_agents}"
+            f"Number of agents {task.env_cfg().game.num_agents} does not match number of agents in map {level_agents}"
         )
 
         # Convert to container for C++ code with explicit casting to Dict[str, Any]


### PR DESCRIPTION
Removes a redundant parameter. Since `self._task` is already available as a class member, there's no need to pass it as an argument to the `_initialize_c_env` method. Moreover, passing it adds (or suggests) that the parameters might be different.

There's more cleanup we could do, like the fact that `labels` are read only off the first task. And it's not great that you need to remember to set a new `_task` before calling init, and that it's done in 2 places. But baby steps.