### PR TITLE
Remove hp

### DIFF
--- a/configs/env/mettagrid/ants.yaml
+++ b/configs/env/mettagrid/ants.yaml
@@ -49,7 +49,6 @@ game:
 
   objects:
     altar:
-      hp: 30
       input_battery: 0
       input_ore.red: ${sampling:1,10,2}
       output_heart: 1

--- a/configs/env/mettagrid/memory/evals/defaults.yaml
+++ b/configs/env/mettagrid/memory/evals/defaults.yaml
@@ -23,7 +23,6 @@ game:
       cooldown: 255
       initial_items: 0
     mine.red:
-      hp: 30
       output_ore.red: 1
       color: 0
       max_output: 1
@@ -31,7 +30,6 @@ game:
       cooldown: 10
       initial_items: 1
     generator.red:
-      hp: 30
       input_ore.red: 1
       output_battery: 3
       color: 0

--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -20,7 +20,6 @@ game:
     # "normal" item limits are lower
     heart_max: 255
     freeze_duration: ${sampling:0, 200, 10}
-    hp: 10
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0
@@ -82,7 +81,6 @@ game:
 
   objects:
     altar:
-      hp: 30
       input_battery.red: 3
       output_heart: 1
       max_output: 5
@@ -91,7 +89,6 @@ game:
       initial_items: 1
 
     mine.red:
-      hp: 30
       output_ore.red: 1
       color: 0
       max_output: 5
@@ -100,7 +97,6 @@ game:
       initial_items: 1
 
     mine.blue:
-      hp: 30
       color: 1
       output_ore.blue: 1
       max_output: 5
@@ -109,7 +105,6 @@ game:
       initial_items: 1
 
     mine.green:
-      hp: 30
       output_ore.green: 1
       color: 2
       max_output: 5
@@ -118,7 +113,6 @@ game:
       initial_items: 1
 
     generator.red:
-      hp: 30
       input_ore.red: 1
       output_battery.red: 1
       color: 0
@@ -128,7 +122,6 @@ game:
       initial_items: 1
 
     generator.blue:
-      hp: 30
       input_ore.blue: 1
       output_battery.blue: 1
       color: 1
@@ -138,7 +131,6 @@ game:
       initial_items: 1
 
     generator.green:
-      hp: 30
       input_ore.green: 1
       output_battery.green: 1
       color: 2
@@ -148,7 +140,6 @@ game:
       initial_items: 1
 
     armory:
-      hp: 30
       input_ore.red: 3
       output_armor: 1
       max_output: 5
@@ -157,7 +148,6 @@ game:
       initial_items: 1
 
     lasery:
-      hp: 30
       input_ore.red: 1
       input_battery.red: 2
       output_laser: 1
@@ -167,7 +157,6 @@ game:
       initial_items: 1
 
     lab:
-      hp: 30
       input_ore.red: 3
       input_battery.red: 3
       output_blueprint: 1
@@ -177,7 +166,6 @@ game:
       initial_items: 1
 
     factory:
-      hp: 30
       input_blueprint: 1
       input_ore.red: 5
       input_battery.red: 5
@@ -189,7 +177,6 @@ game:
       initial_items: 1
 
     temple:
-      hp: 30
       input_heart: 1
       input_blueprint: 1
       output_heart: 5
@@ -199,11 +186,9 @@ game:
       initial_items: 1
 
     wall:
-      hp: ${sampling:1, 20, 10}
       swappable: false
 
     block:
-      hp: ${sampling:1, 20, 10}
       swappable: true
 
   actions:

--- a/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
@@ -28,7 +28,6 @@ game:
       initial_items: 0
 
     mine.red:
-      hp: 30
       output_ore.red: 1
       color: 0
       max_output: 1
@@ -37,7 +36,6 @@ game:
       initial_items: 1
 
     generator.red:
-      hp: 30
       input_ore.red: 1
       output_battery: 3
       color: 0

--- a/configs/env/mettagrid/object_use/evals/shoot_out.yaml
+++ b/configs/env/mettagrid/object_use/evals/shoot_out.yaml
@@ -11,8 +11,7 @@ game:
   objects:
     altar:
       cooldown: 255
