### PR TITLE
Refactor 'Launch SkyPilot Training Job' to use reusable GitHub action

### DIFF
--- a/.github/actions/launch-skypilot-job/action.yml
+++ b/.github/actions/launch-skypilot-job/action.yml
@@ -20,14 +20,6 @@ inputs:
     required: false
     default: ""
 
-outputs:
-  run_name:
-    description: "The W&B run name used for the launched job."
-    value: ${{ inputs.run_name }}
-  sky_job_name:
-    description: "The name given to the SkyPilot job."
-    value: ${{ inputs.run_name }}
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/launch-skypilot-job/action.yml
+++ b/.github/actions/launch-skypilot-job/action.yml
@@ -32,9 +32,9 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python and uv
-      uses: ./.github/actions/setup-uv # Assuming this action is in the repo root
+      uses: ./.github/actions/setup-uv
       with:
-        include-dev: true # Assuming dev dependencies might be needed by launch.py or related scripts
+        include-dev: true
 
     - name: Determine Git Ref
       id: determine_git_ref

--- a/.github/actions/launch-skypilot-job/action.yml
+++ b/.github/actions/launch-skypilot-job/action.yml
@@ -1,0 +1,88 @@
+name: "Launch SkyPilot Job"
+description: "Sets up and launches a SkyPilot job with necessary configurations."
+
+inputs:
+  trainer_env:
+    description: "Training environment configuration (e.g., env/mettagrid/simple)"
+    required: true
+  timeout_hours:
+    description: "Job timeout in hours"
+    required: true
+  run_name:
+    description: "The unique name for the W&B run and SkyPilot job."
+    required: true
+  num_gpus:
+    description: "Number of GPUs to request. If empty, uses SkyPilot task default."
+    required: false
+    default: ""
+  git_ref_override: # Allow overriding the git ref for specific cases, normally determined automatically
+    description: "Specific git ref (commit/branch/tag) to use. If empty, uses current HEAD."
+    required: false
+    default: ""
+
+outputs:
+  run_name:
+    description: "The W&B run name used for the launched job."
+    value: ${{ inputs.run_name }}
+  sky_job_name:
+    description: "The name given to the SkyPilot job."
+    value: ${{ inputs.run_name }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python and uv
+      uses: ./.github/actions/setup-uv # Assuming this action is in the repo root
+      with:
+        include-dev: true # Assuming dev dependencies might be needed by launch.py or related scripts
+
+    - name: Determine Git Ref
+      id: determine_git_ref
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.git_ref_override }}" ]; then
+          echo "Using provided git_ref_override: ${{ inputs.git_ref_override }}"
+          GIT_REF_TO_USE="${{ inputs.git_ref_override }}"
+        else
+          echo "Determining current git ref..."
+          GIT_REF_TO_USE=$(git rev-parse HEAD)
+        fi
+        echo "GIT_REF_TO_USE=$GIT_REF_TO_USE" >> $GITHUB_OUTPUT
+        echo "Using Git Ref: $GIT_REF_TO_USE"
+
+    - name: Set up Weights & Biases credentials
+      shell: bash
+      run: |
+        echo "machine api.wandb.ai" > $HOME/.netrc
+        echo "login user" >> $HOME/.netrc
+        echo "password ${{ secrets.WANDB_API_KEY }}" >> $HOME/.netrc
+        chmod 600 $HOME/.netrc
+      env:
+        WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+
+    - name: Configure SkyPilot API server
+      shell: bash
+      run: |
+        mkdir -p $HOME/.sky
+        echo "api_server:" > $HOME/.sky/config.yaml
+        echo "  endpoint: ${{ secrets.SKYPILOT_API_URL }}" >> $HOME/.sky/config.yaml
+      env:
+        SKYPILOT_API_URL: ${{ secrets.SKYPILOT_API_URL }}
+
+    - name: Launch SkyPilot training job
+      shell: bash
+      run: |
+        GPU_ARG=""
+        if [ -n "${{ inputs.num_gpus }}" ]; then
+          GPU_ARG="--gpus=${{ inputs.num_gpus }}"
+        fi
+
+        chmod +x ./devops/skypilot/launch.py
+
+        ./devops/skypilot/launch.py \\
+          --timeout-hours=${{ inputs.timeout_hours }} \\
+          $GPU_ARG \\
+          --git-ref=${{ steps.determine_git_ref.outputs.GIT_REF_TO_USE }} \\
+          train \\
+          run=${{ inputs.run_name }} \\
+          trainer.curriculum=${{ inputs.trainer_env }}

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -17,12 +17,17 @@ on:
         description: "PR number (if applicable, leave empty otherwise)"
         required: false
         type: string
