### PR TITLE
feat: trigger claude reviews by comment cmd

### DIFF
--- a/.github/workflows/claude-review-orchestrator.yml
+++ b/.github/workflows/claude-review-orchestrator.yml
@@ -1,13 +1,31 @@
 name: "Claude Review: Orchestrator"
 on:
-  pull_request:
-    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       pr_number:
         description: "Pull Request number to review"
         required: true
         type: string
+      run_readme:
+        description: "Run README accuracy review"
+        required: false
+        type: boolean
+        default: true
+      run_comments:
+        description: "Run code comments review"
+        required: false
+        type: boolean
+        default: true
+      run_types:
+        description: "Run type annotations review"
+        required: false
+        type: boolean
+        default: true
+      run_einops:
+        description: "Run einops optimization review"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -15,46 +33,29 @@ permissions:
   id-token: write
 
 jobs:
-  # Validate PR context and check if we should skip
+  # Validate PR context
   validate-pr:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.validate.outputs.pr_number }}
-      should_skip: ${{ steps.check-author.outputs.should_skip }}
     steps:
       - name: Validate PR Number
         id: validate
         run: |
-          PR_NUMBER="${{ inputs.pr_number || github.event.pull_request.number }}"
+          PR_NUMBER="${{ inputs.pr_number }}"
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
-            echo "❌ Error: No valid PR number found"
-            echo "For workflow_dispatch, you must provide a pr_number input"
-            echo "For pull_request events, this should be automatic"
+            echo "❌ Error: No valid PR number provided"
             exit 1
           fi
 
           echo "✅ Valid PR number: $PR_NUMBER"
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-      - name: Check if PR is from Dependabot
-        id: check-author
-        run: |
-          PR_AUTHOR="${{ github.event.pull_request.user.login || 'unknown' }}"
-          echo "PR Author: $PR_AUTHOR"
-
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]] || [[ "$PR_AUTHOR" == "dependabot" ]]; then
-            echo "🤖 Skipping Claude review for Dependabot PR"
-            echo "should_skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "👤 Running Claude review for user PR"
-            echo "should_skip=false" >> $GITHUB_OUTPUT
-          fi
-
-  # Run all review types in parallel (only if not skipping)
+  # Run review types conditionally based on inputs (in parallel)
   review-readme:
     needs: validate-pr
-    if: needs.validate-pr.outputs.should_skip != 'true'
+    if: inputs.run_readme
     secrets: inherit
     uses: ./.github/workflows/claude-review-readme.yml
     with:
@@ -62,7 +63,7 @@ jobs:
 
   review-comments:
     needs: validate-pr
-    if: needs.validate-pr.outputs.should_skip != 'true'
+    if: inputs.run_comments
     secrets: inherit
     uses: ./.github/workflows/claude-review-comments.yml
     with:
@@ -70,7 +71,7 @@ jobs:
 
   review-types:
     needs: validate-pr
-    if: needs.validate-pr.outputs.should_skip != 'true'
+    if: inputs.run_types
     secrets: inherit
     uses: ./.github/workflows/claude-review-typing.yml
     with:
@@ -78,7 +79,7 @@ jobs:
 
   review-einops:
     needs: validate-pr
-    if: needs.validate-pr.outputs.should_skip != 'true'
+    if: inputs.run_einops
     secrets: inherit
     uses: ./.github/workflows/claude-review-einops.yml
     with:
@@ -88,7 +89,7 @@ jobs:
   consolidate-review:
     needs: [validate-pr, review-readme, review-comments, review-types, review-einops]
     runs-on: ubuntu-latest
-    if: always() && needs.validate-pr.outputs.should_skip != 'true'
+    if: always()
     permissions:
       contents: read
       pull-requests: write
@@ -135,19 +136,18 @@ jobs:
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Review Types Run" >> $GITHUB_STEP_SUMMARY
-          echo "- README Accuracy: ${{ needs.review-readme.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Code Comments: ${{ needs.review-comments.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Type Annotations: ${{ needs.review-types.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Einops Suggestions: ${{ needs.review-einops.result }}" >> $GITHUB_STEP_SUMMARY
 
