### PR TITLE
PolicyRecord -> MettaAgent REFACTOR/SQUASH ONLY v0

### DIFF
--- a/metta/agent/metta_agent.py
+++ b/metta/agent/metta_agent.py
@@ -65,12 +65,12 @@ class DistributedMettaAgent(DistributedDataParallel):
 class MettaAgent(nn.Module):
     def __init__(
         self,
-        obs_space: Union[gym.spaces.Space, gym.spaces.Dict],
-        obs_width: int,
-        obs_height: int,
-        action_space: gym.spaces.Space,
-        feature_normalizations: dict[int, float],
-        device: str,
+        obs_space: Optional[Union[gym.spaces.Space, gym.spaces.Dict]] = None,
+        obs_width: Optional[int] = None,
+        obs_height: Optional[int] = None,
+        action_space: Optional[gym.spaces.Space] = None,
+        feature_normalizations: Optional[dict[int, float]] = None,
+        device: Optional[str] = None,
         # PolicyRecord compatibility parameters
         policy_store: "PolicyStore" = None,
         name: str = None,

--- a/metta/agent/metta_agent.py
+++ b/metta/agent/metta_agent.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 import gymnasium as gym
 import hydra
@@ -10,15 +10,13 @@ from torch import nn
 from torch.nn.parallel import DistributedDataParallel
 
 from metta.agent.policy_state import PolicyState
+from metta.agent.policy_store import PolicyStore
 from metta.agent.util.debug import assert_shape
 from metta.agent.util.distribution_utils import evaluate_actions, sample_actions
 from metta.agent.util.safe_get import safe_get_from_obs_space
+from metta.rl.policy import PytorchAgent
 from metta.util.omegaconf import convert_to_dict
 from mettagrid.mettagrid_env import MettaGridEnv
-
-if TYPE_CHECKING:
-    from metta.agent.policy_store import PolicyStore
-    from metta.rl.policy import PytorchAgent
 
 logger = logging.getLogger("metta_agent")
 
@@ -65,17 +63,17 @@ class DistributedMettaAgent(DistributedDataParallel):
 class MettaAgent(nn.Module):
     def __init__(
         self,
-        obs_space: Union[gym.spaces.Space, gym.spaces.Dict, None] = None,
-        obs_width: int = None,
-        obs_height: int = None,
-        action_space: gym.spaces.Space = None,
-        feature_normalizations: dict[int, float] = None,
-        device: str = None,
+        obs_space: Union[gym.spaces.Space, gym.spaces.Dict],
+        obs_width: int,
+        obs_height: int,
+        action_space: gym.spaces.Space,
+        feature_normalizations: dict[int, float],
+        device: str,
         # PolicyRecord compatibility parameters
-        policy_store: "PolicyStore" = None,
-        name: str = None,
-        uri: str = None,
-        metadata: dict = None,
+        policy_store: "PolicyStore",
+        name: str,
+        uri: str,
+        metadata: dict,
         **cfg,
     ):
         super().__init__()

--- a/metta/agent/metta_agent.py
+++ b/metta/agent/metta_agent.py
@@ -72,10 +72,10 @@ class MettaAgent(nn.Module):
         feature_normalizations: dict[int, float],
         device: str,
         # PolicyRecord compatibility parameters
-        policy_store: "PolicyStore",
-        name: str,
-        uri: str,
-        metadata: dict,
+        policy_store: "PolicyStore" = None,
+        name: str = None,
+        uri: str = None,
+        metadata: dict = None,
         **cfg,
     ):
         super().__init__()

--- a/metta/agent/metta_agent.py
+++ b/metta/agent/metta_agent.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import gymnasium as gym
 import hydra
@@ -10,13 +10,15 @@ from torch import nn
 from torch.nn.parallel import DistributedDataParallel
 
 from metta.agent.policy_state import PolicyState
-from metta.agent.policy_store import PolicyStore
 from metta.agent.util.debug import assert_shape
 from metta.agent.util.distribution_utils import evaluate_actions, sample_actions
 from metta.agent.util.safe_get import safe_get_from_obs_space
 from metta.rl.policy import PytorchAgent
 from metta.util.omegaconf import convert_to_dict
 from mettagrid.mettagrid_env import MettaGridEnv
+
+if TYPE_CHECKING:
+    from metta.agent.policy_store import PolicyStore
 
 logger = logging.getLogger("metta_agent")
 

--- a/metta/agent/policy_store.py
+++ b/metta/agent/policy_store.py
@@ -35,7 +35,6 @@ class PolicySelectorConfig(Config):
     metric: str = "score"
 
 
-# Create a PolicyRecord class that can handle unpickling old files
 class PolicyRecord:
     """Compatibility class for loading old PolicyRecord checkpoints."""
 
@@ -43,7 +42,7 @@ class PolicyRecord:
         self._policy_store = policy_store
         self.name = name
         self.uri = uri
-        self.metadata = metadata or {}
+        self.metadata = metadata
         self._policy = None
         self._local_path = None
 

--- a/metta/eval/analysis.py
+++ b/metta/eval/analysis.py
@@ -4,13 +4,13 @@ from typing import Dict, List, Optional
 
 from tabulate import tabulate
 
-from metta.agent.policy_store import PolicyRecord
+from metta.agent.policy_store import MettaAgent
 from metta.eval.analysis_config import AnalysisConfig
 from metta.eval.eval_stats_db import EvalStatsDB
 from mettagrid.util.file import local_copy
 
 
-def analyze(policy_record: PolicyRecord, config: AnalysisConfig) -> None:
+def analyze(policy_record: MettaAgent, config: AnalysisConfig) -> None:
     logger = logging.getLogger(__name__)
     logger.info(f"Analyzing policy: {policy_record.uri}")
     logger.info(f"Using eval DB: {config.eval_db_uri}")
@@ -40,7 +40,7 @@ def analyze(policy_record: PolicyRecord, config: AnalysisConfig) -> None:
 # --------------------------------------------------------------------------- #
 #   helpers                                                                   #
 # --------------------------------------------------------------------------- #
