### PR TITLE
New replay environment every episode

### DIFF
--- a/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
@@ -20,7 +20,7 @@ game:
 
   objects:
     altar:
-      input_battery: 1
+      input_battery.red: 1
       output_heart: 1
       max_output: 1
       conversion_ticks: 1

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -217,12 +217,6 @@ class MettaTrainer:
             for k in ["0verview", "env", "losses", "performance", "train"]:
                 wandb_run.define_metric(f"{k}/*", step_metric="train/agent_step")
 
-        self.replay_sim_config = SingleEnvSimulationConfig(
-            env="/env/mettagrid/mettagrid",
-            num_episodes=1,
-            env_overrides=self._curriculum.get_task().env_cfg(),
-        )
-
         self.timer = Stopwatch(logger)
         self.timer.start()
 
@@ -683,11 +677,16 @@ class MettaTrainer:
 
     def _generate_and_upload_replay(self):
         if self._master:
+            replay_sim_config = SingleEnvSimulationConfig(
+                env="/env/mettagrid/mettagrid",
+                num_episodes=1,
+                env_overrides=self._curriculum.get_task().env_cfg(),
+            )
             logger.info("Generating and saving a replay to wandb and S3.")
 
             replay_simulator = Simulation(
                 name=f"replay_{self.epoch}",
-                config=self.replay_sim_config,
+                config=replay_sim_config,
                 policy_pr=self.last_pr,
                 policy_store=self.policy_store,
                 device=self.device,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Each replay now uses a fresh environment configuration for every episode, improving replay accuracy and consistency.

- **Refactors**
  - Moved replay environment setup into the replay generation method to ensure a new environment is created each time.
  - Updated altar object config to specify the correct input battery type.

<!-- End of auto-generated description by cubic. -->

