### PR TITLE
Fix 'Launch SkyPilot Training Job' by explicitly passing secrets

### DIFF
--- a/.github/actions/launch-skypilot-job/action.yml
+++ b/.github/actions/launch-skypilot-job/action.yml
@@ -19,6 +19,12 @@ inputs:
     description: "Specific git ref (commit/branch/tag) to use. If empty, uses current HEAD."
     required: false
     default: ""
+  wandb_api_key:
+    description: "Weights & Biases API Key"
+    required: true
+  skypilot_api_url:
+    description: "SkyPilot API URL"
+    required: true
 
 runs:
   using: "composite"
@@ -47,19 +53,19 @@ runs:
       run: |
         echo "machine api.wandb.ai" > $HOME/.netrc
         echo "login user" >> $HOME/.netrc
-        echo "password ${{ secrets.WANDB_API_KEY }}" >> $HOME/.netrc
+        echo "password ${{ inputs.wandb_api_key }}" >> $HOME/.netrc
         chmod 600 $HOME/.netrc
       env:
-        WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+        WANDB_API_KEY: ${{ inputs.wandb_api_key }}
 
     - name: Configure SkyPilot API server
       shell: bash
       run: |
         mkdir -p $HOME/.sky
         echo "api_server:" > $HOME/.sky/config.yaml
-        echo "  endpoint: ${{ secrets.SKYPILOT_API_URL }}" >> $HOME/.sky/config.yaml
+        echo "  endpoint: ${{ inputs.skypilot_api_url }}" >> $HOME/.sky/config.yaml
       env:
-        SKYPILOT_API_URL: ${{ secrets.SKYPILOT_API_URL }}
+        SKYPILOT_API_URL: ${{ inputs.skypilot_api_url }}
 
     - name: Launch SkyPilot training job
       shell: bash

--- a/.github/workflows/sky-train.yml
+++ b/.github/workflows/sky-train.yml
@@ -122,6 +122,8 @@ jobs:
           num_gpus: ${{ github.event.inputs.num_gpus || '' }}
           run_name: ${{ steps.generate_run_name.outputs.run_name }} # Pass the fully generated name
           git_ref_override: ${{ github.event.inputs.commit_to_run || '' }} # Pass commit_to_run for manual, default for push
+          wandb_api_key: ${{ secrets.WANDB_API_KEY }}
+          skypilot_api_url: ${{ secrets.SKYPILOT_API_URL }}
 
       - name: Print Run Information
         shell: bash


### PR DESCRIPTION
GitHub actions are not allowed to access secrets directly, so we have to explicitly pass them as arguments.
This PR fixes #1105.

*Why wasn't this problem found during testing for #1105?*
Because testing GitHub workflows is to my knowledge impossible without forking. 