### PR TITLE
Fix SPS calculation after checkpoint

### DIFF
--- a/metta/rl/pufferlib/profile.py
+++ b/metta/rl/pufferlib/profile.py
@@ -51,6 +51,7 @@ class Profile:
     def __init__(self, frequency=1):
         self._profile = PufferProfile(frequency=frequency)
         self.start_time = time.time()
+        self.start_agent_steps = 0
         self.epoch = 0
 
         # Timing stats
@@ -111,7 +112,7 @@ class Profile:
         elapsed = current_time - self.start_time
 
         if elapsed > self.uptime:  # Avoid division by zero on first call
-            self.SPS = global_step / elapsed
+            self.SPS = (global_step - self.start_agent_steps) / elapsed
             self.remaining = (total_timesteps - global_step) / self.SPS if self.SPS > 0 else 0
 
         self.uptime = elapsed

--- a/metta/rl/pufferlib/trainer.py
+++ b/metta/rl/pufferlib/trainer.py
@@ -155,6 +155,7 @@ class PufferTrainer:
 
         self.agent_step = checkpoint.agent_step
         self.epoch = checkpoint.epoch
+        self.profile.start_agent_steps = self.agent_step
         self._last_agent_step = self.agent_step
         self._total_minibatches = 0
 
@@ -616,7 +617,10 @@ class PufferTrainer:
             self.losses.explained_variance = explained_var
             self.epoch += 1
 
-            profile.update_stats(self.agent_step, self.trainer_cfg.total_timesteps)
+            profile.update_stats(
+                self.agent_step,
+                self.trainer_cfg.total_timesteps,
+            )
 
     def _checkpoint_trainer(self):
         if not self._master:
@@ -760,7 +764,7 @@ class PufferTrainer:
 
             training_time = timer_data.get("_rollout", 0) + timer_data.get("_train", 0)
             overhead_time = wall_time - training_time
-            steps_per_sec = self.agent_step / training_time if training_time > 0 else 0
+            steps_per_sec = (self.agent_step - self._last_agent_step) / training_time if training_time > 0 else 0
 
             timing_logs = {
                 # Key performance indicators


### PR DESCRIPTION
## Fix SPS calculation in Pufferlib trainer

- Fix SPS (steps per second) calculation by using relative step counts instead of absolute values
- Add `start_agent_steps` to Profile class to track the starting point for calculations
- Update SPS calculations in both profile.py and trainer.py to use step differences
- Add C++ terrain builder implementation for improved performance in mettagrid
