### PR TITLE
feat: config validation

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -28,8 +28,8 @@ from metta.rl.torch_profiler import TorchProfiler
 from metta.rl.trainer_checkpoint import TrainerCheckpoint
 from metta.rl.vecenv import make_vecenv
 from metta.sim.simulation import Simulation
-from metta.sim.simulation_config import SimulationSuiteConfig, SingleEnvSimulationConfig
 from metta.sim.simulation_suite import SimulationSuite
+from metta.sim.types.simulation_config import SimulationSuiteConfig, SingleEnvSimulationConfig
 from mettagrid.curriculum import curriculum_from_config_path
 from mettagrid.mettagrid_env import MettaGridEnv, dtype_actions
 from mettagrid.util.stopwatch import Stopwatch

--- a/metta/sim/types/simulation_config copy 2.py
+++ b/metta/sim/types/simulation_config copy 2.py
@@ -1,33 +1,8 @@
-# metta/sim/simulation_config.py
-
-from typing import Dict, Optional
+from typing import Dict
 
 from pydantic import model_validator
 
-from metta.util.config import Config
-
-
-class SimulationConfig(Config):
-    """Configuration for a single simulation run."""
-
-    __init__ = Config.__init__
-
-    # Core simulation config
-    num_episodes: int
-    max_time_s: int = 120
-    env_overrides: dict = {}
-
-    npc_policy_uri: Optional[str] = None
-    policy_agents_pct: float = 1.0
-
-
-class SingleEnvSimulationConfig(SimulationConfig):
-    """Configuration for a single simulation run."""
-
-    __init__ = SimulationConfig.__init__
-
-    env: str
-    env_overrides: dict = {}
+from metta.sim.types.simulation_config import SimulationConfig
 
 
 class SimulationSuiteConfig(SimulationConfig):

--- a/metta/sim/types/simulation_config copy.py
+++ b/metta/sim/types/simulation_config copy.py
@@ -1,0 +1,42 @@
+from typing import Dict
+
+from pydantic import model_validator
+
+from metta.sim.types.simulation_config import SimulationConfig
+
+
+class SingleEnvSimulationConfig(SimulationConfig):
+    """Configuration for a single simulation run."""
+
+    __init__ = SimulationConfig.__init__
+
+    env: str
+    env_overrides: dict = {}
+
+
+class SimulationSuiteConfig(SimulationConfig):
+    """A suite of named simulations, with suite-level defaults injected."""
+
+    name: str
+    simulations: Dict[str, SingleEnvSimulationConfig]
+
+    @model_validator(mode="before")
+    @classmethod
+    def propagate_suite_fields(cls, values: dict) -> dict:
+        # collect only fields that were explicitly passed (not defaults)
+        # note: in `mode="before"`, `values` is raw user input
+
+        explicitly_provided = {
+            k: v
+            for k, v in values.items()
+            if k in SimulationConfig.model_fields  # only fields simulation children would know
+        }
+        raw_sims = values.get("simulations", {}) or {}
+        merged: Dict[str, dict] = {}
+
+        for name, sim_cfg in raw_sims.items():
+            # propagate suite values into each child
+            merged[name] = {**explicitly_provided, **sim_cfg}
+
+        values["simulations"] = merged
+        return values

--- a/metta/sim/types/simulation_config.py
+++ b/metta/sim/types/simulation_config.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from metta.util.types.base_config import BaseConfig
+
+
+class SimulationConfig(BaseConfig):
+    """Configuration for a single simulation run."""
+
+    __init__ = BaseConfig.__init__
+
+    num_episodes: int
+    max_time_s: int = 120
+    env_overrides: dict = {}
+
+    npc_policy_uri: Optional[str] = None
+    policy_agents_pct: float = 1.0

