### PR TITLE
Track per-episode timing in env

### DIFF
--- a/mettagrid/mettagrid/util/perf_profiler.py
+++ b/mettagrid/mettagrid/util/perf_profiler.py
@@ -1,0 +1,39 @@
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Callable, Dict, TypeVar
+
+T = TypeVar("T")
+
+
+class PerfProfiler:
+    def __init__(self) -> None:
+        self.stats: Dict[str, float] = defaultdict(float)
+
+    @contextmanager
+    def time(self, name: str):
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.stats[name] += time.perf_counter() - start
+
+    def reset(self) -> None:
+        self.stats.clear()
+
+
+def profiled(name: str) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator to profile a method using ``PerfProfiler`` on ``self``."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(self: Any, *args: Any, **kwargs: Any) -> T:
+            profiler: PerfProfiler = self._profiler
+            with profiler.time(name):
+                result = func(self, *args, **kwargs)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/mettagrid/tests/test_mettagrid_env.py
+++ b/mettagrid/tests/test_mettagrid_env.py
@@ -1,10 +1,12 @@
+import numpy as np
 import pytest
 from omegaconf import OmegaConf
 from omegaconf.errors import ConfigAttributeError
 from pydantic import ValidationError
 
 from mettagrid.curriculum import SingleTaskCurriculum
-from mettagrid.mettagrid_env import MettaGridEnv
+from mettagrid.mettagrid_env import MettaGridEnv, dtype_actions
+from mettagrid.room.random import Random
 
 
 def test_invalid_env_map_type_raises():
@@ -17,3 +19,24 @@ def test_invalid_env_map_type_raises():
 def test_invalid_env_cfg_type_raises():
     with pytest.raises(ValidationError):
         MettaGridEnv({}, render_mode=None)
+
+
+def test_perf_metrics_in_infos():
+    cfg = OmegaConf.load("mettagrid/tests/mettagrid_test_args_env_cfg.json")
+    cfg.game.num_agents = 1
+    cfg.game.max_steps = 1
+    cfg.game.diversity_bonus = {"enabled": False}
+    curriculum = SingleTaskCurriculum("test", cfg)
+    level = Random(width=3, height=3, objects=OmegaConf.create({}), agents=1, border_width=1).build()
+    env = MettaGridEnv(curriculum, render_mode=None, level=level)
+
+    env.reset()
+    noop_idx = env.action_names.index("noop")
+    actions = np.array([[noop_idx, 0]], dtype=dtype_actions)
+    _, _, _, _, infos = env.step(actions)
+
+    expected = {"reset", "reset:make_c_env", "step", "step:episode_end"}
+    assert isinstance(infos.get("perf"), dict)
+    assert expected.issubset(infos["perf"].keys())
+    for name in expected:
+        assert isinstance(infos["perf"][name], float)


### PR DESCRIPTION
## Summary
- record env timings using `PerfProfiler` decorator
- capture reset and step metrics including episode-end processing
- validate perf stats during unit tests

## Testing
- `ruff check mettagrid/mettagrid/mettagrid_env.py mettagrid/mettagrid/util/perf_profiler.py mettagrid/tests/test_mettagrid_env.py`
- `mypy mettagrid/mettagrid/mettagrid_env.py mettagrid/mettagrid/util/perf_profiler.py mettagrid/tests/test_mettagrid_env.py` *(fails: missing stubs)*
- `uv run pytest mettagrid/tests/test_mettagrid_env.py::test_perf_metrics_in_infos -q`

------
https://chatgpt.com/codex/tasks/task_b_684a6e980bcc832baa158509ffd2d9dd