### PR TITLE
Update the Skypilot README

### DIFF
--- a/devops/setup_dev.sh
+++ b/devops/setup_dev.sh
@@ -99,9 +99,9 @@ if [ -z "$IS_DOCKER" ]; then
 
   echo -e "\nInstalling Skypilot..."
   bash "devops/skypilot/install.sh"
+  echo -e "\nRead devops/skypilot/README.md for more information on how to set up aliases for common Skypilot commands."
 
   echo "✅ setup_dev.sh completed successfully!"
-  echo -e "Activate virtual environment with: \033[32;1msource $VENV_PATH/bin/activate\033[0m"
 fi
 
 # ========== CLEAN UP REPO ==========

--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -7,7 +7,7 @@ This script provides a convenient way to launch training jobs on AWS using SkyPi
 - AWS credentials configured with `softmax` profile
 - SkyPilot CLI installed and configured. This results in a ~/.sky/config.yaml
 
-If you have already successfully run  `metta/devops/skypilot/install.sh` or the appropriate setup_machine script for your operating system, these should be handled.
+If you have successfully run  `./devops/skypilot/install.sh` or the appropriate setup_machine script for your operating system, these should be handled.
 
 You can run this command to confirm your connectivity to the Softmax skypilot server, its health, and if you are authenticated.
 
@@ -40,7 +40,7 @@ Note that launching jobs requires a repo with pushed commits (unless using `--sk
 
 There's a [web dashboard](https://skypilot-api.softmax-research.net/) that displays the status of all clusters and jobs.
 
-To sign in, you'll need username/password credentials. You can extract these from your SkyPilot config (at `~/.sky/config.yaml` by default) with this command:
+You will be prompted for username/password credentials. These can be extracted from your Skypilot config with this command:
 
 ```bash
 grep -o 'https://[^:]*:[^@]*@' ~/.sky/config.yaml | sed 's|https://||; s|@||' | sed 's|:| |' | while read username password; do

--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -213,8 +213,6 @@ echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.zshrc
 # For fish users:
 echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.config/fish/config.fish
 
-Source the shell setup script to load all aliases:
-
 
 ### Available Aliases
 

--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -2,11 +2,18 @@
 
 This script provides a convenient way to launch training jobs on AWS using SkyPilot.
 
-## Prerequisites
+## Installation
 
 - AWS credentials configured with `softmax` profile
-- SkyPilot CLI installed and configured
-- Git repository with pushed commits (unless using `--skip-git-check`)
+- SkyPilot CLI installed and configured. This results in a ~/.sky/config.yaml
+
+If you have already successfully run  `metta/devops/skypilot/install.sh` or the appropriate setup_machine script for your operating system, these should be handled.
+
+You can run this command to confirm your connectivity to the Softmax skypilot server, its health, and if you are authenticated.
+
+```bash
+sky api info
+```
 
 ## Usage
 
@@ -27,13 +34,20 @@ For a complete list of optional parameters and their descriptions, use:
 ./devops/skypilot/launch.py --help
 ```
 
+Note that launching jobs requires a repo with pushed commits (unless using `--skip-git-check`)
+
 ## Accessing the Dashboard
 
 There's a [web dashboard](https://skypilot-api.softmax-research.net/) that displays the status of all clusters and jobs.
 
-To sign in, you'll need user/password credentials. You can obtain these by peeking into the URL in your `~/.sky/config.yaml`, or by running `sky api info`.
+To sign in, you'll need username/password credentials. You can extract these from your SkyPilot config (at `~/.sky/config.yaml` by default) with this command:
 
-Warning: if you click the URL with `https://user:password@...` pair in the terminal, it will load the dashboard, but it might show up as empty. To fix this, you'll need to open a new tab with the [dashboard](https://skypilot-api.softmax-research.net/) **without** the user:password pair.
+```bash
+grep -o 'https://[^:]*:[^@]*@' ~/.sky/config.yaml | sed 's|https://||; s|@||' | sed 's|:| |' | while read username password; do
+  echo "Username: $username"
+  echo "Password: $password"
+done
+```
 
 ## Examples
 
@@ -180,21 +194,29 @@ Jobs can have the following statuses:
 
 ## Shell Aliases
 
-To streamline your workflow, we provide convenient shell aliases for common SkyPilot operations.
+To streamline your workflow, we provide a script to set shell aliases for common SkyPilot operations. It also sets `AWS_PROFILE=softmax` automatically.
 
-### Setup
-
-Source the shell setup script to load all aliases:
-
+To add these aliases temporarily:
 ```bash
 source ./devops/skypilot/setup_shell.sh
 ```
 
-This script also sets `AWS_PROFILE=softmax` automatically.
+To add them permanently, add the source command to your shell profile:
+
+```bash
+# For bash users:
+echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.bashrc
+
+# For zsh users:
+echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.zshrc
+
+# For fish users:
+echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.config/fish/config.fish
+
+Source the shell setup script to load all aliases:
+
 
 ### Available Aliases
-
-`source ./devops/skypilot/setup_shell.sh` to configure some convenient aliases.
 
 #### Job Queue Management
 
@@ -220,20 +242,6 @@ This script also sets `AWS_PROFILE=softmax` automatically.
   lt run=my_experiment_001  # Equivalent to: ./devops/skypilot/launch.py train run=my_experiment_001
   ```
 
-### Adding to Your Shell Profile
-
-To make these aliases permanent, add the source command to your shell profile:
-
-```bash
-# For bash users:
-echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.bashrc
-
-# For zsh users:
-echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.zshrc
-
-# For fish users:
-echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.config/fish/config.fish
-```
 
 ## Sandboxes
 


### PR DESCRIPTION
- Added sky api info command to verify setup after installation
- Provided cmd to get dashboard login credentials from config file (confused me at first, and apparently was a common source of confusion)
- Grouped shell alias info for better clarity, and prompted usage of them in setup.dev
   - While I'm here, removed mention of needing to explicitly activate the created virtual env because it may not be necessary for most users
     - `uv run {x}` handles environment selection automatically
     - users that have followed the updated engineering onboarding (through Asana) will have the uv-managed python interpreter selected by now


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210633565112459)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210632432027187