### PR TITLE
Change the Mettascope panels to be hidden by default. 

### DIFF
--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -93,10 +93,10 @@ export const state = {
   showGrid: true,
   showVisualRanges: true,
   showFogOfWar: false,
-  showMiniMap: true,
-  showInfo: true,
-  showControls: true,
-  showAgentPanel: true,
+  showMiniMap: false,
+  showInfo: false,
+  showControls: false,
+  showAgentPanel: false,
 
   showAttackMode: false,
 


### PR DESCRIPTION

Changed the default state so the 
* mini map
* info panel
* controls,
* agent panel 

are now hidden when the app starts for the first time and does not have local storage set.


