### PR TITLE
Make mine and generator colors explicit in yaml files

### DIFF
--- a/configs/env/mettagrid/bases.yaml
+++ b/configs/env/mettagrid/bases.yaml
@@ -26,7 +26,7 @@ game:
         agents: ${div:${....num_agents},4}
 
         objects:
-          generator: ${sampling:1,10,2}
+          generator.red: ${sampling:1,10,2}
           armory: ${sampling:1,5,1}
           lasery: ${sampling:1,5,1}
           lab: ${sampling:1,5,1}
@@ -41,7 +41,7 @@ game:
         border_width: 0
 
         objects:
-          mine: ${sampling:1,20,10}
+          mine.red: ${sampling:1,20,10}
           altar: ${sampling:1,5,1}
           wall: ${sampling:0,20,5}
 
@@ -54,4 +54,4 @@ game:
         objects:
           altar: ${sampling:1,3,2}
           wall: ${sampling:0,20,5}
-          generator: ${sampling:1,10,2}
+          generator.red: ${sampling:1,10,2}

--- a/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
@@ -68,7 +68,7 @@ game:
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}
       initial_items: 0
-    generator:
+    generator.red:
       cooldown: ${sampling:10,25,15}
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}

--- a/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
@@ -69,7 +69,7 @@ game:
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}
       initial_items: 0
-    generator:
+    generator.red:
       cooldown: ${sampling:10,25,15}
       max_output: 100
       conversion_ticks: ${sampling:10,25,15}

--- a/configs/env/mettagrid/game/map_builder/mapgen_auto.yaml
+++ b/configs/env/mettagrid/game/map_builder/mapgen_auto.yaml
@@ -17,8 +17,8 @@ root:
     # Values are absolute counts. (TODO: make them percentages?)
     objects:
       {}
-      # mine: ${uniform:1,800,400}
-      # generator: ${uniform:1,400,80}
+      # mine.red: ${uniform:1,800,400}
+      # generator.red: ${uniform:1,400,80}
       # altar: ${uniform:1,200,40}
       # armory: ${uniform:1,200,40}
       # lasery: ${uniform:1,200,40}
@@ -30,8 +30,8 @@ root:
     # The percentage of objects to generate in each area.
     # The percentage will be sampled from the distribution for each room separately.
     room_objects:
-      mine: ["uniform", 0.0005, 0.01]
-      generator: ["lognormal", 0.0001, 0.01, 0.03]
+      mine.red: ["uniform", 0.0005, 0.01]
+      generator.red: ["lognormal", 0.0001, 0.01, 0.03]
       altar: ["lognormal", 0.0001, 0.01, 0.03]
       armory: ["uniform", 0.0005, 0.01]
       lasery: ["uniform", 0.0005, 0.01]

--- a/configs/env/mettagrid/game/map_builder/mapgen_bsp_complex.yaml
+++ b/configs/env/mettagrid/game/map_builder/mapgen_bsp_complex.yaml
@@ -18,7 +18,7 @@ root:
         type: metta.map.scenes.random.Random
         params:
           objects:
-            generator: 3
+            generator.red: 3
             altar: 3
 
     - limit: 3

--- a/configs/env/mettagrid/game/map_builder/mapgen_demo.yaml
+++ b/configs/env/mettagrid/game/map_builder/mapgen_demo.yaml
@@ -79,8 +79,8 @@ root:
         # Note that for the maze rooms, Random scene will take existing walls into account.
         params:
           objects:
-            mine: 1
-            generator: 2
+            mine.red: 1
+            generator.red: 2
 
     # What if we want to draw a custom scene in one room, but that room shouldn't have a maze? Let's use a lock.
     #

--- a/configs/env/mettagrid/game/map_builder/mapgen_simple.yaml
+++ b/configs/env/mettagrid/game/map_builder/mapgen_simple.yaml
@@ -20,8 +20,8 @@ root:
         type: metta.map.scenes.random.Random
         params:
           objects:
-            mine: ${sampling:1,20,10}
-            generator: ${sampling:1,10,2}
+            mine.red: ${sampling:1,20,10}
+            generator.red: ${sampling:1,10,2}
             altar: ${sampling:1,5,1}
             armory: ${sampling:1,5,1}
             lasery: ${sampling:1,5,1}

--- a/configs/env/mettagrid/game/map_builder/mapgen_species.yaml
+++ b/configs/env/mettagrid/game/map_builder/mapgen_species.yaml
@@ -23,5 +23,5 @@ root:
           objects:
             altar: ${sampling:1,5,1}
             converter: ${sampling:1,15,5}
-            generator: ${sampling:1,50,15}
+            generator.red: ${sampling:1,50,15}
             wall: ${sampling:10,100,40}