-def get_available_metrics(stats_db: EvalStatsDB, policy_record: PolicyRecord) -> List[str]:
+def get_available_metrics(stats_db: EvalStatsDB, policy_record: MettaAgent) -> List[str]:
     policy_key, policy_version = policy_record.key_and_version()
     result = stats_db.query(
         f"""
@@ -65,7 +65,7 @@ def filter_metrics(available_metrics: List[str], patterns: List[str]) -> List[st
 
 def get_metrics_data(
     stats_db: EvalStatsDB,
-    policy_record: PolicyRecord,
+    policy_record: MettaAgent,
     metrics: List[str],
     suite: Optional[str] = None,
 ) -> Dict[str, Dict[str, float]]:
@@ -99,7 +99,7 @@ def get_metrics_data(
     return data
 
 
-def print_metrics_table(metrics_data: Dict[str, Dict[str, float]], policy_record: PolicyRecord) -> None:
+def print_metrics_table(metrics_data: Dict[str, Dict[str, float]], policy_record: MettaAgent) -> None:
     logger = logging.getLogger(__name__)
     if not metrics_data:
         logger.warning(f"No metrics data available for {policy_record.key}:v{policy_record.version}")

--- a/metta/eval/analysis.py
+++ b/metta/eval/analysis.py
@@ -4,54 +4,53 @@ from typing import Dict, List, Optional
 
 from tabulate import tabulate
 
-from metta.agent.policy_store import MettaAgent
+from metta.agent.metta_agent import MettaAgent
 from metta.eval.analysis_config import AnalysisConfig
 from metta.eval.eval_stats_db import EvalStatsDB
 from mettagrid.util.file import local_copy
 
 
-def analyze(policy_record: MettaAgent, config: AnalysisConfig) -> None:
+def analyze(metta_agent: MettaAgent, config: AnalysisConfig) -> None:
     logger = logging.getLogger(__name__)
-    logger.info(f"Analyzing policy: {policy_record.uri}")
+    logger.info(f"Analyzing policy: {metta_agent.uri}")
     logger.info(f"Using eval DB: {config.eval_db_uri}")
 
     with local_copy(config.eval_db_uri) as local_path:
         stats_db = EvalStatsDB(local_path)
 
-        sample_count = stats_db.sample_count(policy_record, config.suite)
+        sample_count = stats_db.sample_count(metta_agent, config.suite)
         if sample_count == 0:
-            logger.warning(f"No samples found for policy: {policy_record.key}:v{policy_record.version}")
+            logger.warning(f"No samples found for policy: {metta_agent.key}:v{metta_agent.version}")
             return
         logger.info(f"Total sample count for specified policy/suite: {sample_count}")
 
-        available_metrics = get_available_metrics(stats_db, policy_record)
+        available_metrics = get_available_metrics(stats_db, metta_agent)
         logger.info(f"Available metrics: {available_metrics}")
 
-        selected_metrics = filter_metrics(available_metrics, config.metrics)
+        selected_metrics = config.metrics or available_metrics
         if not selected_metrics:
-            logger.warning(f"No metrics found matching patterns: {config.metrics}")
+            logger.warning("No metrics specified or found to analyze.")
             return
-        logger.info(f"Selected metrics: {selected_metrics}")
+        logger.info(f"Selected metrics: {', '.join(selected_metrics)}")
 
-        metrics_data = get_metrics_data(stats_db, policy_record, selected_metrics, config.suite)
-        print_metrics_table(metrics_data, policy_record)
+        metrics_data = get_metrics_data(stats_db, metta_agent, selected_metrics, config.suite)
+        print_metrics_table(metrics_data, metta_agent)
 
 
 # --------------------------------------------------------------------------- #
 #   helpers                                                                   #
 # --------------------------------------------------------------------------- #
-def get_available_metrics(stats_db: EvalStatsDB, policy_record: MettaAgent) -> List[str]:
-    policy_key, policy_version = policy_record.key_and_version()
+def get_available_metrics(stats_db: EvalStatsDB, metta_agent: MettaAgent) -> List[str]:
+    policy_key, policy_version = metta_agent.key_and_version()
     result = stats_db.query(
         f"""
         SELECT DISTINCT metric
           FROM policy_simulation_agent_metrics
-         WHERE policy_key     = '{policy_key}'
-           AND policy_version =  {policy_version}
-         ORDER BY metric
-        """
+         WHERE policy_key = '{policy_key}'
+           AND policy_version = {policy_version}
+    """
     )
-    return [] if result.empty else result["metric"].tolist()
+    return result["metric"].tolist()
 
 
 def filter_metrics(available_metrics: List[str], patterns: List[str]) -> List[str]:
