### PR TITLE
Update Brewfile: correct amazon-efs-utils path, add missing taps and a few packages

### DIFF
--- a/devops/macos/Brewfile
+++ b/devops/macos/Brewfile
@@ -1,7 +1,8 @@
 # Developer tools
 tap "withgraphite/tap"
 tap "aws/homebrew-aws"
-brew "amazon-efs-utils"
+tap "spacelift-io/spacelift"
+brew "aws/aws/amazon-efs-utils"
 brew "awscli"
 brew "bazelisk"
 brew "clang-format"
@@ -13,6 +14,8 @@ brew "withgraphite/tap/graphite"
 brew "spacelift-io/spacelift/spacectl"
 brew "uv"
 brew "npm"
+brew "node"
+brew "gh"
 
 # Applications
 cask "cursor"


### PR DESCRIPTION
- AWS moved amazon-efs-utils from the main Homebrew core to their own tap
- Ran into needing to tap spacelift-io
- Fresh laptop, so node and gh weren't around, and ended up being needed for later setup steps :) I figure it's better to have them in here even if very common