### PR TITLE
Redo the timeline/scrubber area.

### DIFF
--- a/mettascope/README.md
+++ b/mettascope/README.md
@@ -79,7 +79,7 @@ python tools/gen_html.py
 - **Play/Pause**: Control playback with the play/pause button
 - **Frame Navigation**: Step forward/backward to move frame by frame
 - **Speed Control**: Adjust playback speed using the speed controls
-- **Timeline**: Drag the scrubber on the timeline to jump to any point in the replay
+- **Timeline**: Drag the scrubber on the timeline to jump to any point in the replay. The timeline also shows key events like agent freezing and acts as a minimap for the trace view.
 
 ### Action Traces
 

--- a/mettascope/index.css
+++ b/mettascope/index.css
@@ -291,6 +291,39 @@ canvas#global-canvas {
     overflow: hidden;
 }
 
+#scrubber-panel #step-redout {
+    position: absolute;
+    display: block;
+    width: 47px;
+    height: 22px;
+    left: 668px;
+    top: 5px;
+    background-color: rgba(0, 0, 0, 1.00);
+    border-radius: 8px;
+    overflow: hidden;
+    border-color: rgba(85, 85, 85, 1.00);
+    border-width: 1px;
+    border-style: solid;
+}
+
+#step-redout #step-counter {
+    position: absolute;
+    display: inline-block;
+    left: 0px;
+    right: 0px;
+    top: 1px;
+    bottom: 0px;
+    color: rgba(255, 255, 255, 1.00);
+    font-family: IBM Plex Mono;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    text-align: center;
+    vertical-align: center;
+    letter-spacing: 0px;
+    line-height: 18.20px;
+}
+
 #trace-panel {
     position: absolute;
     display: block;

--- a/mettascope/index.css
+++ b/mettascope/index.css
@@ -280,28 +280,15 @@ canvas#global-canvas {
     overflow: hidden;
 }
 
-#time-panel {
+#scrubber-panel {
     position: absolute;
-    display: flex;
-    height: fit-content;
+    display: block;
+    height: 64px;
     left: 0px;
     right: 0px;
     bottom: 64px;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    gap: 16px;
-    padding: 16px 32px 16px 32px;
     background-color: rgba(29, 29, 29, 1.00);
     overflow: hidden;
-}
-
-#time-panel input#main-scrubber {
-    position: relative;
-    display: block;
-    width: 100%;
-    height: 32px;
-    align-self: stretch;
-    background-color: rgba(217, 217, 217, 1.00);
 }
 
 #trace-panel {

--- a/mettascope/index.css
+++ b/mettascope/index.css
@@ -280,7 +280,7 @@ canvas#global-canvas {
     overflow: hidden;
 }
 
-#scrubber-panel {
+#timeline-panel {
     position: absolute;
     display: block;
     height: 64px;
@@ -291,12 +291,12 @@ canvas#global-canvas {
     overflow: hidden;
 }
 
-#scrubber-panel #step-redout {
+#timeline-panel #timeline-redout {
     position: absolute;
     display: block;
-    width: 47px;
+    width: 46px;
     height: 22px;
-    left: 668px;
+    left: -55px;
     top: 5px;
     background-color: rgba(0, 0, 0, 1.00);
     border-radius: 8px;
@@ -306,7 +306,7 @@ canvas#global-canvas {
     border-style: solid;
 }
 
-#step-redout #step-counter {
+#timeline-redout #step-counter {
     position: absolute;
     display: inline-block;
     left: 0px;

--- a/mettascope/index.css
+++ b/mettascope/index.css
@@ -296,8 +296,9 @@ canvas#global-canvas {
     display: block;
     width: 46px;
     height: 22px;
-    left: -55px;
+    left: 50%;
     top: 5px;
+    transform: translate(-22.50px, 0);
     background-color: rgba(0, 0, 0, 1.00);
     border-radius: 8px;
     overflow: hidden;

--- a/mettascope/index.css
+++ b/mettascope/index.css
@@ -320,7 +320,7 @@ canvas#global-canvas {
     font-weight: 400;
     font-size: 14px;
     text-align: center;
-    vertical-align: center;
+    vertical-align: middle;
     letter-spacing: 0px;
     line-height: 18.20px;
 }
@@ -1495,7 +1495,7 @@ button#help-button.hover-icon .icon {
     font-weight: 400;
     font-size: 16px;
     text-align: left;
-    vertical-align: center;
+    vertical-align: middle;
     letter-spacing: 0px;
     line-height: 20.80px;
 }

--- a/mettascope/index.html
+++ b/mettascope/index.html
@@ -41,7 +41,11 @@
         <img src="data/ui/cloud.png" alt="#fog-of-war-toggle.hover-icon" id="fog-of-war-toggle" class="hover-icon">
       </div>
     </div>
-    <div id="scrubber-panel"></div>
+    <div id="scrubber-panel">
+      <div id="step-redout">
+        <span id="step-counter">1999</span>
+      </div>
+    </div>
     <div id="trace-panel"></div>
     <div id="worldmap-panel"></div>
     <div id="header">