--- a/metta/util/types/base_config.py
+++ b/metta/util/types/base_config.py
@@ -1,0 +1,211 @@
+"""
+Base configuration type with OmegaConf/Hydra integration.
+
+This module provides the BaseConfig class that all configuration types inherit from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Type, TypeVar, Union, cast
+
+import hydra
+from omegaconf import DictConfig, ListConfig, OmegaConf
+from pydantic import BaseModel, ConfigDict
+
+T = TypeVar("T", bound="BaseConfig")
+
+
+class BaseConfig(BaseModel):
+    """
+    Pydantic-backed config base with OmegaConf/Hydra integration.
+
+    Features:
+    - Direct instantiation from DictConfig or dict: `MyConfig(cfg_node)`
+    - Conversion back to DictConfig: `.dictconfig()`
+    - YAML serialization: `.yaml()`
+    - Extra keys are forbidden by default (fail fast on typos)
+    - Full Pydantic validation
+
+    Usage:
+        class MyConfig(BaseConfig):
+            __init__ = BaseConfig.__init__  # For proper IDE support
+
+            my_field: str
+            my_number: int = 10
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",  # Fail on unknown fields
+        validate_assignment=True,  # Validate on attribute assignment
+    )
+
+    # Sub-classes should use `__init__ = BaseConfig.__init__` for proper IDE support
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if len(args) == 1 and not kwargs and isinstance(args[0], (DictConfig, dict)):
+            super().__init__(**self.prepare_dict(args[0]))
+        else:
+            # normal BaseModel __init__(**kwargs)
+            super().__init__(*args, **kwargs)
+
+    def prepare_dict(self, raw: Union[DictConfig, dict]) -> Dict[str, Any]:
+        """
+        Prepare a dictionary config from various input formats and validate keys.
+
+        Note: OmegaConf.to_container automatically converts any nested ListConfig
+        values to regular Python lists, which is what we want for Pydantic validation.
+        """
+        if isinstance(raw, ListConfig):
+            raise TypeError(f"Cannot create {self.__class__.__name__} from ListConfig. Expected DictConfig or dict.")
+
+        # This converts the entire structure to plain Python types:
+        # - DictConfig -> dict
+        # - ListConfig -> list (for any nested list values)
+        # - Interpolations are resolved
+        data = OmegaConf.to_container(raw, resolve=True) if isinstance(raw, DictConfig) else dict(raw)
+
+        # Ensure data is a proper dict with string keys
+        if isinstance(data, dict):
+            assert all(isinstance(k, str) for k in data.keys()), "All dictionary keys must be strings"
+            return cast(Dict[str, Any], data)
+        else:
+            raise TypeError("Data must be convertible to a dictionary")
+
+    def dictconfig(self) -> DictConfig:
+        """Convert this model back to an OmegaConf DictConfig."""
+        return OmegaConf.create(self.model_dump())
+
+    def yaml(self) -> str:
+        """Render this model as a YAML string."""
+        return OmegaConf.to_yaml(self.dictconfig())
+
+    @classmethod
+    def from_yaml(cls: Type[T], yaml_path: Union[str, Path]) -> T:
+        """
+        Load and validate config from a YAML file.
+
+        Args:
+            yaml_path: Path to YAML file
+
+        Returns:
+            Validated instance of the config class
+        """
+        cfg = OmegaConf.load(yaml_path)
+        return cls(cfg)
+
+    @classmethod
+    def from_hydra_path(
+        cls: Type[T], config_path: str, overrides: Optional[Union[DictConfig, Dict[str, Any]]] = None
+    ) -> T:
+        """
+        Load configuration from a Hydra config path with overrides.
+
+        Args:
+            config_path: Path to the configuration (e.g., "sim/simple")
+            overrides: Optional overrides to apply
+
+        Returns:
+            Validated instance of the config class
+        """
+        cfg = config_from_path(config_path, overrides)
+        return cls(cfg)
+
+    def merge_with(self: T, overrides: Union[DictConfig, Dict[str, Any]]) -> T:
+        """
+        Create a new config instance with overrides applied.
+
+        Args:
+            overrides: Values to override in the config
+
+        Returns:
+            New instance with overrides applied
+        """
+        current = self.dictconfig()
+        merged = OmegaConf.merge(current, overrides)
+        return self.__class__(merged)
+
+
+def config_from_path(config_path: str, overrides: Optional[Union[DictConfig, Dict[str, Any]]] = None) -> DictConfig:
+    """
+    Load configuration from a Hydra path with better error handling.
+
+    Args:
+        config_path: Path to the configuration
+        overrides: Optional overrides to apply to the configuration
+
+    Returns:
+        The loaded configuration
+
+    Raises:
+        ValueError: If the config_path is None or if the configuration could not be loaded
+        TypeError: If overrides is a ListConfig
+    """
+    if config_path is None:
+        raise ValueError("Config path cannot be None")
+
+    if isinstance(overrides, ListConfig):
+        raise TypeError("Overrides cannot be a ListConfig. Use DictConfig or dict instead.")
+
+    cfg = hydra.compose(config_name=config_path)
+
+    # Ensure we got a DictConfig
+    if isinstance(cfg, ListConfig):
+        raise TypeError(f"Config at path '{config_path}' is a ListConfig, expected DictConfig")
+
+    # When hydra loads a config, it "prefixes" the keys with the path of the config file.
+    # We don't want that prefix, so we remove it.
+    if config_path.startswith("/"):
+        config_path = config_path[1:]
+
+    for p in config_path.split("/")[:-1]:
+        cfg = cfg[p]
+
+    if overrides not in [None, {}]:
+        # Allow overrides that are not in the config.
+        OmegaConf.set_struct(cfg, False)
+        # If overrides is a dict with list values, they'll become ListConfigs after merge
+        # but that's OK - they'll be converted to lists when we create Pydantic models
+        cfg = OmegaConf.merge(cfg, overrides)
+        OmegaConf.set_struct(cfg, True)
+
+    return cast(DictConfig, cfg)
+
+
+class ConfigRegistry:
+    """
+    Registry for configuration types.
+
+    Allows registration of config types with their Hydra config group names
+    for automatic type resolution.
+    """
+
+    def __init__(self):
+        self._registry: Dict[str, Type[BaseConfig]] = {}
+        self._path_registry: Dict[str, Type[BaseConfig]] = {}  # For specific config paths
+
+    def register(self, config_group: str, config_class: Type[BaseConfig]) -> None:
+        """Register a config class for a Hydra config group."""
+        self._registry[config_group] = config_class
+
+    def register_path(self, config_path: str, config_class: Type[BaseConfig]) -> None:
+        """Register a config class for a specific config path."""
+        self._path_registry[config_path] = config_class
+
+    def get(self, config_group: str) -> Optional[Type[BaseConfig]]:
+        """Get config class for a config group."""
+        return self._registry.get(config_group)
+
+    def get_by_path(self, config_path: str) -> Optional[Type[BaseConfig]]:
+        """Get config class for a specific path."""
+        return self._path_registry.get(config_path)
+
+    def validate(self, config_group: str, cfg: Union[DictConfig, Dict[str, Any]]) -> BaseConfig:
+        """Validate a config against its registered type."""
+        config_class = self.get(config_group)
+        if not config_class:
+            raise KeyError(f"No config class registered for group: {config_group}")
+        return config_class(cfg)
+
+
+# Global registry instance
+config_registry = ConfigRegistry()

