### PR TITLE
Update mine and generator to have colors in yaml configs

### DIFF
--- a/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
@@ -73,7 +73,7 @@ game:
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}
       initial_items: 0
-    mine:
+    mine.red:
       cooldown: ${sampling:10,25,15}
       max_output: 100
       conversion_ticks: 1

--- a/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
@@ -8,7 +8,7 @@ sampling: 1
 game:
   max_steps: ${sampling:100,500,250} # Reduce and randomize the episode length
   num_agents: 8
-  
+
   agent:
     default_item_max: 1
     heart_max: 1000
@@ -74,7 +74,7 @@ game:
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}
       initial_items: 0
-    mine:
+    mine.red:
       cooldown: ${sampling:10,25,15}
       max_output: 100
       conversion_ticks: 1

--- a/configs/env/mettagrid/object_use/evals/full_sequence.yaml
+++ b/configs/env/mettagrid/object_use/evals/full_sequence.yaml
@@ -17,7 +17,7 @@ game:
     altar:
       initial_items: 0
       cooldown: 255
-    mine:
+    mine.red:
       cooldown: 1
 
   map_builder:

--- a/configs/env/mettagrid/object_use/evals/lasery_use.yaml
+++ b/configs/env/mettagrid/object_use/evals/lasery_use.yaml
@@ -14,7 +14,7 @@ game:
       initial_items: 2
       output_battery.red: 2
       cooldown: 255
-    mine:
+    mine.red:
       cooldown: 255
     lasery:
       initial_items: 0


### PR DESCRIPTION
Updates YAML configs to specify mine objects with color (mine.red) instead of generic names. This makes mine and generator definitions color-specific for better clarity and future extension.

Right now when the environment sees "mine" or "generator", it automatically substitutes "mine.red" or "generator.red"; so settings on non-colored versions of these objects don't actually do anything.