### PR TITLE
Detaching the LSTM state before storing experience

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -420,7 +420,7 @@ class MettaTrainer:
                 # Store LSTM state for performance
                 lstm_state_to_store = None
                 if state.lstm_h is not None:
-                    lstm_state_to_store = {"lstm_h": state.lstm_h, "lstm_c": state.lstm_c}
+                    lstm_state_to_store = {"lstm_h": state.lstm_h.detach(), "lstm_c": state.lstm_c.detach()}
 
                 if str(self.device).startswith("cuda"):
                     torch.cuda.synchronize()


### PR DESCRIPTION
This was a memory leak where-in computational graphs with LSTM state were persisting into the experience replay buffer when they're supposed to be detached.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210633746405092)