### PR TITLE
cleanup upload/download in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -221,20 +221,6 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
 
-      - name: Upload training output
-        uses: actions/upload-artifact@v4
-        with:
-          name: train-output
-          path: train_dir/
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Download training output
-        uses: actions/download-artifact@v4
-        with:
-          name: train-output
-          path: train_dir/
-
       - name: Verify training artifacts
         run: |
           ls -la train_dir/


### PR DESCRIPTION
### TL;DR

Removed unnecessary artifact upload and download steps from the GitHub workflow.

### What changed?

Removed the `Upload training output` and `Download training output` steps from the `.github/workflows/checks.yml` file. These steps were uploading the `train_dir/` directory as an artifact and then immediately downloading it again, which is redundant since the directory is already available in the workflow.

### How to test?

Run the GitHub workflow and verify that the `Verify training artifacts` step still works correctly without the removed upload/download steps.

### Why make this change?

This change eliminates redundant steps in the workflow. Since the `train_dir/` directory is already available in the workflow context, there's no need to upload it as an artifact and then immediately download it again. This will make the workflow more efficient and reduce execution time.