### PR TITLE
Fix grid object bug.

### DIFF
--- a/configs/user/me.yaml
+++ b/configs/user/me.yaml
@@ -3,8 +3,8 @@
 # This file is private property of Andre von Houck.
 # DO NOT MODIFY.
 
-run: andre_local_2025_06_06_b
-policy_uri: wandb://run/andre_local_2025_06_06_b
+run: andre_local_2025_06_17_a
+policy_uri: wandb://run/andre_local_2025_06_17_a
 
 # replay_job:
 #   sim:

--- a/mettagrid/mettagrid/mettagrid_env.py
+++ b/mettagrid/mettagrid/mettagrid_env.py
@@ -189,13 +189,10 @@ class MettaGridEnv(pufferlib.PufferEnv, gym.Env):
         # Note: We explicitly allow invalid actions to be used. The environment will
         # penalize the agent for attempting invalid actions as a side effect of ActionHandler::handle_action()
 
-        if self._replay_writer and self._episode_id:
-            self._replay_writer.log_pre_step(self._episode_id, actions)
-
         self._c_env.step(actions)
 
         if self._replay_writer and self._episode_id:
-            self._replay_writer.log_post_step(self._episode_id, self.rewards)
+            self._replay_writer.log_step(self._episode_id, actions, self.rewards)
 
         infos = {}
         if self.terminals.all() or self.truncations.all():

--- a/mettagrid/mettagrid/replay_writer.py
+++ b/mettagrid/mettagrid/replay_writer.py
@@ -86,7 +86,8 @@ class EpisodeReplay:
         # If key has vanished, add a zero entry.
         for key in grid_object.keys():
             if key not in update_object:
-                grid_object[key].append([step, 0])
+                if grid_object[key][-1][1] != 0:
+                    grid_object[key].append([step, 0])
 
     def get_replay_data(self):
         """Gets full replay as a tree of plain python dictionaries."""

--- a/mettagrid/mettagrid/replay_writer.py
+++ b/mettagrid/mettagrid/replay_writer.py
@@ -23,11 +23,8 @@ class ReplayWriter:
     def start_episode(self, episode_id: str, env: MettaGridEnv):
         self.episodes[episode_id] = EpisodeReplay(env)
 
-    def log_pre_step(self, episode_id: str, actions: np.ndarray):
-        self.episodes[episode_id].log_pre_step(actions)
-
-    def log_post_step(self, episode_id: str, rewards: np.ndarray):
-        self.episodes[episode_id].log_post_step(rewards)
+    def log_step(self, episode_id: str, actions: np.ndarray, rewards: np.ndarray):
+        self.episodes[episode_id].log_step(actions, rewards)
 
     def write_replay(self, episode_id: str) -> str | None:
         """Write the replay to the replay directory and return the URL."""
@@ -58,39 +55,38 @@ class EpisodeReplay:
             "grid_objects": self.grid_objects,
         }
 
-    def log_pre_step(self, actions: np.ndarray):
-        for i, grid_object in enumerate(self.env.grid_objects.values()):
-            if len(self.grid_objects) <= i:
-                self.grid_objects.append({})
-            for key, value in grid_object.items():
-                self._add_sequence_key(self.grid_objects[i], key, self.step, value)
-            if "agent_id" in grid_object:
-                agent_id = grid_object["agent_id"]
-                self._add_sequence_key(self.grid_objects[i], "action", self.step, actions[agent_id].tolist())
-
-    def log_post_step(self, rewards: np.ndarray):
+    def log_step(self, actions: np.ndarray, rewards: np.ndarray):
         self.total_rewards += rewards
         for i, grid_object in enumerate(self.env.grid_objects.values()):
+            update_object = grid_object.copy()
+            if len(self.grid_objects) <= i:
+                self.grid_objects.append({})
             if "agent_id" in grid_object:
-                agent_id = grid_object["agent_id"]
-                self._add_sequence_key(
-                    self.grid_objects[i], "action_success", self.step, bool(self.env.action_success[agent_id])
-                )
-                self._add_sequence_key(self.grid_objects[i], "reward", self.step, rewards[agent_id].item())
-                self._add_sequence_key(
-                    self.grid_objects[i], "total_reward", self.step, self.total_rewards[agent_id].item()
-                )
+                agent_id = update_object["agent_id"]
+                update_object["action"] = actions[agent_id].tolist()
+                update_object["action_success"] = bool(self.env.action_success[agent_id])
+                update_object["reward"] = rewards[agent_id].item()
+                update_object["total_reward"] = self.total_rewards[agent_id].item()
+            self._seq_key_merge(self.grid_objects[i], self.step, update_object)
         self.step += 1
 
-    def _add_sequence_key(self, grid_object: dict, key: str, step: int, value):
-        """Add a key to the replay that is a sequence of values."""
-        if key not in grid_object:
-            # Add new key.
-            grid_object[key] = [[step, value]]
-        else:
-            # Only add new entry if it has changed:
-            if grid_object[key][-1][1] != value:
-                grid_object[key].append([step, value])
+    def _seq_key_merge(self, grid_object: dict, step: int, update_object: dict):
+        """Add a sequence keys to replay grid object."""
+        for key, value in update_object.items():
+            if key not in grid_object:
+                # Add new key.
+                if step == 0:
+                    grid_object[key] = [[step, value]]
+                else:
+                    grid_object[key] = [[0, 0], [step, value]]
+            else:
+                # Only add new entry if it has changed:
+                if grid_object[key][-1][1] != value:
+                    grid_object[key].append([step, value])
+        # If key has vanished, add a zero entry.
+        for key in grid_object.keys():
+            if key not in update_object:
+                grid_object[key].append([step, 0])
 
     def get_replay_data(self):
         """Gets full replay as a tree of plain python dictionaries."""

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -64,7 +64,6 @@ export function processActions(event: KeyboardEvent) {
   // direction, it moves forward.
 
   if (state.ws == null) {
-    console.error("Trying to send commands when not connected to server")
     return
   }
 

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -313,7 +313,7 @@ export function loadReplayStep(replayStep: any) {
         state.replay.agents[value] = state.replay.grid_objects[index]
       }
     }
