### PR TITLE
fix: make log lines wider on skypilot

### DIFF
--- a/metta/util/logging.py
+++ b/metta/util/logging.py
@@ -27,7 +27,7 @@ def restore_io():
 
 # Create a custom formatter that supports milliseconds
 class MillisecondFormatter(logging.Formatter):
-    def formatTime(self, record, datefmt=None):
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         created = datetime.fromtimestamp(record.created)
         # Convert microseconds to milliseconds (keep only 3 digits)
         msec = created.microsecond // 1000
@@ -41,13 +41,13 @@ class MillisecondFormatter(logging.Formatter):
 
 # Create a custom handler that always shows the timestamp
 class AlwaysShowTimeRichHandler(RichHandler):
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         # Force a unique timestamp for each record
         record.created = record.created + (record.relativeCreated % 1000) / 1000000
         super().emit(record)
 
 
-def get_log_level(provided_level=None):
+def get_log_level(provided_level: str | None = None) -> str:
     """
     Determine log level based on priority:
     1. Environment variable LOG_LEVEL
@@ -67,7 +67,7 @@ def get_log_level(provided_level=None):
     return "INFO"
 
 
-def setup_mettagrid_logger(name: str, level=None) -> logging.Logger:
+def setup_mettagrid_logger(name: str, level: str | None = None) -> logging.Logger:
     # Get the appropriate log level based on priority
     log_level = get_log_level(level)
 

--- a/metta/util/logging.py
+++ b/metta/util/logging.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import sys
 from datetime import datetime
 
@@ -67,6 +68,62 @@ def get_log_level(provided_level=None):
     return "INFO"
 
 
+def debug_logging_state(logger: logging.Logger) -> None:
+    """Log detailed debugging information about the logging environment."""
+    logger.info("LOGGING DEBUG INFORMATION")
+
+    # Environment variables
+    logger.info("Environment Variables:")
+    for key, value in sorted(os.environ.items()):
+        # Mask sensitive values
+        if any(sensitive in key.upper() for sensitive in ["PASSWORD", "SECRET", "TOKEN", "KEY"]):
+            logger.info(f"{key}=<MASKED>")
+        else:
+            logger.info(f"{key}={value}")
+
+    # Terminal information
+    logger.info("Terminal Information:")
+    if hasattr(sys.stdin, "fileno"):
+        logger.info(f"stdin isatty: {os.isatty(sys.stdin.fileno())}")
+    if hasattr(sys.stdout, "fileno"):
+        logger.info(f"stdout isatty: {os.isatty(sys.stdout.fileno())}")
+    if hasattr(sys.stderr, "fileno"):
+        logger.info(f"stderr isatty: {os.isatty(sys.stderr.fileno())}")
+
+    # Terminal size
+    try:
+        size = shutil.get_terminal_size()
+        logger.info(f"Terminal size: {size.columns}x{size.lines}")
+    except Exception as e:
+        logger.info(f"Terminal size: error - {e}")
+
+    logger.info(f"COLUMNS env: {os.environ.get('COLUMNS', 'Not set')}")
+    logger.info(f"LINES env: {os.environ.get('LINES', 'Not set')}")
+
+    # AWS environment variables
+    logger.info("AWS Environment Variables:")
+    aws_vars = {k: v for k, v in os.environ.items() if k.startswith("AWS_")}
+    if aws_vars:
+        for key, value in sorted(aws_vars.items()):
+            logger.info(f"{key}={value}")
+    else:
+        logger.info("No AWS environment variables found")
+
+    # System information
+    logger.info("System Information:")
+    logger.info(f"Python: {sys.version.split()[0]}")
+    logger.info(f"Platform: {sys.platform}")
+    logger.info(f"Executable: {sys.executable}")
+
+    # Logging configuration
+    logger.info("Logging Configuration:")
+    logger.info(f"Logger name: {logger.name}")
+    logger.info(f"Logger level: {logging.getLevelName(logger.level)}")
+    root_level = logging.getLogger().level
+    logger.info(f"Root logger level: {logging.getLevelName(root_level)}")
+    logger.info(f"Handler count: {len(logger.handlers)}")
+
+
 def setup_mettagrid_logger(name: str, level=None) -> logging.Logger:
     # Get the appropriate log level based on priority
     log_level = get_log_level(level)
@@ -85,8 +142,16 @@ def setup_mettagrid_logger(name: str, level=None) -> logging.Logger:
     # Set the level
     root_logger.setLevel(getattr(logging, log_level))
 
-    # set env COLUMNS if we are on AWS
-    if os.environ.get("AWS_BATCH_JOB_ID"):
-        os.environ["COLUMNS"] = "200"
+    # Get the logger for the specified name
+    logger = logging.getLogger(name)
 
-    return logging.getLogger(name)
+    # Log debugging information
+    debug_logging_state(logger)
+
+    # Set env COLUMNS if we are on AWS
+    if any(key.startswith("AWS_") for key in os.environ):
+        if "COLUMNS" not in os.environ:
+            os.environ["COLUMNS"] = "200"
+            logger.info("Set COLUMNS=200 (AWS environment)")
+
+    return logger


### PR DESCRIPTION
The changes in #824 seem ineffective on skypilot.

Debug prints show:

```
[12:08:04.496446] INFO     Terminal Information:                
[12:08:04.497338] INFO     stdin isatty: False                   
[12:08:04.498064] INFO     stdout isatty: False            
[12:08:04.498781] INFO     stderr isatty: False          
[12:08:04.499530] INFO     Terminal size: 80x24       
[12:08:04.500305] INFO     COLUMNS env: Not set    
[12:08:04.501004] INFO     LINES env: Not set        
[12:08:04.501711] INFO     AWS Environment Variables:    
[12:08:04.502556] INFO     No AWS environment variables found  
```

I think the easiest is to to set COLUMNS based on `SKYPILOT_TASK_ID` presence too.

testing:

![image](https://github.com/user-attachments/assets/b72167f4-6971-4ac1-b420-1f5465e32044)