--- a/configs/env/mettagrid/game/map_builder/simple.yaml
+++ b/configs/env/mettagrid/game/map_builder/simple.yaml
@@ -11,8 +11,8 @@ room:
   agents: 6
 
   objects:
-    mine: ${sampling:1,20,10}
-    generator: ${sampling:1,10,2}
+    mine.red: ${sampling:1,20,10}
+    generator.red: ${sampling:1,10,2}
     altar: ${sampling:1,5,1}
     armory: ${sampling:1,5,1}
     lasery: ${sampling:1,5,1}

--- a/configs/env/mettagrid/game/map_builder/species.yaml
+++ b/configs/env/mettagrid/game/map_builder/species.yaml
@@ -15,5 +15,5 @@ room:
   objects:
     altar: ${sampling:1,5,1}
     converter: ${sampling:1,15,5}
-    generator: ${sampling:1,50,15}
+    generator.red: ${sampling:1,50,15}
     wall: ${sampling:10,100,40}

--- a/configs/env/mettagrid/game/map_builder/terrain.yaml
+++ b/configs/env/mettagrid/game/map_builder/terrain.yaml
@@ -9,8 +9,8 @@ room:
   agents: 6
 
   objects:
-    mine: ${sampling:1,20,10}
-    generator: ${sampling:1,10,2}
+    mine.red: ${sampling:1,20,10}
+    generator.red: ${sampling:1,10,2}
     altar: ${sampling:1,5,1}
     armory: ${sampling:1,5,1}
     lasery: ${sampling:1,5,1}

--- a/configs/env/mettagrid/object_use/evals/armory_use.yaml
+++ b/configs/env/mettagrid/object_use/evals/armory_use.yaml
@@ -20,4 +20,4 @@ game:
   map_builder:
     objects:
       armory: 1
-      mine: 1
+      mine.red: 1

--- a/configs/env/mettagrid/object_use/evals/full_sequence.yaml
+++ b/configs/env/mettagrid/object_use/evals/full_sequence.yaml
@@ -23,5 +23,5 @@ game:
   map_builder:
     objects:
       altar: 1
-      generator: 1
-      mine: 1
+      generator.red: 1
+      mine.red: 1

--- a/configs/env/mettagrid/object_use/evals/generator_use.yaml
+++ b/configs/env/mettagrid/object_use/evals/generator_use.yaml
@@ -8,7 +8,7 @@ game:
     generator.red:
       initial_items: 0
       cooldown: 255
-    mine:
+    mine.red:
       cooldown: 255
   agent:
     rewards:
@@ -18,5 +18,5 @@ game:
       ore.green: 0
   map_builder:
     objects:
-      generator: 1
-      mine: 1
+      generator.red: 1
+      mine.red: 1

--- a/configs/env/mettagrid/object_use/evals/generator_use_free.yaml
+++ b/configs/env/mettagrid/object_use/evals/generator_use_free.yaml
@@ -13,4 +13,4 @@ game:
       battery.red: 1
   map_builder:
     objects:
-      generator: 1
+      generator.red: 1

--- a/configs/env/mettagrid/object_use/evals/lasery_use.yaml
+++ b/configs/env/mettagrid/object_use/evals/lasery_use.yaml
@@ -22,5 +22,5 @@ game:
   map_builder:
     objects:
       lasery: 1
-      generator: 1
-      mine: 1
+      generator.red: 1
+      mine.red: 1

--- a/configs/env/mettagrid/object_use/evals/mine_use.yaml
+++ b/configs/env/mettagrid/object_use/evals/mine_use.yaml
@@ -13,4 +13,4 @@ game:
       ore.red: 1
   map_builder:
     objects:
-      mine: 1
+      mine.red: 1

--- a/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
+++ b/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
@@ -34,8 +34,8 @@ game:
       agents: 1
       style: all-sparse # ${choose:"all-sparse","balanced","dense","maze"}
       objects:
-        mine: ${sampling:1,5,3}
-        generator: ${sampling:1,5,3}
+        mine.red: ${sampling:1,5,3}
+        generator.red: ${sampling:1,5,3}
         altar: ${sampling:1,5,1}
         armory: ${sampling:1,5,1}
         lasery: ${sampling:1,5,1}

--- a/configs/env/mettagrid/prog_3.yaml
+++ b/configs/env/mettagrid/prog_3.yaml
@@ -18,8 +18,8 @@ game:
       agents: 6
 
       objects:
-        mine: ${sampling:1,10,10}
-        generator: ${sampling:1,10,10}
+        mine.red: ${sampling:1,10,10}
+        generator.red: ${sampling:1,10,10}
         altar: ${sampling:1,5,7}
         armory: ${sampling:0,5,1}
         lasery: ${sampling:0,5,1}

