### PR TITLE
Grad stats

### DIFF
--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -17,7 +17,7 @@ checkpoint_dir: ${run_dir}/checkpoints
 evaluate_interval: 300
 checkpoint_interval: 60
 wandb_checkpoint_interval: 300
-grad_mean_variance_interval: 30 # 0 to disable
+grad_mean_variance_interval: 50 # 0 to disable
 replay_interval: ${trainer.evaluate_interval}
 replay_dir: s3://softmax-public/replays/${run}
 

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -17,7 +17,7 @@ checkpoint_dir: ${run_dir}/checkpoints
 evaluate_interval: 300
 checkpoint_interval: 60
 wandb_checkpoint_interval: 300
-grad_mean_variance_interval: 50 # 0 to disable
+grad_mean_variance_interval: 0 # 0 to disable
 replay_interval: ${trainer.evaluate_interval}
 replay_dir: s3://softmax-public/replays/${run}
 

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -17,6 +17,7 @@ checkpoint_dir: ${run_dir}/checkpoints
 evaluate_interval: 300
 checkpoint_interval: 60
 wandb_checkpoint_interval: 300
+grad_mean_variance_interval: 30 # 0 to disable
 replay_interval: ${trainer.evaluate_interval}
 replay_dir: s3://softmax-public/replays/${run}
 

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -4,7 +4,7 @@ seed: null
 
 defaults:
   # - override /env/mettagrid@env: simple
-  - override /agent: simple
+  - override /agent: fast
   - _self_
 
 policy_uri: pytorch:///tmp/puffer_metta.pt
@@ -33,7 +33,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 1200
+run_id: 1444
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -338,7 +338,7 @@ class MettaTrainer:
             self._maybe_generate_replay()
             self._maybe_update_l2_weights()
             self._maybe_compute_grad_stats()
-            
+
             self._on_train_step()
             # end loop over total_timesteps
 


### PR DESCRIPTION
Calculate grad mean, variance, and norm then plot to WandB depending on `grad_mean_variance_interval` (default to 0 ie off). 

This PR has admittedly less motivation than one with a direct need. Rather, it tracks something that _may_ be useful in examining policy collapse but remains to be tested. One potentially benefit (of a few promised) would be to understand when training has actually plateaued: not when reward seems flat but when grad variance starts to decrease.

**Theoretical Motivation**
Proposed in [Opening the black box of Deep Neural Networks via Information](https://arxiv.org/pdf/1703.00810), models go through two phases: fitting (drift) and compression (diffusion). During drift, the model quickly fits and its loss curve approaches a plateau. During diffusion, the model compresses its representation even though the loss curve may not change significantly. 

The gradient's mean is much higher than the variance during drift. During diffusion, the relationship flips. And while the low mean, high variance, phase seems very noisy, the noise actually acts as a regularizer. 

Thanks to Matt Bull for the recommendation here!

**In Practice**
See [this training example](https://wandb.ai/metta-research/metta/runs/m_alexv_grad_stats_01) and the "grad" plots. Training on the simple environment shows tiny mean and variance the correlations just aren't there. Given the strength of the theory, this is something would be interesting to investigate in other training environments and as we start to make changes to the simple environment.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210644969846468)