-  skip-summary:
-    needs: validate-pr
-    runs-on: ubuntu-latest
-    if: needs.validate-pr.outputs.should_skip == 'true'
-    steps:
-      - name: Skip Summary
-        run: |
-          echo "# 🤖 Claude Review Skipped" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Reason**: This PR was opened by Dependabot" >> $GITHUB_STEP_SUMMARY
-          echo "**Action**: Skipping Claude review for automated dependency updates" >> $GITHUB_STEP_SUMMARY
+          # Show which reviews were requested and their results
+          if [ "${{ inputs.run_readme }}" = "true" ]; then
+            echo "- README Accuracy: ${{ needs.review-readme.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ inputs.run_comments }}" = "true" ]; then
+            echo "- Code Comments: ${{ needs.review-comments.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ inputs.run_types }}" = "true" ]; then
+            echo "- Type Annotations: ${{ needs.review-types.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ inputs.run_einops }}" = "true" ]; then
+            echo "- Einops Suggestions: ${{ needs.review-einops.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          fi
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: write  # Added to trigger workflows
 
 env:
   CLAUDE_MODEL: "claude-sonnet-4-20250514"
@@ -35,34 +36,151 @@ jobs:
           echo "Is Pull Request: ${{ !!github.event.issue.pull_request }}"
           echo "==========================="
 
-      - name: Check for PR creation request
+      - name: Check for action type
         id: check_action
         run: |
           echo "=== ACTION DETECTION DEBUG ==="
           echo "Full comment: ${{ github.event.comment.body }}"
-          if echo "${{ github.event.comment.body }}" | grep -q "@claude open-pr"; then
-            echo "✅ Detected: PR creation request"
-            echo "action=create_pr" >> $GITHUB_OUTPUT
-            echo "fetch_depth=0" >> $GITHUB_OUTPUT
+
+          # Check for review commands first (must be on a PR)
+          if [[ "${{ !!github.event.issue.pull_request }}" == "true" ]]; then
+            if echo "${{ github.event.comment.body }}" | grep -q "@claude review-all"; then
+              echo "✅ Detected: Review all request"
+              echo "action=review_all" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-einops"; then
+              echo "✅ Detected: Review einops request"
+              echo "action=review_einops" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-comments"; then
+              echo "✅ Detected: Review comments request"
+              echo "action=review_comments" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-types"; then
+              echo "✅ Detected: Review types request"
+              echo "action=review_types" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-readme"; then
+              echo "✅ Detected: Review readme request"
+              echo "action=review_readme" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            elif echo "${{ github.event.comment.body }}" | grep -q "@claude open-pr"; then
+              echo "✅ Detected: PR creation request"
+              echo "action=create_pr" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            else
+              echo "✅ Detected: Regular comment request"
+              echo "action=comment" >> $GITHUB_OUTPUT
+              echo "fetch_depth=1" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "✅ Detected: Regular comment request"
-            echo "action=comment" >> $GITHUB_OUTPUT
-            echo "fetch_depth=1" >> $GITHUB_OUTPUT
+            # Not on a PR, check for open-pr or default to comment
+            if echo "${{ github.event.comment.body }}" | grep -q "@claude open-pr"; then
+              echo "✅ Detected: PR creation request"
+              echo "action=create_pr" >> $GITHUB_OUTPUT
+              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+            else
+              echo "✅ Detected: Regular comment request"
+              echo "action=comment" >> $GITHUB_OUTPUT
+              echo "fetch_depth=1" >> $GITHUB_OUTPUT
+            fi
           fi
           echo "=============================="
 