--- a/mettascope/index.html
+++ b/mettascope/index.html
@@ -41,9 +41,7 @@
         <img src="data/ui/cloud.png" alt="#fog-of-war-toggle.hover-icon" id="fog-of-war-toggle" class="hover-icon">
       </div>
     </div>
-    <div id="time-panel">
-      <input id="main-scrubber">
-    </div>
+    <div id="scrubber-panel"></div>
     <div id="trace-panel"></div>
     <div id="worldmap-panel"></div>
     <div id="header">

--- a/mettascope/index.html
+++ b/mettascope/index.html
@@ -41,8 +41,8 @@
         <img src="data/ui/cloud.png" alt="#fog-of-war-toggle.hover-icon" id="fog-of-war-toggle" class="hover-icon">
       </div>
     </div>
-    <div id="scrubber-panel">
-      <div id="step-redout">
+    <div id="timeline-panel">
+      <div id="timeline-redout">
         <span id="step-counter">1999</span>
       </div>
     </div>

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -14,9 +14,9 @@ export const DEFAULT_ZOOM_LEVEL = 1 / 2;
 export const DEFAULT_TRACE_ZOOM_LEVEL = 1 / 4;
 export const SPLIT_DRAG_THRESHOLD = 10;  // pixels to detect split dragging
 export const SCROLL_ZOOM_FACTOR = 1000;  // divisor for scroll delta to zoom conversion
-export const PANEL_BOTTOM_MARGIN = 60;    // bottom margin for panels
-export const HEADER_HEIGHT = 60;          // height of the header
-export const SCRUBBER_HEIGHT = 128;        // height of the scrubber
+export const PANEL_BOTTOM_MARGIN = 60;
+export const HEADER_HEIGHT = 60;
+export const FOOTER_HEIGHT = 128;
 export const SPEEDS = [0.02, 0.1, 0.25, 0.5, 1.0, 5.0];
 
 // Map constants
