### PR TITLE
fix: grant actions/stale cache access

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       issues: write
       pull-requests: write
     steps:


### PR DESCRIPTION
see https://github.com/actions/stale/issues/1133 for context

This PR adds the `actions: write` permission to resolve the state cache error that occurs when the stale action runs.

### Problem
The stale workflow was encountering this error:
```
Warning: Error delete _state: [403] Resource not accessible by integration
the state will be removed
```

### Solution
Added `actions: write` permission to allow the stale action to manage its cache properly. This enables the action to maintain state between runs for better performance.

### Context
The stale action uses GitHub Actions cache to track which issues/PRs it has already processed. Without the `actions: write` permission, it cannot manage this cache and must reprocess all items on each run, which is less efficient but doesn't affect functionality.

As documented in [[actions/stale README](https://github.com/actions/stale#recommended-permissions)](https://github.com/actions/stale#recommended-permissions), this permission is recommended for proper cache management.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210623526928789)