+      # Trigger review workflows
+      - name: Trigger Review All
+        if: steps.check_action.outputs.action == 'review_all'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              // Post acknowledgment comment
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '🔍 **Starting full Claude review...**\n\nI\'ll analyze:\n- README accuracy\n- Code comments\n- Type annotations\n- Einops opportunities\n\nThis may take a few minutes. You can check the progress in the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions).'
+              });
+
+              // Trigger the orchestrator workflow
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'claude-review-orchestrator.yml',
+                ref: context.payload.repository.default_branch,
+                inputs: {
+                  pr_number: context.issue.number.toString()
+                }
+              });
+
+              console.log('✅ Triggered review orchestrator workflow');
+            } catch (error) {
+              console.error('Error triggering workflow:', error);
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `❌ **Failed to trigger review**\n\nError: ${error.message}\n\nPlease check that the workflow file exists and you have the necessary permissions.`
+              });
+            }
+
+      - name: Trigger Individual Review
+        if: contains(fromJson('["review_einops", "review_comments", "review_types", "review_readme"]'), steps.check_action.outputs.action)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const reviewType = '${{ steps.check_action.outputs.action }}'.replace('review_', '');
+            const reviewTypeDisplay = reviewType.charAt(0).toUpperCase() + reviewType.slice(1);
+
+            try {
+              // Post acknowledgment comment
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `🔍 **Starting Claude ${reviewTypeDisplay} review...**\n\nThis may take a few minutes. You can check the progress in the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions).`
+              });
+
+              // Trigger the specific review workflow
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: `claude-review-${reviewType}.yml`,
+                ref: context.payload.repository.default_branch,
+                inputs: {
+                  pr_number: context.issue.number.toString()
+                }
+              });
+
+              console.log(`✅ Triggered ${reviewType} review workflow`);
+            } catch (error) {
+              console.error('Error triggering workflow:', error);
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `❌ **Failed to trigger ${reviewTypeDisplay} review**\n\nError: ${error.message}\n\nPlease check that the workflow file exists and you have the necessary permissions.`
+              });
+            }
+
+      # Only checkout and run Claude if not a review action
       - name: Checkout repository
+        if: contains(fromJson('["comment", "create_pr"]'), steps.check_action.outputs.action)
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ steps.check_action.outputs.fetch_depth == '0' && 0 || 1 }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
+        if: steps.check_action.outputs.action == 'create_pr'
         run: |
           git config --global user.name "Claude Assistant"
           git config --global user.email "claude-assistant@users.noreply.github.com"
 
       - name: Debug - Check Secrets
+        if: contains(fromJson('["comment", "create_pr"]'), steps.check_action.outputs.action)
         run: |
           echo "=== SECRETS DEBUG ==="
           if [ -n "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
@@ -397,6 +515,40 @@ jobs:
                 "You can view the full execution logs in the Actions tab for more details."
               ].join('\n')
             });
+
+      # Add help message for unrecognized commands on PRs
+      - name: Post Help Message
+        if: steps.check_action.outputs.action == 'comment' && github.event.issue.pull_request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Check if the comment might have been trying to use a review command
+            const comment = "${{ github.event.comment.body }}".toLowerCase();
+            if (comment.includes('review')) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: [
+                  "💡 **Claude Review Commands Available**",
+                  "",
+                  "I noticed you mentioned 'review'. Here are the available review commands for PRs:",
+                  "",
+                  "- `@claude review-all` - Run all review types",
+                  "- `@claude review-einops` - Check for einops optimization opportunities",
+                  "- `@claude review-comments` - Review code comments and docstrings",
+                  "- `@claude review-types` - Check type annotations",
+                  "- `@claude review-readme` - Verify README accuracy",
+                  "",
+                  "You can also:",
+                  "- `@claude open-pr` - Create a new PR with changes",
+                  "- `@claude [question]` - Ask me anything about the code",
+                  "",
+                  "*Note: Review commands only work on pull requests.*"
+                ].join('\n')
+              });
+            }
 
       - name: Final Debug Summary
         if: always()

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,26 +44,39 @@ jobs:
 
           # Check for review commands first (must be on a PR)
           if [[ "${{ !!github.event.issue.pull_request }}" == "true" ]]; then
