### PR TITLE
Update mettascope frontend build cmd in README

### DIFF
--- a/mettascope/README.md
+++ b/mettascope/README.md
@@ -8,15 +8,34 @@ This advanced WebGPU viewer allows you to watch and replay any metta replay. It 
 <a href="https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fandre_pufferbox_33%2Freplay.77200.json.z&play=true">Interactive demo</a>
 </p>
 
+
+## Installation
+
+Ensure you have Node.js version 23.11.0 or higher installed. You can check your version with: `node --version`.
+
+Then, install and build mettascope:
+```bash
+./mettascope/install.sh
+```
+
 ## Usage
 
+### Running the server
+From within the metta/mettascope/ directory:
+```bash
+python -m http.server 2000
+```
+
+Then open the browser and go to `http://localhost:2000` to see the player.
+
+### Viewing replays
 You can either drag and drop a replay file or pass a url parameter to the player.
 
 `?replayUrl=...the replay file...`
 
 Most tools dealing with replays will provide a full link.
 
-## Here are some replays to try out:
+Here are some replays to try out:
 
 * [Simple Environment](https://metta-ai.github.io/metta/?replayUrl=https://softmax-public.s3.us-east-1.amazonaws.com/replays/andre_pufferbox_33/replay.77200.json.z)
 
@@ -28,19 +47,6 @@ Most tools dealing with replays will provide a full link.
 
 * [The 280 Agents](https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fdaveey.na.240.1x4%2Freplay.8100.json.z)
 
-## Installation
-
-You need to install Node.js (v23.11.0) and typescript (Version 5.8.3), this might be different for different operating systems.
-
-```bash
-cd mettascope
-npm install
-npm run build
-python tools/gen_atlas.py
-python -m http.server 2000
-```
-
-Then open the browser and go to `http://localhost:2000` to see the player.
 
 ## Development
 

--- a/mettascope/README.md
+++ b/mettascope/README.md
@@ -35,7 +35,7 @@ You need to install Node.js (v23.11.0) and typescript (Version 5.8.3), this migh
 ```bash
 cd mettascope
 npm install
-tsc
+npm run build
 python tools/gen_atlas.py
 python -m http.server 2000
 ```

--- a/mettascope/install.sh
+++ b/mettascope/install.sh
@@ -7,9 +7,8 @@ set -e
 
 # Install dependencies
 cd mettascope
-npm install --force -g typescript
 npm install --force
-tsc
+npm run build
 
 # Generate atlas
 ./tools/gen_atlas.py


### PR DESCRIPTION
The README advises running tsc to build mettascope, which requires a global TypeScript installation that may not exist on fresh systems. changed to use npm run build instead, which uses the locally installed TypeScript compiler that's guaranteed to be available after npm install

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210623243087714)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210632432027187