### PR TITLE
get rid of DEFAULT_NORMALIZATION

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -104,9 +104,10 @@ protected:
 
             agent_target->update_inventory(item, -stolen);
             if (stolen > 0) {
-              actor->stats.add(InventoryItemNames[item] + ".stolen." + actor->group_name, stolen);
+              actor->stats.add(actor->stats.inventory_item_name(item) + ".stolen." + actor->group_name, stolen);
               // Also track what was stolen from the victim's perspective
-              agent_target->stats.add(InventoryItemNames[item] + ".stolen_from." + agent_target->group_name, stolen);
+              agent_target->stats.add(
+                  agent_target->stats.inventory_item_name(item) + ".stolen_from." + agent_target->group_name, stolen);
             }
           }
         }

--- a/mettagrid/src/metta/mettagrid/actions/get_output.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/get_output.hpp
@@ -44,7 +44,7 @@ protected:
       int taken = actor->update_inventory(item, converter->inventory[item]);
 
       if (taken > 0) {
-        actor->stats.add(InventoryItemNames[item] + ".get", taken);
+        actor->stats.add(actor->stats.inventory_item_name(item) + ".get", taken);
         converter->update_inventory(item, -taken);
         items_taken = true;
       }

--- a/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
@@ -42,7 +42,7 @@ protected:
           // We should be able to put this many items into the converter. If not, something is wrong.
           int delta = actor->update_inventory(item, -put);
           assert(delta == -put);
-          actor->stats.add(InventoryItemNames[item] + ".put", put);
+          actor->stats.add(actor->stats.inventory_item_name(item) + ".put", put);
           success = true;
         }
       }

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -41,6 +41,8 @@ public:
   unsigned int current_step;
   unsigned int max_steps;
 
+  std::vector<std::string> inventory_item_names;
+
   // Python API methods
   py::tuple reset();
   // In general, these types need to match what puffer wants to use.
@@ -64,15 +66,14 @@ public:
   py::list action_success();
   py::list max_action_args();
   py::list object_type_names();
-  py::list inventory_item_names();
+  py::list inventory_item_names_py();
   py::array_t<unsigned int> get_agent_groups() const;
-  static Agent* create_agent(int r, int c, const py::dict& agent_group_cfg_py);
+  Agent* create_agent(int r, int c, const py::dict& agent_group_cfg_py);
 
   uint64_t initial_grid_hash;
 
 private:
   // Member variables
-  std::vector<std::string> _inventory_item_names;
   std::map<unsigned int, float> _group_reward_pct;
   std::map<unsigned int, unsigned int> _group_sizes;
   std::unique_ptr<Grid> _grid;

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,12 +1,11 @@
 import copy
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import AfterValidator, BaseModel, Field, RootModel, conint
+from pydantic import BaseModel, Field, RootModel, conint
 
 from metta.mettagrid.mettagrid_config import ConverterConfig as ConverterConfig_py
 from metta.mettagrid.mettagrid_config import GameConfig as GameConfig_py
 from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
-
 
 Byte = conint(ge=0, le=255)
 FeatureId = Byte

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -34,11 +34,12 @@ public:
         GridCoord c,
         unsigned char freeze_duration,
         float action_failure_penalty,
-        std::map<ObsType, uint8_t> max_items_per_type,
-        std::map<ObsType, float> resource_rewards,
-        std::map<ObsType, float> resource_reward_max,
+        std::map<InventoryItem, uint8_t> max_items_per_type,
+        std::map<InventoryItem, float> resource_rewards,
+        std::map<InventoryItem, float> resource_reward_max,
         std::string group_name,
-        unsigned char group_id)
+        unsigned char group_id,
+        const std::vector<std::string>& inventory_item_names)
       : freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
         max_items_per_type(max_items_per_type),
@@ -47,7 +48,8 @@ public:
         group(group_id),
         group_name(group_name),
         color(0),
-        current_resource_reward(0) {
+        current_resource_reward(0),
+        stats(inventory_item_names) {
     GridObject::init(ObjectType::AgentT, GridLocation(r, c, GridLayer::Agent_Layer));
 
     this->frozen = 0;
@@ -72,9 +74,9 @@ public:
     }
 
     if (delta > 0) {
-      this->stats.add(InventoryItemNames[item] + ".gained", delta);
+      this->stats.add(this->stats.inventory_item_name(item) + ".gained", delta);
     } else if (delta < 0) {
-      this->stats.add(InventoryItemNames[item] + ".lost", -delta);
+      this->stats.add(this->stats.inventory_item_name(item) + ".lost", -delta);
     }
 
     this->compute_resource_reward(item);
@@ -126,7 +128,7 @@ public:
   }
 
 private:
-  std::map<ObsType, uint8_t> max_items_per_type;
+  std::map<InventoryItem, uint8_t> max_items_per_type;
 };
 
 #endif  // OBJECTS_AGENT_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/constants.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/constants.hpp
@@ -112,7 +112,6 @@ const std::map<uint8_t, float> FeatureNormalizations = {
     {ObservationFeature::Swappable, 1.0},
 };
 
-const float DEFAULT_NORMALIZATION = 1.0;
 const float DEFAULT_INVENTORY_NORMALIZATION = 100.0;
 
 const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},

