### PR TITLE
Don't run the Asana workflow on draft PRs.

### DIFF
--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   asana_integration:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Skip Asana integration for draft pull requests.

Graphite creates PRs as draft PRs while you're initially editing them -- and it live updates the PRs while you're typing and assigning reviewers, etc. This triggered the Asana integration to run a lot.

Skipping draft PRs (which I'd intended to anyways) should reduce this noise.