### PR TITLE
[Github-Asana] Defend against nulls in API values

### DIFF
--- a/.github/actions/asana/ensure-task/main.py
+++ b/.github/actions/asana/ensure-task/main.py
@@ -87,7 +87,7 @@ def get_asana_users_by_github_logins(
     github_login_to_asana_email = {}
     # Paginate through all tasks in the roster project, since we can't search for multiple github logins at once
     for task in _get_task_custom_fields_from_project(roster_project_id, asana_token):
-        custom_fields = task.get("custom_fields", {})
+        custom_fields = task.get("custom_fields") or {}
         gh_login = None
         asana_email = None
         for field in custom_fields:
@@ -197,10 +197,10 @@ def ensure_asana_task_exists(
 
         # Check if the task needs updates using the data from search
         if existing_task:
-            current_title = existing_task.get("name", "")
-            current_notes = existing_task.get("notes", "")
-            current_completed = existing_task.get("completed", False)
-            current_assignee = existing_task.get("assignee", {}).get("email", "")
+            current_title = existing_task.get("name") or ""
+            current_notes = existing_task.get("notes") or ""
+            current_completed = existing_task.get("completed") or False
+            current_assignee = (existing_task.get("assignee") or {}).get("email") or ""
             # TODO: update followers -- probably only add.
 
             # Update title and description if needed

--- a/.github/actions/asana/update-pr-description/main.py
+++ b/.github/actions/asana/update-pr-description/main.py
@@ -16,6 +16,7 @@ def update_pr_description(repo, pr_number, task_url, token):
     if response.status_code != 200:
         print(f"GitHub API Error: {response.status_code} - {response.text}")
         sys.exit(1)
+    # The body can be None -- we want to treat that as an empty string
     current_body = response.json().get("body") or ""
 
     # Update the description

--- a/.github/actions/asana/update-pr-description/main.py
+++ b/.github/actions/asana/update-pr-description/main.py
@@ -16,7 +16,7 @@ def update_pr_description(repo, pr_number, task_url, token):
     if response.status_code != 200:
         print(f"GitHub API Error: {response.status_code} - {response.text}")
         sys.exit(1)
-    current_body = response.json().get("body", "")
+    current_body = response.json().get("body") or ""
 
     # Update the description
     new_body = current_body


### PR DESCRIPTION
Some API calls return `None` when I might have expected an empty string / empty list / etc. This changes our style to be more robust to such falsey values.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210595627824578)