### PR TITLE
Allow inventory items to be configured from outside cpp

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -8,6 +8,20 @@ game:
   num_observation_tokens: 200
   max_steps: 1000
 
+  # We could figure this out implicitly, but being explicit reduces the risk of people accidentally configuring
+  # inventory they didn't intend (e.g., "ore" instead of "ore.red").
+  inventory_item_names:
+    - ore.red
+    - ore.blue
+    - ore.green
+    - battery.red
+    - battery.blue
+    - battery.green
+    - heart
+    - armor
+    - laser
+    - blueprint
+
   diversity_bonus:
     enabled: false
     similarity_coef: 0.5 # Coefficient for within-group similarity

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -114,7 +114,8 @@
 			"bitset": "cpp",
 			"deque": "cpp",
 			"regex": "cpp",
-			"memory": "cpp"
+			"memory": "cpp",
+			"iostream": "cpp"
 		}
 	}
 }

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -33,6 +33,14 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   game_cfg["obs_height"] = 11;
   game_cfg["num_observation_tokens"] = 100;
 
+  // Inventory item names configuration
+  py::list inventory_item_names;
+  inventory_item_names.append("ore");
+  inventory_item_names.append("heart");
+  inventory_item_names.append("armor");
+  inventory_item_names.append("laser");
+  game_cfg["inventory_item_names"] = inventory_item_names;
+
   // Actions configuration
   py::dict actions_cfg;
   py::dict noop_cfg, move_cfg, rotate_cfg, attack_cfg, swap_cfg, put_cfg, get_cfg, change_color_cfg;
@@ -54,6 +62,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   actions_cfg["put_items"] = put_cfg;
   actions_cfg["get_items"] = get_cfg;
   actions_cfg["change_color"] = change_color_cfg;
+  actions_cfg["armor_item_id"] = 2;
+  actions_cfg["laser_item_id"] = 3;
 
   game_cfg["actions"] = actions_cfg;
 
@@ -61,7 +71,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   py::dict agent_groups;
   py::dict agent_group1, agent_group2;
 
-  agent_group1["default_item_max"] = 0;
   agent_group1["freeze_duration"] = 0;
   agent_group1["action_failure_penalty"] = 0;
   agent_group1["max_items_per_type"] = py::dict();
@@ -71,7 +80,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group1["group_id"] = 0;
   agent_group1["group_reward_pct"] = 0.0f;
 
-  agent_group2["default_item_max"] = 0;
   agent_group2["freeze_duration"] = 0;
   agent_group2["action_failure_penalty"] = 0;
   agent_group2["max_items_per_type"] = py::dict();

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -8,6 +8,18 @@ game:
   num_agents: 24
   num_observation_tokens: 100
 
+  inventory_item_names:
+    - ore.red
+    - ore.blue
+    - ore.green
+    - battery.red
+    - battery.blue
+    - battery.green
+    - heart
+    - armor
+    - laser
+    - blueprint
+
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
     num_rooms: 4

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -5,6 +5,19 @@ desync_episodes: false
 
 game:
   num_observation_tokens: 100
