### PR TITLE
Msb multistage cric

### DIFF
--- a/mettagrid/mettagrid/curriculum/progressive.py
+++ b/mettagrid/mettagrid/curriculum/progressive.py
@@ -5,6 +5,7 @@ import logging
 from typing import Optional
 
 from omegaconf import DictConfig, OmegaConf
+import wandb
 
 from .curriculum import Task
 from .sampling import SamplingCurriculum
@@ -23,6 +24,10 @@ class ProgressiveCurriculum(SamplingCurriculum):
         cfg.game.map.width = self._width
         cfg.game.map.height = self._height
         OmegaConf.resolve(cfg)
+        # Log probability for the single task (always 1.0)
+        if wandb.run is not None:
+            task_id = f"sample({self._cfg_template.sampling})"
+            wandb.run.log({"curriculum/task_probs": {task_id: 1.0}}, commit=False)
         return Task(f"sample({self._cfg_template.sampling})", self, cfg)
 
     def complete_task(self, id: str, score: float):

--- a/mettagrid/mettagrid/curriculum/random.py
+++ b/mettagrid/mettagrid/curriculum/random.py
@@ -18,8 +18,10 @@ class RandomCurriculum(MultiTaskCurriculum):
         task = self._curriculums[task_id].get_task()
         task.add_parent(self, task_id)
         logger.debug(f"Task selected: {task.name()}")
-        # Minimal WandB logging for curriculum task selection
+        # Log sampling probabilities for each task to WandB
         if wandb.run is not None:
-            wandb.run.log({"curriculum/task_id": task_id}, commit=False)
-            wandb.run.log({"curriculum/task_weights": dict(self._task_weights)}, commit=False)
+            total_weight = sum(self._task_weights.values())
+            if total_weight > 0:
+                task_probs = {k: v / total_weight for k, v in self._task_weights.items()}
+                wandb.run.log({"curriculum/task_probs": task_probs}, commit=False)
         return task

--- a/mettagrid/mettagrid/curriculum/random.py
+++ b/mettagrid/mettagrid/curriculum/random.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+import wandb
 
 from mettagrid.curriculum.curriculum import Task
 from mettagrid.curriculum.multi_task import MultiTaskCurriculum
@@ -17,4 +18,8 @@ class RandomCurriculum(MultiTaskCurriculum):
         task = self._curriculums[task_id].get_task()
         task.add_parent(self, task_id)
         logger.debug(f"Task selected: {task.name()}")
+        # Minimal WandB logging for curriculum task selection
+        if wandb.run is not None:
+            wandb.run.log({"curriculum/task_id": task_id}, commit=False)
+            wandb.run.log({"curriculum/task_weights": dict(self._task_weights)}, commit=False)
         return task


### PR DESCRIPTION
Feature: Add WandB logging for curriculum task sampling probabilities

[asana task](https://app.asana.com/1/1209016784099267/project/1210534060817260/task/1210534076114725)

Description:
This PR adds minimal WandB logging to track the probability distribution over curriculum tasks in the RandomCurriculum class. Each time a task is sampled, the current sampling probabilities for all tasks are logged to WandB under the key curriculum/task_probs. This enables monitoring and analysis of how the curriculum distribution evolves over time in the WandB dashboard.

Key changes:
*Added WandB logging in RandomCurriculum.get_task() to report the probability of sampling each task. Since this change is implemented in the RandomClass get_task() method, it is inherited by: Learning Progress, Low Reward. We also add the changes Progressive for similar tracking as it does not inheriet this method directly
*Only the normalized probabilities are logged (not raw weights or task IDs).
*Logging occurs automatically if a WandB run is active.

Impact:
This change allows for better visibility into curriculum task selection dynamics during training, supporting debugging and curriculum analysis.

Sample run avaliable at: https://wandb.ai/metta-research/metta/runs/msb_testLogging_02/workspace
