### PR TITLE
Move global tokens into compute_observation

### DIFF
--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -64,13 +64,6 @@
 		},
 		"terminal.integrated.cwd": "${workspaceFolder}",
 		"terminal.integrated.splitCwd": "workspaceRoot",
-		"files.autoGuessEncoding": false,
-		"files.associations": {
-			"__split_buffer": "cpp",
-			"deque": "cpp",
-			"list": "cpp",
-			"string": "cpp",
-			"vector": "cpp"
-		}
+		"files.autoGuessEncoding": false
 	}
 }

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -1,72 +1,76 @@
 {
-  "folders": [
-    {
-      "name": "metta",
-      "path": "."
-    },
-    {
-      "path": "personal"
-    }
-  ],
-  "settings": {
-    "yaml.schemas": {
-      "envs/griddly/gdy-schema.json": "envs/griddly/power_grid/*.yaml"
-    },
-    "ruff.enable": true,
-    "ruff.nativeServer": "on",
-    "files.excludeGitIgnored": true,
-    "terminal.integrated.profiles.osx": {
-      "metta-0": {
-        "path": "bash",
-        "args": [
-          "-c",
-          "WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta0 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
-        ],
-        "overrideName": true,
-        "name": "metta-0"
-      },
-      "metta-1": {
-        "path": "bash",
-        "args": [
-          "-c",
-          "WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta1 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
-        ],
-        "overrideName": true,
-        "name": "metta-1"
-      },
-      "metta-2": {
-        "path": "bash",
-        "args": [
-          "-c",
-          "WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta2 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
-        ],
-        "overrideName": true,
-        "name": "metta-2"
-      },
-      "metta-3": {
-        "path": "bash",
-        "args": [
-          "-c",
-          "WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta3 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
-        ],
-        "overrideName": true,
-        "name": "metta-3"
-      },
-      "metta-4": {
-        "path": "bash",
-        "args": [
-          "-c",
-          "WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta4 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
-        ],
-        "overrideName": true,
-        "name": "metta-4"
-      }
-    },
-    "terminal.integrated.cwd": "${workspaceFolder}",
-    "terminal.integrated.splitCwd": "workspaceRoot",
-    "files.autoGuessEncoding": false,
-    "files.associations": {
-      "*.json": "jsonc"
-    }
-  }
+	"folders": [
+		{
+			"name": "metta",
+			"path": "."
+		},
+		{
+			"path": "personal"
+		}
+	],
+	"settings": {
+		"yaml.schemas": {
+			"envs/griddly/gdy-schema.json": "envs/griddly/power_grid/*.yaml"
+		},
+		"ruff.enable": true,
+		"ruff.nativeServer": "on",
+		"files.excludeGitIgnored": true,
+		"terminal.integrated.profiles.osx": {
+			"metta-0": {
+				"path": "bash",
+				"args": [
+					"-c",
+					"WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta0 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
+				],
+				"overrideName": true,
+				"name": "metta-0"
+			},
+			"metta-1": {
+				"path": "bash",
+				"args": [
+					"-c",
+					"WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta1 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
+				],
+				"overrideName": true,
+				"name": "metta-1"
+			},
+			"metta-2": {
+				"path": "bash",
+				"args": [
+					"-c",
+					"WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta2 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
+				],
+				"overrideName": true,
+				"name": "metta-2"
+			},
+			"metta-3": {
+				"path": "bash",
+				"args": [
+					"-c",
+					"WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta3 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
+				],
+				"overrideName": true,
+				"name": "metta-3"
+			},
+			"metta-4": {
+				"path": "bash",
+				"args": [
+					"-c",
+					"WANDB_KEY=$(cat ~/.netrc | awk '/machine api.wandb.ai/{getline; getline; print $2}') && ssh -i ~/.ssh/id_ed25519 -t metta@metta4 'export WANDB_API_KEY=\"'\"$WANDB_KEY\"'\" SSH_USER=\"'\"$USER\"'\"; bash'"
+				],
+				"overrideName": true,
+				"name": "metta-4"
+			}
+		},
+		"terminal.integrated.cwd": "${workspaceFolder}",
+		"terminal.integrated.splitCwd": "workspaceRoot",
+		"files.autoGuessEncoding": false,
+		"files.associations": {
+			"__split_buffer": "cpp",
+			"deque": "cpp",
+			"list": "cpp",
+			"string": "cpp",
+			"vector": "cpp"
+		}
+	}
 }

--- a/mettagrid/mettagrid/action_handler.hpp
+++ b/mettagrid/mettagrid/action_handler.hpp
@@ -9,8 +9,8 @@
 #include "grid_object.hpp"
 #include "objects/agent.hpp"
 #include "objects/constants.hpp"
+#include "types.hpp"
 
-typedef unsigned char ActionArg;
 typedef std::map<std::string, int> ActionConfig;
 
 class ActionHandler {

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -333,7 +333,7 @@ void MettaGrid::_compute_observations(py::array_t<ActionType, py::array::c_style
   } else {
     for (size_t idx = 0; idx < _agents.size(); idx++) {
       auto& agent = _agents[idx];
-      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, -1, -1);
+      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, 0, 0);
     }
   }
 }