+      num_gpus:
+        description: "Number of GPUs to request (e.g., 1, 4). If empty, defaults to SkyPilot task definition (usually 1)."
+        required: false
+        type: string
   push:
     branches: [main]
 
 env:
   TRAINER_ENV: ${{ github.event.inputs.trainer_env || 'env/mettagrid/simple' }}
   TIMEOUT_HOURS: ${{ github.event.inputs.timeout_hours || 1 }}
+  NUM_GPUS: ${{ github.event.inputs.num_gpus || '' }}
 
 jobs:
   launch-batch-job:
@@ -90,8 +95,13 @@ jobs:
 
       - name: Launch SkyPilot training job
         run: |
+          GPU_ARG=""
+          if [ -n "$NUM_GPUS" ]; then
+            GPU_ARG="--gpus=$NUM_GPUS"
+          fi
           ./devops/skypilot/launch.py \
             --timeout-hours=$TIMEOUT_HOURS \
+            $GPU_ARG \
             train \
             run=${{ steps.generate_run_name.outputs.run_name }} \
             trainer.curriculum=$TRAINER_ENV

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -20,14 +20,14 @@ on:
       num_gpus:
         description: "Number of GPUs to request (e.g., 1, 4). If empty, defaults to SkyPilot task definition (usually 1)."
         required: false
-        type: string
+        type: string # Keep as string to allow empty, action handles default
   push:
     branches: [main]
 
 env:
-  TRAINER_ENV: ${{ github.event.inputs.trainer_env || 'env/mettagrid/simple' }}
-  TIMEOUT_HOURS: ${{ github.event.inputs.timeout_hours || 1 }}
-  NUM_GPUS: ${{ github.event.inputs.num_gpus || '' }}
+  DEFAULT_TRAINER_ENV: "env/mettagrid/simple"
+  DEFAULT_TIMEOUT_HOURS: 1
+  RUN_NAME_PREFIX: "github.sky" # Define the prefix for run names here
 
 jobs:
   launch-batch-job:
@@ -39,69 +39,56 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # Need at least 2 commits to detect merge commit messages
+          fetch-depth: 0 # Full history is useful as the action determines the exact git ref.
 
-      - name: Setup Python and uv
-        uses: ./.github/actions/setup-uv
-        with:
-          include-dev: true
+      - name: Determine PR Number for Push Events
+        id: pr_info
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          PR_FROM_COMMIT=$(git log -1 --pretty=format:"%s" | sed -n 's/.*(#\\([0-9][0-9]*\\)).*/\\1/p')
+          echo "Extracted PR number from commit message (if any): $PR_FROM_COMMIT"
+          echo "pr_number_for_name_generation=${PR_FROM_COMMIT}" >> $GITHUB_OUTPUT
 
-      - name: Generate run name
+      - name: Generate Run Name
         id: generate_run_name
+        shell: bash
         run: |
           set -eo pipefail
+          PR_NUMBER_TO_USE="${{ github.event.inputs.pr_number || steps.pr_info.outputs.pr_number_for_name_generation || '' }}"
 
-          # Use PR number if available (either from manual input or extracted from merge commit)
-          PR_NUMBER="${{ github.event.inputs.pr_number }}"
-          if [ -z "$PR_NUMBER" ] && [ "${{ github.event_name }}" == "push" ]; then
-            # Try to extract PR number from the merge commit message
-            PR_NUMBER=$(git log -1 --pretty=format:"%s" | sed -n 's/.*(#\([0-9][0-9]*\)).*/\1/p')
-          fi
+          SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
 
