### PR TITLE
Add a shell.nix to make it easier to setup on Linux

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
   pkgs = import (fetchTarball {
-    url = "https://nixos.org/channels/nixos-25.05/nixexprs.tar.xz";
+    url = "https://nixos.org/channels/nixos-24.11/nixexprs.tar.xz";
   }) {
     config.allowUnfree = true;
   };
@@ -22,8 +22,10 @@ pkgs.mkShell {
     cmake
     stdenv.cc.cc.lib
 
+    # nix 24.11 comes with gcc13, which works with nvcc 12
+
     # for mettascope
-    nodejs_24
+    nodejs_22
     typescript
   ];
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,59 @@
+let
+  pkgs = import (fetchTarball {
+    url = "https://nixos.org/channels/nixos-25.05/nixexprs.tar.xz";
+  }) {
+    config.allowUnfree = true;
+  };
+
+  flake-compat = import (fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/master.tar.gz";
+  });
+  nixpkgs-python = (flake-compat {
+    src = fetchTarball "https://github.com/cachix/nixpkgs-python/archive/master.tar.gz";
+  }).defaultNix;
+  mettaPython = nixpkgs-python.packages.x86_64-linux."3.11.7";
+in
+pkgs.mkShell {
+  name = "metta-dev";
+
+  buildInputs = with pkgs; [
+    mettaPython
+    uv
+    cmake
+    stdenv.cc.cc.lib
+
+    # for mettascope
+    nodejs_24
+    typescript
+  ];
+
+  shellHook = ''
+    # Prevent uv from downloading its own Python
+    export UV_PYTHON="${mettaPython}/bin/python3.11"
+    # Clear PYTHONPATH to avoid conflicts
+    export PYTHONPATH=""
+
+    # set LD_LIBRARY_PATH for cmake to run properly during uv sync
+    export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+
+    # Create and activate a virtual environment with uv
+    uv sync
+    source .venv/bin/activate
+
+    # build frontend
+    pushd mettascope
+    npm install
+    tsc
+    python tools/gen_atlas.py
+    echo "Frontend built"
+    popd
+
+    echo "# Python version: $(python --version)"
+    echo "# uv version: $(uv --version)"
+    echo "# -------------------------------------------"
+    echo "# ./tools/train.py run=my_experiment +hardware=macbook wandb=off"
+    echo "# ./tools/sim.py run=my_experiment +hardware=macbook wandb=off"
+    echo "# ./tools/play.py run=my_experiment +hardware=macbook wandb=off"
+    echo "# -------------------------------------------"
+  '';
+}


### PR DESCRIPTION
- Wanted to get the project running locally on CPU on Linux, made a `shell.nix` to automate setting up the specific version of python and everything.
- I've tested this working on cpu on 2 systems. one is a laptop running NixOS, and also on a Fedora server with Nix installed.

- I don't currently have an Nvidia system to test on, but it should probably work if nvcc is in the environment and working.