### PR TITLE
Update mettascope frontend build cmd in README

### DIFF
--- a/mettascope/README.md
+++ b/mettascope/README.md
@@ -35,7 +35,7 @@ You need to install Node.js (v23.11.0) and typescript (Version 5.8.3), this migh
 ```bash
 cd mettascope
 npm install
-tsc
+npm run build
 python tools/gen_atlas.py
 python -m http.server 2000
 ```


### PR DESCRIPTION
the mettascope server (launched via `tools.play`) was failing because the frontend files weren't built. The README advised running `tsc`, which requires a global TypeScript installation that may not exist on fresh systems

changed to use `npm run build` instead, which uses the locally installed TypeScript compiler that's guaranteed to be available after `npm install`