### PR TITLE
Make hover panels show/hide better.

### DIFF
--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -49,6 +49,7 @@ export const ui = {
   mouseDoubleClick: false,
   mousePos: new Vec2f(0, 0),
   mouseTarget: "",
+  mouseTargets: [] as string[],
   dragging: "",
   dragHtml: null as HTMLElement | null,
   dragOffset: new Vec2f(0, 0),

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -48,7 +48,6 @@ export const ui = {
   mouseClick: false,
   mouseDoubleClick: false,
   mousePos: new Vec2f(0, 0),
-  mouseTarget: "",
   mouseTargets: [] as string[],
   dragging: "",
   dragHtml: null as HTMLElement | null,

--- a/mettascope/src/hoverpanels.ts
+++ b/mettascope/src/hoverpanels.ts
@@ -92,6 +92,13 @@ hoverPanel.addEventListener("mousedown", (e: MouseEvent) => {
 /** Update the hover panel, visibility and position, and dom tree. */
 export function updateHoverPanel(object: any) {
   if (object !== null && object !== undefined) {
+    let typeName = state.replay.object_types[getAttr(object, "type")];
+    if (typeName == "wall") {
+      // Don't show hover panel for walls.
+      hoverPanel.classList.add("hidden");
+      return;
+    }
+
     updateDom(hoverPanel, object);
     hoverPanel.classList.remove("hidden");
 

--- a/mettascope/src/hoverpanels.ts
+++ b/mettascope/src/hoverpanels.ts
@@ -111,6 +111,12 @@ export function updateHoverPanel(object: any) {
   findIn(hoverPanel, ".close").classList.add("hidden");
 }
 
+/** Hides the hover panel. */
+export function hideHoverPanel() {
+  ui.delayedHoverObject = null;
+  hoverPanel.classList.add("hidden");
+}
+
 /** Update the dom tree of the info panel. */
 function updateDom(htmlPanel: HTMLElement, object: any) {
   // Update the readout.

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -201,7 +201,6 @@ onEvent("wheel", "body", (target: HTMLElement, e: Event) => {
 /** Mouse moved outside the window. */
 document.addEventListener('mouseout', function (e) {
   if (!e.relatedTarget) {
-    console.log('Mouse has left the document/window.');
     hideHoverPanel();
     requestFrame();
   }
@@ -209,7 +208,6 @@ document.addEventListener('mouseout', function (e) {
 
 /** The window got de-focused. */
 document.addEventListener('blur', function (e) {
-  console.log('Window got de-focused.');
   hideHoverPanel();
   requestFrame();
 });

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -126,7 +126,6 @@ onEvent("mousemove", "body", (target: HTMLElement, e: Event) => {
   while (target.id === "" && target.parentElement != null) {
     target = target.parentElement as HTMLElement;
   }
-  ui.mouseTarget = target.id;
   ui.mouseTargets = [];
   let p = event.target as HTMLElement;
   while (p != null) {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -8,7 +8,7 @@ import { drawMiniMap } from './minimap.js';
 import { processActions, initActionButtons } from './actions.js';
 import { initAgentTable, updateAgentTable } from './agentpanel.js';
 import { localStorageSetNumber, onEvent, find } from './htmlutils.js';
-import { updateReadout } from './hoverpanels.js';
+import { updateReadout, hideHoverPanel } from './hoverpanels.js';
 import { initObjectMenu } from './objmenu.js';
 import { drawTimeline, initTimeline, updateTimeline, onScrubberChange } from './timeline.js';
 
@@ -127,13 +127,26 @@ onEvent("mousemove", "body", (target: HTMLElement, e: Event) => {
     target = target.parentElement as HTMLElement;
   }
   ui.mouseTarget = target.id;
+  ui.mouseTargets = [];
+  let p = event.target as HTMLElement;
+  while (p != null) {
+    if (p.id !== "") {
+      ui.mouseTargets.push("#" + p.id);
+    }
+    for (const className of p.classList) {
+      ui.mouseTargets.push("." + className);
+    }
+    p = p.parentElement as HTMLElement;
+  }
 
   // If mouse is close to a panels edge change cursor to edge changer.
   document.body.style.cursor = "default";
   if (Math.abs(ui.mousePos.y() - ui.tracePanel.y) < Common.SPLIT_DRAG_THRESHOLD) {
     document.body.style.cursor = "ns-resize";
   }
-  if (Math.abs(ui.mousePos.y() - (ui.agentPanel.y + ui.agentPanel.height)) < Common.SPLIT_DRAG_THRESHOLD) {
+  if (state.showAgentPanel &&
+    Math.abs(ui.mousePos.y() - (ui.agentPanel.y + ui.agentPanel.height)) < Common.SPLIT_DRAG_THRESHOLD
+  ) {
     document.body.style.cursor = "ns-resize";
   }
 
@@ -159,6 +172,13 @@ onEvent("mousemove", "body", (target: HTMLElement, e: Event) => {
     onScrubberChange(event);
   }
 
+
+  console.log("Mouse targets: ", ui.mouseTargets);
+  if (!ui.mouseTargets.includes("#worldmap-panel") && !ui.mouseTargets.includes(".hover-panel")) {
+    console.log("Hiding because: ", ui.mouseTargets);
+    hideHoverPanel();
+  }
+
   requestFrame();
 })
 
@@ -180,6 +200,22 @@ onEvent("wheel", "body", (target: HTMLElement, e: Event) => {
   event.preventDefault();
   requestFrame();
 })
+
+/** Mouse moved outside the window. */
+document.addEventListener('mouseout', function (e) {
+  if (!e.relatedTarget) {
+    console.log('Mouse has left the document/window.');
+    hideHoverPanel();
+    requestFrame();
+  }
+});
+
+/** The window got de-focused. */
+document.addEventListener('blur', function (e) {
+  console.log('Window got de-focused.');
+  hideHoverPanel();
+  requestFrame();
+});
 
 /** Update all URL parameters without creating browser history entries. */
 function updateUrlParams() {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -172,10 +172,7 @@ onEvent("mousemove", "body", (target: HTMLElement, e: Event) => {
     onScrubberChange(event);
   }
 
-
-  console.log("Mouse targets: ", ui.mouseTargets);
   if (!ui.mouseTargets.includes("#worldmap-panel") && !ui.mouseTargets.includes(".hover-panel")) {
-    console.log("Hiding because: ", ui.mouseTargets);
     hideHoverPanel();
   }
 

--- a/mettascope/src/panels.ts
+++ b/mettascope/src/panels.ts
@@ -55,7 +55,7 @@ export class PanelInfo {
   /** Update the pan and zoom level based on the mouse position and scroll delta. */
   updatePanAndZoom(): boolean {
 
-    if ("#" + ui.mouseTarget != this.name || ui.dragging != "") {
+    if (!ui.mouseTargets.includes(this.name) || ui.dragging != "") {
       return false;
     }
 

--- a/mettascope/src/timeline.ts
+++ b/mettascope/src/timeline.ts
@@ -17,7 +17,7 @@ import { getAttr } from "./replay.js";
 
 /** Initialize the timeline. */
 export function initTimeline() {
-  console.log("Initializing timeline");
+  console.info("Initializing timeline");
   // Move the step counter off screen for now.
   html.stepCounter.parentElement!.style.left = "-1000px";
 }

--- a/mettascope/src/traces.ts
+++ b/mettascope/src/traces.ts
@@ -13,7 +13,7 @@ export function drawTrace(panel: PanelInfo) {
   }
 
   // Handle mouse events for the trace panel.
-  if (ui.mouseTarget == "trace-panel") {
+  if (ui.mouseTargets.includes("#trace-panel")) {
     if (ui.mouseDoubleClick) {
       // Toggle followSelection on double-click
       console.info("Trace double click - following selection");

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -688,7 +688,7 @@ function attackGrid(orientation: number, idx: number) {
 function drawAttackMode() {
   // We might be clicking on the map to attack something.
   var gridMousePos: Vec2f | null = null;
-  if (ui.mouseUp && ui.mouseTarget == "worldmap-panel" && state.showAttackMode) {
+  if (ui.mouseUp && ui.mouseTargets.includes("#worldmap-panel") && state.showAttackMode) {
     state.showAttackMode = false;
     const localMousePos = ui.mapPanel.transformOuter(ui.mousePos);
     if (localMousePos != null) {
@@ -751,7 +751,7 @@ export function drawMap(panel: PanelInfo) {
   }
 
   // Handle mouse events for the map panel.
-  if (ui.mouseTarget == "worldmap-panel" && ui.dragging == "" && !state.showAttackMode) {
+  if (ui.mouseTargets.includes("#worldmap-panel") && ui.dragging == "" && !state.showAttackMode) {
     // Find object under the mouse:
     var objectUnderMouse = null;
     const localMousePos = panel.transformOuter(ui.mousePos);
@@ -798,7 +798,7 @@ export function drawMap(panel: PanelInfo) {
     ui.hoverObject = objectUnderMouse;
     clearTimeout(ui.hoverTimer);
     ui.hoverTimer = setTimeout(() => {
-      if (ui.mouseTarget == "worldmap-panel") {
+      if (ui.mouseTargets.includes("#worldmap-panel")) {
         ui.delayedHoverObject = ui.hoverObject;
         updateHoverPanel(ui.delayedHoverObject)
       }


### PR DESCRIPTION
It was annoying to have hover panels show up when you don't want too.

* Hide hover when hovering over non map (trace, footer, header etc...)
* Hide hover when leaving the page.
* Hide hover when page becomes inactive (blur).

Also clean up logic around hover `mouseTargets`.
Also fix a bug when hovering over the hidden agent panel and having the mouse pointer. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved hover panel behavior so it only shows on the map, hides when leaving the page or switching tabs, and does not appear over walls.

- **Bug Fixes**
  - Fixed hover panel showing in unwanted areas like the header, footer, or hidden agent panel.
  - Cleaned up hover logic and replaced single mouse target tracking with a more reliable method.

<!-- End of auto-generated description by cubic. -->

