### PR TITLE
Remove unused `inventory_size`

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -25,7 +25,6 @@ class AgentConfig(BaseModel):
 
     default_item_max: Optional[int] = None
     freeze_duration: Optional[int] = None
-    inventory_size: Optional[int] = None
     rewards: Optional[AgentRewards] = None
 
 

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -41,7 +41,7 @@ def base_config():
         },
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {"wall": {"type_id": 1}, "altar": {"type_id": 4}},
-        "agent": {"inventory_size": 10},
+        "agent": {},
     }
 
 

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -61,9 +61,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
             "wall": {"type_id": 1},
             "block": {"type_id": 2},
         },
-        "agent": {
-            "inventory_size": 0,
-        },
+        "agent": {},
     }
 
     # Apply config overrides if provided

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -49,9 +49,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
             "wall": {"type_id": 1},
             "block": {"type_id": 2},
         },
-        "agent": {
-            "inventory_size": 0,
-        },
+        "agent": {},
     }
 
     return MettaGrid(game_config, game_map.tolist())


### PR DESCRIPTION
Removes the `inventory_size` parameter from the `AgentConfig` class and related test configurations.


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210605501583679)