-          # Generate the run name
-          if [ -n "$PR_NUMBER" ]; then
-            RUN_NAME="github.sky.pr${PR_NUMBER}"
-            echo "Using PR #$PR_NUMBER in run name"
+          if [ -n "$PR_NUMBER_TO_USE" ]; then
+            RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.pr${PR_NUMBER_TO_USE}"
+            echo "Using PR #$PR_NUMBER_TO_USE in run name"
           else
-            # Get branch name
-            BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9]/_/g')
-            RUN_NAME="github.sky.$BRANCH"
-            echo "Using branch name '$BRANCH' in run name"
+            BRANCH_NAME_RAW=$(git rev-parse --abbrev-ref HEAD)
+            BRANCH_NAME_SANITISED=$(echo "$BRANCH_NAME_RAW" | sed 's/[^a-zA-Z0-9_-]/-/g')
+            RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.${BRANCH_NAME_SANITISED}"
+            echo "Using branch name '$BRANCH_NAME_SANITISED' in run name (PR number not provided/found)"
           fi
 
-          # Get current timestamp in a format suitable for filenames
           TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
+          FINAL_RUN_NAME="$RUN_NAME_BASE.$SHORT_COMMIT_HASH.$TIMESTAMP"
 
-          # Get short commit hash
-          COMMIT_HASH=$(git rev-parse --short HEAD)
+          echo "Generated run name for SkyPilot: $FINAL_RUN_NAME"
+          echo "run_name=$FINAL_RUN_NAME" >> $GITHUB_OUTPUT
 
-          RUN_NAME="$RUN_NAME.$COMMIT_HASH.$TIMESTAMP"
+      - name: Launch SkyPilot Job via Custom Action
+        id: skylaunch
+        uses: ./.github/actions/launch-skypilot-job
+        with:
+          trainer_env: ${{ github.event.inputs.trainer_env || env.DEFAULT_TRAINER_ENV }}
+          timeout_hours: ${{ github.event.inputs.timeout_hours || env.DEFAULT_TIMEOUT_HOURS }}
+          num_gpus: ${{ github.event.inputs.num_gpus || '' }}
+          run_name: ${{ steps.generate_run_name.outputs.run_name }} # Pass the fully generated name
+          # git_ref_override: '' # Default in action is current HEAD, pass only if specific override needed.
 
-          echo "Generated run name: $RUN_NAME"
-          echo "run_name=$RUN_NAME" >> $GITHUB_OUTPUT
-
-      - name: Set up Weights & Biases credentials
+      - name: Print Run Information
+        shell: bash
         run: |
-          echo "machine api.wandb.ai" > $HOME/.netrc
-          echo "login user" >> $HOME/.netrc
-          echo "password ${{ secrets.WANDB_API_KEY }}" >> $HOME/.netrc
-          chmod 600 $HOME/.netrc
-
-      - name: Configure SkyPilot API server
-        run: |
-          mkdir -p $HOME/.sky
-          echo "api_server:" > $HOME/.sky/config.yaml
-          echo "  endpoint: ${{ secrets.SKYPILOT_API_URL }}" >> $HOME/.sky/config.yaml
-
-      - name: Launch SkyPilot training job
-        run: |
-          GPU_ARG=""
-          if [ -n "$NUM_GPUS" ]; then
-            GPU_ARG="--gpus=$NUM_GPUS"
-          fi
-          ./devops/skypilot/launch.py \
-            --timeout-hours=$TIMEOUT_HOURS \
-            $GPU_ARG \
-            train \
-            run=${{ steps.generate_run_name.outputs.run_name }} \
-            trainer.curriculum=$TRAINER_ENV
+          echo "Workflow triggered by: ${{ github.event_name }}"
+          echo "SkyPilot Job Name / W&B Run Name (from action output): ${{ steps.skylaunch.outputs.run_name }}"
+          echo "SkyPilot Task Name (from action output): ${{ steps.skylaunch.outputs.sky_job_name }}"
+          echo "To see logs for this job in SkyPilot, you might use: sky jobs logs ${{ steps.skylaunch.outputs.sky_job_name }} (if job was successfully submitted)"

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -40,10 +40,18 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout code
+      - name: Checkout specific commit for dispatch
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full history is useful as the action determines the exact git ref.
+          ref: ${{ github.event.inputs.commit_to_run }}
+          fetch-depth: 1
+
+      - name: Checkout full history for push
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Determine PR Number for Push Events
         id: pr_info
