### PR TITLE
new default npc

### DIFF
--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -58,7 +58,7 @@ simulations:
   npc/simple:
     env: env/mettagrid/simple
     policy_agents_pct: 0.5
-    npc_policy_uri: wandb://run/b.rwalters.0618.nav.pr989.2
+    npc_policy_uri: wandb://run/georgedeane.nav_scratch
   objectuse/altar_use_free:
     env: env/mettagrid/object_use/evals/altar_use_free
     policy_agents_pct: 1.0

--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -58,7 +58,7 @@ simulations:
   npc/simple:
     env: env/mettagrid/simple
     policy_agents_pct: 0.5
-    npc_policy_uri: wandb://run/b.daphne.npc_simple
+    npc_policy_uri: wandb://run/b.rwalters.0618.nav.pr989.2
   objectuse/altar_use_free:
     env: env/mettagrid/object_use/evals/altar_use_free
     policy_agents_pct: 1.0


### PR DESCRIPTION
```
Error executing job with overrides: ['run=relh.nav.speedup.1', 'trainer.curriculum=env/mettagrid/curriculum/navigation', '+hardware=pufferbox']
Traceback (most recent call last):
  File "/workspace/metta/./tools/train.py", line 95, in main
    train(cfg, wandb_run, logger)
  File "/workspace/metta/./tools/train.py", line 65, in train
    trainer.train()
  File "/workspace/metta/metta/rl/trainer.py", line 268, in train
    self._evaluate_policy()
  File "/workspace/metta/metta/rl/trainer.py", line 320, in _evaluate_policy
    result = sim.simulate()
             ^^^^^^^^^^^^^^
  File "/workspace/metta/metta/sim/simulation_suite.py", line 55, in simulate
    sim = Simulation(
          ^^^^^^^^^^^
  File "/workspace/metta/metta/sim/simulation.py", line 128, in __init__
    npc_agent: MettaAgent | DistributedMettaAgent = self._npc_pr.policy_as_metta_agent()
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/metta/metta/agent/policy_store.py", line 59, in policy_as_metta_agent
    policy = self.policy()
             ^^^^^^^^^^^^^
  File "/workspace/metta/metta/agent/policy_store.py", line 52, in policy
    pr = self._policy_store.load_from_uri(self.uri)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/metta/metta/agent/policy_store.py", line 446, in load_from_uri
    return self._load_wandb_artifact(uri[len("wandb://") :])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/metta/metta/agent/policy_store.py", line 559, in _load_wandb_artifact
    pr = self._load_from_file(os.path.join(artifact_path, "model.pt"))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/metta/metta/agent/policy_store.py", line 534, in _load_from_file
    pr = torch.load(
         ^^^^^^^^^^^
  File "/workspace/metta/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1525, in load
    return _load(
           ^^^^^^
  File "/workspace/metta/.venv/lib/python3.11/site-packages/torch/serialization.py", line 2114, in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/workspace/metta/.venv/lib/python3.11/site-packages/torch/serialization.py", line 2103, in find_class
    return super().find_class(mod_name, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'metta.agent.lib.obs_shaper'

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```
---

I think that we are currently setting the npc policy to an old policy that has classes that don't exist anymore. 

This will be fixed soon when we do AgentRevisioning:

https://github.com/Metta-AI/metta/pull/973

But for now we can set a newer default.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the default NPC policy in the simple simulation to use a newer model and avoid missing class errors.

<!-- End of auto-generated description by cubic. -->