-    wall:
-      hp: 1
+
     lasery:
       initial_items: 20
   map_builder:

--- a/configs/sweep/fast.yaml
+++ b/configs/sweep/fast.yaml
@@ -12,5 +12,4 @@ trainer:
     game:
       objects:
         altar:
-          hp: 10
           cooldown: ${ss:int, 1, 20, 10}

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -41,7 +41,7 @@ game:
   agent:
     default_item_max: 50
     freeze_duration: 10
-    hp: 10
+
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0
@@ -104,7 +104,6 @@ game:
 
   objects:
     altar:
-      hp: 30
       input_battery.red: 3
       output_heart: 1
       max_output: 5
@@ -113,7 +112,6 @@ game:
       initial_items: 1
 
     mine.red:
-      hp: 30
       output_ore.red: 1
       color: 0
       max_output: 5
@@ -122,7 +120,6 @@ game:
       initial_items: 1
 
     mine.blue:
-      hp: 30
       color: 1
       output_ore.blue: 1
       max_output: 5
@@ -131,7 +128,6 @@ game:
       initial_items: 1
 
     mine.green:
-      hp: 30
       output_ore.green: 1
       color: 2
       max_output: 5
@@ -140,7 +136,6 @@ game:
       initial_items: 1
 
     generator.red:
-      hp: 30
       input_ore.red: 1
       output_battery.red: 1
       color: 0
@@ -150,7 +145,6 @@ game:
       initial_items: 1
 
     generator.blue:
-      hp: 30
       input_ore.blue: 1
       output_battery.blue: 1
       color: 1
@@ -160,7 +154,6 @@ game:
       initial_items: 1
 
     generator.green:
-      hp: 30
       input_ore.green: 1
       output_battery.green: 1
       color: 2
@@ -170,7 +163,6 @@ game:
       initial_items: 1
 
     armory:
-      hp: 30
       input_ore.red: 3
       output_armor: 1
       max_output: 5
@@ -179,7 +171,6 @@ game:
       initial_items: 1
 
     lasery:
-      hp: 30
       input_ore.red: 1
       input_battery.red: 2
       output_laser: 1
@@ -189,7 +180,6 @@ game:
       initial_items: 1
 
     lab:
-      hp: 30
       input_ore.red: 3
       input_battery.red: 3
       output_blueprint: 1
@@ -199,7 +189,6 @@ game:
       initial_items: 1
 
     factory:
-      hp: 30
       input_blueprint: 1
       input_ore.red: 5
       input_battery.red: 5
@@ -211,7 +200,6 @@ game:
       initial_items: 1
 
     temple:
-      hp: 30
       input_heart: 1
       input_blueprint: 1
       output_heart: 5
@@ -221,11 +209,9 @@ game:
       initial_items: 1
 
     wall:
-      hp: 20
       swappable: false
 
     block:
-      hp: 20
       swappable: true
 
   actions:

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -34,32 +34,27 @@ game:
     heart_max: 255
     freeze_duration: 10
     energy_reward: 0
-    hp: 1
     use_cost: 0
     rewards:
       heart: 1
 
   objects:
     altar:
-      hp: 30
       cooldown: 2
       use_cost: 100
 
     converter:
-      hp: 30
       cooldown: 2
       energy_output.r1: 100
       energy_output.r2: 10
       energy_output.r3: 1
 
     generator.red:
-      hp: 30
       cooldown: 5
       initial_resources: 30
       use_cost: 0
 
-    wall:
-      hp: 10
+
 
   actions:
     noop:

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -54,6 +54,7 @@ game:
       initial_resources: 30
       use_cost: 0
 
+    wall: {}
 
 
   actions:

--- a/mettagrid/mettagrid/actions/attack.hpp
+++ b/mettagrid/mettagrid/actions/attack.hpp
@@ -98,21 +98,6 @@ protected:
       }
     }
 
