### PR TITLE
fix: accurate loss reporting

### DIFF
--- a/metta/rl/losses.py
+++ b/metta/rl/losses.py
@@ -3,19 +3,39 @@ class Losses:
         self.zero()
 
     def zero(self):
-        """Reset all loss values to 0.0"""
-        self.policy_loss = 0.0
-        self.value_loss = 0.0
-        self.entropy = 0.0
-        self.old_approx_kl = 0.0
-        self.approx_kl = 0.0
-        self.clipfrac = 0.0
+        """Reset all loss values and counters"""
+        # Cumulative values
+        self.policy_loss_sum = 0.0
+        self.value_loss_sum = 0.0
+        self.entropy_sum = 0.0
+        self.old_approx_kl_sum = 0.0
+        self.approx_kl_sum = 0.0
+        self.clipfrac_sum = 0.0
+        self.l2_reg_loss_sum = 0.0
+        self.l2_init_loss_sum = 0.0
+        self.ks_action_loss_sum = 0.0
+        self.ks_value_loss_sum = 0.0
+
+        # Special case - this is computed once at the end
         self.explained_variance = 0.0
-        self.l2_reg_loss = 0.0
-        self.l2_init_loss = 0.0
-        self.ks_action_loss = 0.0
-        self.ks_value_loss = 0.0
+
+        # Counter for actual minibatches processed
+        self.minibatches_processed = 0
 
     def to_dict(self) -> dict[str, float]:
-        """Convert losses to dictionary for stats/logging"""
-        return {k: v for k, v in vars(self).items() if not k.startswith("_")}
+        """Convert losses to dictionary with proper averages"""
+        n = max(1, self.minibatches_processed)
+
+        return {
+            "policy_loss": self.policy_loss_sum / n,
+            "value_loss": self.value_loss_sum / n,
+            "entropy": self.entropy_sum / n,
+            "old_approx_kl": self.old_approx_kl_sum / n,
+            "approx_kl": self.approx_kl_sum / n,
+            "clipfrac": self.clipfrac_sum / n,
+            "l2_reg_loss": self.l2_reg_loss_sum / n,
+            "l2_init_loss": self.l2_init_loss_sum / n,
+            "ks_action_loss": self.ks_action_loss_sum / n,
+            "ks_value_loss": self.ks_value_loss_sum / n,
+            "explained_variance": self.explained_variance,
+        }

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -495,7 +495,6 @@ class MettaTrainer:
             experience.flatten_batch(advantages_np)
 
         # Optimizing the policy and value network
-        total_minibatches = experience.num_minibatches * self.trainer_cfg.update_epochs
         for _epoch in range(self.trainer_cfg.update_epochs):
             lstm_state = PolicyState()
             teacher_lstm_state = []

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -742,17 +742,6 @@ class MettaTrainer:
         epoch = self.epoch
         learning_rate = self.optimizer.param_groups[0]["lr"]
 
-        loss_stats = self.losses.to_dict()
-
-        # don't plot losses that are unused
-        if self.trainer_cfg.l2_reg_loss_coef == 0:
-            loss_stats.pop("l2_reg_loss")
-        if self.trainer_cfg.l2_init_loss_coef == 0:
-            loss_stats.pop("l2_init_loss")
-        if not self.kickstarter.enabled:
-            loss_stats.pop("ks_action_loss")
-            loss_stats.pop("ks_value_loss")
-
         performance = {k: v for k, v in self.profile}
 
         overview = {"SPS": sps}
@@ -764,6 +753,17 @@ class MettaTrainer:
             score = self._eval_suite_avgs.get(f"{category}_score", None)
             if score is not None:
                 overview[f"{category}_evals"] = score
