### PR TITLE
feat: launch skypilot training from anywhere

### DIFF
--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -104,6 +104,9 @@ def main():
     parser.add_argument("-c", "--confirm", action="store_true", help="Show confirmation prompt")
     (args, cmd_args) = parser.parse_known_args(filtered_args)
 
+    if not args.cmd or not args.cmd.strip():
+        parser.error("cmd argument cannot be empty!")
+
     if run_id is None:
         parser.error("run= parameter is required")
 

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -104,9 +104,6 @@ def main():
     parser.add_argument("-c", "--confirm", action="store_true", help="Show confirmation prompt")
     (args, cmd_args) = parser.parse_known_args(filtered_args)
 
-    if not args.cmd or not args.cmd.strip():
-        parser.error("cmd argument cannot be empty!")
-
     if run_id is None:
         parser.error("run= parameter is required")
 

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -1,3 +1,28 @@
+#!/bin/bash
+
+cd_repo_root() {
+    local current_dir="$(pwd)"
+    local search_dir="$current_dir"
+
+    # Search current directory and all parent directories
+    while [[ "$search_dir" != "/" ]]; do
+        if [[ -d "$search_dir/.git" ]]; then
+            cd "$search_dir"
+            return 0
+        fi
+        search_dir="$(dirname "$search_dir")"
+    done
+
+    # Check root directory as well
+    if [[ -d "/.git" ]]; then
+        cd "/"
+        return 0
+    fi
+
+    echo "Repository root not found - no .git directory in current path or parent directories" >&2
+    return 1
+}
+
 export AWS_PROFILE=softmax
 
 # list jobs
@@ -15,4 +40,13 @@ alias jll='sky jobs logs $(jj | grep -A1 TASK | grep -v TASK | awk "{print \$1}"
 alias jllc='sky jobs logs --controller $(jj | grep -A1 TASK | grep -v TASK | awk "{print \$1}")'
 
 # launch training
-alias lt="./devops/skypilot/launch.py train"
+unalias lt 2>/dev/null
+lt() {
+    local original_dir="$(pwd)"
+    if cd_repo_root; then
+        ./devops/skypilot/launch.py "$@"
+        local exit_code=$?
+        cd "$original_dir"
+        return $exit_code
+    fi
+}

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -29,6 +29,7 @@ alias jllc='sky jobs logs --controller $(jj | grep -A1 TASK | grep -v TASK | awk
 
 # launch training
 unalias lt 2>/dev/null
+
 lt() {
     local original_dir="$(pwd)"
     if cd_repo_root; then
@@ -37,4 +38,6 @@ lt() {
         cd "$original_dir"
         return $exit_code
     fi
+    return $?  # Return the error code from cd_repo_root
 }
+

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -32,7 +32,7 @@ unalias lt 2>/dev/null
 lt() {
     local original_dir="$(pwd)"
     if cd_repo_root; then
-        ./devops/skypilot/launch.py "$@"
+        ./devops/skypilot/launch.py "train $@"
         local exit_code=$?
         cd "$original_dir"
         return $exit_code

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -32,7 +32,7 @@ unalias lt 2>/dev/null
 lt() {
     local original_dir="$(pwd)"
     if cd_repo_root; then
-        ./devops/skypilot/launch.py "train $@"
+        ./devops/skypilot/launch.py "train" "$@"
         local exit_code=$?
         cd "$original_dir"
         return $exit_code

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -30,14 +30,21 @@ alias jllc='sky jobs logs --controller $(jj | grep -A1 TASK | grep -v TASK | awk
 # launch training
 unalias lt 2>/dev/null
 
+
 lt() {
     local original_dir="$(pwd)"
-    if cd_repo_root; then
+    cd_repo_root
+    local repo_result=$?
+    
+    if [ $repo_result -eq 0 ]; then
         ./devops/skypilot/launch.py "train" "$@"
         local exit_code=$?
-        cd "$original_dir"
-        return $exit_code
+    else
+        local exit_code=$repo_result
     fi
-    return $?  # Return the error code from cd_repo_root
+    
+    cd "$original_dir"
+    return $exit_code
 }
+
 

--- a/devops/skypilot/setup_shell.sh
+++ b/devops/skypilot/setup_shell.sh
@@ -1,26 +1,14 @@
 #!/bin/bash
 
 cd_repo_root() {
-    local current_dir="$(pwd)"
-    local search_dir="$current_dir"
-
-    # Search current directory and all parent directories
-    while [[ "$search_dir" != "/" ]]; do
-        if [[ -d "$search_dir/.git" ]]; then
-            cd "$search_dir"
-            return 0
-        fi
-        search_dir="$(dirname "$search_dir")"
+    while [[ "$PWD" != "/" && ! -d ".git" ]]; do
+        cd ..
     done
 
-    # Check root directory as well
-    if [[ -d "/.git" ]]; then
-        cd "/"
-        return 0
+    if [[ ! -d ".git" ]]; then
+        echo "Repository root not found - no .git directory in current path or parent directories" >&2
+        return 1
     fi
-
-    echo "Repository root not found - no .git directory in current path or parent directories" >&2
-    return 1
 }
 
 export AWS_PROFILE=softmax


### PR DESCRIPTION

This PR enhances the `lt` alias to work from any directory within the repository by automatically finding and changing to the repository root before executing the launch script.

## Changes
  - Replaces the simple alias with a bash function that accepts arguments
  - Automatically navigates to repo root before launching
  - Restores original working directory after execution
  - Preserves exit codes from the launch script

## Usage
Before this change, `lt` only worked from the repository root:
```bash
# Only worked from repo root
./devops/skypilot/launch.py train
```

After this change, `lt` works from anywhere in the repo:
```bash
# Now works from any subdirectory
cd src/models/
lt train trainer.curriculum=env/mettagrid/simple --timeout-hours=3 -c --no-spot run=my.job.1
```

## Technical Details
- The function searches upward through the directory tree until it finds a `.git` directory
- Uses `unalias lt 2>/dev/null` to handle cases where an alias might already exist
- Preserves all command-line arguments with `"$@"`
- Maintains the original working directory after script execution

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210644958829352)