--- a/mettagrid/src/metta/mettagrid/objects/constants.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/constants.hpp
@@ -79,21 +79,6 @@ constexpr std::array<const char*, ObjectTypeCount> ObjectTypeNamesArray = {
 
 const std::vector<std::string> ObjectTypeNames(ObjectTypeNamesArray.begin(), ObjectTypeNamesArray.end());
 
-// TODO: We now have this available in the config, so we should use that instead. We haven't done this yet
-// because we need to pass through the configuration. For now, this means things are unstable.
-constexpr std::array<const char*, 10> InventoryItemNamesArray = {{"ore.red",
-                                                                  "ore.blue",
-                                                                  "ore.green",
-                                                                  "battery.red",
-                                                                  "battery.blue",
-                                                                  "battery.green",
-                                                                  "heart",
-                                                                  "armor",
-                                                                  "laser",
-                                                                  "blueprint"}};
-
-const std::vector<std::string> InventoryItemNames(InventoryItemNamesArray.begin(), InventoryItemNamesArray.end());
-
 const std::map<uint8_t, std::string> FeatureNames = {
     {ObservationFeature::TypeId, "type_id"},
     {ObservationFeature::Group, "agent:group"},

--- a/mettagrid/src/metta/mettagrid/stats_tracker.hpp
+++ b/mettagrid/src/metta/mettagrid/stats_tracker.hpp
@@ -9,6 +9,8 @@
 // Forward declaration
 class MettaGrid;
 
+using InventoryItem = uint8_t;
+
 class StatsTracker {
 private:
   std::map<std::string, float> _stats;
@@ -17,6 +19,7 @@ private:
   std::map<std::string, float> _min_value;
   std::map<std::string, float> _max_value;
   std::map<std::string, int> _update_count;
+  std::vector<std::string> _inventory_item_names;
   MettaGrid* _env;
 
   // Track timing for any update
@@ -52,10 +55,17 @@ private:
   friend class StatsTrackerTest;
 
 public:
-  StatsTracker() : _env(nullptr) {}
+  explicit StatsTracker(const std::vector<std::string>& inventory_item_names)
+      : _env(nullptr), _inventory_item_names(inventory_item_names) {}
 
   void set_environment(MettaGrid* env) {
     _env = env;
+  }
+
+  // We expose this through stats since "what name will be meaningful" to people is a reasonable domain of stats.
+  // Implemented when mettagrid is complete.
+  const std::string& inventory_item_name(InventoryItem item) const {
+    return _inventory_item_names[item];
   }
 
   void add(const std::string& key, float amount) {

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -11,7 +11,6 @@
 #include "objects/wall.hpp"
 
 // Test-specific inventory item type constants
-// These don't need to correspond to InventoryItemNamesArray as that may be changing
 namespace TestItems {
 constexpr uint8_t ORE = 0;
 constexpr uint8_t LASER = 1;
@@ -55,6 +54,10 @@ protected:
     resource_reward_max[TestItems::HEART] = 10.0f;
     return resource_reward_max;
   }
+
+  std::vector<std::string> create_test_inventory_item_names() {
+    return {"ore", "laser", "armor", "heart"};
+  }
 };
 
 // ==================== Agent Tests ====================
@@ -63,9 +66,10 @@ TEST_F(MettaGridCppTest, AgentRewards) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
+  auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(
-      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
+  std::unique_ptr<Agent> agent(new Agent(
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names));
 
   // Test reward values
   EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ORE], 0.125f);
@@ -78,9 +82,10 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
+  auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(
-      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1));
+  std::unique_ptr<Agent> agent(new Agent(
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names));
 
   float dummy_reward = 0.0f;
   agent->init(&dummy_reward);
@@ -135,7 +140,9 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
-  Agent* agent = new Agent(2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1);
+  auto inventory_item_names = create_test_inventory_item_names();
+  Agent* agent = new Agent(
+      2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names);
 
   grid.add_object(agent);
 
@@ -165,10 +172,13 @@ TEST_F(MettaGridCppTest, AttackAction) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
+  auto inventory_item_names = create_test_inventory_item_names();
 
   // Create attacker and target
-  Agent* attacker = new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
-  Agent* target = new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2);
+  Agent* attacker =
+      new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
+  Agent* target =
+      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names);
 
   float attacker_reward = 0.0f;
   float target_reward = 0.0f;
@@ -224,8 +234,10 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
+  auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent = new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
+  Agent* agent =
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -241,7 +253,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.cooldown = 10;
   generator_cfg.initial_items = 0;
   generator_cfg.color = 0;
-
+  generator_cfg.inventory_item_names = inventory_item_names;
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorT);
   grid.add_object(generator);
@@ -281,8 +293,10 @@ TEST_F(MettaGridCppTest, GetOutput) {
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
+  auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent = new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1);
+  Agent* agent =
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -298,7 +312,7 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator_cfg.cooldown = 10;
   generator_cfg.initial_items = 1;
   generator_cfg.color = 0;
-
+  generator_cfg.inventory_item_names = inventory_item_names;
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorT);
   grid.add_object(generator);
@@ -372,7 +386,7 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.cooldown = 10;
   converter_cfg.initial_items = 0;
   converter_cfg.color = 0;
-
+  converter_cfg.inventory_item_names = create_test_inventory_item_names();
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, ObjectType::GeneratorT));
 
   ASSERT_NE(converter, nullptr);

--- a/mettagrid/tests/test_stats_tracker.cpp
+++ b/mettagrid/tests/test_stats_tracker.cpp
@@ -11,7 +11,9 @@ public:
 // Test fixture for StatsTracker
 class StatsTrackerTest : public ::testing::Test {
 protected:
-  StatsTracker stats;
+  std::vector<std::string> empty_inventory_item_names;
+  StatsTracker stats{empty_inventory_item_names};
+
   MockMettaGrid mock_env;
 
   void SetUp() override {


### PR DESCRIPTION
Removes unused constant `DEFAULT_NORMALIZATION` from constants.hpp


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210644670362557)