-            if echo "${{ github.event.comment.body }}" | grep -q "@claude review-all"; then
-              echo "✅ Detected: Review all request"
-              echo "action=review_all" >> $GITHUB_OUTPUT
+            if echo "${{ github.event.comment.body }}" | grep -q "@claude review"; then
+              echo "✅ Detected: Review request"
+              echo "action=review" >> $GITHUB_OUTPUT
               echo "fetch_depth=0" >> $GITHUB_OUTPUT
-            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-einops"; then
-              echo "✅ Detected: Review einops request"
-              echo "action=review_einops" >> $GITHUB_OUTPUT
-              echo "fetch_depth=0" >> $GITHUB_OUTPUT
-            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-comments"; then
-              echo "✅ Detected: Review comments request"
-              echo "action=review_comments" >> $GITHUB_OUTPUT
-              echo "fetch_depth=0" >> $GITHUB_OUTPUT
-            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-types"; then
-              echo "✅ Detected: Review types request"
-              echo "action=review_types" >> $GITHUB_OUTPUT
-              echo "fetch_depth=0" >> $GITHUB_OUTPUT
-            elif echo "${{ github.event.comment.body }}" | grep -q "@claude review-readme"; then
-              echo "✅ Detected: Review readme request"
-              echo "action=review_readme" >> $GITHUB_OUTPUT
-              echo "fetch_depth=0" >> $GITHUB_OUTPUT
+
+              # Extract review types from the comment
+              # This regex captures everything after "review" until end of line or next @claude
+              REVIEW_ARGS=$(echo "${{ github.event.comment.body }}" | sed -n 's/.*@claude review\s*\([^@]*\).*/\1/p' | head -1)
+              echo "Review arguments: '$REVIEW_ARGS'"
+
+              # Parse the review types
+              REVIEW_TYPES=""
+
+              # Check for special keywords first
+              if echo "$REVIEW_ARGS" | grep -qw "all"; then
+                echo "✅ Detected: All reviews requested"
+                REVIEW_TYPES="readme,comments,types,einops"
+              else
+                # Parse comma-separated list
+                # Remove brackets if present, normalize spacing
+                PARSED_TYPES=$(echo "$REVIEW_ARGS" | sed 's/[\[\]]//g' | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(readme|comments|types|einops)$' | tr '\n' ',' | sed 's/,$//')
+
+                if [ -z "$PARSED_TYPES" ]; then
+                  echo "⚠️ No valid review types found, defaulting to all"
+                  REVIEW_TYPES="readme,comments,types,einops"
+                else
+                  REVIEW_TYPES="$PARSED_TYPES"
+                fi
+              fi
+
+              echo "review_types=$REVIEW_TYPES" >> $GITHUB_OUTPUT
+              echo "✅ Review types to run: $REVIEW_TYPES"
+
             elif echo "${{ github.event.comment.body }}" | grep -q "@claude open-pr"; then
               echo "✅ Detected: PR creation request"
               echo "action=create_pr" >> $GITHUB_OUTPUT
@@ -88,20 +101,34 @@ jobs:
           echo "=============================="
 
       # Trigger review workflows
-      - name: Trigger Review All
-        if: steps.check_action.outputs.action == 'review_all'
+      - name: Trigger Review
+        if: steps.check_action.outputs.action == 'review'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
+              const reviewTypes = '${{ steps.check_action.outputs.review_types }}'.split(',');
+              const reviewTypesDisplay = reviewTypes.map(t =>
+                t.charAt(0).toUpperCase() + t.slice(1)
+              ).join(', ');
+
               // Post acknowledgment comment
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: '🔍 **Starting full Claude review...**\n\nI\'ll analyze:\n- README accuracy\n- Code comments\n- Type annotations\n- Einops opportunities\n\nThis may take a few minutes. You can check the progress in the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions).'
+                body: `🔍 **Starting Claude review...**\n\nI'll analyze:\n${reviewTypes.map(t => `- ${t.charAt(0).toUpperCase() + t.slice(1)}`).join('\n')}\n\nThis may take a few minutes. You can check the progress in the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions).`
               });
