### PR TITLE
fix: convert DictConfig before using

### DIFF
--- a/mettagrid/mettagrid/replay_writer.py
+++ b/mettagrid/mettagrid/replay_writer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from omegaconf import DictConfig, OmegaConf
+
 if TYPE_CHECKING:
     from mettagrid.mettagrid_env import MettaGridEnv
 
@@ -97,8 +99,14 @@ class EpisodeReplay:
             for key, changes in list(grid_object.items()):
                 if isinstance(changes, list) and len(changes) == 1:
                     grid_object[key] = changes[0][1]
+
         # Store the env config.
-        self.replay_data["config"] = self.env.config
+        config = self.env.config
+        if isinstance(config, DictConfig):
+            self.replay_data["config"] = OmegaConf.to_container(config, resolve=True)
+        else:
+            self.replay_data["config"] = config
+
         return self.replay_data
 
     def write_replay(self, path: str):


### PR DESCRIPTION

This PR fixes a bug where training crashes when no checkpoint exists due to attempting to serialize an OmegaConf `DictConfig` object that contains non-serializable methods.

## Problem
When starting training with a fresh `train_dir`, the replay writer attempts to store the environment configuration directly:
```python
self.replay_data["config"] = self.env.config
```

However, `self.env.config` is a Hydra/OmegaConf `DictConfig` object that can contain callable attributes and methods, which causes `json.dumps()` to fail with:
```
TypeError: Object of type method is not JSON serializable
```

This error only occurs on the first run because subsequent runs load from an existing checkpoint where the config has already been processed.

## Solution
Convert the `DictConfig` to a plain Python dictionary before storing it in the replay data:
```python
config = self.env.config
if isinstance(config, DictConfig):
    self.replay_data["config"] = OmegaConf.to_container(config, resolve=True)
else:
    self.replay_data["config"] = config
```

The `resolve=True` parameter ensures that any interpolations or references in the config are resolved to their actual values.