--- a/configs/env/mettagrid/puffer.yaml
+++ b/configs/env/mettagrid/puffer.yaml
@@ -23,8 +23,8 @@ game:
       agents: 6
 
       objects:
-        mine: 10
-        generator: 2
+        mine.red: 10
+        generator.red: 2
         altar: 1
         armory: 1
         lasery: 1

--- a/configs/env/mettagrid/school.yaml
+++ b/configs/env/mettagrid/school.yaml
@@ -25,7 +25,7 @@ game:
         agents: 1
         objects:
           altar: 1
-          generator: 3
+          generator.red: 3
           converter: 1
           wall: ${..width}
 
@@ -37,7 +37,7 @@ game:
         agents: 3
         objects:
           altar: 1
-          generator: 3
+          generator.red: 3
           converter: 2
           wall: ${..width}
 
@@ -49,7 +49,7 @@ game:
         agents: 2
         objects:
           altar: 1
-          generator: 1
+          generator.red: 1
           converter: 1
           wall: ${..width}
 
@@ -63,7 +63,7 @@ game:
           prey: 3
         objects:
           altar: 1
-          generator: 1
+          generator.red: 1
           converter: 1
           wall: ${..width}
 
@@ -88,7 +88,7 @@ game:
             height: ${sampling:5,20,10}
             agents: 1
             objects:
-              generator: 1
+              generator.red: 1
               converter: 1
               wall: ${..width}
           - _target_: mettagrid.room.random.Random

--- a/configs/env/mettagrid/split.yaml
+++ b/configs/env/mettagrid/split.yaml
@@ -44,7 +44,7 @@ game:
         border_width: 0
 
         objects:
-          generator: ${sampling:1,20,10}
+          generator.red: ${sampling:1,20,10}
           wall: ${sampling:10,60,10}
 
       converters:

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -22,8 +22,8 @@ game:
       agents: 6
 
       objects:
-        mine: 10
-        generator: 2
+        mine.red: 10
+        generator.red: 2
         altar: 1
         armory: 1
         lasery: 1

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -15,7 +15,7 @@ game:
     objects:
       altar: 1
       converter: 3
-      generator: 15
+      generator.red: 15
       wall: 40
 
   num_agents: 5

--- a/tests/map/scenes/test_auto.py
+++ b/tests/map/scenes/test_auto.py
@@ -5,8 +5,8 @@ from tests.map.scenes.utils import assert_connected, render_scene
 def test_basic():
     params = {
         "num_agents": 1,
-        "objects": {"mine": 2},
-        "room_objects": {"mine": ["uniform", 0.0005, 0.01]},
+        "objects": {"altar": 2},
+        "room_objects": {"altar": ["uniform", 0.0005, 0.01]},
         "room_symmetry": {"horizontal": 1, "vertical": 1, "x4": 1, "none": 1},
         "layout": {"grid": 1, "bsp": 1},
         "grid": {"rows": 3, "columns": 3},

--- a/tests/map/scenes/test_random.py
+++ b/tests/map/scenes/test_random.py
@@ -9,10 +9,10 @@ def make_grid(height: int, width: int) -> np.ndarray:
 
 
 def test_objects():
-    scene = render_scene(Random, {"objects": {"mine": 3, "generator": 2}}, (3, 3))
+    scene = render_scene(Random, {"objects": {"altar": 3, "temple": 2}}, (3, 3))
 
-    assert (scene.grid == "mine").sum() == 3
-    assert (scene.grid == "generator").sum() == 2
+    assert (scene.grid == "altar").sum() == 3
+    assert (scene.grid == "temple").sum() == 2
 
 
 def test_agents():

--- a/tests/map/scenes/test_random_objects.py
+++ b/tests/map/scenes/test_random_objects.py
@@ -5,9 +5,9 @@ from tests.map.scenes.utils import render_scene
 def test_objects():
     scene = render_scene(
         RandomObjects,
-        dict(object_ranges={"mine": ("uniform", 0.2, 0.5)}),
+        dict(object_ranges={"altar": ("uniform", 0.2, 0.5)}),
         (10, 10),
     )
 
-    mine_count = (scene.grid == "mine").sum()
-    assert 0.2 * 100 <= mine_count <= 0.5 * 100
+    altar_count = (scene.grid == "altar").sum()
+    assert 0.2 * 100 <= altar_count <= 0.5 * 100


### PR DESCRIPTION
Updated all YAML config files to make mine and generator object colors explicit by renaming them to mine.red and generator.red.

This removes (or at least weakens) a dependency on the environment automatically mapping `mine` to `mine.red`.