--- a/metta/util/types/validator.py
+++ b/metta/util/types/validator.py
@@ -1,0 +1,315 @@
+"""
+Configuration validation decorators and utilities for Hydra applications.
+
+This module provides decorators to add runtime type validation to Hydra-based
+applications, ensuring configs match their expected Pydantic schemas.
+"""
+
+import functools
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
+
+from omegaconf import DictConfig, ListConfig
+from pydantic import ValidationError
+
+from metta.util.types.base_config import BaseConfig, config_registry
+
+T = TypeVar("T", bound=BaseConfig)
+
+
+def validate_config(config_class: Type[T]) -> Callable:
+    """
+    Decorator to validate entire Hydra config against a Pydantic model.
+
+    The decorated function will receive a validated instance of config_class
+    instead of the raw DictConfig.
+
+    Usage:
+        @hydra.main(version_base=None, config_path="../configs", config_name="train")
+        @validate_config(TrainerConfig)
+        def train(cfg: TrainerConfig):
+            # cfg is now a validated TrainerConfig instance
+            print(cfg.learning_rate)  # Full IDE support!
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(cfg: Any) -> Any:
+            if isinstance(cfg, ListConfig):
+                raise TypeError(
+                    "validate_config decorator received ListConfig instead of DictConfig. "
+                    "This usually means the config file contains a list at the root level."
+                )
+
+            try:
+                # Convert OmegaConf to Pydantic model
+                validated_cfg = config_class(cfg)
+                # Call original function with validated config
+                return func(validated_cfg)
+            except ValidationError as e:
+                print(f"Configuration validation failed for {config_class.__name__}:")
+                print(e)
+                raise
+            except Exception as e:
+                print(f"Unexpected error validating config with {config_class.__name__}:")
+                print(e)
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+def validate_subconfig(
+    field_name: str, config_class: Type[T], optional: bool = False, in_place: bool = True
+) -> Callable:
+    """
+    Decorator to validate a specific field in the Hydra config.
+
+    Args:
+        field_name: Dot-separated path to the field (e.g., "trainer.optimizer")
+        config_class: Pydantic model to validate against
+        optional: If True, missing field is not an error
+        in_place: If True, replaces the field with validated dict in the original config
+
+    Usage:
+        @hydra.main(version_base=None, config_path="../configs", config_name="train")
+        @validate_subconfig("simulation", SimulationConfig)
+        @validate_subconfig("trainer.optimizer", OptimizerConfig, optional=True)
+        def train(cfg: DictConfig):
+            # cfg.simulation is validated
+            # cfg.trainer.optimizer is validated if present
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(cfg: Any) -> Any:
+            if isinstance(cfg, ListConfig):
+                raise TypeError(
+                    f"validate_subconfig decorator received ListConfig instead of DictConfig. "
+                    f"Cannot access field '{field_name}' in a list."
+                )
+
+            # Navigate to the field
+            field_parts = field_name.split(".")
+            current = cfg
+
+            # Check if field exists
+            try:
+                for i, part in enumerate(field_parts):
+                    current = current[part]
+                    # Check if we hit a ListConfig along the way
+                    if isinstance(current, ListConfig) and i < len(field_parts) - 1:
+                        raise TypeError(
+                            f"Encountered ListConfig at '{'.'.join(field_parts[: i + 1])}' "
+                            f"while navigating to '{field_name}'. Cannot access dict keys in a list."
+                        )
+            except (KeyError, AttributeError) as e:
+                if optional:
+                    return func(cfg)
+                raise ValueError(f"Required config field '{field_name}' not found: {e}") from e
+
+            try:
+                # Validate the subconfig
+                validated_subconfig = config_class(current)
+
+                if in_place:
+                    # Replace with validated version as dict to maintain OmegaConf structure
+                    current = cfg
+                    for part in field_parts[:-1]:
+                        current = current[part]
+                    current[field_parts[-1]] = validated_subconfig.model_dump()
+
+                return func(cfg)
+            except ValidationError as e:
+                print(f"Validation failed for config field '{field_name}':")
+                print(e)
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+def validate_configs(*validations: tuple[str, Type[BaseConfig], bool]) -> Callable:
+    """
+    Decorator to validate multiple config fields at once.
+
+    Args:
+        *validations: Tuples of (field_name, config_class, optional)
+
+    Usage:
+        @hydra.main(version_base=None, config_path="../configs", config_name="train")
+        @validate_configs(
+            ("simulation", SimulationConfig, False),
+            ("trainer", TrainerConfig, False),
+            ("wandb", WandbConfig, True),
+        )
+        def train(cfg: DictConfig):
+            # All specified fields are validated
+    """
+
+    def decorator(func: Callable) -> Callable:
+        # Apply validators in reverse order so they execute in the order specified
+        decorated = func
+        for field_name, config_class, optional in reversed(validations):
+            decorated = validate_subconfig(field_name, config_class, optional)(decorated)
+        return decorated
+
+    return decorator
+
+
+def auto_validate_config(func: Callable) -> Callable:
+    """
+    Decorator that automatically validates configs based on registered types.
+
+    Requires config groups to be registered with config_registry.
+
+    Usage:
+        # Register config types
+        config_registry.register("sim", SimulationConfig)
+        config_registry.register("trainer", TrainerConfig)
+
+        @hydra.main(version_base=None, config_path="../configs", config_name="train")
+        @auto_validate_config
+        def train(cfg: DictConfig):
+            # All registered config groups in cfg are automatically validated
+    """
+
+    @functools.wraps(func)
+    def wrapper(cfg: Any) -> Any:
+        if isinstance(cfg, ListConfig):
+            raise TypeError(
+                "auto_validate_config decorator received ListConfig instead of DictConfig. "
+                "This usually means the config file contains a list at the root level."
+            )
+
+        errors = {}
+
+        # Check each field in config
+        for field_name in cfg:
+            config_class = config_registry.get(field_name)
+            if config_class:
+                try:
+                    field_value = cfg[field_name]
+                    if isinstance(field_value, ListConfig):
+                        errors[field_name] = f"Field is a ListConfig, cannot validate with {config_class.__name__}"
+                        continue
+
+                    validated = config_class(field_value)
+                    cfg[field_name] = validated.model_dump()
+                except ValidationError as e:
+                    errors[field_name] = str(e)
+
+        if errors:
+            error_msg = "Configuration validation failed:\n"
+            for field, error in errors.items():
+                error_msg += f"\n{field}:\n{error}\n"
+            raise ValidationError(error_msg)
+
+        return func(cfg)
+
+    return wrapper
+
+
+class ValidatedConfig:
+    """
+    Context manager for validated configs.
+
+    Provides a way to validate configs in existing code without decorators.
+
+    Usage:
+        with ValidatedConfig(cfg.simulation, SimulationConfig) as sim_cfg:
+            # Use sim_cfg as a validated SimulationConfig instance
+            run_simulation(sim_cfg)
+    """
+
+    def __init__(self, cfg: Union[DictConfig, Dict[str, Any]], config_class: Type[T], strict: bool = True):
+        if isinstance(cfg, ListConfig):
+            raise TypeError(
+                f"ValidatedConfig received ListConfig instead of DictConfig. "
+                f"Cannot validate a list with {config_class.__name__}."
+            )
+
+        self.cfg = cfg
+        self.config_class = config_class
+        self.strict = strict
+        self.validated_cfg: Optional[T] = None
+
+    def __enter__(self) -> T:
+        try:
+            self.validated_cfg = self.config_class(self.cfg)
+            return self.validated_cfg
+        except ValidationError as e:
+            if self.strict:
+                raise
+            print(f"Warning: Configuration validation failed: {e}")
+            # Return a best-effort instance using model_construct (skips validation)
+            return self.config_class.model_construct(**self.cfg)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def extract_validated_configs(cfg: DictConfig, **field_mappings: Type[BaseConfig]) -> Dict[str, BaseConfig]:
+    """
+    Extract and validate multiple config fields at once.
+
+    Args:
+        cfg: The main config
+        **field_mappings: Mapping of field names to config classes
+
+    Returns:
+        Dictionary of validated config instances
+
+    Usage:
+        configs = extract_validated_configs(
+            cfg,
+            simulation=SimulationConfig,
+            trainer=TrainerConfig,
+            wandb=WandbConfig,
+        )
+
+        sim_cfg = configs["simulation"]  # Validated SimulationConfig
+    """
+    if isinstance(cfg, ListConfig):
+        raise TypeError(
+            "extract_validated_configs received ListConfig instead of DictConfig. "
+            "This function requires a dictionary-like config."
+        )
+
+    validated = {}
+    errors = {}
+
+    for field_name, config_class in field_mappings.items():
+        try:
+            # Handle nested fields
+            field_parts = field_name.split(".")
+            current = cfg
+            for i, part in enumerate(field_parts):
+                current = current[part]
+                # Check if we hit a ListConfig along the way
+                if isinstance(current, ListConfig) and i < len(field_parts) - 1:
+                    raise TypeError(
+                        f"Encountered ListConfig at '{'.'.join(field_parts[: i + 1])}' "
+                        f"while navigating to '{field_name}'. Cannot access dict keys in a list."
+                    )
+
+            # Final value shouldn't be a ListConfig either
+            if isinstance(current, ListConfig):
+                raise TypeError(f"Field '{field_name}' is a ListConfig, cannot validate with {config_class.__name__}")
+
+            validated[field_name] = config_class(current)
+        except (KeyError, AttributeError) as e:
+            errors[field_name] = f"Field not found in config: {e}"
+        except TypeError as e:
+            errors[field_name] = str(e)
+        except ValidationError as e:
+            errors[field_name] = str(e)
+
+    if errors:
+        error_msg = "Failed to extract and validate configs:\n"
+        for field, error in errors.items():
+            error_msg += f"\n{field}: {error}\n"
+        raise ValidationError(error_msg)
+
+    return validated


### PR DESCRIPTION
# 1. Simple full config validation
@hydra.main(config_path="../configs", config_name="train")
@validate_config(TrainerConfig)
def train(cfg: TrainerConfig):  # Full type support!
    print(cfg.learning_rate)

# 2. Validate specific subconfigs
@hydra.main(config_path="../configs", config_name="experiment")
@validate_subconfig("model", ModelConfig)
@validate_subconfig("data", DataConfig)
def experiment(cfg: DictConfig):
    # cfg.model and cfg.data are validated
    pass

# 3. Context manager for existing code
def process(cfg: DictConfig):
    with ValidatedConfig(cfg.processor, ProcessorConfig) as proc_cfg:
        # proc_cfg is typed and validated
        run_processor(proc_cfg)

# 4. Auto-validation with registry
config_registry.register("model", ModelConfig)
config_registry.register("trainer", TrainerConfig)

@hydra.main(config_path="../configs", config_name="train")
@auto_validate_config
def train(cfg: DictConfig):
    # All registered configs are validated
    pass