### PR TITLE
remove type_id from relative location

### DIFF
--- a/mettagrid/src/metta/mettagrid/grid.hpp
+++ b/mettagrid/src/metta/mettagrid/grid.hpp
@@ -142,22 +142,8 @@ public:
     return GridLocation(new_r, new_c, loc.layer);
   }
 
-  inline const GridLocation relative_location(const GridLocation& loc,
-                                              Orientation orientation,
-                                              GridCoord distance,
-                                              GridCoord offset,
-                                              TypeId type_id) {
-    GridLocation rloc = this->relative_location(loc, orientation, distance, offset);
-    rloc.layer = this->layer_for_type_id[type_id];
-    return rloc;
-  }
-
   inline const GridLocation relative_location(const GridLocation& loc, Orientation orientation) {
     return this->relative_location(loc, orientation, 1, 0);
-  }
-
-  inline const GridLocation relative_location(const GridLocation& loc, Orientation orientation, TypeId type_id) {
-    return this->relative_location(loc, orientation, 1, 0, type_id);
   }
 
   inline char is_empty(unsigned int row, unsigned int col) {

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -122,14 +122,11 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map) {
       grid_hash_data += std::to_string(r) + "," + std::to_string(c) + ":" + cell + ";";
 
       Converter* converter = nullptr;
-      if (cell == "wall") {
-        Wall* wall = new Wall(r, c, cfg["objects"]["wall"].cast<ObjectConfig>());
+      if (cell == "wall" || cell == "block") {
+        auto wall_cfg = _create_wall_config(cfg["objects"][py::str(cell)]);
+        Wall* wall = new Wall(r, c, wall_cfg);
         _grid->add_object(wall);
-        _stats->incr("objects.wall");
-      } else if (cell == "block") {
-        Wall* block = new Wall(r, c, cfg["objects"]["block"].cast<ObjectConfig>());
-        _grid->add_object(block);
-        _stats->incr("objects.block");
+        _stats->incr("objects." + cell);
       } else if (cell == "mine_red") {
         auto converter_cfg = _create_converter_config(cfg["objects"]["mine_red"]);
         converter = new Converter(r, c, converter_cfg, ObjectType::MineRedT);
@@ -728,6 +725,11 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
   ObsType color = converter_cfg_py["color"].cast<ObsType>();
   return ConverterConfig{
       recipe_input, recipe_output, max_output, conversion_ticks, cooldown, initial_items, color, inventory_item_names};
+}
+
+WallConfig MettaGrid::_create_wall_config(const py::dict& wall_cfg_py) {
+  bool swappable = wall_cfg_py.contains("swappable") ? wall_cfg_py["swappable"].cast<bool>() : false;
+  return WallConfig{swappable};
 }
 
 // Pybind11 module definition

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -27,6 +27,7 @@ class Agent;
 class ObservationEncoder;
 class GridObject;
 class ConverterConfig;
+class WallConfig;
 
 namespace py = pybind11;
 
@@ -120,6 +121,7 @@ private:
 
   void _handle_invalid_action(size_t agent_idx, const std::string& stat, ActionType type, ActionArg arg);
   ConverterConfig _create_converter_config(const py::dict& converter_cfg_py);
+  WallConfig _create_wall_config(const py::dict& wall_cfg_py);
 };
 
 #endif  // METTAGRID_C_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/metta_object.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/metta_object.hpp
@@ -5,9 +5,6 @@
 #include <string>
 
 #include "../grid_object.hpp"
-
-typedef std::map<std::string, int> ObjectConfig;
-
 class MettaObject : public GridObject {
 public:
   virtual bool swappable() const {

--- a/mettagrid/src/metta/mettagrid/objects/wall.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/wall.hpp
@@ -8,13 +8,17 @@
 #include "constants.hpp"
 #include "metta_object.hpp"
 
+struct WallConfig {
+  bool swappable;
+};
+
 class Wall : public MettaObject {
 public:
   bool _swappable;
 
-  Wall(GridCoord r, GridCoord c, ObjectConfig cfg) {
+  Wall(GridCoord r, GridCoord c, WallConfig cfg) {
     GridObject::init(ObjectType::WallT, GridLocation(r, c, GridLayer::Object_Layer));
-    this->_swappable = cfg["swappable"];
+    this->_swappable = cfg.swappable;
   }
 
   virtual vector<PartialObservationToken> obs_features() const override {

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -367,7 +367,7 @@ TEST_F(MettaGridCppTest, ObjectTypes) {
 // ==================== Wall/Block Tests ====================
 
 TEST_F(MettaGridCppTest, WallCreation) {
-  ObjectConfig wall_cfg;
+  WallConfig wall_cfg;
 
   std::unique_ptr<Wall> wall(new Wall(2, 3, wall_cfg));
 


### PR DESCRIPTION
Removes unused relative_location overloads that included type_id parameters.

This change simplifies the API of the `Grid` class by removing unused methods. This removes a reference to type_id, which I'd like to downplay as we make objects more configurable.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210653693215742)