+
+  inventory_item_names:
+    - ore.red
+    - ore.blue
+    - ore.green
+    - battery.red
+    - battery.blue
+    - battery.green
+    - heart
+    - armor
+    - laser
+    - blueprint
+
   map_builder:
     _target_: metta.mettagrid.room.random.Random
     width: 25

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -13,8 +13,11 @@
 
 class Attack : public ActionHandler {
 public:
-  explicit Attack(const ActionConfig& cfg, const std::string& action_name = "attack")
-      : ActionHandler(cfg, action_name) {
+  explicit Attack(const ActionConfig& cfg,
+                  InventoryItem laser_item_id,
+                  InventoryItem armor_item_id,
+                  const std::string& action_name = "attack")
+      : ActionHandler(cfg, action_name), _laser_item_id(laser_item_id), _armor_item_id(armor_item_id) {
     priority = 1;
   }
 
@@ -23,12 +26,15 @@ public:
   }
 
 protected:
+  InventoryItem _laser_item_id;
+  InventoryItem _armor_item_id;
+
   bool _handle_action(Agent* actor, ActionArg arg) override {
     if (arg > 9 || arg < 1) {
       return false;
     }
 
-    if (actor->update_inventory(InventoryItem::laser, -1) == 0) {
+    if (actor->update_inventory(_laser_item_id, -1) == 0) {
       return false;
     }
 
@@ -62,7 +68,7 @@ protected:
 
       was_frozen = agent_target->frozen > 0;
 
-      if (agent_target->update_inventory(InventoryItem::armor, -1)) {
+      if (agent_target->update_inventory(_armor_item_id, -1)) {
         actor->stats.incr("attack.blocked." + agent_target->group_name);
         actor->stats.incr("attack.blocked." + agent_target->group_name + "." + actor->group_name);
       } else {

--- a/mettagrid/src/metta/mettagrid/actions/attack_nearest.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack_nearest.hpp
@@ -10,7 +10,8 @@
 
 class AttackNearest : public Attack {
 public:
-  explicit AttackNearest(const ActionConfig& cfg) : Attack(cfg, "attack_nearest") {}
+  explicit AttackNearest(const ActionConfig& cfg, InventoryItem laser_item_id, InventoryItem armor_item_id)
+      : Attack(cfg, laser_item_id, armor_item_id, "attack_nearest") {}
 
   unsigned char max_arg() const override {
     return 0;
@@ -18,7 +19,7 @@ public:
 
 protected:
   bool _handle_action(Agent* actor, ActionArg arg) override {
-    if (actor->update_inventory(InventoryItem::laser, -1) == 0) {
+    if (actor->update_inventory(_laser_item_id, -1) == 0) {
       return false;
     }
 

--- a/mettagrid/src/metta/mettagrid/grid_object.hpp
+++ b/mettagrid/src/metta/mettagrid/grid_object.hpp
@@ -12,6 +12,7 @@ typedef unsigned short Layer;
 typedef uint8_t TypeId;
 typedef unsigned int GridCoord;
 using ObsType = uint8_t;
+using InventoryItem = uint8_t;
 
 // These may make more sense in observation_encoder.hpp, but we need to include that
 // header in a lot of places, and it's nice to have these types defined in one place.

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -26,6 +26,7 @@ class ActionHandler;
 class Agent;
 class ObservationEncoder;
 class GridObject;
+class ConverterConfig;
 
 namespace py = pybind11;
 
@@ -71,6 +72,7 @@ public:
 
 private:
   // Member variables
+  std::vector<std::string> _inventory_item_names;
   std::map<unsigned int, float> _group_reward_pct;
   std::map<unsigned int, unsigned int> _group_sizes;
   std::unique_ptr<Grid> _grid;
@@ -116,6 +118,7 @@ private:
   void _step(py::array_t<ActionType, py::array::c_style> actions);
 
   void _handle_invalid_action(size_t agent_idx, const std::string& stat, ActionType type, ActionArg arg);
+  ConverterConfig _create_converter_config(const py::dict& converter_cfg_py);
 };
 
 #endif  // METTAGRID_C_HPP_

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,13 +1,14 @@
 import copy
 from typing import Annotated, Any, Dict, List, Optional
 
-from pydantic import AfterValidator, BaseModel, Field, RootModel
+from pydantic import AfterValidator, BaseModel, Field, RootModel, conint
 
 from metta.mettagrid.mettagrid_config import ConverterConfig as ConverterConfig_py
 from metta.mettagrid.mettagrid_config import GameConfig as GameConfig_py
 from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
 
-Byte = Annotated[int, AfterValidator(lambda v: 0 <= v <= 255)]
+
+Byte = conint(ge=0, le=255)
 FeatureId = Byte
 
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,9 +1,14 @@
 import copy
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import AfterValidator, BaseModel, Field, RootModel
 
+from metta.mettagrid.mettagrid_config import ConverterConfig as ConverterConfig_py
 from metta.mettagrid.mettagrid_config import GameConfig as GameConfig_py
+from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
+
+Byte = Annotated[int, AfterValidator(lambda v: 0 <= v <= 255)]
+FeatureId = Byte
 
 
 class BaseModelWithForbidExtra(BaseModel):
@@ -13,12 +18,11 @@ class BaseModelWithForbidExtra(BaseModel):
 class AgentGroupConfig_cpp(BaseModelWithForbidExtra):
     """Agent group configuration."""
 
-    default_item_max: int = Field(ge=0)
     freeze_duration: int = Field(ge=0)
     action_failure_penalty: float = Field(default=0, ge=0)
-    max_items_per_type: Dict[str, int] = Field(default_factory=dict)
-    resource_rewards: Dict[str, float] = Field(default_factory=dict)
-    resource_reward_max: Dict[str, float] = Field(default_factory=dict)
+    max_items_per_type: Dict[FeatureId, int] = Field(default_factory=dict)
+    resource_rewards: Dict[FeatureId, float] = Field(default_factory=dict)
+    resource_reward_max: Dict[FeatureId, float] = Field(default_factory=dict)
     group_name: str
     group_id: int
     group_reward_pct: float = Field(ge=0, le=1)
@@ -41,6 +45,8 @@ class ActionsConfig_cpp(BaseModelWithForbidExtra):
     attack: ActionConfig_cpp
     swap: ActionConfig_cpp
     change_color: ActionConfig_cpp
+    laser_item_id: FeatureId
+    armor_item_id: FeatureId
 
 
 class WallConfig_cpp(BaseModelWithForbidExtra):
@@ -52,36 +58,13 @@ class WallConfig_cpp(BaseModelWithForbidExtra):
 class ConverterConfig_cpp(BaseModelWithForbidExtra):
     """Converter configuration for objects that convert items."""
 
-    # Input items (e.g., "input_ore.red": 3)
-    input_ore_red: Optional[int] = Field(default=None, alias="input_ore.red", ge=0, le=255)
-    input_ore_blue: Optional[int] = Field(default=None, alias="input_ore.blue", ge=0, le=255)
-    input_ore_green: Optional[int] = Field(default=None, alias="input_ore.green", ge=0, le=255)
-    input_battery_red: Optional[int] = Field(default=None, alias="input_battery.red", ge=0, le=255)
-    input_battery_blue: Optional[int] = Field(default=None, alias="input_battery.blue", ge=0, le=255)
-    input_battery_green: Optional[int] = Field(default=None, alias="input_battery.green", ge=0, le=255)
-    input_heart: Optional[int] = Field(default=None, alias="input_heart", ge=0, le=255)
-    input_armor: Optional[int] = Field(default=None, alias="input_armor", ge=0, le=255)
-    input_laser: Optional[int] = Field(default=None, alias="input_laser", ge=0, le=255)
-    input_blueprint: Optional[int] = Field(default=None, alias="input_blueprint", ge=0, le=255)
-
-    # Output items (e.g., "output_ore.red": 1)
-    output_ore_red: Optional[int] = Field(default=None, alias="output_ore.red", ge=0, le=255)
-    output_ore_blue: Optional[int] = Field(default=None, alias="output_ore.blue", ge=0, le=255)
-    output_ore_green: Optional[int] = Field(default=None, alias="output_ore.green", ge=0, le=255)
-    output_battery_red: Optional[int] = Field(default=None, alias="output_battery.red", ge=0, le=255)
-    output_battery_blue: Optional[int] = Field(default=None, alias="output_battery.blue", ge=0, le=255)
-    output_battery_green: Optional[int] = Field(default=None, alias="output_battery.green", ge=0, le=255)
-    output_heart: Optional[int] = Field(default=None, alias="output_heart", ge=0, le=255)
-    output_armor: Optional[int] = Field(default=None, alias="output_armor", ge=0, le=255)
-    output_laser: Optional[int] = Field(default=None, alias="output_laser", ge=0, le=255)
-    output_blueprint: Optional[int] = Field(default=None, alias="output_blueprint", ge=0, le=255)
-
-    # Converter properties
+    recipe_input: Dict[FeatureId, int] = Field(default_factory=dict)
+    recipe_output: Dict[FeatureId, int] = Field(default_factory=dict)
     max_output: int = Field(ge=-1)
     conversion_ticks: int = Field(ge=0)
     cooldown: int = Field(ge=0)
     initial_items: int = Field(ge=0)
-    color: Optional[int] = Field(default=None, ge=0, le=255)
+    color: Byte = Field(default=0)
 
 
 class ObjectsConfig_cpp(BaseModelWithForbidExtra):
@@ -118,6 +101,7 @@ class RewardSharingConfig_cpp(BaseModelWithForbidExtra):
 class GameConfig_cpp(BaseModelWithForbidExtra):
     """Game configuration."""
 
+    inventory_item_names: List[str]
     num_agents: int = Field(ge=1)
     max_steps: int = Field(ge=0)
     obs_width: int = Field(ge=1)
@@ -131,6 +115,9 @@ class GameConfig_cpp(BaseModelWithForbidExtra):
 
 def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
     """Convert a mettagrid_config.GameConfig to a mettagrid_c_config.GameConfig."""
+
+    inventory_item_names = list(mettagrid_config.inventory_item_names)
+    inventory_item_ids = dict((name, i) for i, name in enumerate(inventory_item_names))
 
     agent_group_configs = {}
 
@@ -149,20 +136,26 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
             else:
                 merged_config[key] = value
 
+        default_item_max = merged_config.get("default_item_max", 0)
+
         agent_group_config = {
-            "default_item_max": merged_config.get("default_item_max", 0),
             "freeze_duration": merged_config.get("freeze_duration", 0),
             "group_id": group_config.id,
             "group_name": group_name,
             "action_failure_penalty": merged_config.get("rewards", {}).get("action_failure_penalty", 0),
             "max_items_per_type": dict(
-                (k[:-4], v) for k, v in merged_config.items() if k.endswith("_max") and k != "default_item_max"
+                (item_id, merged_config.get(item_name + "_max", default_item_max))
+                for (item_id, item_name) in enumerate(inventory_item_names)
             ),
             "resource_rewards": dict(
-                (k, v) for k, v in merged_config.get("rewards", {}).items() if not k.endswith("_max")
+                (inventory_item_ids[k], v)
+                for k, v in merged_config.get("rewards", {}).items()
+                if not k.endswith("_max") and k != "action_failure_penalty"
             ),
             "resource_reward_max": dict(
-                (k[:-4], v) for k, v in merged_config.get("rewards", {}).items() if k.endswith("_max")
+                (inventory_item_ids[k[:-4]], v)
+                for k, v in merged_config.get("rewards", {}).items()
+                if k.endswith("_max")
             ),
             "group_reward_pct": group_config.group_reward_pct or 0,
         }
@@ -174,10 +167,35 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
 
         agent_group_configs["agent." + group_name] = AgentGroupConfig_cpp(**agent_group_config)
 
+    object_configs = {}
+    for object_type, object_config in mettagrid_config.objects.items():
+        if isinstance(object_config, ConverterConfig_py):
+            converter_config_dict = object_config.model_dump(by_alias=True, exclude_unset=True)
+            converter_config_cpp_dict = {
+                "recipe_input": {},
+                "recipe_output": {},
+            }
+            for k, v in converter_config_dict.items():
+                if k.startswith("input_"):
+                    converter_config_cpp_dict["recipe_input"][inventory_item_ids[k[6:]]] = v
+                elif k.startswith("output_"):
+                    converter_config_cpp_dict["recipe_output"][inventory_item_ids[k[7:]]] = v
+                else:
+                    converter_config_cpp_dict[k] = v
+            object_configs[object_type] = ConverterConfig_cpp(**converter_config_cpp_dict)
+        elif isinstance(object_config, WallConfig_py):
+            object_configs[object_type] = WallConfig_cpp(**object_config.model_dump(by_alias=True, exclude_unset=True))
+        else:
+            raise ValueError(f"Unknown object type: {object_type}")
+
     game_config = mettagrid_config.model_dump(by_alias=True, exclude_none=True)
     game_config["agent_groups"] = agent_group_configs
     del game_config["agent"]
     del game_config["groups"]
+    game_config["objects"] = object_configs
+    # TODO: make this configurable at a higher level
+    game_config["actions"]["laser_item_id"] = inventory_item_ids["laser"]
+    game_config["actions"]["armor_item_id"] = inventory_item_ids["armor"]
 
     return GameConfig_cpp(**game_config)
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -128,25 +128,6 @@ class ConverterConfig(BaseModelWithForbidExtra):
     color: Optional[int] = Field(default=None, ge=0, le=255)
 
 
-class ObjectsConfig(BaseModelWithForbidExtra):
-    """Objects configuration."""
-
-    altar: Optional[ConverterConfig] = None
-    mine_red: Optional[ConverterConfig] = None
-    mine_blue: Optional[ConverterConfig] = None
-    mine_green: Optional[ConverterConfig] = None
-    generator_red: Optional[ConverterConfig] = None
-    generator_blue: Optional[ConverterConfig] = None
-    generator_green: Optional[ConverterConfig] = None
-    armory: Optional[ConverterConfig] = None
-    lasery: Optional[ConverterConfig] = None
-    lab: Optional[ConverterConfig] = None
-    factory: Optional[ConverterConfig] = None
-    temple: Optional[ConverterConfig] = None
-    wall: Optional[WallConfig] = None
-    block: Optional[WallConfig] = None
-
-
 class RewardSharingGroup(RootModel[Dict[str, float]]):
     """Reward sharing configuration for a group."""
 
@@ -162,6 +143,7 @@ class RewardSharingConfig(BaseModelWithForbidExtra):
 class GameConfig(BaseModelWithForbidExtra):
     """Game configuration."""
 
+    inventory_item_names: List[str]
     num_agents: int = Field(ge=1)
     # zero means "no limit"
     max_steps: int = Field(ge=0)
@@ -172,5 +154,5 @@ class GameConfig(BaseModelWithForbidExtra):
     # Every agent must be in a group, so we need at least one group
     groups: Dict[str, GroupConfig] = Field(min_length=1)
     actions: ActionsConfig
-    objects: ObjectsConfig
+    objects: Dict[str, ConverterConfig | WallConfig]
     reward_sharing: Optional[RewardSharingConfig] = None

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -32,16 +32,18 @@ public:
 
   Agent(GridCoord r,
         GridCoord c,
-        unsigned char default_item_max,
         unsigned char freeze_duration,
         float action_failure_penalty,
-        std::map<std::string, unsigned int> max_items_per_type_,
-        std::map<std::string, float> resource_rewards_,
-        std::map<std::string, float> resource_reward_max_,
+        std::map<ObsType, uint8_t> max_items_per_type,
+        std::map<ObsType, float> resource_rewards,
+        std::map<ObsType, float> resource_reward_max,
         std::string group_name,
         unsigned char group_id)
       : freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
+        max_items_per_type(max_items_per_type),
+        resource_rewards(resource_rewards),
+        resource_reward_max(resource_reward_max),
         group(group_id),
         group_name(group_name),
         color(0),
@@ -50,24 +52,6 @@ public:
 
     this->frozen = 0;
     this->orientation = 0;
-
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (max_items_per_type_.count(InventoryItemNames[i]) > 0) {
-        this->max_items_per_type[static_cast<InventoryItem>(i)] = max_items_per_type_[InventoryItemNames[i]];
-      } else {
-        this->max_items_per_type[static_cast<InventoryItem>(i)] = default_item_max;
-      }
-    }
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (resource_rewards_.count(InventoryItemNames[i]) > 0) {
-        this->resource_rewards[static_cast<InventoryItem>(i)] = resource_rewards_[InventoryItemNames[i]];
-      }
-    }
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (resource_reward_max_.count(InventoryItemNames[i]) > 0) {
-        this->resource_reward_max[static_cast<InventoryItem>(i)] = resource_reward_max_[InventoryItemNames[i]];
-      }
-    }
     this->reward = nullptr;
   }
 

--- a/mettagrid/src/metta/mettagrid/objects/constants.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/constants.hpp
@@ -79,58 +79,34 @@ constexpr std::array<const char*, ObjectTypeCount> ObjectTypeNamesArray = {
 
 const std::vector<std::string> ObjectTypeNames(ObjectTypeNamesArray.begin(), ObjectTypeNamesArray.end());
 
-enum InventoryItem {
-  // These are "ore.red", etc everywhere else. They're differently named here because
-  // of enum naming limitations.
-  ore_red = 0,
-  ore_blue = 1,
-  ore_green = 2,
-  battery_red = 3,
-  battery_blue = 4,
-  battery_green = 5,
-  heart = 6,
-  armor = 7,
-  laser = 8,
-  blueprint = 9,
-  InventoryItemCount
-};
-
-constexpr std::array<const char*, InventoryItemCount> InventoryItemNamesArray = {{"ore.red",
-                                                                                  "ore.blue",
-                                                                                  "ore.green",
-                                                                                  "battery.red",
-                                                                                  "battery.blue",
-                                                                                  "battery.green",
-                                                                                  "heart",
-                                                                                  "armor",
-                                                                                  "laser",
-                                                                                  "blueprint"}};
+// TODO: We now have this available in the config, so we should use that instead. We haven't done this yet
+// because we need to pass through the configuration. For now, this means things are unstable.
+constexpr std::array<const char*, 10> InventoryItemNamesArray = {{"ore.red",
+                                                                  "ore.blue",
+                                                                  "ore.green",
+                                                                  "battery.red",
+                                                                  "battery.blue",
+                                                                  "battery.green",
+                                                                  "heart",
+                                                                  "armor",
+                                                                  "laser",
+                                                                  "blueprint"}};
 
 const std::vector<std::string> InventoryItemNames(InventoryItemNamesArray.begin(), InventoryItemNamesArray.end());
 
-constexpr std::array<const char*, ObservationFeature::ObservationFeatureCount> ObservationFeatureNamesArray = {
-    {"type_id",
-     "agent:group",
-     "hp",
-     "agent:frozen",
-     "agent:orientation",
-     "agent:color",
-     "converting",
-     "swappable",
-     "episode_completion_pct",
-     "last_action",
-     "last_action_arg",
-     "last_reward"}};
-
-const std::vector<std::string> ObservationFeatureNames = []() {
-  std::vector<std::string> names;
-  names.reserve(ObservationFeatureNamesArray.size() + InventoryItemNamesArray.size());
-  names.insert(names.end(), ObservationFeatureNamesArray.begin(), ObservationFeatureNamesArray.end());
-  for (const auto& name : InventoryItemNames) {
-    names.push_back("inv:" + name);
-  }
-  return names;
-}();
+const std::map<uint8_t, std::string> FeatureNames = {
+    {ObservationFeature::TypeId, "type_id"},
+    {ObservationFeature::Group, "agent:group"},
+    {ObservationFeature::Hp, "hp"},
+    {ObservationFeature::Frozen, "agent:frozen"},
+    {ObservationFeature::Orientation, "agent:orientation"},
+    {ObservationFeature::Color, "agent:color"},
+    {ObservationFeature::ConvertingOrCoolingDown, "converting"},
+    {ObservationFeature::Swappable, "swappable"},
+    {ObservationFeature::EpisodeCompletionPct, "episode_completion_pct"},
+    {ObservationFeature::LastAction, "last_action"},
+    {ObservationFeature::LastActionArg, "last_action_arg"},
+    {ObservationFeature::LastReward, "last_reward"}};
 
 // ##ObservationNormalization
 // These are approximate maximum values for each feature. Ideally they would be defined closer to their source,
@@ -149,19 +125,10 @@ const std::map<uint8_t, float> FeatureNormalizations = {
     {ObservationFeature::Color, 255.0},
     {ObservationFeature::ConvertingOrCoolingDown, 1.0},
     {ObservationFeature::Swappable, 1.0},
-    {InventoryFeatureOffset + InventoryItem::ore_red, 100.0},
-    {InventoryFeatureOffset + InventoryItem::ore_blue, 100.0},
-    {InventoryFeatureOffset + InventoryItem::ore_green, 100.0},
-    {InventoryFeatureOffset + InventoryItem::battery_red, 100.0},
-    {InventoryFeatureOffset + InventoryItem::battery_blue, 100.0},
-    {InventoryFeatureOffset + InventoryItem::battery_green, 100.0},
-    {InventoryFeatureOffset + InventoryItem::heart, 100.0},
-    {InventoryFeatureOffset + InventoryItem::laser, 100.0},
-    {InventoryFeatureOffset + InventoryItem::armor, 100.0},
-    {InventoryFeatureOffset + InventoryItem::blueprint, 100.0},
 };
 
 const float DEFAULT_NORMALIZATION = 1.0;
+const float DEFAULT_INVENTORY_NORMALIZATION = 100.0;
 
 const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},
                                                   {ObjectType::WallT, GridLayer::Object_Layer},

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -13,6 +13,16 @@
 #include "has_inventory.hpp"
 #include "metta_object.hpp"
 
+struct ConverterConfig {
+  std::map<ObsType, uint8_t> recipe_input;
+  std::map<ObsType, uint8_t> recipe_output;
+  short max_output;
+  unsigned short conversion_ticks;
+  unsigned short cooldown;
+  unsigned char initial_items;
+  ObsType color;
+};
+
 class Converter : public HasInventory {
 private:
   // This should be called any time the converter could start converting. E.g.,
@@ -77,43 +87,30 @@ public:
   // is to make Mines (etc) have a maximum output.
   // -1 means no limit
   short max_output;
-  unsigned char conversion_ticks;  // Time to produce output
-  unsigned char cooldown;          // Time to wait after producing before starting again
-  bool converting;                 // Currently in production phase
-  bool cooling_down;               // Currently in cooldown phase
+  unsigned short conversion_ticks;  // Time to produce output
+  unsigned short cooldown;          // Time to wait after producing before starting again
+  bool converting;                  // Currently in production phase
+  bool cooling_down;                // Currently in cooldown phase
   unsigned char color;
   EventManager* event_manager;
   StatsTracker stats;
 
-  Converter(GridCoord r, GridCoord c, ObjectConfig cfg, TypeId type_id) {
+  Converter(GridCoord r, GridCoord c, ConverterConfig cfg, TypeId type_id)
+      : recipe_input(cfg.recipe_input),
+        recipe_output(cfg.recipe_output),
+        max_output(cfg.max_output),
+        conversion_ticks(cfg.conversion_ticks),
+        cooldown(cfg.cooldown),
+        color(cfg.color) {
     GridObject::init(type_id, GridLocation(r, c, GridLayer::Object_Layer));
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (cfg.count("input_" + InventoryItemNames[i])) {
-        this->recipe_input.insert({static_cast<InventoryItem>(i), cfg["input_" + InventoryItemNames[i]]});
-      }
-      if (cfg.count("output_" + InventoryItemNames[i])) {
-        this->recipe_output.insert({static_cast<InventoryItem>(i), cfg["output_" + InventoryItemNames[i]]});
-      }
-    }
-    this->max_output = cfg["max_output"];
-    this->conversion_ticks = cfg["conversion_ticks"];
-    this->cooldown = cfg["cooldown"];
-    this->color = cfg.count("color") ? cfg["color"] : 0;
     this->converting = false;
     this->cooling_down = false;
 
     // Initialize inventory with initial_items for all output types
-    // Default to recipe_output values if initial_items is not present
-    unsigned char initial_items = cfg["initial_items"];
-    for (unsigned int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      if (this->recipe_output.count(static_cast<InventoryItem>(i)) > 0 &&
-          this->recipe_output[static_cast<InventoryItem>(i)] > 0) {
-        HasInventory::update_inventory(static_cast<InventoryItem>(i), initial_items);
-      }
+    for (const auto& [item, _] : this->recipe_output) {
+      HasInventory::update_inventory(item, cfg.initial_items);
     }
   }
-
-  Converter(GridCoord r, GridCoord c, ObjectConfig cfg) : Converter(r, c, cfg, ObjectType::GenericConverterT) {}
 
   void set_event_manager(EventManager* event_manager) {
     this->event_manager = event_manager;

--- a/mettagrid/src/metta/mettagrid/observation_encoder.hpp
+++ b/mettagrid/src/metta/mettagrid/observation_encoder.hpp
@@ -14,13 +14,15 @@
 
 class ObservationEncoder {
 public:
-  ObservationEncoder() {
+  explicit ObservationEncoder(const std::vector<std::string>& inventory_item_names) {
     _feature_normalizations = FeatureNormalizations;
-    for (int i = 0; i < ObservationFeature::ObservationFeatureCount; i++) {
-      _feature_normalizations.insert({i, DEFAULT_NORMALIZATION});
-    }
-    for (int i = 0; i < InventoryItem::InventoryItemCount; i++) {
-      _feature_normalizations.insert({static_cast<uint8_t>(InventoryFeatureOffset + i), DEFAULT_NORMALIZATION});
+    _feature_names = FeatureNames;
+    assert(_feature_names.size() == InventoryFeatureOffset);
+    assert(_feature_names.size() == _feature_normalizations.size());
+    for (int i = 0; i < inventory_item_names.size(); i++) {
+      _feature_normalizations.insert(
+          {static_cast<uint8_t>(InventoryFeatureOffset + i), DEFAULT_INVENTORY_NORMALIZATION});
+      _feature_names.insert({static_cast<uint8_t>(InventoryFeatureOffset + i), "inv:" + inventory_item_names[i]});
     }
   }
 
@@ -46,8 +48,13 @@ public:
     return _feature_normalizations;
   }
 
+  const std::map<uint8_t, std::string>& feature_names() const {
+    return _feature_names;
+  }
+
 private:
   std::map<uint8_t, float> _feature_normalizations;
+  std::map<uint8_t, std::string> _feature_names;
 };
 
 #endif  // OBSERVATION_ENCODER_HPP_

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -7,6 +7,18 @@
     "obs_width": 11,
     "obs_height": 11,
     "max_steps": 1000,
+    "inventory_items": [
+      "ore.red",
+      "ore.blue",
+      "ore.green",
+      "battery.red",
+      "battery.blue",
+      "battery.green",
+      "heart",
+      "armor",
+      "laser",
+      "blueprint"
+    ],
     "agent": {
       "default_item_max": 50,
       "freeze_duration": 10,

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -30,6 +30,7 @@ def base_config():
         "obs_width": OBS_WIDTH,
         "obs_height": OBS_HEIGHT,
         "num_observation_tokens": NUM_OBS_TOKENS,
+        "inventory_item_names": ["laser", "armor"],
         "actions": {
             "noop": {"enabled": True},
             "move": {"enabled": True},
@@ -88,6 +89,8 @@ def configured_env(base_config):
         game_config = base_config.copy()
         if config_overrides:
             game_config.update(config_overrides)
+
+        print(cpp_config_dict(game_config))
 
         env = MettaGrid(cpp_config_dict(game_config), game_map)
 

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -46,6 +46,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
         "obs_width": OBS_WIDTH,
         "obs_height": OBS_HEIGHT,
         "num_observation_tokens": NUM_OBS_TOKENS,
+        "inventory_item_names": ["laser", "armor"],
         "actions": {
             # don't really care about the actions for this test
             "noop": {"enabled": True},

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -10,6 +10,15 @@
 #include "objects/converter.hpp"
 #include "objects/wall.hpp"
 
+// Test-specific inventory item type constants
+// These don't need to correspond to InventoryItemNamesArray as that may be changing
+namespace TestItems {
+constexpr uint8_t ORE = 0;
+constexpr uint8_t LASER = 1;
+constexpr uint8_t ARMOR = 2;
+constexpr uint8_t HEART = 3;
+}  // namespace TestItems
+
 // Pure C++ tests without any Python/pybind dependencies - we will test those with pytest
 class MettaGridCppTest : public ::testing::Test {
 protected:
@@ -18,44 +27,32 @@ protected:
   void TearDown() override {}
 
   // Helper function to create test max_items_per_type map
-  std::map<std::string, unsigned int> create_test_max_items_per_type() {
-    std::map<std::string, unsigned int> max_items_per_type;
-    max_items_per_type["heart"] = 50;
-    max_items_per_type["ore.red"] = 50;
-    max_items_per_type["ore.green"] = 50;
-    max_items_per_type["ore.blue"] = 50;
-    max_items_per_type["battery.red"] = 50;
-    max_items_per_type["battery.green"] = 50;
-    max_items_per_type["battery.blue"] = 50;
-    max_items_per_type["laser"] = 50;
+  std::map<uint8_t, uint8_t> create_test_max_items_per_type() {
+    std::map<uint8_t, uint8_t> max_items_per_type;
+    max_items_per_type[TestItems::ORE] = 50;
+    max_items_per_type[TestItems::LASER] = 50;
+    max_items_per_type[TestItems::ARMOR] = 50;
+    max_items_per_type[TestItems::HEART] = 50;
     return max_items_per_type;
   }
 
   // Helper function to create test rewards map
-  std::map<std::string, float> create_test_rewards() {
-    std::map<std::string, float> rewards;
-    rewards["heart"] = 1.0f;
-    rewards["ore.red"] = 0.125f;
-    rewards["ore.green"] = 0.5f;
-    rewards["ore.blue"] = 0.0f;
-    rewards["battery.red"] = 0.0f;
-    rewards["battery.green"] = 0.0f;
-    rewards["battery.blue"] = 0.0f;
-    rewards["laser"] = 0.0f;
+  std::map<uint8_t, float> create_test_rewards() {
+    std::map<uint8_t, float> rewards;
+    rewards[TestItems::ORE] = 0.125f;
+    rewards[TestItems::LASER] = 0.0f;
+    rewards[TestItems::ARMOR] = 0.0f;
+    rewards[TestItems::HEART] = 1.0f;
     return rewards;
   }
 
   // Helper function to create test resource_reward_max map
-  std::map<std::string, float> create_test_resource_reward_max() {
-    std::map<std::string, float> resource_reward_max;
-    resource_reward_max["heart"] = 10.0f;
-    resource_reward_max["ore.red"] = 10.0f;
-    resource_reward_max["ore.green"] = 10.0f;
-    resource_reward_max["ore.blue"] = 10.0f;
-    resource_reward_max["battery.red"] = 10.0f;
-    resource_reward_max["battery.green"] = 10.0f;
-    resource_reward_max["battery.blue"] = 10.0f;
-    resource_reward_max["laser"] = 10.0f;
+  std::map<uint8_t, float> create_test_resource_reward_max() {
+    std::map<uint8_t, float> resource_reward_max;
+    resource_reward_max[TestItems::ORE] = 10.0f;
+    resource_reward_max[TestItems::LASER] = 10.0f;
+    resource_reward_max[TestItems::ARMOR] = 10.0f;
+    resource_reward_max[TestItems::HEART] = 10.0f;
     return resource_reward_max;
   }
 };
@@ -68,12 +65,13 @@ TEST_F(MettaGridCppTest, AgentRewards) {
   auto resource_reward_max = create_test_resource_reward_max();
 
   std::unique_ptr<Agent> agent(
-      new Agent(0, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
+      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
 
   // Test reward values
-  EXPECT_FLOAT_EQ(agent->resource_rewards[InventoryItem::heart], 1.0f);
-  EXPECT_FLOAT_EQ(agent->resource_rewards[InventoryItem::ore_red], 0.125f);
-  EXPECT_FLOAT_EQ(agent->resource_rewards[InventoryItem::ore_green], 0.5f);
+  EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ORE], 0.125f);
+  EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::LASER], 0.0f);
+  EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ARMOR], 0.0f);
+  EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::HEART], 1.0f);
 }
 
 TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
@@ -82,32 +80,32 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   auto resource_reward_max = create_test_resource_reward_max();
 
   std::unique_ptr<Agent> agent(
-      new Agent(0, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
+      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
 
   float dummy_reward = 0.0f;
   agent->init(&dummy_reward);
 
   // Test adding items
-  int delta = agent->update_inventory(InventoryItem::heart, 5);
+  int delta = agent->update_inventory(TestItems::ORE, 5);
   EXPECT_EQ(delta, 5);
-  EXPECT_EQ(agent->inventory[InventoryItem::heart], 5);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 5);
 
   // Test removing items
-  delta = agent->update_inventory(InventoryItem::heart, -2);
+  delta = agent->update_inventory(TestItems::ORE, -2);
   EXPECT_EQ(delta, -2);
-  EXPECT_EQ(agent->inventory[InventoryItem::heart], 3);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 3);
 
   // Test hitting zero
-  delta = agent->update_inventory(InventoryItem::heart, -10);
+  delta = agent->update_inventory(TestItems::ORE, -10);
   EXPECT_EQ(delta, -3);  // Should only remove what's available
   // check that the item is not in the inventory
-  EXPECT_EQ(agent->inventory.find(InventoryItem::heart), agent->inventory.end());
+  EXPECT_EQ(agent->inventory.find(TestItems::ORE), agent->inventory.end());
 
   // Test hitting max_items_per_type limit
-  agent->update_inventory(InventoryItem::heart, 30);
-  delta = agent->update_inventory(InventoryItem::heart, 50);  // max_items_per_type is 50
-  EXPECT_EQ(delta, 20);                                       // Should only add up to max_items_per_type
-  EXPECT_EQ(agent->inventory[InventoryItem::heart], 50);
+  agent->update_inventory(TestItems::ORE, 30);
+  delta = agent->update_inventory(TestItems::ORE, 50);  // max_items_per_type is 50
+  EXPECT_EQ(delta, 20);                                 // Should only add up to max_items_per_type
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 50);
 }
 
 // ==================== Grid Tests ====================
@@ -137,7 +135,7 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
-  Agent* agent = new Agent(2, 3, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1);
+  Agent* agent = new Agent(2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1);
 
   grid.add_object(agent);
 
@@ -169,8 +167,8 @@ TEST_F(MettaGridCppTest, AttackAction) {
   auto resource_reward_max = create_test_resource_reward_max();
 
   // Create attacker and target
-  Agent* attacker = new Agent(2, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
-  Agent* target = new Agent(0, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2);
+  Agent* attacker = new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
+  Agent* target = new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2);
 
   float attacker_reward = 0.0f;
   float target_reward = 0.0f;
@@ -181,21 +179,21 @@ TEST_F(MettaGridCppTest, AttackAction) {
   grid.add_object(target);
 
   // Give attacker a laser
-  attacker->update_inventory(InventoryItem::laser, 1);
-  EXPECT_EQ(attacker->inventory[InventoryItem::laser], 1);
+  attacker->update_inventory(TestItems::LASER, 1);
+  EXPECT_EQ(attacker->inventory[TestItems::LASER], 1);
 
   // Give target some items
-  target->update_inventory(InventoryItem::heart, 2);
-  target->update_inventory(InventoryItem::battery_red, 3);
-  EXPECT_EQ(target->inventory[InventoryItem::heart], 2);
-  EXPECT_EQ(target->inventory[InventoryItem::battery_red], 3);
+  target->update_inventory(TestItems::ORE, 2);
+  target->update_inventory(TestItems::ARMOR, 3);
+  EXPECT_EQ(target->inventory[TestItems::ORE], 2);
+  EXPECT_EQ(target->inventory[TestItems::ARMOR], 3);
 
   // Verify attacker orientation
   EXPECT_EQ(attacker->orientation, Orientation::Up);
 
   // Create attack action handler
   ActionConfig attack_cfg;
-  Attack attack(attack_cfg);
+  Attack attack(attack_cfg, TestItems::LASER, TestItems::ARMOR);
   attack.init(&grid);
 
   // Perform attack (arg 5 targets directly in front)
@@ -203,16 +201,16 @@ TEST_F(MettaGridCppTest, AttackAction) {
   EXPECT_TRUE(success);
 
   // Verify laser was consumed
-  EXPECT_EQ(attacker->inventory[InventoryItem::laser], 0);
+  EXPECT_EQ(attacker->inventory[TestItems::LASER], 0);
 
   // Verify target was frozen
   EXPECT_GT(target->frozen, 0);
 
   // Verify target's inventory was stolen
-  EXPECT_EQ(target->inventory[InventoryItem::heart], 0);
-  EXPECT_EQ(target->inventory[InventoryItem::battery_red], 0);
-  EXPECT_EQ(attacker->inventory[InventoryItem::heart], 2);
-  EXPECT_EQ(attacker->inventory[InventoryItem::battery_red], 3);
+  EXPECT_EQ(target->inventory[TestItems::ORE], 0);
+  EXPECT_EQ(target->inventory[TestItems::ARMOR], 0);
+  EXPECT_EQ(attacker->inventory[TestItems::ORE], 2);
+  EXPECT_EQ(attacker->inventory[TestItems::ARMOR], 3);
 }
 
 TEST_F(MettaGridCppTest, PutRecipeItems) {
@@ -227,21 +225,22 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
 
-  Agent* agent = new Agent(1, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
+  Agent* agent = new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
   grid.add_object(agent);
 
   // Create a generator that takes red ore and outputs batteries
-  ObjectConfig generator_cfg;
-  generator_cfg["input_ore.red"] = 1;
-  generator_cfg["output_battery.red"] = 1;
+  ConverterConfig generator_cfg;
+  generator_cfg.recipe_input[TestItems::ORE] = 1;
+  generator_cfg.recipe_output[TestItems::ARMOR] = 1;
   // Set the max_output to 0 so it won't consume things we put in it.
-  generator_cfg["max_output"] = 0;
-  generator_cfg["conversion_ticks"] = 1;
-  generator_cfg["cooldown"] = 10;
-  generator_cfg["initial_items"] = 0;
+  generator_cfg.max_output = 0;
+  generator_cfg.conversion_ticks = 1;
+  generator_cfg.cooldown = 10;
+  generator_cfg.initial_items = 0;
+  generator_cfg.color = 0;
 
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorT);
@@ -249,8 +248,8 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator->set_event_manager(&event_manager);
 
   // Give agent some items
-  agent->update_inventory(InventoryItem::ore_red, 1);
-  agent->update_inventory(InventoryItem::ore_blue, 1);
+  agent->update_inventory(TestItems::ORE, 1);
+  agent->update_inventory(TestItems::HEART, 1);
 
   // Create put_recipe_items action handler
   ActionConfig put_cfg;
@@ -260,15 +259,15 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   // Test putting matching items
   bool success = put.handle_action(agent->id, 0);
   EXPECT_TRUE(success);
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 0);      // Red ore consumed
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);     // Blue ore unchanged
-  EXPECT_EQ(generator->inventory[InventoryItem::ore_red], 1);  // Red ore added to generator
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 0);      // Ore consumed
+  EXPECT_EQ(agent->inventory[TestItems::HEART], 1);    // Heart unchanged
+  EXPECT_EQ(generator->inventory[TestItems::ORE], 1);  // Ore added to generator
 
   // Test putting non-matching items
   success = put.handle_action(agent->id, 0);
-  EXPECT_FALSE(success);                                        // Should fail since we only have blue ore left
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_blue], 1);      // Blue ore unchanged
-  EXPECT_EQ(generator->inventory[InventoryItem::ore_blue], 0);  // No blue ore in generator
+  EXPECT_FALSE(success);                                 // Should fail since we only have heart left
+  EXPECT_EQ(agent->inventory[TestItems::HEART], 1);      // Heart unchanged
+  EXPECT_EQ(generator->inventory[TestItems::HEART], 0);  // No heart in generator
 }
 
 TEST_F(MettaGridCppTest, GetOutput) {
@@ -283,21 +282,22 @@ TEST_F(MettaGridCppTest, GetOutput) {
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
 
-  Agent* agent = new Agent(1, 0, 50, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
+  Agent* agent = new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
   grid.add_object(agent);
 
   // Create a generator with initial output
-  ObjectConfig generator_cfg;
-  generator_cfg["input_ore.red"] = 1;
-  generator_cfg["output_battery.red"] = 1;
+  ConverterConfig generator_cfg;
+  generator_cfg.recipe_input[TestItems::ORE] = 1;
+  generator_cfg.recipe_output[TestItems::ARMOR] = 1;
   // Set the max_output to 0 so it won't consume things we put in it.
-  generator_cfg["max_output"] = 1;
-  generator_cfg["conversion_ticks"] = 1;
-  generator_cfg["cooldown"] = 10;
-  generator_cfg["initial_items"] = 1;
+  generator_cfg.max_output = 1;
+  generator_cfg.conversion_ticks = 1;
+  generator_cfg.cooldown = 10;
+  generator_cfg.initial_items = 1;
+  generator_cfg.color = 0;
 
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorT);
@@ -305,7 +305,7 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator->set_event_manager(&event_manager);
 
   // Give agent some items
-  agent->update_inventory(InventoryItem::ore_red, 1);
+  agent->update_inventory(TestItems::ORE, 1);
 
   // Create get_output action handler
   ActionConfig get_cfg;
@@ -315,9 +315,9 @@ TEST_F(MettaGridCppTest, GetOutput) {
   // Test getting output
   bool success = get.handle_action(agent->id, 0);
   EXPECT_TRUE(success);
-  EXPECT_EQ(agent->inventory[InventoryItem::ore_red], 1);          // Still have red ore
-  EXPECT_EQ(agent->inventory[InventoryItem::battery_red], 1);      // Also have a battery
-  EXPECT_EQ(generator->inventory[InventoryItem::battery_red], 0);  // Generator gave away its battery
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 1);        // Still have ore
+  EXPECT_EQ(agent->inventory[TestItems::ARMOR], 1);      // Also have armor
+  EXPECT_EQ(generator->inventory[TestItems::ARMOR], 0);  // Generator gave away its armor
 }
 
 // ==================== Event System Tests ====================
@@ -350,17 +350,6 @@ TEST_F(MettaGridCppTest, ObjectTypes) {
   EXPECT_TRUE(ObjectLayers.find(ObjectType::GeneratorT) != ObjectLayers.end());
 }
 
-TEST_F(MettaGridCppTest, InventoryItems) {
-  // Test that inventory item constants are properly defined
-  EXPECT_NE(InventoryItem::heart, InventoryItem::battery_red);
-  EXPECT_NE(InventoryItem::heart, InventoryItem::ore_red);
-  EXPECT_NE(InventoryItem::battery_red, InventoryItem::ore_red);
-
-  // Test that inventory item names exist
-  EXPECT_FALSE(InventoryItemNames.empty());
-  EXPECT_GT(InventoryItemNames.size(), 0);
-}
-
 // ==================== Wall/Block Tests ====================
 
 TEST_F(MettaGridCppTest, WallCreation) {
@@ -376,12 +365,13 @@ TEST_F(MettaGridCppTest, WallCreation) {
 // ==================== Converter Tests ====================
 
 TEST_F(MettaGridCppTest, ConverterCreation) {
-  ObjectConfig converter_cfg;
-  converter_cfg["input_ore.red"] = 2;
-  converter_cfg["output_battery.red"] = 1;
-  converter_cfg["conversion_ticks"] = 5;
-  converter_cfg["cooldown"] = 10;
-  converter_cfg["initial_items"] = 0;
+  ConverterConfig converter_cfg;
+  converter_cfg.recipe_input[TestItems::ORE] = 2;
+  converter_cfg.recipe_output[TestItems::ARMOR] = 1;
+  converter_cfg.conversion_ticks = 5;
+  converter_cfg.cooldown = 10;
+  converter_cfg.initial_items = 0;
+  converter_cfg.color = 0;
 
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, ObjectType::GeneratorT));
 

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -184,9 +184,9 @@ TEST_F(MettaGridCppTest, AttackAction) {
 
   // Give target some items
   target->update_inventory(TestItems::ORE, 2);
-  target->update_inventory(TestItems::ARMOR, 3);
+  target->update_inventory(TestItems::HEART, 3);
   EXPECT_EQ(target->inventory[TestItems::ORE], 2);
-  EXPECT_EQ(target->inventory[TestItems::ARMOR], 3);
+  EXPECT_EQ(target->inventory[TestItems::HEART], 3);
 
   // Verify attacker orientation
   EXPECT_EQ(attacker->orientation, Orientation::Up);
@@ -208,9 +208,9 @@ TEST_F(MettaGridCppTest, AttackAction) {
 
   // Verify target's inventory was stolen
   EXPECT_EQ(target->inventory[TestItems::ORE], 0);
-  EXPECT_EQ(target->inventory[TestItems::ARMOR], 0);
+  EXPECT_EQ(target->inventory[TestItems::HEART], 0);
   EXPECT_EQ(attacker->inventory[TestItems::ORE], 2);
-  EXPECT_EQ(attacker->inventory[TestItems::ARMOR], 3);
+  EXPECT_EQ(attacker->inventory[TestItems::HEART], 3);
 }
 
 TEST_F(MettaGridCppTest, PutRecipeItems) {

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -34,6 +34,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
         "obs_width": OBS_WIDTH,
         "obs_height": OBS_HEIGHT,
         "num_observation_tokens": NUM_OBS_TOKENS,
+        "inventory_item_names": ["laser", "armor"],
         "actions": {
             # don't really care about the actions for this test
             "noop": {"enabled": True},

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -68,7 +68,6 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
         },
     }
 
-    print(cpp_config_dict(game_config))
     return MettaGrid(cpp_config_dict(game_config), game_map)
 
 

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -40,6 +40,7 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
         "obs_width": OBS_WIDTH,
         "obs_height": OBS_HEIGHT,
         "num_observation_tokens": NUM_OBS_TOKENS,
+        "inventory_item_names": ["laser", "armor", "heart"],
         "actions": {
             "noop": {"enabled": True},
             "get_items": {"enabled": True},
@@ -67,6 +68,7 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
         },
     }
 
+    print(cpp_config_dict(game_config))
     return MettaGrid(cpp_config_dict(game_config), game_map)
 
 
@@ -89,6 +91,7 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
         "obs_width": OBS_WIDTH,
         "obs_height": OBS_HEIGHT,
         "num_observation_tokens": NUM_OBS_TOKENS,
+        "inventory_item_names": ["laser", "armor", "heart"],
         "actions": {
             "noop": {"enabled": True},
             "move": {"enabled": True},


### PR DESCRIPTION
Adds explicit inventory item configuration to the MettaGrid environment, replacing the previous hardcoded enum approach with a more flexible system. The inventory items are now defined in the game configuration and passed through to the C++ code.

* Gets rid of InventoryItem
* Does some weird passing of "what's a laser, what's armor".
* Still has hard-coded names, which we use for stats. We'll need to pass the inventory names in separately.

This also requires "inventory_item_names" to be defined up at the top, which causes a little redundancy, but gives easier understanding / safety.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210642391358505)