### PR TITLE
skypilot connect script

### DIFF
--- a/devops/skypilot/connect.py
+++ b/devops/skypilot/connect.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env -S uv run
+
+import argparse
+import shlex
+import subprocess
+
+import sky.jobs
+
+from metta.util.colorama import bold
+
+
+def get_jobs_controller_name():
+    job_clusters = sky.get(sky.status(all_users=True, cluster_names=["sky-jobs-controller*"]))
+    if len(job_clusters) == 0:
+        raise ValueError("No job controller cluster found, is it running?")
+    return job_clusters[0]["name"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Connect to a running skypilot job")
+    parser.add_argument(
+        "--mode",
+        choices=["container", "host"],
+        default="container",
+        help="Whether to connect to the job container or the host machine where the job is running",
+    )
+    parser.add_argument("job_id", type=int, help="The job ID to connect to")
+    args = parser.parse_args()
+
+    job_id = args.job_id
+
+    print("Looking up EC2 instance...")
+    instance = subprocess.check_output(
+        [
+            "aws",
+            "ec2",
+            "describe-instances",
+            "--filters",
+            f"Name=tag:Name,Values=*-{job_id}-*",
+            "--query",
+            "Reservations[0].Instances[0].PrivateDnsName",
+            "--output",
+            "text",
+        ],
+        text=True,
+    )
+    instance = instance.strip()
+
+    print("Looking up skypilot job...")
+    request_id = sky.jobs.queue(refresh=True, skip_finished=True, all_users=True)
+    jobs = sky.get(request_id)
+    job = next((job for job in jobs if job["job_id"] == job_id), None)
+    if job is None:
+        print(jobs[0])
+        raise ValueError(f"Job {job_id} not found")
+
+    user_hash = job["user_hash"]
+
+    if args.mode == "container":
+        job_host_command = "docker exec -it $(docker ps -q) bash"
+    elif args.mode == "host":
+        job_host_command = "bash"
+    else:
+        raise ValueError(f"Invalid mode: {args.mode}")
+
+    key_path = f"/home/ubuntu/.sky/clients/{user_hash}/ssh/sky-key"
+    inner_ssh_command = shlex.join(["ssh", "-t", "-i", key_path, f"ubuntu@{instance}", job_host_command])
+
+    print("Looking up jobs controller...")
+    jobs_controller_name = get_jobs_controller_name()
+
+    full_command = shlex.join(["ssh", "-t", jobs_controller_name, inner_ssh_command])
+    print(f"Connecting with: {bold(full_command)}")
+
+    subprocess.run(full_command, shell=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Helper script for debugging running skypilot jobs.

Goes through all three layers in one command (job controller -> job EC2 instance -> docker).

```
$ ./devops/skypilot/connect.py 869
Looking up EC2 instance...
Looking up skypilot job...
Looking up jobs controller...
Connecting with: ssh -t sky-jobs-controller-e7ac67be 'ssh -t -i /home/ubuntu/.sky/clients/7e1c6f93/ssh/sky-key ubuntu@ip-172-31-20-205.ec2.internal '"'"'docker exec -it $(docker ps -q) bash'"'"''
Warning: Permanently added '54.90.135.160' (ED25519) to the list of known hosts.
 🐡
```