### PR TITLE
guarantee https remote in docker image

### DIFF
--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -57,6 +57,9 @@ RUN git config --remove-section http."https://github.com/" || true
 # Make sure the remote is configured for anonymous access
 RUN git remote remove origin && git remote add origin https://github.com/Metta-AI/metta.git
 
+# Doesn't do anything but guarantees that the remote is configured for anonymous access
+RUN git fetch
+
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --locked
 

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -54,6 +54,9 @@ ADD . .
 # When building in CI, actions/checkout stores an auth token in .git/config that we need to remove
 RUN git config --remove-section http."https://github.com/" || true
 
+# Make sure the remote is configured for anonymous access
+RUN git remote remove origin && git remote add origin https://github.com/Metta-AI/metta.git
+
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --locked
 


### PR DESCRIPTION
The Docker image now always uses an HTTPS remote for the Git repository to ensure anonymous access during training runs.