--- a/mettagrid/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/mettagrid/mettagrid_c.cpp
@@ -215,7 +215,8 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
                                      unsigned short obs_width,
                                      unsigned short obs_height,
                                      size_t agent_idx,
-                                     size_t start_idx) {
+                                     ActionType action,
+                                     ActionArg action_arg) {
   // Calculate observation boundaries
   unsigned int obs_width_radius = obs_width >> 1;
   unsigned int obs_height_radius = obs_height >> 1;
@@ -236,8 +237,27 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
   // we don't need to do that here.
   if (_use_observation_tokens) {
     size_t attempted_tokens_written = 0;
-    size_t tokens_written = start_idx;
+    size_t tokens_written = 4;
     auto observation_view = _observations.mutable_unchecked<3>();
+    auto rewards_view = _rewards.unchecked<1>();
+
+    // Global tokens
+    ObservationToken* tokens = reinterpret_cast<ObservationToken*>(observation_view.mutable_data(agent_idx, 0, 0));
+    unsigned int episode_completion_pct = 0;
+    if (max_steps > 0) {
+      episode_completion_pct = static_cast<unsigned int>(std::round((static_cast<double>(current_step) / max_steps) * 255.0));
+    }
+    tokens[0] = {0, ObservationFeature::EpisodeCompletionPct, static_cast<uint8_t>(episode_completion_pct)};
+    tokens[1] = {0, ObservationFeature::LastAction,
+                  static_cast<uint8_t>(action)};
+    tokens[2] = {0, ObservationFeature::LastActionArg,
+                  static_cast<uint8_t>(action_arg)};
+    int reward_int = static_cast<int>(std::round(rewards_view(agent_idx) * 100.0f));
+    reward_int = std::clamp(reward_int, 0, 255);
+    tokens[3] = {0, ObservationFeature::LastReward, static_cast<uint8_t>(reward_int)};
+
+
+
     // Order the tokens by distance from the agent, so if we need to drop tokens, we drop the farthest ones first.
     for (unsigned int distance = 0; distance <= obs_width_radius + obs_height_radius; distance++) {
       for (unsigned int r = r_start; r < r_end; r++) {
@@ -304,31 +324,16 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
 
 void MettaGrid::_compute_observations(py::array_t<ActionType, py::array::c_style> actions) {
   auto actions_view = actions.unchecked<2>();
-  auto rewards_view = _rewards.unchecked<1>();
   if (_use_observation_tokens) {
     auto observation_view = _observations.mutable_unchecked<3>();
     for (size_t idx = 0; idx < _agents.size(); idx++) {
-      ObservationToken* tokens = reinterpret_cast<ObservationToken*>(observation_view.mutable_data(idx, 0, 0));
-      unsigned int episode_completion_pct = 0;
-      if (max_steps > 0) {
-        episode_completion_pct = static_cast<unsigned int>(std::round((static_cast<double>(current_step) / max_steps) * 255.0));
-      }
-      tokens[0] = {0, ObservationFeature::EpisodeCompletionPct, static_cast<uint8_t>(episode_completion_pct)};
-      tokens[1] = {0, ObservationFeature::LastAction,
-                   static_cast<uint8_t>(actions_view(idx, 0))};
-      tokens[2] = {0, ObservationFeature::LastActionArg,
-                   static_cast<uint8_t>(actions_view(idx, 1))};
-      int reward_int = static_cast<int>(std::round(rewards_view(idx) * 100.0f));
-      reward_int = std::clamp(reward_int, 0, 255);
-      tokens[3] = {0, ObservationFeature::LastReward, static_cast<uint8_t>(reward_int)};
-
       auto& agent = _agents[idx];
-      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, 4);
+      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, actions_view(idx, 0), actions_view(idx, 1));
     }
   } else {
     for (size_t idx = 0; idx < _agents.size(); idx++) {
       auto& agent = _agents[idx];
-      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, 0);
+      _compute_observation(agent->location.r, agent->location.c, obs_width, obs_height, idx, -1, -1);
     }
   }
 }

--- a/mettagrid/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/mettagrid/mettagrid_c.hpp
@@ -115,7 +115,8 @@ private:
                             unsigned short obs_width,
                             unsigned short obs_height,
                             size_t agent_idx,
-                            size_t start_idx);
+                            ActionType action,
+                            ActionArg action_arg);
   void _compute_observations(py::array_t<ActionType, py::array::c_style> actions);
   void _step(py::array_t<ActionType, py::array::c_style> actions);
 };

--- a/mettagrid/mettagrid/types.hpp
+++ b/mettagrid/mettagrid/types.hpp
@@ -47,6 +47,7 @@ typedef bool TerminalType;
 typedef bool TruncationType;
 typedef float RewardType;
 typedef int32_t ActionType;
+typedef unsigned char ActionArg;
 typedef bool MaskType;
 typedef bool SuccessType;
 


### PR DESCRIPTION
### TL;DR

Refactored observation computation in MettaGrid to pass action parameters directly and moved ActionArg type definition to types.hpp.

