### PR TITLE
hotfix: repair `test_mettagrid_env_benchmark.cpp` benchmark

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -33,6 +33,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   game_cfg["obs_width"] = 11;
   game_cfg["obs_height"] = 11;
   game_cfg["use_observation_tokens"] = true;
+  game_cfg["num_observation_tokens"] = 100;
 
   // Actions configuration
   py::dict actions_cfg;


### PR DESCRIPTION
 Someday we will have a pydantic validator
 
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the num_observation_tokens setting to the benchmark config to fix test failures.

<!-- End of auto-generated description by cubic. -->