@@ -68,7 +68,7 @@ export const ui = {
   tracePanel: new PanelInfo("#trace-panel"),
   infoPanel: new PanelInfo("#info-panel"),
   agentPanel: new PanelInfo("#agent-panel"),
-  scrubberPanel: new PanelInfo("#scrubber-panel"),
+  timelinePanel: new PanelInfo("#timeline-panel"),
 
   infoPanels: [] as InfoPanel[],
   hoverObject: null as any,
@@ -112,9 +112,6 @@ export const html = {
   fileName: find('#file-name') as HTMLDivElement,
   helpButton: find('#help-button') as HTMLButtonElement,
   shareButton: find('#share-button') as HTMLButtonElement,
-
-  // Bottom area
-  // scrubber: find('#main-scrubber') as HTMLInputElement,
 
   rewindToStartButton: find('#rewind-to-start') as HTMLImageElement,
   stepBackButton: find('#step-back') as HTMLImageElement,

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -144,6 +144,7 @@ export const html = {
   visualRangeToggle: find('#visual-range-toggle') as HTMLImageElement,
   fogOfWarToggle: find('#fog-of-war-toggle') as HTMLImageElement,
 
+  stepCounter: find('#step-counter') as HTMLSpanElement,
 
   // Utility
   modal: find('#modal') as HTMLDivElement,

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -56,6 +56,7 @@ export const ui = {
   mouseDownPos: new Vec2f(0, 0),
   scrollDelta: 0,
   lastClickTime: 0, // For double-click detection
+  mainScrubberDown: false,
 
   // Split between trace and info panels.
   traceSplit: localStorageGetNumber("traceSplit", 0.8),

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -16,7 +16,7 @@ export const SPLIT_DRAG_THRESHOLD = 10;  // pixels to detect split dragging
 export const SCROLL_ZOOM_FACTOR = 1000;  // divisor for scroll delta to zoom conversion
 export const PANEL_BOTTOM_MARGIN = 60;    // bottom margin for panels
 export const HEADER_HEIGHT = 60;          // height of the header
-export const SCRUBBER_HEIGHT = 120;        // height of the scrubber
+export const SCRUBBER_HEIGHT = 128;        // height of the scrubber
 export const SPEEDS = [0.02, 0.1, 0.25, 0.5, 1.0, 5.0];
 
 // Map constants
@@ -67,6 +67,7 @@ export const ui = {
   tracePanel: new PanelInfo("#trace-panel"),
   infoPanel: new PanelInfo("#info-panel"),
   agentPanel: new PanelInfo("#agent-panel"),
+  scrubberPanel: new PanelInfo("#scrubber-panel"),
 
   infoPanels: [] as InfoPanel[],
   hoverObject: null as any,
@@ -112,7 +113,7 @@ export const html = {
   shareButton: find('#share-button') as HTMLButtonElement,
 
   // Bottom area
-  scrubber: find('#main-scrubber') as HTMLInputElement,
+  // scrubber: find('#main-scrubber') as HTMLInputElement,
 
   rewindToStartButton: find('#rewind-to-start') as HTMLImageElement,
   stepBackButton: find('#step-back') as HTMLImageElement,

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -7,9 +7,10 @@ import { drawTrace } from './traces.js';
 import { drawMiniMap } from './minimap.js';
 import { processActions, initActionButtons } from './actions.js';
 import { initAgentTable, updateAgentTable } from './agentpanel.js';
-import { localStorageSetNumber, onEvent } from './htmlutils.js';
+import { localStorageSetNumber, onEvent, find } from './htmlutils.js';
 import { updateReadout } from './infopanels.js';
 import { initObjectMenu } from './objmenu.js';
+import { drawScrubber, initScrubber } from './scrubber.js';
 
 /** Handles resize events. */
 export function onResize() {
@@ -51,6 +52,12 @@ export function onResize() {
   ui.tracePanel.width = screenWidth;
   ui.tracePanel.height = screenHeight - ui.tracePanel.y - Common.SCRUBBER_HEIGHT;
 
+  // Scrubber panel is always on the bottom of the screen.
+  ui.scrubberPanel.x = 0;
+  ui.scrubberPanel.y = screenHeight - 64 - 64;
+  ui.scrubberPanel.width = screenWidth;
+  ui.scrubberPanel.height = 64;
+
   // Agent panel is always on the top of the screen.
   ui.agentPanel.x = 0;
   ui.agentPanel.y = Common.HEADER_HEIGHT;
@@ -64,6 +71,7 @@ export function onResize() {
   ui.infoPanel.updateDiv();
   ui.tracePanel.updateDiv();
   ui.agentPanel.updateDiv();
+  ui.scrubberPanel.updateDiv();
 
   // Redraw the square after resizing.
   requestFrame();
@@ -221,7 +229,8 @@ export function updateStep(newStep: number, skipScrubberUpdate = false) {
 
   // Update the scrubber value (unless told to skip)
   if (!skipScrubberUpdate) {
-    html.scrubber.value = state.step.toString();
+    //html.scrubber.value = state.step.toString();
+    console.log("Scrubber value:", state.step);
   }
   updateAgentTable();
   requestFrame();
@@ -238,10 +247,10 @@ export function updateSelection(object: any, setFollow = false) {
   requestFrame();
 }
 
-/** Handle scrubber change events. */
-function onScrubberChange() {
-  updateStep(parseInt(html.scrubber.value), true);
-}
+// /** Handle scrubber change events. */
+// function onScrubberChange() {
+//   //updateStep(parseInt(html.scrubber.value), true);
+// }
 
 /** Handle key down events. */
 onEvent("keydown", "body", (target: HTMLElement, e: Event) => {
@@ -304,6 +313,9 @@ export function onFrame() {
 
   ctx.useMesh("trace");
   drawTrace(ui.tracePanel);
+
+  ctx.useMesh("scrubber");
+  drawScrubber(ui.scrubberPanel);
 
   if (state.showInfo) {
     ui.infoPanel.div.classList.remove("hidden");
@@ -492,6 +504,7 @@ ui.agentPanel.div.classList.add("hidden");
 ui.mapPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 ui.tracePanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 ui.miniMapPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
+ui.scrubberPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 
 // Add event listener to resize the canvas when the window is resized.
 window.addEventListener('resize', onResize);
@@ -508,10 +521,10 @@ onEvent("click", "#help-button", () => {
   window.open("https://github.com/Metta-AI/metta/blob/main/mettascope/README.md", "_blank");
 });
 
-// Bottom area
-html.scrubber.addEventListener('input', onScrubberChange);
-html.scrubber.setAttribute("type", "range");
-html.scrubber.setAttribute("value", "0");
+// // Bottom area
+// html.scrubber.addEventListener('input', onScrubberChange);
+// html.scrubber.setAttribute("type", "range");
+// html.scrubber.setAttribute("value", "0");
 
 onEvent("click", "#rewind-to-start", () => {
   setIsPlaying(false);
@@ -641,6 +654,7 @@ toggleOpacity(html.agentPanelToggle, state.showAgentPanel);
 initActionButtons();
 initAgentTable();
 initObjectMenu();
+initScrubber();
 
 window.addEventListener('load', async () => {
   // Use local atlas texture.

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -255,11 +255,6 @@ export function updateSelection(object: any, setFollow = false) {
   requestFrame();
 }
 
-// /** Handle scrubber change events. */
-// function onScrubberChange() {
-//   //updateStep(parseInt(html.scrubber.value), true);
-// }
-
 /** Handle key down events. */
 onEvent("keydown", "body", (target: HTMLElement, e: Event) => {
   let event = e as KeyboardEvent;

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -10,7 +10,7 @@ import { initAgentTable, updateAgentTable } from './agentpanel.js';
 import { localStorageSetNumber, onEvent, find } from './htmlutils.js';
 import { updateReadout } from './infopanels.js';
 import { initObjectMenu } from './objmenu.js';
-import { drawScrubber, initScrubber, updateScrubber, onScrubberChange } from './scrubber.js';
+import { drawTimeline, initTimeline, updateTimeline, onScrubberChange } from './timeline.js';
 
 /** Handles resize events. */
 export function onResize() {
@@ -28,7 +28,7 @@ export function onResize() {
   ui.mapPanel.x = 0;
   ui.mapPanel.y = Common.HEADER_HEIGHT;
   ui.mapPanel.width = screenWidth;
-  let maxMapHeight = screenHeight - Common.HEADER_HEIGHT - Common.SCRUBBER_HEIGHT;
+  let maxMapHeight = screenHeight - Common.HEADER_HEIGHT - Common.FOOTER_HEIGHT;
   ui.mapPanel.height = Math.min(screenHeight * ui.traceSplit - Common.HEADER_HEIGHT, maxMapHeight);
 
   // Minimap goes in the bottom left corner of the mapPanel.
@@ -50,13 +50,13 @@ export function onResize() {
   ui.tracePanel.x = 0;
   ui.tracePanel.y = ui.mapPanel.y + ui.mapPanel.height;
   ui.tracePanel.width = screenWidth;
-  ui.tracePanel.height = screenHeight - ui.tracePanel.y - Common.SCRUBBER_HEIGHT;
+  ui.tracePanel.height = screenHeight - ui.tracePanel.y - Common.FOOTER_HEIGHT;
 
-  // Scrubber panel is always on the bottom of the screen.
-  ui.scrubberPanel.x = 0;
-  ui.scrubberPanel.y = screenHeight - 64 - 64;
-  ui.scrubberPanel.width = screenWidth;
-  ui.scrubberPanel.height = 64;
+  // Timeline panel is always on the bottom of the screen.
+  ui.timelinePanel.x = 0;
+  ui.timelinePanel.y = screenHeight - 64 - 64;
+  ui.timelinePanel.width = screenWidth;
+  ui.timelinePanel.height = 64;
 
   // Agent panel is always on the top of the screen.
   ui.agentPanel.x = 0;
@@ -71,9 +71,9 @@ export function onResize() {
   ui.infoPanel.updateDiv();
   ui.tracePanel.updateDiv();
   ui.agentPanel.updateDiv();
-  ui.scrubberPanel.updateDiv();
+  ui.timelinePanel.updateDiv();
 
-  updateScrubber();
+  updateTimeline();
 
   // Redraw the square after resizing.
   requestFrame();
@@ -236,9 +236,8 @@ export function updateStep(newStep: number, skipScrubberUpdate = false) {
 
   // Update the scrubber value (unless told to skip)
   if (!skipScrubberUpdate) {
-    //html.scrubber.value = state.step.toString();
-    console.log("Scrubber value:", state.step);
-    updateScrubber();
+    console.info("Scrubber value:", state.step);
+    updateTimeline();
   }
   updateAgentTable();
   requestFrame();
@@ -317,8 +316,8 @@ export function onFrame() {
   ctx.useMesh("trace");
   drawTrace(ui.tracePanel);
 
-  ctx.useMesh("scrubber");
-  drawScrubber(ui.scrubberPanel);
+  ctx.useMesh("timeline");
+  drawTimeline(ui.timelinePanel);
 
   if (state.showInfo) {
     ui.infoPanel.div.classList.remove("hidden");
@@ -507,7 +506,7 @@ ui.agentPanel.div.classList.add("hidden");
 ui.mapPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 ui.tracePanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 ui.miniMapPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
-ui.scrubberPanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
+ui.timelinePanel.div.style.backgroundColor = "rgba(0, 0, 0, 0.0)";
 
 // Add event listener to resize the canvas when the window is resized.
 window.addEventListener('resize', onResize);
@@ -652,7 +651,7 @@ toggleOpacity(html.agentPanelToggle, state.showAgentPanel);
 initActionButtons();
 initAgentTable();
 initObjectMenu();
-initScrubber();
+initTimeline();
 
 window.addEventListener('load', async () => {
   // Use local atlas texture.

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -73,6 +73,8 @@ export function onResize() {
   ui.agentPanel.updateDiv();
   ui.scrubberPanel.updateDiv();
 
+  updateScrubber();
+
   // Redraw the square after resizing.
   requestFrame();
 }

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -524,11 +524,6 @@ onEvent("click", "#help-button", () => {
   window.open("https://github.com/Metta-AI/metta/blob/main/mettascope/README.md", "_blank");
 });
 
-// // Bottom area
-// html.scrubber.addEventListener('input', onScrubberChange);
-// html.scrubber.setAttribute("type", "range");
-// html.scrubber.setAttribute("value", "0");
-
 onEvent("click", "#rewind-to-start", () => {
   setIsPlaying(false);
   updateStep(0)

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -10,7 +10,7 @@ import { initAgentTable, updateAgentTable } from './agentpanel.js';
 import { localStorageSetNumber, onEvent, find } from './htmlutils.js';
 import { updateReadout } from './infopanels.js';
 import { initObjectMenu } from './objmenu.js';
-import { drawScrubber, initScrubber } from './scrubber.js';
+import { drawScrubber, initScrubber, updateScrubber } from './scrubber.js';
 
 /** Handles resize events. */
 export function onResize() {
@@ -231,6 +231,7 @@ export function updateStep(newStep: number, skipScrubberUpdate = false) {
   if (!skipScrubberUpdate) {
     //html.scrubber.value = state.step.toString();
     console.log("Scrubber value:", state.step);
+    updateScrubber();
   }
   updateAgentTable();
   requestFrame();

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -10,7 +10,7 @@ import { initAgentTable, updateAgentTable } from './agentpanel.js';
 import { localStorageSetNumber, onEvent, find } from './htmlutils.js';
 import { updateReadout } from './infopanels.js';
 import { initObjectMenu } from './objmenu.js';
-import { drawScrubber, initScrubber, updateScrubber } from './scrubber.js';
+import { drawScrubber, initScrubber, updateScrubber, onScrubberChange } from './scrubber.js';
 
 /** Handles resize events. */
 export function onResize() {
@@ -107,6 +107,7 @@ onEvent("mouseup", "body", () => {
   ui.dragging = "";
   ui.dragHtml = null;
   ui.dragOffset = new Vec2f(0, 0);
+  ui.mainScrubberDown = false;
 
   // Due to how we select objects on mouse-up (mouse-down is drag/pan),
   // we need to check for double-click on mouse-up as well.
@@ -152,6 +153,10 @@ onEvent("mousemove", "body", (target: HTMLElement, e: Event) => {
   if (ui.dragHtml != null) {
     ui.dragHtml.style.left = (ui.mousePos.x() - ui.dragOffset.x()) + "px";
     ui.dragHtml.style.top = (ui.mousePos.y() - ui.dragOffset.y()) + "px";
+  }
+
+  if (ui.mainScrubberDown) {
+    onScrubberChange(event);
   }
 
   requestFrame();

--- a/mettascope/src/minimap.ts
+++ b/mettascope/src/minimap.ts
@@ -1,6 +1,6 @@
-import { Vec2f, Mat3f } from './vector_math.js';
+import { Vec2f } from './vector_math.js';
 import * as Common from './common.js';
-import { ui, state, html, ctx, setFollowSelection } from './common.js';
+import { ui, state, ctx } from './common.js';
 import { getAttr } from './replay.js';
 import { PanelInfo } from './panels.js';
 import { parseHtmlColor } from './htmlutils.js';
@@ -67,7 +67,8 @@ export function drawMiniMap(panel: PanelInfo) {
     const type = getAttr(gridObject, "type");
     const typeName = state.replay.object_types[type];
     if (typeName === "agent") {
-      ctx.drawSprite("minimapPip.png",
+      ctx.drawSprite(
+        "minimapPip.png",
         x * Common.MINI_MAP_TILE_SIZE + 1,
         y * Common.MINI_MAP_TILE_SIZE + 1,
         [1, 0, 0, 1],

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -263,7 +263,8 @@ async function loadReplayJson(url: string, replayData: any) {
 
 
   // Set the scrubber max value to the max steps.
-  html.scrubber.max = (state.replay.max_steps - 1).toString();
+  //html.scrubber.max = (state.replay.max_steps - 1).toString();
+  console.log("Scrubber max:", state.replay.max_steps);
 
   if (state.replay.file_name) {
     html.fileName.textContent = state.replay.file_name;

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -261,11 +261,6 @@ async function loadReplayJson(url: string, replayData: any) {
 
   fixReplay();
 
-
-  // Set the scrubber max value to the max steps.
-  //html.scrubber.max = (state.replay.max_steps - 1).toString();
-  console.log("Scrubber max:", state.replay.max_steps);
-
   if (state.replay.file_name) {
     html.fileName.textContent = state.replay.file_name;
   } else {

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -43,8 +43,9 @@ export function updateScrubber() {
   }
 
   let scrubberWidth = ui.scrubberPanel.width - 32;
+  let fullSteps = state.replay.max_steps - 1;
   html.stepCounter.textContent = state.step.toString();
-  html.stepCounter.parentElement!.style.left = (16 + state.step / state.replay.max_steps * scrubberWidth - 46 / 2).toString() + "px";
+  html.stepCounter.parentElement!.style.left = (16 + state.step / fullSteps * scrubberWidth - 46 / 2).toString() + "px";
 }
 
 /** Draw the scrubber. */
@@ -58,6 +59,7 @@ export function drawScrubber(panel: PanelInfo) {
   ctx.translate(panel.x, panel.y);
 
   let scrubberWidth = panel.width - 32;
+  let fullSteps = state.replay.max_steps - 1;
 
   // Draw the background of the scrubber.
   ctx.drawSolidRect(
@@ -69,12 +71,12 @@ export function drawScrubber(panel: PanelInfo) {
   // Draw the foreground of the scrubber.
   ctx.drawSolidRect(
     16, 34,
-    scrubberWidth * state.step / state.replay.max_steps, 16,
+    scrubberWidth * state.step / fullSteps, 16,
     [1, 1, 1, 1]
   );
 
   // The the position of the traces view.
-  let scrubberTileSize = scrubberWidth / state.replay.max_steps
+  let scrubberTileSize = scrubberWidth / fullSteps
   let tracesX = -ui.tracePanel.panPos.x() / Common.TRACE_WIDTH * scrubberTileSize
   let zoomLevel = ui.tracePanel.zoomLevel;
   let tracesW = (ui.tracePanel.width / zoomLevel) / Common.TRACE_WIDTH * scrubberTileSize;
@@ -93,7 +95,7 @@ export function drawScrubber(panel: PanelInfo) {
       // Draw frozen state.
       let frozen = getAttr(agent, "agent:frozen", j);
       if (frozen > 0 && prevFrozen == 0) {
-        let x = j / state.replay.max_steps * scrubberWidth;
+        let x = j / fullSteps * scrubberWidth;
         ctx.drawSprite(
           "agents/frozen.png",
           x,

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -15,11 +15,13 @@ import { updateStep } from './main.js';
 import { clamp } from "./context3d.js";
 import { getAttr } from "./replay.js";
 
+/** Initialize the scrubber. */
 export function initScrubber() {
   console.log("Initializing scrubber");
 }
 
-function updateScrubber(event: MouseEvent) {
+/** Update the scrubber. */
+function onScrubberChange(event: MouseEvent) {
   let mouseX = event.clientX;
   let scrubberWidth = ui.scrubberPanel.width - 32;
   let s = Math.floor((mouseX - 16) / scrubberWidth * state.replay.max_steps);
@@ -31,7 +33,7 @@ function updateScrubber(event: MouseEvent) {
 onEvent("mousedown", "#scrubber-panel", (target: HTMLElement, event: Event) => {
   console.log("Scrubber clicked");
   ui.mouseDown = true;
-  updateScrubber(event as MouseEvent);
+  onScrubberChange(event as MouseEvent);
 });
 
 /** Handle mouse up on the scrubber, which will update the step. */
@@ -42,10 +44,18 @@ onEvent("mouseup", "#scrubber-panel", (target: HTMLElement, event: Event) => {
 /** Handle mouse move on the scrubber, which will update the step. */
 onEvent("mousemove", "#scrubber-panel", (target: HTMLElement, event: Event) => {
   if (ui.mouseDown) {
-    updateScrubber(event as MouseEvent);
+    onScrubberChange(event as MouseEvent);
   }
 });
 
+/** Update the scrubber. */
+export function updateScrubber() {
+  let scrubberWidth = ui.scrubberPanel.width - 32;
+  html.stepCounter.textContent = state.step.toString();
+  html.stepCounter.parentElement!.style.left = (16 + state.step / state.replay.max_steps * scrubberWidth - 46 / 2).toString() + "px";
+}
+
+/** Draw the scrubber. */
 export function drawScrubber(panel: PanelInfo) {
   if (state.replay === null || ctx === null || ctx.ready === false) {
     return;
@@ -109,7 +119,6 @@ export function drawScrubber(panel: PanelInfo) {
         );
       }
       prevFrozen = frozen;
-
 
     }
   }

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -50,6 +50,10 @@ onEvent("mousemove", "#scrubber-panel", (target: HTMLElement, event: Event) => {
 
 /** Update the scrubber. */
 export function updateScrubber() {
+  if (state.replay === null) {
+    return;
+  }
+
   let scrubberWidth = ui.scrubberPanel.width - 32;
   html.stepCounter.textContent = state.step.toString();
   html.stepCounter.parentElement!.style.left = (16 + state.step / state.replay.max_steps * scrubberWidth - 46 / 2).toString() + "px";

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -21,7 +21,7 @@ export function initScrubber() {
 }
 
 /** Update the scrubber. */
-function onScrubberChange(event: MouseEvent) {
+export function onScrubberChange(event: MouseEvent) {
   let mouseX = event.clientX;
   let scrubberWidth = ui.scrubberPanel.width - 32;
   let s = Math.floor((mouseX - 16) / scrubberWidth * state.replay.max_steps);
@@ -32,20 +32,8 @@ function onScrubberChange(event: MouseEvent) {
 /** Handle mouse down on the scrubber, which will update the step. */
 onEvent("mousedown", "#scrubber-panel", (target: HTMLElement, event: Event) => {
   console.log("Scrubber clicked");
-  ui.mouseDown = true;
+  ui.mainScrubberDown = true;
   onScrubberChange(event as MouseEvent);
-});
-
-/** Handle mouse up on the scrubber, which will update the step. */
-onEvent("mouseup", "#scrubber-panel", (target: HTMLElement, event: Event) => {
-  ui.mouseDown = false;
-});
-
-/** Handle mouse move on the scrubber, which will update the step. */
-onEvent("mousemove", "#scrubber-panel", (target: HTMLElement, event: Event) => {
-  if (ui.mouseDown) {
-    onScrubberChange(event as MouseEvent);
-  }
 });
 
 /** Update the scrubber. */

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -2,7 +2,7 @@
  * This file handles the timeline scrubber.
  * Main features is that clicking on the scrubber will update the step.
  * It shows the current step as a counter.
- * It can show key actions on the time line.
+ * It can show key actions on the timeline.
  * It has a box which is that the traces view is looking at, so it sort of
  * acts like a traces minimap.
 */

--- a/mettascope/src/scrubber.ts
+++ b/mettascope/src/scrubber.ts
@@ -1,0 +1,118 @@
+/**
+ * This file handles the timeline scrubber.
+ * Main features is that clicking on the scrubber will update the step.
+ * It shows the current step as a counter.
+ * It can show key actions on the time line.
+ * It has a box which is that the traces view is looking at, so it sort of
+ * acts like a traces minimap.
+*/
+
+import { PanelInfo } from "./panels.js"
+import * as Common from './common.js';
+import { ui, state, html, ctx, setFollowSelection } from './common.js';
+import { onEvent } from "./htmlutils.js";
+import { updateStep } from './main.js';
+import { clamp } from "./context3d.js";
+import { getAttr } from "./replay.js";
+
+export function initScrubber() {
+  console.log("Initializing scrubber");
+}
+
+function updateScrubber(event: MouseEvent) {
+  let mouseX = event.clientX;
+  let scrubberWidth = ui.scrubberPanel.width - 32;
+  let s = Math.floor((mouseX - 16) / scrubberWidth * state.replay.max_steps);
+  let step = clamp(s, 0, state.replay.max_steps - 1);
+  updateStep(step);
+}
+
+/** Handle mouse down on the scrubber, which will update the step. */
+onEvent("mousedown", "#scrubber-panel", (target: HTMLElement, event: Event) => {
+  console.log("Scrubber clicked");
+  ui.mouseDown = true;
+  updateScrubber(event as MouseEvent);
+});
+
+/** Handle mouse up on the scrubber, which will update the step. */
+onEvent("mouseup", "#scrubber-panel", (target: HTMLElement, event: Event) => {
+  ui.mouseDown = false;
+});
+
+/** Handle mouse move on the scrubber, which will update the step. */
+onEvent("mousemove", "#scrubber-panel", (target: HTMLElement, event: Event) => {
+  if (ui.mouseDown) {
+    updateScrubber(event as MouseEvent);
+  }
+});
+
+export function drawScrubber(panel: PanelInfo) {
+  if (state.replay === null || ctx === null || ctx.ready === false) {
+    return;
+  }
+
+  ctx.save();
+  ctx.setScissorRect(panel.x, panel.y, panel.width, panel.height);
+  ctx.translate(panel.x, panel.y);
+
+  let scrubberWidth = panel.width - 32;
+
+  // Draw the background of the scrubber.
+  ctx.drawSolidRect(
+    16, 34,
+    scrubberWidth, 16,
+    [0.5, 0.5, 0.5, 0.5] // White with 50% opacity
+  );
+
+  // Draw the foreground of the scrubber.
+  ctx.drawSolidRect(
+    16, 34,
+    scrubberWidth * state.step / state.replay.max_steps, 16,
+    [1, 1, 1, 1]
+  );
+
+  // The the position of the traces view.
+  let scrubberTileSize = scrubberWidth / state.replay.max_steps
+  let tracesX = -ui.tracePanel.panPos.x() / Common.TRACE_WIDTH * scrubberTileSize
+  let zoomLevel = ui.tracePanel.zoomLevel;
+  let tracesW = (ui.tracePanel.width / zoomLevel) / Common.TRACE_WIDTH * scrubberTileSize;
+  ctx.drawStrokeRect(
+    16 + tracesX - tracesW / 2 - 1, 0,
+    tracesW, 64,
+    1,
+    [1, 1, 1, 1]
+  );
+
+  // Draw key actions on the scrubber.
+  for (let agent of state.replay.agents) {
+    let prevFrozen = 0;
+    for (let j = 0; j < state.replay.max_steps; j++) {
+
+      // Draw frozen state.
+      let frozen = getAttr(agent, "agent:frozen", j);
+      if (frozen > 0 && prevFrozen == 0) {
+        let x = j / state.replay.max_steps * scrubberWidth;
+        ctx.drawSprite(
+          "agents/frozen.png",
+          x,
+          12,
+          [1, 1, 1, 1],
+          0.1,
+          0
+        );
+        ctx.drawSolidRect(
+          x,
+          24,
+          1,
+          8,
+          [1, 1, 1, 1]
+        );
+      }
+      prevFrozen = frozen;
+
+
+    }
+  }
+
+  ctx.restore();
+}

--- a/mettascope/src/timeline.ts
+++ b/mettascope/src/timeline.ts
@@ -18,6 +18,8 @@ import { getAttr } from "./replay.js";
 /** Initialize the timeline. */
 export function initTimeline() {
   console.log("Initializing timeline");
+  // Move the step counter off screen for now.
+  html.stepCounter.parentElement!.style.left = "-1000px";
 }
 
 /** Update the scrubber. */

--- a/mettascope/src/timeline.ts
+++ b/mettascope/src/timeline.ts
@@ -76,7 +76,7 @@ export function drawTimeline(panel: PanelInfo) {
     [1, 1, 1, 1]
   );
 
-  // The the position of the traces view.
+  // Draw the position of the traces view.
   let scrubberTileSize = scrubberWidth / fullSteps
   let tracesX = -ui.tracePanel.panPos.x() / Common.TRACE_WIDTH * scrubberTileSize
   let zoomLevel = ui.tracePanel.zoomLevel;

--- a/mettascope/src/timeline.ts
+++ b/mettascope/src/timeline.ts
@@ -15,41 +15,40 @@ import { updateStep } from './main.js';
 import { clamp } from "./context3d.js";
 import { getAttr } from "./replay.js";
 
-/** Initialize the scrubber. */
-export function initScrubber() {
-  console.log("Initializing scrubber");
+/** Initialize the timeline. */
+export function initTimeline() {
+  console.log("Initializing timeline");
 }
 
 /** Update the scrubber. */
 export function onScrubberChange(event: MouseEvent) {
   let mouseX = event.clientX;
-  let scrubberWidth = ui.scrubberPanel.width - 32;
+  let scrubberWidth = ui.timelinePanel.width - 32;
   let s = Math.floor((mouseX - 16) / scrubberWidth * state.replay.max_steps);
   let step = clamp(s, 0, state.replay.max_steps - 1);
   updateStep(step);
 }
 
-/** Handle mouse down on the scrubber, which will update the step. */
-onEvent("mousedown", "#scrubber-panel", (target: HTMLElement, event: Event) => {
-  console.log("Scrubber clicked");
+/** Handle mouse down on the timeline, which will update the step. */
+onEvent("mousedown", "#timeline-panel", (target: HTMLElement, event: Event) => {
   ui.mainScrubberDown = true;
   onScrubberChange(event as MouseEvent);
 });
 
-/** Update the scrubber. */
-export function updateScrubber() {
+/** Update the timeline. */
+export function updateTimeline() {
   if (state.replay === null) {
     return;
   }
 
-  let scrubberWidth = ui.scrubberPanel.width - 32;
+  let scrubberWidth = ui.timelinePanel.width - 32;
   let fullSteps = state.replay.max_steps - 1;
   html.stepCounter.textContent = state.step.toString();
   html.stepCounter.parentElement!.style.left = (16 + state.step / fullSteps * scrubberWidth - 46 / 2).toString() + "px";
 }
 
-/** Draw the scrubber. */
-export function drawScrubber(panel: PanelInfo) {
+/** Draw the timeline. */
+export function drawTimeline(panel: PanelInfo) {
   if (state.replay === null || ctx === null || ctx.ready === false) {
     return;
   }
@@ -87,7 +86,7 @@ export function drawScrubber(panel: PanelInfo) {
     [1, 1, 1, 1]
   );
 
-  // Draw key actions on the scrubber.
+  // Draw key actions on the timeline.
   for (let agent of state.replay.agents) {
     let prevFrozen = 0;
     for (let j = 0; j < state.replay.max_steps; j++) {
@@ -113,7 +112,6 @@ export function drawScrubber(panel: PanelInfo) {
         );
       }
       prevFrozen = frozen;
-
     }
   }
 

--- a/mettascope/style.css
+++ b/mettascope/style.css
@@ -89,7 +89,7 @@ html {
 #toast.hiding {
   opacity: 0;
   /* Animate upward when hiding */
-  transform: translateX(-50%) translateY(-20px);
+  transform: translateX(-50%) translateY(120px);
 }
 
 #modal.error {

--- a/mettascope/tools/gen_html.py
+++ b/mettascope/tools/gen_html.py
@@ -585,7 +585,14 @@ html, body {
 
             if "textAlignVertical" in style:
                 # No exact match in CSS for vertical text alignment on blocks
-                css["vertical-align"] = style["textAlignVertical"].lower()
+                if style["textAlignVertical"].lower() == "top":
+                    css["vertical-align"] = "top"
+                elif style["textAlignVertical"].lower() == "center":
+                    css["vertical-align"] = "middle"
+                elif style["textAlignVertical"].lower() == "bottom":
+                    css["vertical-align"] = "bottom"
+                else:
+                    print("Unknown vertical text alignment:", style["textAlignVertical"])
 
             if "letterSpacing" in style:
                 css["letter-spacing"] = px(style["letterSpacing"])


### PR DESCRIPTION
The scrubber shows current step as a number.
Scrubber area is now more of a mini map view for the trace panel. 
You can see key events like agents being frozen.
You can see what part of the timeline the trace panel is zoomed into.

![image](https://github.com/user-attachments/assets/7c2f7429-963f-4786-88af-b753a5819a3d)
