### PR TITLE
Switch inventory to be maps

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/get_output.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/get_output.hpp
@@ -37,18 +37,15 @@ protected:
     // Actions is only successful if we take at least one item.
     bool items_taken = false;
 
-    for (size_t i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (converter->recipe_output[i] == 0) {
-        // We only want to take things the converter can produce. Otherwise it's a pain to
-        // collect resources from a converter that's in the middle of processing a queue.
+    for (const auto& [item, amount] : converter->recipe_output) {
+      if (converter->inventory.count(item) == 0) {
         continue;
       }
-
-      int taken = actor->update_inventory(static_cast<InventoryItem>(i), converter->inventory[i]);
+      int taken = actor->update_inventory(item, converter->inventory[item]);
 
       if (taken > 0) {
-        actor->stats.add(InventoryItemNames[i] + ".get", taken);
-        converter->update_inventory(static_cast<InventoryItem>(i), -taken);
+        actor->stats.add(InventoryItemNames[item] + ".get", taken);
+        converter->update_inventory(item, -taken);
         items_taken = true;
       }
     }

--- a/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
@@ -32,7 +32,10 @@ protected:
 
     bool success = false;
     for (const auto& [item, amount] : converter->recipe_input) {
-      int max_to_put = std::min(amount, actor->inventory.count(item) > 0 ? actor->inventory.at(item) : 0);
+      if (actor->inventory.count(item) == 0) {
+        continue;
+      }
+      int max_to_put = std::min(amount, actor->inventory.at(item));
       if (max_to_put > 0) {
         int put = converter->update_inventory(item, max_to_put);
         if (put > 0) {

--- a/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
@@ -31,15 +31,15 @@ protected:
     }
 
     bool success = false;
-    for (size_t i = 0; i < converter->recipe_input.size(); i++) {
-      int max_to_put = std::min(converter->recipe_input[i], actor->inventory[i]);
+    for (const auto& [item, amount] : converter->recipe_input) {
+      int max_to_put = std::min(amount, actor->inventory.count(item) > 0 ? actor->inventory.at(item) : 0);
       if (max_to_put > 0) {
-        int put = converter->update_inventory(static_cast<InventoryItem>(i), max_to_put);
+        int put = converter->update_inventory(item, max_to_put);
         if (put > 0) {
           // We should be able to put this many items into the converter. If not, something is wrong.
-          int delta = actor->update_inventory(static_cast<InventoryItem>(i), -put);
+          int delta = actor->update_inventory(item, -put);
           assert(delta == -put);
-          actor->stats.add(InventoryItemNames[i] + ".put", put);
+          actor->stats.add(InventoryItemNames[item] + ".put", put);
           success = true;
         }
       }

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -16,9 +16,9 @@ public:
   unsigned char frozen;
   unsigned char freeze_duration;
   unsigned char orientation;
-  std::vector<unsigned char> inventory;
-  std::vector<float> resource_rewards;
-  std::vector<float> resource_reward_max;
+  std::map<InventoryItem, uint8_t> inventory;
+  std::map<InventoryItem, float> resource_rewards;
+  std::map<InventoryItem, float> resource_reward_max;
   float action_failure_penalty;
   std::string group_name;
   unsigned char color;
@@ -47,22 +47,23 @@ public:
 
     this->frozen = 0;
     this->orientation = 0;
-    this->inventory.resize(InventoryItem::InventoryItemCount);
-    this->max_items_per_type.resize(InventoryItem::InventoryItemCount);
+
     for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (max_items_per_type_.find(InventoryItemNames[i]) != max_items_per_type_.end()) {
-        this->max_items_per_type[i] = max_items_per_type_[InventoryItemNames[i]];
+      if (max_items_per_type_.count(InventoryItemNames[i]) > 0) {
+        this->max_items_per_type[static_cast<InventoryItem>(i)] = max_items_per_type_[InventoryItemNames[i]];
       } else {
-        this->max_items_per_type[i] = default_item_max;
+        this->max_items_per_type[static_cast<InventoryItem>(i)] = default_item_max;
       }
     }
-    this->resource_rewards.resize(InventoryItem::InventoryItemCount);
     for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      this->resource_rewards[i] = resource_rewards_[InventoryItemNames[i]];
+      if (resource_rewards_.count(InventoryItemNames[i]) > 0) {
+        this->resource_rewards[static_cast<InventoryItem>(i)] = resource_rewards_[InventoryItemNames[i]];
+      }
     }
-    this->resource_reward_max.resize(InventoryItem::InventoryItemCount);
     for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      this->resource_reward_max[i] = resource_reward_max_[InventoryItemNames[i]];
+      if (resource_reward_max_.count(InventoryItemNames[i]) > 0) {
+        this->resource_reward_max[static_cast<InventoryItem>(i)] = resource_reward_max_[InventoryItemNames[i]];
+      }
     }
     this->reward = nullptr;
   }
@@ -77,7 +78,11 @@ public:
     new_amount = std::clamp(new_amount, 0, static_cast<int>(this->max_items_per_type[item]));
 
     int delta = new_amount - current_amount;
-    this->inventory[item] = new_amount;
+    if (new_amount > 0) {
+      this->inventory[item] = new_amount;
+    } else {
+      this->inventory.erase(item);
+    }
 
     if (delta > 0) {
       this->stats.add(InventoryItemNames[item] + ".gained", delta);
@@ -90,18 +95,24 @@ public:
     return delta;
   }
 
+  // Recalculates resource rewards for the agent.
+  // item -- the item that was added or removed from the inventory, triggering the reward recalculation.
   inline void compute_resource_reward(InventoryItem item) {
-    if (this->resource_rewards[item] == 0) {
+    if (this->resource_rewards.count(item) == 0) {
+      // If the item is not in the resource_rewards map, we don't need to recalculate the reward.
       return;
     }
 
+    // Recalculate resource rewards. Note that we're recalculating our total reward, not just the reward for the
+    // item that was added or removed.
+    // TODO: consider doing this only once per step, and not every time the inventory changes.
     float new_reward = 0;
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      float max_val = static_cast<float>(this->inventory[i]);
-      if (max_val > this->resource_reward_max[i]) {
-        max_val = this->resource_reward_max[i];
+    for (const auto& [item, amount] : this->inventory) {
+      float max_val = static_cast<float>(amount);
+      if (this->resource_reward_max.count(item) > 0 && max_val > this->resource_reward_max[item]) {
+        max_val = this->resource_reward_max[item];
       }
-      new_reward += this->resource_rewards[i] * max_val;
+      new_reward += this->resource_rewards[item] * max_val;
     }
     *this->reward += (new_reward - this->current_resource_reward);
     this->current_resource_reward = new_reward;
@@ -113,22 +124,22 @@ public:
 
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
-    features.reserve(5 + InventoryItem::InventoryItemCount);
+    features.reserve(5 + this->inventory.size());
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Group, group});
     features.push_back({ObservationFeature::Frozen, frozen});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (inventory[i] > 0) {
-        features.push_back({static_cast<uint8_t>(InventoryFeatureOffset + i), inventory[i]});
-      }
+    for (const auto& [item, amount] : this->inventory) {
+      // inventory should only contain non-zero amounts
+      assert(amount > 0);
+      features.push_back({static_cast<uint8_t>(InventoryFeatureOffset + item), amount});
     }
     return features;
   }
 
 private:
-  std::vector<unsigned char> max_items_per_type;
+  std::map<ObsType, uint8_t> max_items_per_type;
 };
 
 #endif  // OBJECTS_AGENT_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -16,6 +16,9 @@ public:
   unsigned char frozen;
   unsigned char freeze_duration;
   unsigned char orientation;
+  // inventory is a map of item to amount.
+  // keys should be deleted when the amount is 0, to keep iteration faster.
+  // however, this should not be relied on for correctness.
   std::map<InventoryItem, uint8_t> inventory;
   std::map<InventoryItem, float> resource_rewards;
   std::map<InventoryItem, float> resource_reward_max;

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -29,9 +29,9 @@ private:
     }
     // Check if the converter is already at max output.
     unsigned short total_output = 0;
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (this->recipe_output[i] > 0) {
-        total_output += this->inventory[i];
+    for (const auto& [item, amount] : this->inventory) {
+      if (this->recipe_output.count(item) > 0) {
+        total_output += amount;
       }
     }
     if (this->max_output >= 0 && total_output >= this->max_output) {
@@ -39,18 +39,16 @@ private:
       return;
     }
     // Check if the converter has enough input.
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (this->inventory[i] < this->recipe_input[i]) {
+    for (const auto& [item, input_amount] : this->recipe_input) {
+      if (this->inventory.count(item) > 0 && this->inventory.at(item) < input_amount) {
         stats.incr("blocked.insufficient_input");
         return;
       }
     }
     // produce.
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      this->inventory[i] -= this->recipe_input[i];
-      if (this->recipe_input[i] > 0) {
-        stats.add(InventoryItemNames[i] + ".consumed", this->recipe_input[i]);
-      }
+    for (const auto& [item, input_amount] : this->recipe_input) {
+      this->update_inventory(item, -input_amount);
+      stats.add(InventoryItemNames[item] + ".consumed", input_amount);
     }
     // All the previous returns were "we don't start converting".
     // This one is us starting to convert.
@@ -60,8 +58,8 @@ private:
   }
 
 public:
-  vector<unsigned char> recipe_input;
-  vector<unsigned char> recipe_output;
+  std::map<InventoryItem, uint8_t> recipe_input;
+  std::map<InventoryItem, uint8_t> recipe_output;
   // The converter won't convert if its output already has this many things of
   // the type it produces. This may be clunky in some cases, but the main usage
   // is to make Mines (etc) have a maximum output.
@@ -77,12 +75,13 @@ public:
 
   Converter(GridCoord r, GridCoord c, ObjectConfig cfg, TypeId type_id) {
     GridObject::init(type_id, GridLocation(r, c, GridLayer::Object_Layer));
-    HasInventory::init_has_inventory(cfg);
-    this->recipe_input.resize(InventoryItem::InventoryItemCount);
-    this->recipe_output.resize(InventoryItem::InventoryItemCount);
     for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      this->recipe_input[i] = cfg["input_" + InventoryItemNames[i]];
-      this->recipe_output[i] = cfg["output_" + InventoryItemNames[i]];
+      if (cfg.count("input_" + InventoryItemNames[i])) {
+        this->recipe_input.insert({static_cast<InventoryItem>(i), cfg["input_" + InventoryItemNames[i]]});
+      }
+      if (cfg.count("output_" + InventoryItemNames[i])) {
+        this->recipe_output.insert({static_cast<InventoryItem>(i), cfg["output_" + InventoryItemNames[i]]});
+      }
     }
     this->max_output = cfg["max_output"];
     this->conversion_ticks = cfg["conversion_ticks"];
@@ -95,7 +94,8 @@ public:
     // Default to recipe_output values if initial_items is not present
     unsigned char initial_items = cfg["initial_items"];
     for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (this->recipe_output[i] > 0) {
+      if (this->recipe_output.count(static_cast<InventoryItem>(i)) > 0 &&
+          this->recipe_output[static_cast<InventoryItem>(i)] > 0) {
         HasInventory::update_inventory(static_cast<InventoryItem>(i), initial_items);
       }
     }
@@ -113,11 +113,9 @@ public:
     stats.incr("conversions.completed");
 
     // Add output to inventory
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (this->recipe_output[i] > 0) {
-        HasInventory::update_inventory(static_cast<InventoryItem>(i), this->recipe_output[i]);
-        stats.add(InventoryItemNames[i] + ".produced", this->recipe_output[i]);
-      }
+    for (const auto& [item, amount] : this->recipe_output) {
+      HasInventory::update_inventory(item, amount);
+      stats.add(InventoryItemNames[item] + ".produced", amount);
     }
 
     if (this->cooldown > 0) {
@@ -156,14 +154,14 @@ public:
 
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
-    features.reserve(5 + InventoryItem::InventoryItemCount);
+    features.reserve(5 + this->inventory.size());
     features.push_back({ObservationFeature::TypeId, _type_id});
     features.push_back({ObservationFeature::Color, color});
     features.push_back({ObservationFeature::ConvertingOrCoolingDown, this->converting || this->cooling_down});
-    for (uint8_t i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (inventory[i] > 0) {
-        features.push_back({static_cast<uint8_t>(InventoryFeatureOffset + i), inventory[i]});
-      }
+    for (const auto& [item, amount] : this->inventory) {
+      // inventory should only contain non-zero amounts
+      assert(amount > 0);
+      features.push_back({static_cast<uint8_t>(item + InventoryFeatureOffset), amount});
     }
     return features;
   }

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -46,9 +46,16 @@ private:
       }
     }
     // produce.
+    // Get the amounts to consume from input, so we don't update the inventory
+    // while iterating over it.
+    std::map<InventoryItem, uint8_t> amounts_to_consume;
     for (const auto& [item, input_amount] : this->recipe_input) {
-      this->update_inventory(item, -input_amount);
-      stats.add(InventoryItemNames[item] + ".consumed", input_amount);
+      amounts_to_consume[item] = input_amount;
+    }
+
+    for (const auto& [item, amount] : amounts_to_consume) {
+      this->update_inventory(item, -amount);
+      stats.add(InventoryItemNames[item] + ".consumed", amount);
     }
     // All the previous returns were "we don't start converting".
     // This one is us starting to convert.

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -54,7 +54,12 @@ private:
     }
 
     for (const auto& [item, amount] : amounts_to_consume) {
-      this->update_inventory(item, -amount);
+      // Don't call update_inventory here, because it will call maybe_start_converting again,
+      // which will cause an infinite loop.
+      this->inventory[item] -= amount;
+      if (this->inventory[item] == 0) {
+        this->inventory.erase(item);
+      }
       stats.add(InventoryItemNames[item] + ".consumed", amount);
     }
     // All the previous returns were "we don't start converting".

