### PR TITLE
feat: adjust timeouts based on trainer checkpoint

### DIFF
--- a/common/src/metta/common/fs.py
+++ b/common/src/metta/common/fs.py
@@ -2,9 +2,12 @@ import os
 from pathlib import Path
 
 
-def cd_repo_root():
+def get_repo_root() -> Path:
     """
-    Ensure we're running in the repository root.
+    Get the repository root directory.
+
+    Returns:
+        Path to the repository root
 
     Raises:
         SystemExit: If repository root cannot be found
@@ -14,8 +17,18 @@ def cd_repo_root():
 
     for parent in search_paths:
         if (parent / ".git").exists():
-            os.chdir(parent)
-            return
+            return parent
 
     # If we get here, no .git directory was found
     raise SystemExit("Repository root not found - no .git directory in current path or parent directories")
+
+
+def cd_repo_root():
+    """
+    Ensure we're running in the repository root.
+
+    Raises:
+        SystemExit: If repository root cannot be found
+    """
+    repo_root = get_repo_root()
+    os.chdir(repo_root)

--- a/devops/docker/build.py
+++ b/devops/docker/build.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 
-from common.src.metta.common.fs import cd_repo_root
+from metta.common.fs import cd_repo_root
 from metta.common.util.cli import get_user_confirmation
 
 

--- a/devops/docker/push_image.py
+++ b/devops/docker/push_image.py
@@ -7,7 +7,7 @@ import argparse
 import subprocess
 import sys
 
-from common.src.metta.common.fs import cd_repo_root
+from metta.common.fs import cd_repo_root
 from metta.common.util.cli import get_user_confirmation, sh
 from metta.common.util.colorama import bold
 

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -6,13 +6,13 @@ import sys
 
 import sky
 
-from common.src.metta.common.fs import cd_repo_root
 from devops.skypilot.utils import (
     check_config_files,
     check_git_state,
     display_job_summary,
     launch_task,
 )
+from metta.common.fs import cd_repo_root
 from metta.common.util.cli import get_user_confirmation
 from metta.common.util.colorama import red
 from metta.common.util.git import get_current_commit, validate_git_ref

--- a/metta/rl/util/trainer_state.py
+++ b/metta/rl/util/trainer_state.py
@@ -1,0 +1,96 @@
+from typing import Optional
+
+from metta.common.fs import get_repo_root
+from metta.common.stopwatch import Stopwatch
+from metta.rl.trainer_checkpoint import TrainerCheckpoint
+
+
+def get_elapsed_time(
+    run_name: str, filename: str = "trainer_state.pt", train_dir: str = "train_dir"
+) -> Optional[float]:
+    """
+    Get elapsed time from the trainer state file for a training run.
+    This is a standalone helper function that can be called from skypilot scripts
+    to check training progress.
+
+    Args:
+        run_name: Name of the training run
+        filename: Name of the trainer state file (default: "trainer_state.pt")
+        train_dir: Base training directory (default: "train_dir")
+
+    Returns:
+        Elapsed time in seconds from the global timer, or None if not found
+    """
+    repo_root = get_repo_root()
+    run_dir = repo_root / train_dir / run_name
+
+    if not run_dir.exists():
+        return None
+
+    try:
+        # Load trainer checkpoint
+        trainer_checkpoint = TrainerCheckpoint.load(str(run_dir), filename)
+
+        if trainer_checkpoint is None or trainer_checkpoint.stopwatch_state is None:
+            return None
+
+        # Create stopwatch and load the saved state
+        stopwatch = Stopwatch()
+        stopwatch.load_state(trainer_checkpoint.stopwatch_state, resume_running=False)
+
+        # Get elapsed time from global timer
+        elapsed_time = stopwatch.get_elapsed()
+
+        if elapsed_time > 0:
+            return elapsed_time
+        else:
+            return None
+
+    except Exception as e:
+        print(f"Failed to load trainer checkpoint: {e}")
+        return None
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python trainer_state.py <run_name> [filename] [train_dir]")
+        print("Example: python trainer_state.py my_training_run_001")
+        print("Example: python trainer_state.py my_run trainer_state.pt custom_train_dir")
+        sys.exit(1)
+
+    run_name = sys.argv[1]
+    filename = sys.argv[2] if len(sys.argv) > 2 else "trainer_state.pt"
+    train_dir = sys.argv[3] if len(sys.argv) > 3 else "train_dir"
+
+    print(f"Checking elapsed time for run: {run_name}")
+    print(f"Trainer state file: {filename}")
+    print(f"Train directory: {train_dir}")
+
+    try:
+        elapsed_time = get_elapsed_time(run_name, filename, train_dir)
+
+        if elapsed_time is not None:
+            # Format the time in a human-readable way
+            if elapsed_time < 60:
+                formatted = f"{elapsed_time:.1f} seconds"
+            elif elapsed_time < 3600:
+                formatted = f"{elapsed_time / 60:.1f} minutes"
+            elif elapsed_time < 86400:
+                formatted = f"{elapsed_time / 3600:.1f} hours"
+            else:
+                formatted = f"{elapsed_time / 86400:.1f} days"
+            print(f"✓ Training has been running for {elapsed_time:.2f} seconds")
+            print(f"✓ Formatted: {formatted}")
+        else:
+            print("✗ Could not determine elapsed time")
+            print("  Possible reasons:")
+            print("  - No run directory found")
+            print("  - No trainer state file found")
+            print("  - No stopwatch_state in trainer checkpoint")
+            print("  - No elapsed time in stopwatch")
+
+    except Exception as e:
+        print(f"✗ Error: {e}")
+        sys.exit(1)


### PR DESCRIPTION

This PR adds timeout adjustment for training jobs that accounts for elapsed training time when resuming jobs. When launching a training job with a timeout, the system now checks how long the job has already been running and adjusts the timeout accordingly to prevent jobs from running longer than intended.

## Problem

Previously, when resuming a training job with a timeout (e.g., `--timeout-hours=2.0`), the full timeout would be applied regardless of how long the job had already been running. This could cause jobs to run significantly longer than intended:

- Start job with 2-hour timeout → job runs for 1.5 hours, gets interrupted
- Resume same job with 2-hour timeout → job could run for another 2 hours (3.5 total)
- This defeats the purpose of having timeouts for cost control and resource management

### Key components

1. **New utility module** (`metta/rl/util/trainer_state.py`):
   - `get_elapsed_time()`: Extracts elapsed time from trainer checkpoint files
   - Loads stopwatch state from `trainer_state.pt` files
   - Handles missing files and corrupted state gracefully

2. **Enhanced launch script** (`devops/skypilot/launch.py`):
   - Automatically calculates adjusted timeout before job launch
   - Shows clear messages about timeout adjustments
   - Displays both original and adjusted timeouts in job summary

3. **Timeout calculation logic** (`devops/skypilot/utils.py`):
   - `calculate_adjusted_timeout()`: Core logic for timeout adjustment
   - Handles three scenarios:
     - No existing training → use original timeout
     - Partial training → use remaining time
     - Exceeded timeout → apply minimal timeout with warning