### PR TITLE
hotfix: use output instead of code 78

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -268,33 +268,35 @@ jobs:
 
       - name: Check evals smoke test policy availability
         id: check_evals_policy
+        continue-on-error: true
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
-          # Smoke test configuration
           EVAL_SMOKE_TEST_POLICY="b.rwalters.0605.nav.pr811.00"
+          echo "policy=$EVAL_SMOKE_TEST_POLICY" >> "$GITHUB_OUTPUT"
 
           echo "Checking WANDB for metta-research/metta/runs/$EVAL_SMOKE_TEST_POLICY"
+
           STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $WANDB_API_KEY" \
             "https://api.wandb.ai/runs/metta-research/metta/$EVAL_SMOKE_TEST_POLICY")
 
           echo "WANDB run check returned HTTP $STATUS_CODE"
 
-          if [ "$STATUS_CODE" != "200" ]; then
-            exit 78  # Exit with code 78 to signal a neutral result — this causes
-                    # GitHub Actions to mark the step as 'skipped' rather than 'success' or 'failure'.
-                    # This allows conditional steps to check:
-                    #   if: steps.check_evals_policy.outcome == 'success'  # to continue
+          if [ "$STATUS_CODE" = "200" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run evals smoke test
         id: eval_smoke_test
-        if: steps.check_evals_policy.outcome == 'success'
+        if: steps.check_evals_policy.outputs.result == 'success'
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           AWS_ACCESS_KEY_ID: set_but_not_used
           AWS_SECRET_ACCESS_KEY: set_but_not_used
+          EVAL_SMOKE_TEST_POLICY: ${{ steps.check_evals_policy.outputs.policy }}
         # We retry evals a few times because they're not deterministic (despite our best efforts)
         # Our smoke tests should pass at least 90% of the time if they're working, so this should have
         # a spurious failure rate of less than 0.01%. We assume that spurious successes should be
@@ -303,7 +305,6 @@ jobs:
           source .github/scripts/benchmark.sh
 
           # Smoke test configuration
-          EVAL_SMOKE_TEST_POLICY="b.rwalters.0605.nav.pr811.00"
           SMOKE_TEST_MIN_REWARD=0.15
           MAX_ATTEMPTS=4
 


### PR DESCRIPTION

I was misled by the LLMs