### PR TITLE
fixing user environmental issue in mettaboxes

### DIFF
--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -18,4 +18,4 @@ vectorization: multiprocessing
 seed: 0
 device: cuda
 
-stats_user: ${oc.env:USER}
+stats_user: ${oc.env:USER,unknown}


### PR DESCRIPTION
Error executing job with overrides: ['run=relh.nav.main.1', 'trainer.curriculum=env/mettagrid/curriculum/navigation', '+hardware=pufferbox']
Traceback (most recent call last):
  File "/workspace/metta/./tools/train.py", line 80, in main
    logger.info(f"Train job config: {OmegaConf.to_yaml(cfg, resolve=True)}")
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
omegaconf.errors.InterpolationResolutionError: KeyError raised while resolving interpolation: "Environment variable 'USER' not found"
    full_key: stats_user
    object_type=dict

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
 🐡
 
 ---
 
 This error happens because we're now checking for user in our YAML but Docker containers often dont have $USER set
 
 ---

The error was happening because the configs/common.yaml file was trying to read the USER environment variable, which isn't set in your environment. This is a common issue in Docker containers, CI/CD environments, or certain shell configurations.
I've fixed it by updating the configuration to include a default value. The change was:
From: stats_user: ${oc.env:USER}
To: stats_user: ${oc.env:USER,unknown}
This means if the USER environment variable doesn't exist, it will use "unknown" as the default value instead of throwing an error.
You should now be able to run your training command successfully:

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a config error that caused training jobs to fail when the USER environment variable was missing. Now, if USER is not set, the value defaults to "unknown" instead of throwing an error.

<!-- End of auto-generated description by cubic. -->