@@ -59,29 +67,48 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          PR_NUMBER_TO_USE="${{ github.event.inputs.pr_number || steps.pr_info.outputs.pr_number_for_name_generation || '' }}"
-
-          # Use the provided commit_to_run for SHORT_COMMIT_HASH if available (manual dispatch), otherwise use HEAD
-          if [ -n "${{ github.event.inputs.commit_to_run }}" ]; then
-            SHORT_COMMIT_HASH=$(echo "${{ github.event.inputs.commit_to_run }}" | cut -c1-7)
-            echo "Using provided commit_to_run (${{ github.event.inputs.commit_to_run }}) for run name, short hash: $SHORT_COMMIT_HASH"
-          else
-            SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
-            echo "Using current HEAD's short commit hash: $SHORT_COMMIT_HASH"
-          fi
-
-          if [ -n "$PR_NUMBER_TO_USE" ]; then
-            RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.pr${PR_NUMBER_TO_USE}"
-            echo "Using PR #$PR_NUMBER_TO_USE in run name"
-          else
-            BRANCH_NAME_RAW=$(git rev-parse --abbrev-ref HEAD)
-            BRANCH_NAME_SANITISED=$(echo "$BRANCH_NAME_RAW" | sed 's/[^a-zA-Z0-9_-]/-/g')
-            RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.${BRANCH_NAME_SANITISED}"
-            echo "Using branch name '$BRANCH_NAME_SANITISED' in run name (PR number not provided/found)"
-          fi
-
           TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
-          FINAL_RUN_NAME="$RUN_NAME_BASE.$SHORT_COMMIT_HASH.$TIMESTAMP"
+          # SHORT_COMMIT_HASH is derived from the actual checked-out HEAD.
+          # This HEAD is set by the conditional 'Checkout code' steps:
+          # - For 'push', it's the trigger commit.
+          # - For 'workflow_dispatch', it's github.event.inputs.commit_to_run.
+          SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Manual dispatch: run name is github.sky.<short_hash>.<timestamp>
+            # The github.event.inputs.pr_number is not used for the run name itself here.
+            if [ -z "${{ github.event.inputs.commit_to_run }}" ]; then
+              echo "Error: commit_to_run is required for workflow_dispatch and was not provided."
+              exit 1
+            fi
+            # Sanity check that checked-out commit matches the input
+            INPUT_SHORT_HASH=$(echo "${{ github.event.inputs.commit_to_run }}" | cut -c1-7)
+            if [ "$SHORT_COMMIT_HASH" != "$INPUT_SHORT_HASH" ]; then
+                echo "Warning: Checked out HEAD's short hash ($SHORT_COMMIT_HASH) does not match input commit_to_run's short hash ($INPUT_SHORT_HASH). Using checked out HEAD."
+            fi
+            RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}"
+            FINAL_RUN_NAME="$RUN_NAME_BASE.$SHORT_COMMIT_HASH.$TIMESTAMP"
+            echo "Manual dispatch: Using commit ($SHORT_COMMIT_HASH). Run name: $FINAL_RUN_NAME"
+
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            # Push event: run name includes PR number (if found) or branch name.
+            PR_NUMBER_FROM_COMMIT="${{ steps.pr_info.outputs.pr_number_for_name_generation || '' }}"
+
+            if [ -n "$PR_NUMBER_FROM_COMMIT" ]; then
+              RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.pr${PR_NUMBER_FROM_COMMIT}"
+              echo "Push event: Using PR #$PR_NUMBER_FROM_COMMIT in run name base: $RUN_NAME_BASE"
+            else
+              BRANCH_NAME_RAW=$(git rev-parse --abbrev-ref HEAD)
+              BRANCH_NAME_SANITISED=$(echo "$BRANCH_NAME_RAW" | sed 's/[^a-zA-Z0-9_-]/-/g')
+              RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.${BRANCH_NAME_SANITISED}"
+              echo "Push event: Using branch name '$BRANCH_NAME_SANITISED' in run name base: $RUN_NAME_BASE (PR number not found in commit)"
+            fi
+            FINAL_RUN_NAME="$RUN_NAME_BASE.$SHORT_COMMIT_HASH.$TIMESTAMP"
+            echo "Push event: Run name: $FINAL_RUN_NAME"
+          else
+            echo "Error: Unhandled event type ${{ github.event_name }}"
+            exit 1
+          fi
 
           echo "Generated run name for SkyPilot: $FINAL_RUN_NAME"
           echo "run_name=$FINAL_RUN_NAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -127,6 +127,6 @@ jobs:
         shell: bash
         run: |
           echo "Workflow triggered by: ${{ github.event_name }}"
