### PR TITLE
fix: adjust batch size for mac parallel

### DIFF
--- a/configs/hardware/mac_parallel.yaml
+++ b/configs/hardware/mac_parallel.yaml
@@ -15,7 +15,7 @@ vectorization: multiprocessing
 trainer:
   num_workers: 4 # Number of "parallel" worker processes (i.e. cores)
   update_epochs: 1
-  batch_size: 1024
+  batch_size: 4096
   minibatch_size: 1024
   forward_pass_minibatch_target_size: 512
   async_factor: 1

--- a/configs/hardware/mac_serial.yaml
+++ b/configs/hardware/mac_serial.yaml
@@ -3,7 +3,7 @@
 # Serial vectorization configuration for CPU training
 #
 # This setup uses a single CPU core with serial execution,
-# which is simpler but typically has lower throughput (SPS) 
+# which is simpler but typically has lower throughput (SPS)
 # compared to multiprocessing configurations.
 
 device: cpu

--- a/devops/train.sh
+++ b/devops/train.sh
@@ -33,7 +33,7 @@ if [ -z "$NUM_CPUS" ]; then
     NUM_CPUS=$(sysctl -n hw.ncpu)
     NUM_CPUS=$((NUM_CPUS / 2))
   else
-    NUM_CPUS=8  # fallback
+    NUM_CPUS=1  # fallback
   fi
 fi
 

--- a/devops/train.sh
+++ b/devops/train.sh
@@ -24,8 +24,17 @@ export HEARTBEAT_FILE
 
 # System configuration
 if [ -z "$NUM_CPUS" ]; then
-  NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
-  NUM_CPUS=$((NUM_CPUS / 2))
+  if command -v lscpu &> /dev/null; then
+    # Linux
+    NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
+    NUM_CPUS=$((NUM_CPUS / 2))
+  elif command -v sysctl &> /dev/null; then
+    # macOS
+    NUM_CPUS=$(sysctl -n hw.ncpu)
+    NUM_CPUS=$((NUM_CPUS / 2))
+  else
+    NUM_CPUS=8  # fallback
+  fi
 fi
 
 # Auto-detect GPUs if not set


### PR DESCRIPTION

`(metta) rwalters@robblocal metta % ./devops/train.sh run=test_uv  wandb.enabled=false +hardware=mac_parallel`

crashes with

`
  hydra.errors.InstantiationException: Error in call to target 'metta.rl.trainer.MettaTrainer':
  ZeroDivisionError('integer division or modulo by zero')
  full_key: trainer
`

on main.. The comments in trainer suggest the way to fix this is to increase the target batch size.



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210644114901177)