### PR TITLE
Improve terrain build speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,6 @@ find_package(pybind11 CONFIG REQUIRED)
 
 pybind11_add_module(fast_gae "metta/rl/fast_gae.cpp")
 install(TARGETS fast_gae DESTINATION "metta/rl")
+
+pybind11_add_module(terrain_utils "mettagrid/mettagrid/room/terrain_utils.cpp")
+install(TARGETS terrain_utils DESTINATION "mettagrid/room")

--- a/mettagrid/mettagrid/room/terrain_from_numpy.py
+++ b/mettagrid/mettagrid/room/terrain_from_numpy.py
@@ -10,6 +10,7 @@ from botocore.exceptions import NoCredentialsError
 from filelock import FileLock
 from omegaconf import DictConfig
 
+from mettagrid.room import terrain_utils
 from mettagrid.room.room import Room
 
 logger = logging.getLogger("terrain_from_numpy")
@@ -88,19 +89,7 @@ class TerrainFromNumpy(Room):
         super().__init__(border_width=border_width, border_object=border_object, labels=["terrain"])
 
     def get_valid_positions(self, level):
-        valid_positions = []
-        for i in range(1, level.shape[0] - 1):
-            for j in range(1, level.shape[1] - 1):
-                if level[i, j] == "empty":
-                    # Check if position is accessible from at least one direction
-                    if (
-                        level[i - 1, j] == "empty"
-                        or level[i + 1, j] == "empty"
-                        or level[i, j - 1] == "empty"
-                        or level[i, j + 1] == "empty"
-                    ):
-                        valid_positions.append((i, j))
-        return valid_positions
+        return terrain_utils.get_valid_positions(level)
 
     def _build(self):
         # TODO: add some way of sampling

--- a/mettagrid/mettagrid/room/terrain_utils.cpp
+++ b/mettagrid/mettagrid/room/terrain_utils.cpp
@@ -1,0 +1,43 @@
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+static py::list get_valid_positions(py::array level) {
+    py::buffer_info info = level.request();
+    if (info.ndim != 2) {
+        throw std::runtime_error("level must be 2D");
+    }
+    auto rows = info.shape[0];
+    auto cols = info.shape[1];
+    auto data = static_cast<PyObject**>(info.ptr);
+    auto stride_row = info.strides[0] / sizeof(PyObject*);
+    auto stride_col = info.strides[1] / sizeof(PyObject*);
+
+    py::list positions;
+    for (ssize_t i = 1; i < rows - 1; ++i) {
+        for (ssize_t j = 1; j < cols - 1; ++j) {
+            PyObject* cell = data[i * stride_row + j * stride_col];
+            std::string value = py::str(py::handle(cell));
+            if (value == "empty") {
+                PyObject* up = data[(i - 1) * stride_row + j * stride_col];
+                PyObject* down = data[(i + 1) * stride_row + j * stride_col];
+                PyObject* left = data[i * stride_row + (j - 1) * stride_col];
+                PyObject* right = data[i * stride_row + (j + 1) * stride_col];
+                if (std::string(py::str(py::handle(up))) == "empty" ||
+                    std::string(py::str(py::handle(down))) == "empty" ||
+                    std::string(py::str(py::handle(left))) == "empty" ||
+                    std::string(py::str(py::handle(right))) == "empty") {
+                    positions.append(py::make_tuple(i, j));
+                }
+            }
+        }
+    }
+    return positions;
+}
+
+PYBIND11_MODULE(terrain_utils, m) {
+    m.doc() = "Utilities for terrain generation";
+    m.def("get_valid_positions", &get_valid_positions, "Return valid spawn positions");
+}

--- a/tests/mettagrid/test_terrain_build.py
+++ b/tests/mettagrid/test_terrain_build.py
@@ -1,0 +1,60 @@
+import random
+
+import numpy as np
+from omegaconf import DictConfig
+
+from mettagrid.room import terrain_utils
+from mettagrid.room.terrain_from_numpy import TerrainFromNumpy
+
+
+def python_valid_positions(level: np.ndarray) -> list[tuple[int, int]]:
+    positions = []
+    for i in range(1, level.shape[0] - 1):
+        for j in range(1, level.shape[1] - 1):
+            if level[i, j] == "empty":
+                if (
+                    level[i - 1, j] == "empty"
+                    or level[i + 1, j] == "empty"
+                    or level[i, j - 1] == "empty"
+                    or level[i, j + 1] == "empty"
+                ):
+                    positions.append((i, j))
+    return positions
+
+
+def test_cpp_valid_positions_matches_python():
+    grid = np.array(
+        [
+            ["wall", "wall", "wall", "wall"],
+            ["wall", "empty", "empty", "wall"],
+            ["wall", "empty", "empty", "wall"],
+            ["wall", "wall", "wall", "wall"],
+        ],
+        dtype=object,
+    )
+
+    expected = python_valid_positions(grid)
+    actual = terrain_utils.get_valid_positions(grid)
+    assert sorted(expected) == sorted(actual)
+
+
+def test_build_with_cpp(tmp_path):
+    grid = np.array(
+        [
+            ["wall", "wall", "wall", "wall"],
+            ["wall", "empty", "empty", "wall"],
+            ["wall", "agent.agent", "empty", "wall"],
+            ["wall", "wall", "wall", "wall"],
+        ],
+        dtype=object,
+    )
+
+    path = tmp_path / "test.npy"
+    np.save(path, grid)
+
+    room = TerrainFromNumpy(objects=DictConfig({"rock": 1}), agents=1, dir=str(tmp_path), file="test.npy")
+    random.seed(0)
+    level = room.build().grid
+
+    assert (level == "agent.agent").sum() == 1
+    assert (level == "rock").sum() == 1


### PR DESCRIPTION
## Summary
- create `terrain_utils` C++ extension for valid position search
- use new extension in `TerrainFromNumpy`
- add tests covering extension and build workflow
- compile new module in CMake

## Testing
- `ruff format mettagrid/mettagrid/room/terrain_from_numpy.py tests/mettagrid/test_terrain_build.py`
- `ruff check mettagrid/mettagrid/room/terrain_from_numpy.py tests/mettagrid/test_terrain_build.py`
- `mypy mettagrid/mettagrid/room/terrain_from_numpy.py` *(fails: pyenv: mypy: command not found)*
- `uv pip install -e .`
- `uv pip install -e ./mettagrid`
- `pytest -k "not stats_server"`

------
https://chatgpt.com/codex/tasks/task_b_684d8cbae654832b8c47fc3ea3d83628