-    // Make sure that the keys that don't exist are set to null too.
+    // Make sure that the keys that don't exist in the update are set to null too.
     for (const key in state.replay.grid_objects[index]) {
       if (gridObject[key] === undefined) {
         state.replay.grid_objects[index][key] = null

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -316,7 +316,7 @@ export function loadReplayStep(replayStep: any) {
     // Make sure that the keys that don't exist in the update are set to null too.
     for (const key in state.replay.grid_objects[index]) {
       if (gridObject[key] === undefined) {
-        state.replay.grid_objects[index][key] = null
+        state.replay.grid_objects[index][key][step] = null
       }
     }
   }

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -294,7 +294,9 @@ export function loadReplayStep(replayStep: any) {
         state.replay.grid_objects.push({})
       }
       // Ensure that the key exists.
-      if (state.replay.grid_objects[index][key] === undefined || state.replay.grid_objects[index][key] === null) {
+      if (state.replay.grid_objects[index][key] === undefined ||
+        state.replay.grid_objects[index][key] === null
+      ) {
         state.replay.grid_objects[index][key] = []
         while (state.replay.grid_objects[index][key].length <= step) {
           state.replay.grid_objects[index][key].push(null)

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -294,14 +294,14 @@ export function loadReplayStep(replayStep: any) {
         state.replay.grid_objects.push({})
       }
       // Ensure that the key exists.
-      if (state.replay.grid_objects[index][key] === undefined) {
+      if (state.replay.grid_objects[index][key] === undefined || state.replay.grid_objects[index][key] === null) {
         state.replay.grid_objects[index][key] = []
         while (state.replay.grid_objects[index][key].length <= step) {
           state.replay.grid_objects[index][key].push(null)
         }
       }
-      state.replay.grid_objects[index][key][step] = value
 
+      state.replay.grid_objects[index][key][step] = value
 
       if (key == "agent_id") {
         // Update the agent.
@@ -309,6 +309,12 @@ export function loadReplayStep(replayStep: any) {
           state.replay.agents.push({})
         }
         state.replay.agents[value] = state.replay.grid_objects[index]
+      }
+    }
+    // Make sure that the keys that don't exist are set to null too.
+    for (const key in state.replay.grid_objects[index]) {
+      if (gridObject[key] === undefined) {
+        state.replay.grid_objects[index][key] = null
       }
     }
   }

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -319,7 +319,7 @@ function drawInventory() {
     let numItems = 0
     for (const [key, [icon, color]] of state.replay.resource_inventory) {
       const num = getAttr(gridObject, key)
-      if (num > 0) {
+      if (num !== null && num !== undefined && num > 0) {
         numItems += num
       }
     }
@@ -327,7 +327,7 @@ function drawInventory() {
     let advanceX = Math.min(32, (Common.TILE_SIZE - Common.INVENTORY_PADDING * 2) / numItems)
     for (const [key, [icon, color]] of state.replay.resource_inventory) {
       const num = getAttr(gridObject, key)
-      if (num > 0) {
+      if (num !== null && num !== undefined && num > 0) {
         for (let i = 0; i < num; i++) {
           ctx.drawSprite(
             icon,

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -319,22 +319,26 @@ function drawInventory() {
     let numItems = 0
     for (const [key, [icon, color]] of state.replay.resource_inventory) {
       const num = getAttr(gridObject, key)
-      numItems += num
+      if (num > 0) {
+        numItems += num
+      }
     }
     // Draw the actual inventory icons.
     let advanceX = Math.min(32, (Common.TILE_SIZE - Common.INVENTORY_PADDING * 2) / numItems)
     for (const [key, [icon, color]] of state.replay.resource_inventory) {
       const num = getAttr(gridObject, key)
-      for (let i = 0; i < num; i++) {
-        ctx.drawSprite(
-          icon,
-          x * Common.TILE_SIZE + inventoryX - Common.TILE_SIZE / 2,
-          y * Common.TILE_SIZE - Common.TILE_SIZE / 2 + 16,
-          color,
-          1 / 8,
-          0
-        )
-        inventoryX += advanceX
+      if (num > 0) {
+        for (let i = 0; i < num; i++) {
+          ctx.drawSprite(
+            icon,
+            x * Common.TILE_SIZE + inventoryX - Common.TILE_SIZE / 2,
+            y * Common.TILE_SIZE - Common.TILE_SIZE / 2 + 16,
+            color,
+            1 / 8,
+            0
+          )
+          inventoryX += advanceX
+        }
       }
     }
   }


### PR DESCRIPTION
Recently grid_object() was changed to only return keys that are non-zero because of a switch to tokens.

My code did not handle that it thought that zero was zero and missing was missing. But now missing is zero more work needs to be done.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where missing grid object keys were not handled as zeros, causing replay and UI issues.

- **Bug Fixes**
  - Updated replay writer and frontend code to treat missing keys as zero or null.
  - Fixed inventory display to only count and show items with positive values.

<!-- End of auto-generated description by cubic. -->