-          echo "SkyPilot Job Name / W&B Run Name (from action output): ${{ steps.skylaunch.outputs.run_name }}"
-          echo "SkyPilot Task Name (from action output): ${{ steps.skylaunch.outputs.sky_job_name }}"
-          echo "To see logs for this job in SkyPilot, you might use: sky jobs logs ${{ steps.skylaunch.outputs.sky_job_name }} (if job was successfully submitted)"
+          echo "SkyPilot Job Name / W&B Run Name: ${{ steps.generate_run_name.outputs.run_name }}"
+          echo "SkyPilot Task Name: ${{ steps.generate_run_name.outputs.run_name }}"
+          echo "To see logs for this job in SkyPilot, you might use: sky jobs logs ${{ steps.generate_run_name.outputs.run_name }} (if job was successfully submitted)"

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -13,8 +13,12 @@ on:
         required: true
         default: "env/mettagrid/simple"
         type: string
+      commit_to_run:
+        description: "The full commit hash to run the job against (required for manual runs)."
+        required: true
+        type: string
       pr_number:
-        description: "PR number (if applicable, leave empty otherwise)"
+        description: "PR number (for naming/context if running a PR's commit, leave empty otherwise)"
         required: false
         type: string
       num_gpus:
@@ -57,7 +61,14 @@ jobs:
           set -eo pipefail
           PR_NUMBER_TO_USE="${{ github.event.inputs.pr_number || steps.pr_info.outputs.pr_number_for_name_generation || '' }}"
 
-          SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
+          # Use the provided commit_to_run for SHORT_COMMIT_HASH if available (manual dispatch), otherwise use HEAD
+          if [ -n "${{ github.event.inputs.commit_to_run }}" ]; then
+            SHORT_COMMIT_HASH=$(echo "${{ github.event.inputs.commit_to_run }}" | cut -c1-7)
+            echo "Using provided commit_to_run (${{ github.event.inputs.commit_to_run }}) for run name, short hash: $SHORT_COMMIT_HASH"
+          else
+            SHORT_COMMIT_HASH=$(git rev-parse --short HEAD)
+            echo "Using current HEAD's short commit hash: $SHORT_COMMIT_HASH"
+          fi
 
           if [ -n "$PR_NUMBER_TO_USE" ]; then
             RUN_NAME_BASE="${{ env.RUN_NAME_PREFIX }}.pr${PR_NUMBER_TO_USE}"
@@ -83,7 +94,7 @@ jobs:
           timeout_hours: ${{ github.event.inputs.timeout_hours || env.DEFAULT_TIMEOUT_HOURS }}
           num_gpus: ${{ github.event.inputs.num_gpus || '' }}
           run_name: ${{ steps.generate_run_name.outputs.run_name }} # Pass the fully generated name
-          # git_ref_override: '' # Default in action is current HEAD, pass only if specific override needed.
+          git_ref_override: ${{ github.event.inputs.commit_to_run || '' }} # Pass commit_to_run for manual, default for push
 
       - name: Print Run Information
         shell: bash


### PR DESCRIPTION
The GitHub workflow 'Launch SkyPilot Training Job' handles all the necessary credential stuff to simply create a new SkyPilot training run. So far, this workflow is being used for a smoke test on new merges to main.

**Changes**
Refactor the 'Launch SkyPilot Training Job' workflow to use a newly created GitHub action to deploy the SkyPilot job.

**Context**
I am working on a smoke test for distributed training that also needs to deploy SkyPilot jobs, and copying this workflow would be suboptimal.