-    target_loc.layer = GridLayer::Object_Layer;
-    MettaObject* object_target = static_cast<MettaObject*>(_grid->object_at(target_loc));
-    if (object_target) {
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[object_target->_type_id]);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[object_target->_type_id] + "." +
-                        actor->group_name);
-      object_target->hp -= 1;
-      actor->stats.incr("damage." + ObjectTypeNames[object_target->_type_id]);
-      if (object_target->hp <= 0) {
-        actor->stats.incr("destroyed." + ObjectTypeNames[object_target->_type_id]);
-        _grid->remove_object(object_target);  // This will invalidate the pointer
-      }
-      return true;
-    }
-
     return false;
   }
 };

--- a/mettagrid/mettagrid/objects/agent.hpp
+++ b/mettagrid/mettagrid/objects/agent.hpp
@@ -36,7 +36,6 @@ public:
         // actions or inventory changes.
         std::map<std::string, float> rewards) {
     GridObject::init(ObjectType::AgentT, GridLocation(r, c, GridLayer::Agent_Layer));
-    MettaObject::init_mo(cfg);
 
     this->group_name = group_name;
     this->group = group_id;
@@ -132,7 +131,6 @@ public:
     size_t offset_idx = 0;
     obs[offsets[offset_idx++]] = _type_id;
     obs[offsets[offset_idx++]] = group;
-    obs[offsets[offset_idx++]] = hp;
     obs[offsets[offset_idx++]] = frozen;
     obs[offsets[offset_idx++]] = orientation;
     obs[offsets[offset_idx++]] = color;
@@ -146,7 +144,6 @@ public:
     std::vector<uint8_t> names;
     names.push_back(ObservationFeature::TypeId);
     names.push_back(ObservationFeature::Group);
-    names.push_back(ObservationFeature::Hp);
     names.push_back(ObservationFeature::Frozen);
     names.push_back(ObservationFeature::Orientation);
     names.push_back(ObservationFeature::Color);

--- a/mettagrid/mettagrid/objects/converter.hpp
+++ b/mettagrid/mettagrid/objects/converter.hpp
@@ -76,7 +76,6 @@ public:
 
   Converter(GridCoord r, GridCoord c, ObjectConfig cfg, TypeId type_id) {
     GridObject::init(type_id, GridLocation(r, c, GridLayer::Object_Layer));
-    MettaObject::init_mo(cfg);
     HasInventory::init_has_inventory(cfg);
     this->recipe_input.resize(InventoryItem::InventoryItemCount);
     this->recipe_output.resize(InventoryItem::InventoryItemCount);
@@ -172,7 +171,6 @@ public:
     const auto offsets = Converter::offsets();
     size_t offset_idx = 0;
     obs[offsets[offset_idx++]] = _type_id;
-    obs[offsets[offset_idx++]] = this->hp;
     obs[offsets[offset_idx++]] = this->color;
     obs[offsets[offset_idx++]] = this->converting || this->cooling_down;
     for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
@@ -186,7 +184,6 @@ public:
     // the observation space. At the moment we don't expose the recipe, since
     // we expect converters to be hard coded.
     ids.push_back(ObservationFeature::TypeId);
-    ids.push_back(ObservationFeature::Hp);
     ids.push_back(ObservationFeature::Color);
     ids.push_back(ObservationFeature::ConvertingOrCoolingDown);
     for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {

--- a/mettagrid/mettagrid/objects/metta_object.hpp
+++ b/mettagrid/mettagrid/objects/metta_object.hpp
@@ -10,12 +10,6 @@ typedef std::map<std::string, int> ObjectConfig;
 
 class MettaObject : public GridObject {
 public:
-  uint8_t hp;
-
-  void init_mo(ObjectConfig cfg) {
-    this->hp = cfg["hp"];
-  }
-
   virtual bool swappable() const {
     return false;
   }

--- a/mettagrid/mettagrid/objects/wall.hpp
+++ b/mettagrid/mettagrid/objects/wall.hpp
@@ -14,7 +14,6 @@ public:
 
   Wall(GridCoord r, GridCoord c, ObjectConfig cfg) {
     GridObject::init(ObjectType::WallT, GridLocation(r, c, GridLayer::Object_Layer));
-    MettaObject::init_mo(cfg);
     this->_swappable = cfg["swappable"];
   }
 
@@ -33,14 +32,12 @@ public:
     const auto offsets = Wall::offsets();
     size_t offset_idx = 0;
     obs[offsets[offset_idx++]] = _type_id;
-    obs[offsets[offset_idx++]] = this->hp;
     obs[offsets[offset_idx++]] = this->_swappable;
   }
 
   static std::vector<uint8_t> offsets() {
     std::vector<uint8_t> ids;
     ids.push_back(ObservationFeature::TypeId);
-    ids.push_back(ObservationFeature::Hp);
     ids.push_back(ObservationFeature::Swappable);
     return ids;
   }

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -10,7 +10,6 @@
     "agent": {
       "default_item_max": 50,
       "freeze_duration": 10,
-      "hp": 10,
       "rewards": {
         "action_failure_penalty": 0,
         "ore.red": 0.005,
@@ -69,7 +68,6 @@
     },
     "objects": {
       "altar": {
-        "hp": 30,
         "input_battery.red": 3,
         "output_heart": 1,
         "max_output": 5,
@@ -78,7 +76,6 @@
         "initial_items": 1
       },
       "mine.red": {
-        "hp": 30,
         "output_ore.red": 1,
         "color": 0,
         "max_output": 5,
@@ -87,7 +84,6 @@
         "initial_items": 1
       },
       "mine.blue": {
-        "hp": 30,
         "color": 1,
         "output_ore.blue": 1,
         "max_output": 5,
@@ -96,7 +92,6 @@
         "initial_items": 1
       },
       "mine.green": {
-        "hp": 30,
         "output_ore.green": 1,
         "color": 2,
         "max_output": 5,
@@ -105,7 +100,6 @@
         "initial_items": 1
       },
       "generator.red": {
-        "hp": 30,
         "input_ore.red": 1,
         "output_battery.red": 1,
         "color": 0,
@@ -115,7 +109,6 @@
         "initial_items": 1
       },
       "generator.blue": {
-        "hp": 30,
         "input_ore.blue": 1,
         "output_battery.blue": 1,
         "color": 1,
@@ -125,7 +118,6 @@
         "initial_items": 1
       },
       "generator.green": {
-        "hp": 30,
         "input_ore.green": 1,
         "output_battery.green": 1,
         "color": 2,
@@ -135,7 +127,6 @@
         "initial_items": 1
       },
       "armory": {
-        "hp": 30,
         "input_ore.red": 3,
         "output_armor": 1,
         "max_output": 5,
@@ -144,7 +135,6 @@
         "initial_items": 1
       },
       "lasery": {
-        "hp": 30,
         "input_ore.red": 1,
         "input_battery.red": 2,
         "output_laser": 1,
@@ -154,7 +144,6 @@
         "initial_items": 1
       },
       "lab": {
-        "hp": 30,
         "input_ore.red": 3,
         "input_battery.red": 3,
         "output_blueprint": 1,
@@ -164,7 +153,6 @@
         "initial_items": 1
       },
       "factory": {
-        "hp": 30,
         "input_blueprint": 1,
         "input_ore.red": 5,
         "input_battery.red": 5,
@@ -176,7 +164,6 @@
         "initial_items": 1
       },
       "temple": {
-        "hp": 30,
         "input_heart": 1,
         "input_blueprint": 1,
         "output_heart": 5,
@@ -186,11 +173,9 @@
         "initial_items": 1
       },
       "wall": {
-        "hp": 10,
         "swappable": false
       },
       "block": {
-        "hp": 10,
         "swappable": true
       }
     },

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -41,8 +41,8 @@ def base_config():
             "change_color": {"enabled": True},
         },
         "groups": {"red": {"id": 0, "props": {}}},
-        "objects": {"wall": {"type_id": 1, "hp": 100}, "altar": {"type_id": 4, "hp": 100}},
-        "agent": {"inventory_size": 10, "hp": 100},
+        "objects": {"wall": {"type_id": 1}, "altar": {"type_id": 4}},
+        "agent": {"inventory_size": 10},
     }
 
 

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -55,12 +55,11 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
             },
             "groups": {"red": {"id": 0, "props": {}}},
             "objects": {
-                "wall": {"type_id": 1, "hp": 100},
-                "block": {"type_id": 2, "hp": 100},
+                "wall": {"type_id": 1},
+                "block": {"type_id": 2},
             },
             "agent": {
                 "inventory_size": 0,
-                "hp": 100,
             },
         }
     }

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -279,7 +279,6 @@ TEST_F(MettaGridCppTest, GetOutput) {
 
   // Create a generator with initial output
   ObjectConfig generator_cfg;
-  generator_cfg["hp"] = 30;
   generator_cfg["input_ore.red"] = 1;
   generator_cfg["output_battery.red"] = 1;
   // Set the max_output to 0 so it won't consume things we put in it.
@@ -360,7 +359,6 @@ TEST_F(MettaGridCppTest, WallCreation) {
   ASSERT_NE(wall, nullptr);
   EXPECT_EQ(wall->location.r, 2);
   EXPECT_EQ(wall->location.c, 3);
-  EXPECT_EQ(wall->hp, 100);
 }
 
 // ==================== Converter Tests ====================
@@ -378,5 +376,4 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   ASSERT_NE(converter, nullptr);
   EXPECT_EQ(converter->location.r, 1);
   EXPECT_EQ(converter->location.c, 2);
-  EXPECT_EQ(converter->hp, 50);
 }

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -224,7 +224,6 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
 
   // Create a generator that takes red ore and outputs batteries
   ObjectConfig generator_cfg;