--- a/mettagrid/src/metta/mettagrid/objects/has_inventory.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/has_inventory.hpp
@@ -10,11 +10,7 @@
 
 class HasInventory : public MettaObject {
 public:
-  vector<unsigned char> inventory;
-
-  void init_has_inventory(ObjectConfig cfg) {
-    this->inventory.resize(InventoryItem::InventoryItemCount);
-  }
+  std::map<InventoryItem, uint8_t> inventory;
 
   // Whether the inventory is accessible to an agent.
   virtual bool inventory_is_accessible() {
@@ -25,7 +21,11 @@ public:
     int initial_amount = this->inventory[item];
     int new_amount = initial_amount + amount;
     new_amount = std::clamp(new_amount, 0, 255);
-    this->inventory[item] = new_amount;
+    if (new_amount == 0) {
+      this->inventory.erase(item);
+    } else {
+      this->inventory[item] = new_amount;
+    }
     return new_amount - initial_amount;
   }
 };

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -100,7 +100,8 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   // Test hitting zero
   delta = agent->update_inventory(InventoryItem::heart, -10);
   EXPECT_EQ(delta, -3);  // Should only remove what's available
-  EXPECT_EQ(agent->inventory[InventoryItem::heart], 0);
+  // check that the item is not in the inventory
+  EXPECT_EQ(agent->inventory.find(InventoryItem::heart), agent->inventory.end());
 
   // Test hitting max_items_per_type limit
   agent->update_inventory(InventoryItem::heart, 30);


### PR DESCRIPTION
Changes inventory representation from fixed-size vectors to maps. This isn't strictly required to make things more configurable, but maps better-match the mental model I think we should have for inventory (and tokens), and should be more efficient if we have a vaguely-unbounded number of types of things in inventory; or if we want inventory items to not have to start at zero.

As per many PRs, this is an extraction from another PR.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210633750368373)