+
+              // Build inputs object based on requested reviews
+              const inputs = {
+                pr_number: context.issue.number.toString(),
+                run_readme: reviewTypes.includes('readme') ? 'true' : 'false',
+                run_comments: reviewTypes.includes('comments') ? 'true' : 'false',
+                run_types: reviewTypes.includes('types') ? 'true' : 'false',
+                run_einops: reviewTypes.includes('einops') ? 'true' : 'false'
+              };
 
               // Trigger the orchestrator workflow
               const result = await github.rest.actions.createWorkflowDispatch({
@@ -109,12 +136,10 @@ jobs:
                 repo: context.repo.repo,
                 workflow_id: 'claude-review-orchestrator.yml',
                 ref: context.payload.repository.default_branch,
-                inputs: {
-                  pr_number: context.issue.number.toString()
-                }
+                inputs: inputs
               });
 
-              console.log('✅ Triggered review orchestrator workflow');
+              console.log(`✅ Triggered review for: ${reviewTypesDisplay}`);
             } catch (error) {
               console.error('Error triggering workflow:', error);
               await github.rest.issues.createComment({
@@ -122,46 +147,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: `❌ **Failed to trigger review**\n\nError: ${error.message}\n\nPlease check that the workflow file exists and you have the necessary permissions.`
-              });
-            }
-
-      - name: Trigger Individual Review
-        if: contains(fromJson('["review_einops", "review_comments", "review_types", "review_readme"]'), steps.check_action.outputs.action)
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const reviewType = '${{ steps.check_action.outputs.action }}'.replace('review_', '');
-            const reviewTypeDisplay = reviewType.charAt(0).toUpperCase() + reviewType.slice(1);
-
-            try {
-              // Post acknowledgment comment
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `🔍 **Starting Claude ${reviewTypeDisplay} review...**\n\nThis may take a few minutes. You can check the progress in the [Actions tab](${{ github.server_url }}/${{ github.repository }}/actions).`
-              });
-
-              // Trigger the specific review workflow
-              const result = await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: `claude-review-${reviewType}.yml`,
-                ref: context.payload.repository.default_branch,
-                inputs: {
-                  pr_number: context.issue.number.toString()
-                }
-              });
-
-              console.log(`✅ Triggered ${reviewType} review workflow`);
-            } catch (error) {
-              console.error('Error triggering workflow:', error);
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `❌ **Failed to trigger ${reviewTypeDisplay} review**\n\nError: ${error.message}\n\nPlease check that the workflow file exists and you have the necessary permissions.`
               });
             }
 
@@ -390,7 +375,7 @@ jobs:
               const targetBranch = "${{ steps.branches.outputs.target_branch }}";
               const newBranch = "${{ steps.branches.outputs.new_branch }}";
               const contextInfo = "${{ steps.branches.outputs.context_info }}";
-              const commitCount = "${{ steps.verify_git.outputs.commit_count }}";
+              const commitCount = "${{ steps.push_branch.outputs.commit_count }}";
 
               console.log(`Creating PR: ${newBranch} -> ${targetBranch}`);
               console.log(`Context: ${contextInfo}`);
@@ -467,9 +452,9 @@ jobs:
                   "**Debug info:**",
                   `- New branch: \`${{ steps.branches.outputs.new_branch }}\``,
                   `- Target branch: \`${{ steps.branches.outputs.target_branch }}\``,
-                  `- Branch pushed: ${{ steps.verify_git.outputs.branch_pushed }}`,
-                  `- Has commits: ${{ steps.verify_git.outputs.has_commits }}`,
-                  `- Commit count: ${{ steps.verify_git.outputs.commit_count }}`,
+                  `- Branch pushed: ${{ steps.push_branch.outputs.branch_pushed }}`,
+                  `- Has commits: ${{ steps.push_branch.outputs.has_commits }}`,
+                  `- Commit count: ${{ steps.push_branch.outputs.commit_count }}`,
                   "",
                   "Please check the Actions logs for more details."
                 ].join('\n')