-  generator_cfg["hp"] = 30;
   generator_cfg["input_ore.red"] = 1;
   generator_cfg["output_battery.red"] = 1;
   // Set the max_output to 0 so it won't consume things we put in it.
@@ -355,7 +354,6 @@ TEST_F(MettaGridCppTest, InventoryItems) {
 
 TEST_F(MettaGridCppTest, WallCreation) {
   ObjectConfig wall_cfg;
-  wall_cfg["hp"] = 100;
 
   std::unique_ptr<Wall> wall(new Wall(2, 3, wall_cfg));
 
@@ -369,7 +367,6 @@ TEST_F(MettaGridCppTest, WallCreation) {
 
 TEST_F(MettaGridCppTest, ConverterCreation) {
   ObjectConfig converter_cfg;
-  converter_cfg["hp"] = 50;
   converter_cfg["input_ore.red"] = 2;
   converter_cfg["output_battery"] = 1;
   converter_cfg["conversion_ticks"] = 5;

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -48,12 +48,11 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
             },
             "groups": {"red": {"id": 0, "props": {}}},
             "objects": {
-                "wall": {"type_id": 1, "hp": 100},
-                "block": {"type_id": 2, "hp": 100},
+                "wall": {"type_id": 1},
+                "block": {"type_id": 2},
             },
             "agent": {
                 "inventory_size": 0,
-                "hp": 100,
             },
         }
     }

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -53,10 +53,9 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
             },
             "groups": {"red": {"id": 0, "props": {}}},
             "objects": {
-                "wall": {"type_id": 1, "hp": 100},
+                "wall": {"type_id": 1},
                 "altar": {
                     "type_id": 4,
-                    "hp": 100,
                     "output_heart": 1,
                     "initial_items": 5,  # Start with some hearts
                     "max_output": 50,
@@ -66,7 +65,6 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
             },
             "agent": {
                 "default_item_max": 10,
-                "hp": 100,
                 "rewards": {"heart": 1.0},  # This gives 1.0 reward per heart collected
             },
         }
@@ -111,8 +109,8 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
                 "blue": {"id": 2, "group_reward_pct": 0.0, "props": {"max_inventory": 50}},
             },
             "objects": {
-                "wall": {"hp": 100},
-                "block": {"hp": 50},
+                "wall": {},
+                "block": {},
             },
             "agent": {"freeze_duration": 100, "max_inventory": 50, "rewards": {"heart": 1.0}},
         }


### PR DESCRIPTION
Removed all uses of the hp (hit points) property from object configs, code, and tests in mettagrid.

https://app.asana.com/1/1209016784099267/project/1209096222434381/task/1210479366909720