@@ -65,7 +64,7 @@ def filter_metrics(available_metrics: List[str], patterns: List[str]) -> List[st
 
 def get_metrics_data(
     stats_db: EvalStatsDB,
-    policy_record: MettaAgent,
+    metta_agent: MettaAgent,
     metrics: List[str],
     suite: Optional[str] = None,
 ) -> Dict[str, Dict[str, float]]:
@@ -77,46 +76,40 @@ def get_metrics_data(
         • K_recorded  – rows in policy_simulation_agent_metrics.
         • N_potential – total agent-episode pairs for that filter.
     """
-    policy_key, policy_version = policy_record.key_and_version()
+    data = {}
+    policy_key, policy_version = metta_agent.key_and_version()
     filter_condition = f"sim_suite = '{suite}'" if suite else None
 
-    data: Dict[str, Dict[str, float]] = {}
     for m in metrics:
-        mean = stats_db.get_average_metric_by_filter(m, policy_record, filter_condition)
-        if mean is None:
-            continue
-        std = stats_db.get_std_metric_by_filter(m, policy_record, filter_condition) or 0.0
+        data[m] = {}
+        mean = stats_db.get_average_metric_by_filter(m, metta_agent, filter_condition)
+        if mean is not None:
+            data[m]["mean"] = mean
+            std = stats_db.get_std_metric_by_filter(m, metta_agent, filter_condition) or 0.0
+            data[m]["std"] = std
 
-        k_recorded = stats_db.count_metric_agents(policy_key, policy_version, m, filter_condition)
-        n_potential = stats_db.potential_samples_for_metric(policy_key, policy_version, filter_condition)
-
-        data[m] = {
-            "mean": mean,
-            "std": std,
-            "count": k_recorded,
-            "samples": n_potential,
-        }
     return data
 
 
-def print_metrics_table(metrics_data: Dict[str, Dict[str, float]], policy_record: MettaAgent) -> None:
+def print_metrics_table(metrics_data: Dict[str, Dict[str, float]], metta_agent: MettaAgent) -> None:
     logger = logging.getLogger(__name__)
     if not metrics_data:
-        logger.warning(f"No metrics data available for {policy_record.key}:v{policy_record.version}")
+        logger.warning(f"No metrics data available for {metta_agent.key}:v{metta_agent.version}")
         return
 
-    headers = ["Metric", "Average", "Std Dev", "Metric Samples", "Agent Samples"]
-    rows = [
-        [
-            metric,
-            f"{stats['mean']:.4f}",
-            f"{stats['std']:.4f}",
-            str(int(stats["count"])),
-            str(int(stats["samples"])),
-        ]
-        for metric, stats in metrics_data.items()
-    ]
+    # Filter out empty metrics
+    metrics_data = {k: v for k, v in metrics_data.items() if v}
 
-    logger.info(f"\nMetrics for policy: {policy_record.uri}\n")
-    print(tabulate(rows, headers=headers, tablefmt="grid"))
+    headers = ["Metric", "Mean", "Std Dev"]
+    table_data = [[k, v.get("mean", "N/A"), v.get("std", "N/A")] for k, v in metrics_data.items()]
+
+    # Format numbers to 4 decimal places
+    for row in table_data:
+        if isinstance(row[1], float):
+            row[1] = f"{row[1]:.4f}"
+        if isinstance(row[2], float):
+            row[2] = f"{row[2]:.4f}"
+
+    logger.info(f"\nMetrics for policy: {metta_agent.uri}\n")
+    logger.info(tabulate(table_data, headers=headers, tablefmt="grid"))
     logger.info("")

--- a/metta/eval/eval_stats_db.py
+++ b/metta/eval/eval_stats_db.py
@@ -22,7 +22,7 @@ from typing import Dict, Optional
 
 import pandas as pd
 
-from metta.agent.policy_store import PolicyRecord
+from metta.agent.policy_store import MettaAgent
 from metta.sim.simulation_stats_db import SimulationStatsDB
 from mettagrid.util.file import local_copy
 
@@ -193,7 +193,7 @@ class EvalStatsDB(SimulationStatsDB):
     def get_average_metric_by_filter(
         self,
         metric: str,
-        policy_record: PolicyRecord,
+        policy_record: MettaAgent,
         filter_condition: str | None = None,
     ) -> Optional[float]:
         pk, pv = policy_record.key_and_version()
@@ -202,7 +202,7 @@ class EvalStatsDB(SimulationStatsDB):
     def get_sum_metric_by_filter(
         self,
         metric: str,
-        policy_record: PolicyRecord,
+        policy_record: MettaAgent,
         filter_condition: str | None = None,
     ) -> Optional[float]:
         pk, pv = policy_record.key_and_version()
@@ -211,7 +211,7 @@ class EvalStatsDB(SimulationStatsDB):
     def get_std_metric_by_filter(
         self,
         metric: str,
-        policy_record: PolicyRecord,
+        policy_record: MettaAgent,
         filter_condition: str | None = None,
     ) -> Optional[float]:
         pk, pv = policy_record.key_and_version()
@@ -222,7 +222,7 @@ class EvalStatsDB(SimulationStatsDB):
     # ------------------------------------------------------------------ #
     def sample_count(
         self,
-        policy_record: Optional[PolicyRecord] = None,
+        policy_record: Optional[MettaAgent] = None,
         sim_suite: Optional[str] = None,
         sim_name: Optional[str] = None,
         sim_env: Optional[str] = None,
@@ -243,7 +243,7 @@ class EvalStatsDB(SimulationStatsDB):
     # ------------------------------------------------------------------ #
     #   Per‑simulation breakdown                                         #
     # ------------------------------------------------------------------ #
-    def simulation_scores(self, policy_record: PolicyRecord, metric: str) -> Dict[tuple[str, str, str], float]:
+    def simulation_scores(self, policy_record: MettaAgent, metric: str) -> Dict[tuple[str, str, str], float]:
         """Return { (suite,name,env) : normalised mean(metric) }."""
         pk, pv = policy_record.key_and_version()
         sim_rows = self.query(f"""
@@ -263,7 +263,7 @@ class EvalStatsDB(SimulationStatsDB):
     def metric_by_policy_eval(
         self,
         metric: str,
-        policy_record: PolicyRecord | None = None,
+        policy_record: MettaAgent | None = None,
     ) -> pd.DataFrame:
         """
         Return a DataFrame with columns

--- a/metta/rl/kickstarter.py
+++ b/metta/rl/kickstarter.py
@@ -39,21 +39,14 @@ class Kickstarter:
     def _load_policies(self):
         self.teachers = []
         for teacher_cfg in self.teacher_cfgs:
-            if (
-                teacher_cfg is not None
-                and teacher_cfg.get("enabled", False)
-                and teacher_cfg.get("teacher_uri") is not None
-            ):
-                self.enabled = True
-                self.teacher_uri = teacher_cfg["teacher_uri"]
-                metta_agent = self.policy_store.policy(teacher_cfg["teacher_uri"])
-                policy = metta_agent.policy()
-                policy.action_loss_coef = teacher_cfg["action_loss_coef"]
-                policy.value_loss_coef = teacher_cfg["value_loss_coef"]
-                policy.activate_actions(self.action_names, self.action_max_params, self.device)
-                if self.compile:
-                    policy = torch.compile(policy, mode=self.compile_mode)
-                self.teachers.append(policy)
+            metta_agent = self.policy_store.policy(teacher_cfg["teacher_uri"])
+            policy = metta_agent.policy()
+            policy.action_loss_coef = teacher_cfg["action_loss_coef"]
+            policy.value_loss_coef = teacher_cfg["value_loss_coef"]
+            policy.activate_actions(self.action_names, self.action_max_params, self.device)
+            if self.compile:
+                policy = torch.compile(policy, mode=self.compile_mode)
+            self.teachers.append(policy)
 
     def loss(self, agent_step, student_normalized_logits, student_value, o, teacher_lstm_state: List[PolicyState]):
         ks_value_loss = torch.tensor(0.0, device=self.device)

--- a/metta/rl/kickstarter.py
+++ b/metta/rl/kickstarter.py
@@ -39,14 +39,21 @@ class Kickstarter:
     def _load_policies(self):
         self.teachers = []
         for teacher_cfg in self.teacher_cfgs:
-            policy_record = self.policy_store.policy(teacher_cfg["teacher_uri"])
-            policy = policy_record.policy()
-            policy.action_loss_coef = teacher_cfg["action_loss_coef"]
-            policy.value_loss_coef = teacher_cfg["value_loss_coef"]
-            policy.activate_actions(self.action_names, self.action_max_params, self.device)
-            if self.compile:
-                policy = torch.compile(policy, mode=self.compile_mode)
-            self.teachers.append(policy)
+            if (
+                teacher_cfg is not None
+                and teacher_cfg.get("enabled", False)
+                and teacher_cfg.get("teacher_uri") is not None
+            ):
+                self.enabled = True
+                self.teacher_uri = teacher_cfg["teacher_uri"]
+                metta_agent = self.policy_store.policy(teacher_cfg["teacher_uri"])
+                policy = metta_agent.policy()
+                policy.action_loss_coef = teacher_cfg["action_loss_coef"]
+                policy.value_loss_coef = teacher_cfg["value_loss_coef"]
+                policy.activate_actions(self.action_names, self.action_max_params, self.device)
+                if self.compile:
+                    policy = torch.compile(policy, mode=self.compile_mode)
+                self.teachers.append(policy)
 
     def loss(self, agent_step, student_normalized_logits, student_value, o, teacher_lstm_state: List[PolicyState]):
         ks_value_loss = torch.tensor(0.0, device=self.device)

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -311,7 +311,7 @@ class MettaTrainer:
         logger.info(f"Simulating policy: {self.last_ma.uri} with config: {self.sim_suite_config}")
         sim = SimulationSuite(
             config=self.sim_suite_config,
-            policy_ma=self.last_ma,
+            metta_agent=self.last_ma,
             policy_store=self.policy_store,
             device=self.device,
             vectorization=self.cfg.vectorization,
@@ -730,7 +730,7 @@ class MettaTrainer:
             replay_simulator = Simulation(
                 name=f"replay_{self.epoch}",
                 config=replay_sim_config,
-                policy_ma=self.last_ma,
+                metta_agent=self.last_ma,
                 policy_store=self.policy_store,
                 device=self.device,
                 vectorization=self.cfg.vectorization,

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -17,7 +17,6 @@ from pufferlib import unroll_nested_dict
 
 from metta.agent.metta_agent import DistributedMettaAgent, MettaAgent
 from metta.agent.policy_state import PolicyState
-from metta.agent.policy_store import MettaAgent as PolicyMettaAgent
 from metta.agent.policy_store import PolicyStore
 from metta.agent.util.debug import assert_shape
 from metta.app.stats_client import StatsClient
@@ -675,7 +674,7 @@ class MettaTrainer:
         )
         checkpoint.save(self.cfg.run_dir)
 
-    def _checkpoint_policy(self) -> PolicyMettaAgent | None:
+    def _checkpoint_policy(self) -> MettaAgent | None:
         if not self._master:
             return
 

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -112,17 +112,16 @@ class MettaTrainer:
         os.makedirs(trainer_cfg.checkpoint_dir, exist_ok=True)
 
         checkpoint = TrainerCheckpoint.load(cfg.run_dir)
-        policy_record = self._load_policy(checkpoint, policy_store, metta_grid_env)
+        metta_agent = self._load_policy(checkpoint, policy_store, metta_grid_env)
 
-        assert policy_record is not None, "No policy found"
+        assert metta_agent is not None, "No policy found"
 
         if self._master:
-            logger.info(f"MettaTrainer loaded: {policy_record.policy()}")
+            logger.info(f"MettaTrainer loaded: {metta_agent.policy()}")
 
-        self._initial_ma = policy_record
-        self.last_ma = policy_record
-        self.policy = policy_record.policy().to(self.device)
-        self.policy_record = policy_record
+        self._initial_ma = metta_agent
+        self.last_ma = metta_agent
+        self.policy = metta_agent.policy().to(self.device)
         self.uncompiled_policy = self.policy
 
         # Note that these fields are specific to MettaGridEnv, which is why we can't keep

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -25,7 +25,7 @@ from omegaconf import OmegaConf
 
 from metta.agent.metta_agent import DistributedMettaAgent, MettaAgent
 from metta.agent.policy_state import PolicyState
-from metta.agent.policy_store import MettaAgent, PolicyStore
+from metta.agent.policy_store import PolicyStore
 from metta.app.stats_client import StatsClient
 from metta.rl.policy import PytorchAgent
 from metta.rl.vecenv import make_vecenv

--- a/metta/sim/simulation_stats_db.py
+++ b/metta/sim/simulation_stats_db.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Tuple, Union
 
 import duckdb
 
-from metta.agent.policy_store import PolicyRecord
+from metta.agent.policy_store import MettaAgent
 from mettagrid.episode_stats_db import EpisodeStatsDB
 from mettagrid.util.file import exists, local_copy, write_file
 
@@ -80,11 +80,11 @@ class SimulationStatsDB(EpisodeStatsDB):
     def from_shards_and_context(
         sim_id: str,
         dir_with_shards: Union[str, Path],
-        agent_map: Dict[int, PolicyRecord],
+        agent_map: Dict[int, MettaAgent],
         sim_name: str,
         sim_suite: str,
         env: str,
-        policy_record: PolicyRecord,
+        policy_record: MettaAgent,
     ) -> "SimulationStatsDB":
         dir_with_shards = Path(dir_with_shards).expanduser().resolve()
         merged_path = dir_with_shards / "merged.duckdb"
@@ -116,7 +116,7 @@ class SimulationStatsDB(EpisodeStatsDB):
         logger.debug(f"Found {len(all_episode_ids)} episodes across all shards")
 
         if all_episode_ids:
-            # Convert agent_map with PolicyRecord to agent_map with (key, version) tuples
+            # Convert agent_map with MettaAgent to agent_map with (key, version) tuples
             agent_tuple_map = {agent_id: record.key_and_version() for agent_id, record in agent_map.items()}
 
             merged._insert_agent_policies(all_episode_ids, agent_tuple_map)

--- a/metta/sim/simulation_stats_db.py
+++ b/metta/sim/simulation_stats_db.py
@@ -9,7 +9,6 @@ Extends EpisodeStatsDB with tables for simulation metadata:
 from __future__ import annotations
 
 import logging
-import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
@@ -88,36 +87,49 @@ class SimulationStatsDB(EpisodeStatsDB):
         metta_agent: MettaAgent,
     ) -> "SimulationStatsDB":
         dir_with_shards = Path(dir_with_shards).expanduser().resolve()
-        assert dir_with_shards.is_dir(), f"Directory with shards not found at: {dir_with_shards}"
+        merged_path = dir_with_shards / "merged.duckdb"
 
-        # Create a temporary, unique path for the merged DB
-        # TODO: This should be in a temporary directory
-        merged_db_path = Path(f"{dir_with_shards}/all_{uuid.uuid4().hex[:8]}.duckdb")
-        merged_db = SimulationStatsDB(merged_db_path)
+        # Find shards
+        shards = [s for s in dir_with_shards.glob("*.duckdb") if s.name != merged_path.name]
 
-        all_episode_ids = []
-        shard_paths = list(dir_with_shards.glob(f"{sim_id}*.duckdb"))
-        for shard_path in shard_paths:
-            merged_db.merge_in(shard_path)
-            # after merging, we can delete the shard
-            # os.remove(shard_path)
+        logger = logging.getLogger(__name__)
+        if not shards:
+            logger.warning(f"No shards found in {dir_with_shards}")
+            merged = SimulationStatsDB(merged_path)
+            return merged
+
+        if merged_path.exists():
+            merged_path.unlink()
+
+        merged = SimulationStatsDB(merged_path)
+
+        policy_key, policy_version = metta_agent.key_and_version()
+        merged._insert_simulation(sim_id, sim_name, sim_suite, env, policy_key, policy_version)
+
+        # Merge each shard
+        for shard_path in shards:
+            logger.debug(f"Merging shard {shard_path}")
+            merged._merge_db(shard_path)
+
+        # Update all episodes to use our simulation ID
+        all_episode_ids = [row[0] for row in merged.con.execute("SELECT id FROM episodes").fetchall()]
+        logger.debug(f"Found {len(all_episode_ids)} episodes across all shards")
 
         if all_episode_ids:
             # Convert agent_map with MettaAgent to agent_map with (key, version) tuples
             agent_tuple_map = {agent_id: record.key_and_version() for agent_id, record in agent_map.items()}
 
-            merged_db._add_simulation_entry(
-                sim_id,
-                sim_name,
-                sim_suite,
-                env,
-                metta_agent.key(),
-                metta_agent.version(),
-                agent_tuple_map,
-                all_episode_ids,
+            merged._insert_agent_policies(all_episode_ids, agent_tuple_map)
+            merged._update_episode_simulations(all_episode_ids, sim_id)
+
+        else:
+            logger.warning(
+                "No episodes found in merged database. This suggests an issue with environment instrumentation. "
+                "Check that stats_writer.start_episode() and end_episode() are being called properly."
             )
 
-        return merged_db
+        merged.con.commit()
+        return merged
 
     def export(self, dest: str) -> None:
         """

--- a/metta/sim/simulation_suite.py
+++ b/metta/sim/simulation_suite.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from pathlib import Path
+from typing import Optional
 
 import torch
 
@@ -21,23 +22,23 @@ class SimulationSuite:
     def __init__(
         self,
         config: SimulationSuiteConfig,
-        policy_ma: MettaAgent,
+        metta_agent: MettaAgent,
         policy_store: PolicyStore,
         device: torch.device,
         vectorization: str,
-        stats_dir: str = "/tmp/stats",
-        replay_dir: str | None = None,
-        stats_client: StatsClient | None = None,
-        stats_epoch_id: uuid.UUID | None = None,
+        stats_dir: str,
+        replay_dir: Optional[str] = None,
+        stats_client: Optional[StatsClient] = None,
+        stats_epoch_id: Optional[str] = None,
     ):
         self._config = config
-        self._policy_ma = policy_ma
+        self.name = config.name
+        self._metta_agent = metta_agent
         self._policy_store = policy_store
-        self._replay_dir = replay_dir
-        self._stats_dir = stats_dir
         self._device = device
         self._vectorization = vectorization
-        self.name = config.name
+        self._stats_dir = stats_dir
+        self._replay_dir = replay_dir
         self._stats_client = stats_client
         self._stats_epoch_id = stats_epoch_id
 
@@ -56,7 +57,7 @@ class SimulationSuite:
                 sim = Simulation(
                     name,
                     sim_config,
-                    self._policy_ma,
+                    self._metta_agent,
                     self._policy_store,
                     device=self._device,
                     vectorization=self._vectorization,

--- a/metta/sim/simulation_suite.py
+++ b/metta/sim/simulation_suite.py
@@ -1,14 +1,15 @@
 import logging
-import uuid
-from pathlib import Path
+from typing import Optional
 
 import torch
 
-from metta.agent.policy_store import PolicyRecord, PolicyStore
+from metta.agent.policy_store import MettaAgent, PolicyStore
 from metta.app.stats_client import StatsClient
 from metta.sim.simulation import Simulation, SimulationCompatibilityError, SimulationResults
 from metta.sim.simulation_config import SimulationSuiteConfig
 from metta.sim.simulation_stats_db import SimulationStatsDB
+
+logger = logging.getLogger("simulation-suite")
 
 
 class SimulationSuite:
@@ -20,70 +21,52 @@ class SimulationSuite:
     def __init__(
         self,
         config: SimulationSuiteConfig,
-        policy_pr: PolicyRecord,
+        policy_ma: MettaAgent,
         policy_store: PolicyStore,
         device: torch.device,
         vectorization: str,
-        stats_dir: str = "/tmp/stats",
-        replay_dir: str | None = None,
-        stats_client: StatsClient | None = None,
-        stats_epoch_id: uuid.UUID | None = None,
+        stats_dir: str,
+        stats_client: Optional[StatsClient] = None,
+        stats_epoch_id: Optional[str] = None,
     ):
         self._config = config
-        self._policy_pr = policy_pr
+        self._policy_ma = policy_ma
         self._policy_store = policy_store
-        self._replay_dir = replay_dir
-        self._stats_dir = stats_dir
         self._device = device
         self._vectorization = vectorization
-        self.name = config.name
+        self._stats_dir = stats_dir
         self._stats_client = stats_client
         self._stats_epoch_id = stats_epoch_id
 
     def simulate(self) -> SimulationResults:
-        """Run every simulation, merge their DBs/replay dicts, and return a single `SimulationResults`."""
-        logger = logging.getLogger(__name__)
-        # Make a new merged db with a random uuid each time so that we don't copy old stats dbs
-        merged_db: SimulationStatsDB = SimulationStatsDB(Path(f"{self._stats_dir}/all_{uuid.uuid4().hex[:8]}.duckdb"))
+        results = SimulationResults()
+        stats_db = SimulationStatsDB(self._stats_dir)
 
-        successful_simulations = 0
+        total_sims = len(self._config.simulations)
+        logger.info(f"Running simulation suite with {total_sims} simulations")
 
-        for name, sim_config in self._config.simulations.items():
+        for idx, (sim_name, sim_config) in enumerate(self._config.simulations.items(), 1):
             try:
-                # merge global simulation suite overrides with simulation-specific overrides
-                sim_config.env_overrides = {**self._config.env_overrides, **sim_config.env_overrides}
+                logger.info(f"[{idx}/{total_sims}] Running simulation: {sim_name}")
                 sim = Simulation(
-                    name,
-                    sim_config,
-                    self._policy_pr,
-                    self._policy_store,
+                    name=sim_name,
+                    config=sim_config,
+                    policy_ma=self._policy_ma,
+                    policy_store=self._policy_store,
                     device=self._device,
+                    suite_name=self._config.name,
                     vectorization=self._vectorization,
-                    sim_suite_name=self.name,
                     stats_dir=self._stats_dir,
-                    replay_dir=self._replay_dir,
                     stats_client=self._stats_client,
                     stats_epoch_id=self._stats_epoch_id,
                 )
-                logger.info("=== Simulation '%s' ===", name)
                 sim_result = sim.simulate()
-                merged_db.merge_in(sim_result.stats_db)
-                sim_result.stats_db.close()
-                successful_simulations += 1
-
+                results.merge(sim_result)
+                logger.info(f"[{idx}/{total_sims}] Completed simulation: {sim_name}")
             except SimulationCompatibilityError as e:
-                # Only skip for NPC-related compatibility issues
-                error_msg = str(e).lower()
-                if "npc" in error_msg or "non-player" in error_msg:
-                    logger.warning("Skipping simulation '%s' due to NPC compatibility issue: %s", name, str(e))
-                    continue
-                else:
-                    # Re-raise for non-NPC compatibility issues
-                    logger.error("Critical compatibility error in simulation '%s': %s", name, str(e))
-                    raise
+                logger.warning(f"[{idx}/{total_sims}] Skipping simulation {sim_name}: {e}")
+            except Exception as e:
+                logger.error(f"[{idx}/{total_sims}] Failed to run simulation {sim_name}: {e}", exc_info=True)
 
-        if successful_simulations == 0:
-            raise RuntimeError("No simulations could be run successfully")
-
-        logger.info("Completed %d/%d simulations successfully", successful_simulations, len(self._config.simulations))
-        return SimulationResults(merged_db)
+        results.stats_db = stats_db
+        return results

--- a/metta/sim/simulation_suite.py
+++ b/metta/sim/simulation_suite.py
@@ -1,15 +1,16 @@
 import logging
+import uuid
+from pathlib import Path
 from typing import Optional
 
 import torch
 
-from metta.agent.policy_store import MettaAgent, PolicyStore
+from metta.agent.metta_agent import MettaAgent
+from metta.agent.policy_store import PolicyStore
 from metta.app.stats_client import StatsClient
 from metta.sim.simulation import Simulation, SimulationCompatibilityError, SimulationResults
 from metta.sim.simulation_config import SimulationSuiteConfig
 from metta.sim.simulation_stats_db import SimulationStatsDB
-
-logger = logging.getLogger("simulation-suite")
 
 
 class SimulationSuite:
@@ -39,6 +40,10 @@ class SimulationSuite:
         self._stats_epoch_id = stats_epoch_id
 
     def simulate(self) -> SimulationResults:
+        """Run every simulation, merge their DBs/replay dicts, and return a single `SimulationResults`."""
+        logger = logging.getLogger(__name__)
+        # Make a new merged db with a random uuid each time so that we don't copy old stats dbs
+        merged_db: SimulationStatsDB = SimulationStatsDB(Path(f"{self._stats_dir}/all_{uuid.uuid4().hex[:8]}.duckdb"))
         results = SimulationResults()
         stats_db = SimulationStatsDB(self._stats_dir)
 

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -21,8 +21,8 @@ def main(cfg: DictConfig) -> None:
     config = AnalysisConfig(cfg.analysis)
 
     policy_store = PolicyStore(cfg, None)
-    policy_ma = policy_store.policy(cfg.policy_uri, selector_type=cfg.selector_type, n=1, metric=cfg.metric)
-    analyze(policy_ma, config)
+    metta_agent = policy_store.policy(cfg.policy_uri, selector_type=cfg.selector_type, n=1, metric=cfg.metric)
+    analyze(metta_agent, config)
 
 
 if __name__ == "__main__":

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -21,10 +21,8 @@ def main(cfg: DictConfig) -> None:
     config = AnalysisConfig(cfg.analysis)
 
     policy_store = PolicyStore(cfg, None)
-    policy_pr = policy_store.policy(
-        config.policy_uri, config.policy_selector.type, metric=config.policy_selector.metric
-    )
-    analyze(policy_pr, config)
+    policy_ma = policy_store.policy(cfg.policy_uri, selector_type=cfg.selector_type, n=1, metric=cfg.metric)
+    analyze(policy_ma, config)
 
 
 if __name__ == "__main__":

--- a/tools/renderer.py
+++ b/tools/renderer.py
@@ -210,8 +210,8 @@ def _load_trained_policy(env: MettaGridEnv, cfg: DictConfig) -> Policy:
         from metta.agent.policy_store import PolicyStore
 
         policy_store = PolicyStore(cfg, None)
-        policy_ma = policy_store.policy(cfg.policy_uri)
-        return TrainedPolicyWrapper(policy_ma.policy(), env)
+        metta_agent = policy_store.policy(cfg.policy_uri)
+        return TrainedPolicyWrapper(metta_agent.policy(), env)
     except Exception as e:
         print(f"Failed to load trained policy: {e}")
         print("Falling back to simple policy")

--- a/tools/renderer.py
+++ b/tools/renderer.py
@@ -210,8 +210,8 @@ def _load_trained_policy(env: MettaGridEnv, cfg: DictConfig) -> Policy:
         from metta.agent.policy_store import PolicyStore
 
         policy_store = PolicyStore(cfg, None)
-        policy_pr = policy_store.policy(cfg.policy_uri)
-        return TrainedPolicyWrapper(policy_pr.policy(), env)
+        policy_ma = policy_store.policy(cfg.policy_uri)
+        return TrainedPolicyWrapper(policy_ma.policy(), env)
     except Exception as e:
         print(f"Failed to load trained policy: {e}")
         print("Falling back to simple policy")

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S uv run
 # Generate a replay file that can be used in MettaScope to visualize a single run.
 
-import os
 import platform
 import webbrowser
 
@@ -39,37 +38,28 @@ def main(cfg):
     with WandbContext(cfg.wandb, cfg) as wandb_run:
         policy_store = PolicyStore(cfg, wandb_run)
         replay_job = ReplayJob(cfg.replay_job)
-        ma = policy_store.policy(cfg.replay_job.policy_uri)
-        logger.info(f"Generating replays for policy: {ma.name}")
-
-        if not os.path.exists(cfg.replay_job.replay_dir):
-            os.makedirs(cfg.replay_job.replay_dir, exist_ok=True)
-        if not os.path.exists(cfg.replay_job.stats_dir):
-            os.makedirs(cfg.replay_job.stats_dir, exist_ok=True)
-
+        policy_ma = policy_store.policy(replay_job.policy_uri)
         sim_config = SingleEnvSimulationConfig(cfg.replay_job.sim)
 
+        sim_name = sim_config.env.split("/")[-1]
+        replay_dir = f"{replay_job.replay_dir}/{sim_name}"
+
         sim = Simulation(
-            name=f"replay_{ma.name.replace('/', '_')}",
-            config=sim_config,
-            policy_ma=ma,
-            policy_store=policy_store,
+            sim_name,
+            sim_config,
+            policy_ma,
+            policy_store,
             device=cfg.device,
             vectorization=cfg.vectorization,
-            replay_dir=cfg.replay_job.replay_dir,
-            stats_dir=cfg.replay_job.stats_dir,
+            stats_dir=replay_job.stats_dir,
+            replay_dir=replay_dir,
         )
-        results = sim.simulate()
-
-        replay_urls = results.stats_db.get_replay_urls(policy_key=ma.key(), policy_version=ma.version())
-        if len(replay_urls) > 0:
-            logger.info("Replay URLs:")
-            for url in replay_urls:
-                logger.info(f"  {url}")
+        result = sim.simulate()
+        replay_url = result.stats_db.get_replay_urls(policy_key=policy_ma.key(), policy_version=policy_ma.version())[0]
 
         # Only on macos open a browser to the replay
         if platform.system() == "Darwin":
-            webbrowser.open(f"https://metta-ai.github.io/metta/?replayUrl={http_url(replay_urls[0])}")
+            webbrowser.open(f"https://metta-ai.github.io/metta/?replayUrl={http_url(replay_url)}")
 
 
 if __name__ == "__main__":

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -65,17 +65,17 @@ def simulate_policy(
     policy_store = PolicyStore(cfg, None)
     # TODO: institutionalize this better?
     metric = sim_job.simulation_suite.name + "_score"
-    policy_prs = policy_store.policies(policy_uri, sim_job.selector_type, n=1, metric=metric)
+    policy_mas = policy_store.policies(policy_uri, sim_job.selector_type, n=1, metric=metric)
 
     stats_client: StatsClient | None = get_stats_client(cfg, logger)
 
     # For each checkpoint of the policy, simulate
-    for pr in policy_prs:
-        logger.info(f"Evaluating policy {pr.uri}")
-        replay_dir = f"{sim_job.replay_dir}/{pr.name}"
+    for ma in policy_mas:
+        logger.info(f"Evaluating policy {ma.uri}")
+        replay_dir = f"{sim_job.replay_dir}/{ma.name}"
         sim = SimulationSuite(
             config=sim_job.simulation_suite,
-            policy_pr=pr,
+            policy_ma=ma,
             policy_store=policy_store,
             replay_dir=replay_dir,
             stats_dir=sim_job.stats_dir,
@@ -86,7 +86,7 @@ def simulate_policy(
         sim_results = sim.simulate()
 
         # Collect metrics from the results
-        checkpoint_data = {"name": pr.name, "uri": pr.uri, "metrics": {}}
+        checkpoint_data = {"name": ma.name, "uri": ma.uri, "metrics": {}}
 
         # Get average reward
         rewards_df = sim_results.stats_db.query(
@@ -101,7 +101,7 @@ def simulate_policy(
         logger.info("Exporting merged stats DB → %s", sim_job.stats_db_uri)
         sim_results.stats_db.export(sim_job.stats_db_uri)
 
-        logger.info("Evaluation complete for policy %s", pr.uri)
+        logger.info("Evaluation complete for policy %s", ma.uri)
 
     return results
 

--- a/tools/sim.py
+++ b/tools/sim.py
@@ -70,12 +70,12 @@ def simulate_policy(
     stats_client: StatsClient | None = get_stats_client(cfg, logger)
 
     # For each checkpoint of the policy, simulate
-    for ma in policy_mas:
-        logger.info(f"Evaluating policy {ma.uri}")
-        replay_dir = f"{sim_job.replay_dir}/{ma.name}"
+    for metta_agent in policy_mas:
+        logger.info(f"Evaluating policy {metta_agent.uri}")
+        replay_dir = f"{sim_job.replay_dir}/{metta_agent.name}"
         sim = SimulationSuite(
             config=sim_job.simulation_suite,
-            policy_ma=ma,
+            metta_agent=metta_agent,
             policy_store=policy_store,
             replay_dir=replay_dir,
             stats_dir=sim_job.stats_dir,
@@ -86,7 +86,7 @@ def simulate_policy(
         sim_results = sim.simulate()
 
         # Collect metrics from the results
-        checkpoint_data = {"name": ma.name, "uri": ma.uri, "metrics": {}}
+        checkpoint_data = {"name": metta_agent.name, "uri": metta_agent.uri, "metrics": {}}
 
         # Get average reward
         rewards_df = sim_results.stats_db.query(
@@ -101,7 +101,7 @@ def simulate_policy(
         logger.info("Exporting merged stats DB → %s", sim_job.stats_db_uri)
         sim_results.stats_db.export(sim_job.stats_db_uri)
 
-        logger.info("Evaluation complete for policy %s", ma.uri)
+        logger.info("Evaluation complete for policy %s", metta_agent.uri)
 
     return results
 

--- a/tools/sweep_eval.py
+++ b/tools/sweep_eval.py
@@ -58,7 +58,7 @@ def main(cfg: DictConfig | ListConfig) -> int:
     with WandbContext(cfg.wandb, cfg) as wandb_run:
         policy_store = PolicyStore(cfg, wandb_run)
         try:
-            policy_pr = policy_store.policy("wandb://run/" + cfg.run)
+            policy_ma = policy_store.policy("wandb://run/" + cfg.run)
         except Exception as e:
             logger.error(f"Error getting policy for run {cfg.run}: {e}")
             WandbCarbs._record_failure(wandb_run)
@@ -66,7 +66,7 @@ def main(cfg: DictConfig | ListConfig) -> int:
 
         eval = SimulationSuite(
             simulation_suite_cfg,
-            policy_pr,
+            policy_ma,
             policy_store,
             device=cfg.device,
             vectorization=cfg.vectorization,
@@ -86,18 +86,18 @@ def main(cfg: DictConfig | ListConfig) -> int:
         # Start evaluation
         eval_start_time = time.time()
 
-        logger.info(f"Evaluating policy {policy_pr.name}")
+        logger.info(f"Evaluating policy {policy_ma.name}")
         log_file(cfg.run_dir, "sweep_eval_config.yaml", cfg, wandb_run)
 
         results = eval.simulate()
         eval_time = time.time() - eval_start_time
         eval_stats_db = EvalStatsDB.from_sim_stats_db(results.stats_db)
-        eval_metric = eval_stats_db.get_average_metric_by_filter(cfg.metric, policy_pr)
+        eval_metric = eval_stats_db.get_average_metric_by_filter(cfg.metric, policy_ma)
 
         # Get training stats from metadata if available
-        train_time = policy_pr.metadata.get("train_time", 0)
-        agent_step = policy_pr.metadata.get("agent_step", 0)
-        epoch = policy_pr.metadata.get("epoch", 0)
+        train_time = policy_ma.metadata.get("train_time", 0)
+        agent_step = policy_ma.metadata.get("agent_step", 0)
+        epoch = policy_ma.metadata.get("epoch", 0)
 
         # Update sweep stats with evaluation results
         stats_update = {
@@ -106,7 +106,7 @@ def main(cfg: DictConfig | ListConfig) -> int:
             "time.train": train_time,
             "time.eval": eval_time,
             "time.total": train_time + eval_time,
-            "uri": policy_pr.uri,
+            "uri": policy_ma.uri,
             "score": eval_metric,
         }
 
@@ -114,14 +114,14 @@ def main(cfg: DictConfig | ListConfig) -> int:
 
         # Update lineage stats
         for stat in ["train.agent_step", "train.epoch", "time.train", "time.eval", "time.total"]:
-            sweep_stats["lineage." + stat] = sweep_stats[stat] + policy_pr.metadata.get("lineage." + stat, 0)
+            sweep_stats["lineage." + stat] = sweep_stats[stat] + policy_ma.metadata.get("lineage." + stat, 0)
 
         # Update wandb summary
         wandb_run.summary.update(sweep_stats)
         logger.info("Sweep Stats: \n" + json.dumps({k: str(v) for k, v in sweep_stats.items()}, indent=4))
 
         # Update policy metadata
-        policy_pr.metadata.update(
+        policy_ma.metadata.update(
             {
                 **sweep_stats,
                 "training_run": cfg.run,
@@ -129,7 +129,7 @@ def main(cfg: DictConfig | ListConfig) -> int:
         )
 
         # Add policy to wandb sweep
-        policy_store.add_to_wandb_sweep(cfg.sweep_name, policy_pr)
+        policy_store.add_to_wandb_sweep(cfg.sweep_name, policy_ma)
 
         # Record observation in CARBS if enabled
         total_time = train_time + eval_time


### PR DESCRIPTION
This is part 1 of a larger change outlined here https://github.com/Metta-AI/metta/pull/1043 and here https://github.com/Metta-AI/metta/pull/973.

In part 1, we change to conceptually only dealing with `MettaAgent`s and not `PolicyRecords`. A MettaAgent may be currently saved on disk or loaded in memory, but we shouldn't have to worry or think about this.

This part 1 ONLY refactors all mentions of `policy_record` to `metta_agent` (and other abbreviations like pr -> ma). It also squashes the MettaAgent <-> PolicyRecord class into one class (for now).

In part 2, we will change functionality so that the MettaAgent class becomes a wrapper for either a BrainPolicy (built by us) or a PytorchPolicy (anything external). 

In part 3, we will change how saving/loading works so that we can use this new wrapper class to load any model, even if it's old. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210593809315077)