@@ -533,13 +518,22 @@ jobs:
                 body: [
                   "💡 **Claude Review Commands Available**",
                   "",
-                  "I noticed you mentioned 'review'. Here are the available review commands for PRs:",
+                  "I noticed you mentioned 'review'. Here's how to use review commands:",
                   "",
-                  "- `@claude review-all` - Run all review types",
-                  "- `@claude review-einops` - Check for einops optimization opportunities",
-                  "- `@claude review-comments` - Review code comments and docstrings",
-                  "- `@claude review-types` - Check type annotations",
-                  "- `@claude review-readme` - Verify README accuracy",
+                  "**Syntax:** `@claude review <types>`",
+                  "",
+                  "**Examples:**",
+                  "- `@claude review all` - Run all review types",
+                  "- `@claude review einops` - Check for einops optimization opportunities",
+                  "- `@claude review comments, types` - Review comments and type annotations",
+                  "- `@claude review readme, einops, comments` - Run multiple specific reviews",
+                  "",
+                  "**Available review types:**",
+                  "- `readme` - Verify README accuracy",
+                  "- `comments` - Review code comments and docstrings",
+                  "- `types` - Check type annotations",
+                  "- `einops` - Suggest einops optimizations",
+                  "- `all` - Run all review types",
                   "",
                   "You can also:",
                   "- `@claude open-pr` - Create a new PR with changes",

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -51,6 +51,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
 # Install sources
 ADD . .
 
+# When building in CI, actions/checkout stores an auth token in .git/config that we need to remove
+RUN git config --remove-section http."https://github.com/" || true
+
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --locked
 


### PR DESCRIPTION
Running all four Claude reviews every time a PR is opened or reopened was pretty spammy. This PR changes the Claude reviews to be triggered manually by user request.

## New Review Command Syntax

The workflow now recognizes these commands when used on pull requests:
- `@claude review all` - Run all review types
- `@claude review einops` - Check for einops optimization opportunities  
- `@claude review comments` - Review code comments and docstrings
- `@claude review types` - Check type annotations
- `@claude review readme` - Verify README accuracy
- `@claude review readme, einops, types` - Run multiple specific reviews

## Key Changes

### 1. Removed Automatic Triggers
- The orchestrator no longer runs automatically on PR open/reopen events
- Reviews are now opt-in rather than automatic
- Reduces noise in PR comments

### 2. Unified Review Command
- Changed from `@claude review-type` to `@claude review type1, type2`
- Supports comma-separated lists for running multiple reviews
- Single code path for all review requests

### 3. Simplified Orchestrator
- Now accepts boolean parameters for each review type
- Removed Dependabot checking (no longer needed)
- All reviews go through the orchestrator for consistent output

### 4. Enhanced User Experience
- Acknowledgment comment posted when review starts
- Link to Actions tab for monitoring progress
- Help message if review command syntax is incorrect
- Single consolidated GitHub review regardless of which types run

## Usage Examples

```bash
# Run all reviews
@claude review all

# Run a single review
@claude review einops

# Run multiple specific reviews
@claude review comments, types

# Ask a question (unchanged)
@claude what does this function do?

# Create a PR (unchanged)
@claude open-pr fix the bug in line 42
```

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Claude reviews now run only when a user comments a specific command on a pull request, instead of running automatically on every PR open or reopen.

- **New Features**
  - Added support for comment commands like `@claude review-all` and `@claude review-types` to trigger targeted reviews.
  - Each review type can be triggered separately.
  - Posts an acknowledgment comment and a help message if the command is incorrect.
  - Review commands only work on pull requests.

<!-- End of auto-generated description by cubic. -->