+
+        losses = self.losses.to_dict()
+
+        # don't plot losses that are unused
+        if self.trainer_cfg.l2_reg_loss_coef == 0:
+            losses.pop("l2_reg_loss")
+        if self.trainer_cfg.l2_init_loss_coef == 0:
+            losses.pop("l2_init_loss")
+        if not self.kickstarter.enabled:
+            losses.pop("ks_action_loss")
+            losses.pop("ks_value_loss")
 
         environment = {f"env_{k.split('/')[0]}/{'/'.join(k.split('/')[1:])}": v for k, v in self.stats.items()}
 
@@ -795,7 +795,7 @@ class MettaTrainer:
             self.wandb_run.log(
                 {
                     **{f"overview/{k}": v for k, v in overview.items()},
-                    **loss_stats,
+                    **{f"losses/{k}": v for k, v in losses.items()},
                     **{f"performance/{k}": v for k, v in performance.items()},
                     **environment,
                     **weight_metrics,

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -590,19 +590,21 @@ class MettaTrainer:
                         torch.cuda.synchronize()
 
                 with profile.train_misc:
-                    self.losses.policy_loss += pg_loss.item() / total_minibatches
-                    self.losses.value_loss += v_loss.item() / total_minibatches
-                    self.losses.entropy += entropy_loss.item() / total_minibatches
-                    self.losses.old_approx_kl += old_approx_kl.item() / total_minibatches
-                    self.losses.approx_kl += approx_kl.item() / total_minibatches
-                    self.losses.clipfrac += clipfrac.item() / total_minibatches
-                    self.losses.l2_reg_loss += l2_reg_loss.item() / total_minibatches
-                    self.losses.l2_init_loss += l2_init_loss.item() / total_minibatches
-                    self.losses.ks_action_loss += ks_action_loss.item() / total_minibatches
-                    self.losses.ks_value_loss += ks_value_loss.item() / total_minibatches
+                    self.losses.policy_loss_sum += pg_loss.item()
+                    self.losses.value_loss_sum += v_loss.item()
+                    self.losses.entropy_sum += entropy_loss.item()
+                    self.losses.old_approx_kl_sum += old_approx_kl.item()
+                    self.losses.approx_kl_sum += approx_kl.item()
+                    self.losses.clipfrac_sum += clipfrac.item()
+                    self.losses.l2_reg_loss_sum += l2_reg_loss.item()
+                    self.losses.l2_init_loss_sum += l2_init_loss.item()
+                    self.losses.ks_action_loss_sum += ks_action_loss.item()
+                    self.losses.ks_value_loss_sum += ks_value_loss.item()
+                    self.losses.minibatches_processed += 1
 
             if self.trainer_cfg.target_kl is not None:
-                if approx_kl > self.trainer_cfg.target_kl:
+                average_approx_kl = self.losses.approx_kl_sum / self.losses.minibatches_processed
+                if average_approx_kl > self.trainer_cfg.target_kl:
                     break
 
         with profile.train_misc:


### PR DESCRIPTION
### Problem

We have been reporting incremental averages during loss accumulation:

```python
self.losses.policy_loss += pg_loss.item() / total_minibatches
```

This approach will lead to **Incorrect averages on early exit**: 

When training exits early due to KL divergence threshold, we've divided by total_minibatches but only accumulated a subset


### Solution

This PR changes the loss tracking to:
1. Accumulate raw loss values without division
2. Track the actual number of minibatches processed
4. Compute averages only when needed in `to_dict()`

### Changes

- Modified `Losses` class to store cumulative sums (`*_sum` attributes)
- Added `minibatches_processed` counter
- Updated `to_dict()` to compute true averages: `sum / actual_minibatches_processed`
- Fixed KL divergence check to use the running average instead of the last minibatch value

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed loss averaging to ensure accurate training stats and correct KL-based early stopping, even when training exits early.

- **Bug Fixes**
  - Loss values now accumulate raw sums and track the number of minibatches processed.
  - Averages are computed only when needed, using actual minibatch counts.
  - KL divergence check now uses the running average, not just the last minibatch.

<!-- End of auto-generated description by cubic. -->

