### PR TITLE
Remove layer_for_type_id

### DIFF
--- a/mettagrid/src/metta/mettagrid/grid.hpp
+++ b/mettagrid/src/metta/mettagrid/grid.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "grid_object.hpp"
+#include "objects/constants.hpp"
 
 using std::max;
 using std::unique_ptr;
@@ -16,16 +17,12 @@ class Grid {
 public:
   unsigned int width;
   unsigned int height;
-  vector<Layer> layer_for_type_id;
-  Layer num_layers;
 
   GridType grid;
   vector<std::unique_ptr<GridObject>> objects;
 
-  inline Grid(unsigned int width, unsigned int height, vector<Layer> layer_for_type_id)
-      : width(width), height(height), layer_for_type_id(layer_for_type_id) {
-    num_layers = *max_element(layer_for_type_id.begin(), layer_for_type_id.end()) + 1;
-    grid.resize(height, vector<vector<GridObjectId>>(width, vector<GridObjectId>(this->num_layers, 0)));
+  inline Grid(unsigned int width, unsigned int height) : width(width), height(height) {
+    grid.resize(height, vector<vector<GridObjectId>>(width, vector<GridObjectId>(GridLayer::GridLayerCount, 0)));
 
     // 0 is reserved for empty space
     objects.push_back(nullptr);
@@ -34,7 +31,7 @@ public:
   virtual ~Grid() = default;
 
   inline char add_object(GridObject* obj) {
-    if (obj->location.r >= height || obj->location.c >= width || obj->location.layer >= num_layers) {
+    if (obj->location.r >= height || obj->location.c >= width || obj->location.layer >= GridLayer::GridLayerCount) {
       return false;
     }
     if (this->grid[obj->location.r][obj->location.c][obj->location.layer] != 0) {
@@ -58,7 +55,7 @@ public:
   }
 
   inline char move_object(GridObjectId id, const GridLocation& loc) {
-    if (loc.r >= height || loc.c >= width || loc.layer >= num_layers) {
+    if (loc.r >= height || loc.c >= width || loc.layer >= GridLayer::GridLayerCount) {
       return false;
     }
 
@@ -99,7 +96,7 @@ public:
   }
 
   inline GridObject* object_at(const GridLocation& loc) {
-    if (loc.r >= height || loc.c >= width || loc.layer >= num_layers) {
+    if (loc.r >= height || loc.c >= width || loc.layer >= GridLayer::GridLayerCount) {
       return nullptr;
     }
     if (grid[loc.r][loc.c][loc.layer] == 0) {
@@ -150,7 +147,7 @@ public:
     GridLocation loc;
     loc.r = row;
     loc.c = col;
-    for (int layer = 0; layer < num_layers; ++layer) {
+    for (int layer = 0; layer < GridLayer::GridLayerCount; ++layer) {
       loc.layer = layer;
       if (object_at(loc) != nullptr) {
         return 0;

--- a/mettagrid/src/metta/mettagrid/grid.hpp
+++ b/mettagrid/src/metta/mettagrid/grid.hpp
@@ -142,22 +142,8 @@ public:
     return GridLocation(new_r, new_c, loc.layer);
   }
 
-  inline const GridLocation relative_location(const GridLocation& loc,
-                                              Orientation orientation,
-                                              GridCoord distance,
-                                              GridCoord offset,
-                                              TypeId type_id) {
-    GridLocation rloc = this->relative_location(loc, orientation, distance, offset);
-    rloc.layer = this->layer_for_type_id[type_id];
-    return rloc;
-  }
-
   inline const GridLocation relative_location(const GridLocation& loc, Orientation orientation) {
     return this->relative_location(loc, orientation, 1, 0);
-  }
-
-  inline const GridLocation relative_location(const GridLocation& loc, Orientation orientation, TypeId type_id) {
-    return this->relative_location(loc, orientation, 1, 0, type_id);
   }
 
   inline char is_empty(unsigned int row, unsigned int col) {

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -45,14 +45,10 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map) {
 
   current_step = 0;
 
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
   int height = map.size();
   int width = map[0].cast<py::list>().size();
 
-  _grid = std::make_unique<Grid>(width, height, layer_for_type_id);
+  _grid = std::make_unique<Grid>(width, height);
   _obs_encoder = std::make_unique<ObservationEncoder>(inventory_item_names);
   _feature_normalizations = _obs_encoder->feature_normalizations();
 
@@ -291,7 +287,7 @@ void MettaGrid::_compute_observation(unsigned int observer_row,
         // c could still be outside of our bounds.
         if (c < c_start || c >= c_end) continue;
 
-        for (unsigned int layer = 0; layer < _grid->num_layers; layer++) {
+        for (unsigned int layer = 0; layer < GridLayer::GridLayerCount; layer++) {
           GridLocation object_loc(r, c, layer);
           auto obj = _grid->object_at(object_loc);
           if (!obj) continue;

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -122,14 +122,11 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map) {
       grid_hash_data += std::to_string(r) + "," + std::to_string(c) + ":" + cell + ";";
 
       Converter* converter = nullptr;
-      if (cell == "wall") {
-        Wall* wall = new Wall(r, c, cfg["objects"]["wall"].cast<ObjectConfig>());
+      if (cell == "wall" || cell == "block") {
+        auto wall_cfg = _create_wall_config(cfg["objects"][py::str(cell)]);
+        Wall* wall = new Wall(r, c, wall_cfg);
         _grid->add_object(wall);
-        _stats->incr("objects.wall");
-      } else if (cell == "block") {
-        Wall* block = new Wall(r, c, cfg["objects"]["block"].cast<ObjectConfig>());
-        _grid->add_object(block);
-        _stats->incr("objects.block");
+        _stats->incr("objects." + cell);
       } else if (cell == "mine_red") {
         auto converter_cfg = _create_converter_config(cfg["objects"]["mine_red"]);
         converter = new Converter(r, c, converter_cfg, ObjectType::MineRedT);
@@ -728,6 +725,11 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
   ObsType color = converter_cfg_py["color"].cast<ObsType>();
   return ConverterConfig{
       recipe_input, recipe_output, max_output, conversion_ticks, cooldown, initial_items, color, inventory_item_names};
+}
+
+WallConfig MettaGrid::_create_wall_config(const py::dict& wall_cfg_py) {
+  bool swappable = wall_cfg_py.contains("swappable") ? wall_cfg_py["swappable"].cast<bool>() : false;
+  return WallConfig{swappable};
 }
 
 // Pybind11 module definition

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -27,6 +27,7 @@ class Agent;
 class ObservationEncoder;
 class GridObject;
 class ConverterConfig;
+class WallConfig;
 
 namespace py = pybind11;
 
@@ -120,6 +121,7 @@ private:
 
   void _handle_invalid_action(size_t agent_idx, const std::string& stat, ActionType type, ActionArg arg);
   ConverterConfig _create_converter_config(const py::dict& converter_cfg_py);
+  WallConfig _create_wall_config(const py::dict& wall_cfg_py);
 };
 
 #endif  // METTAGRID_C_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/constants.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/constants.hpp
@@ -131,19 +131,4 @@ const std::map<uint8_t, float> FeatureNormalizations = {
 
 const float DEFAULT_INVENTORY_NORMALIZATION = 100.0;
 
-const std::map<TypeId, GridLayer> ObjectLayers = {{ObjectType::AgentT, GridLayer::Agent_Layer},
-                                                  {ObjectType::WallT, GridLayer::Object_Layer},
-                                                  {ObjectType::MineRedT, GridLayer::Object_Layer},
-                                                  {ObjectType::MineBlueT, GridLayer::Object_Layer},
-                                                  {ObjectType::MineGreenT, GridLayer::Object_Layer},
-                                                  {ObjectType::GeneratorRedT, GridLayer::Object_Layer},
-                                                  {ObjectType::GeneratorBlueT, GridLayer::Object_Layer},
-                                                  {ObjectType::GeneratorGreenT, GridLayer::Object_Layer},
-                                                  {ObjectType::AltarT, GridLayer::Object_Layer},
-                                                  {ObjectType::ArmoryT, GridLayer::Object_Layer},
-                                                  {ObjectType::LaseryT, GridLayer::Object_Layer},
-                                                  {ObjectType::LabT, GridLayer::Object_Layer},
-                                                  {ObjectType::FactoryT, GridLayer::Object_Layer},
-                                                  {ObjectType::TempleT, GridLayer::Object_Layer}};
-
 #endif  // OBJECTS_CONSTANTS_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/metta_object.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/metta_object.hpp
@@ -5,9 +5,6 @@
 #include <string>
 
 #include "../grid_object.hpp"
-
-typedef std::map<std::string, int> ObjectConfig;
-
 class MettaObject : public GridObject {
 public:
   virtual bool swappable() const {

--- a/mettagrid/src/metta/mettagrid/objects/wall.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/wall.hpp
@@ -8,13 +8,17 @@
 #include "constants.hpp"
 #include "metta_object.hpp"
 
+struct WallConfig {
+  bool swappable;
+};
+
 class Wall : public MettaObject {
 public:
   bool _swappable;
 
-  Wall(GridCoord r, GridCoord c, ObjectConfig cfg) {
+  Wall(GridCoord r, GridCoord c, WallConfig cfg) {
     GridObject::init(ObjectType::WallT, GridLocation(r, c, GridLayer::Object_Layer));
-    this->_swappable = cfg["swappable"];
+    this->_swappable = cfg.swappable;
   }
 
   virtual vector<PartialObservationToken> obs_features() const override {

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -116,25 +116,14 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
 // ==================== Grid Tests ====================
 
 TEST_F(MettaGridCppTest, GridCreation) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 5, layer_for_type_id);
+  Grid grid(10, 5);
 
   EXPECT_EQ(grid.width, 10);
   EXPECT_EQ(grid.height, 5);
-  EXPECT_EQ(grid.num_layers, GridLayer::GridLayerCount);
 }
 
 TEST_F(MettaGridCppTest, GridObjectManagement) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
 
   // Create and add an agent
   auto max_items_per_type = create_test_max_items_per_type();
@@ -162,12 +151,7 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
 // ==================== Action Tests ====================
 
 TEST_F(MettaGridCppTest, AttackAction) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
 
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
@@ -224,12 +208,7 @@ TEST_F(MettaGridCppTest, AttackAction) {
 }
 
 TEST_F(MettaGridCppTest, PutRecipeItems) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
 
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
@@ -283,12 +262,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
 }
 
 TEST_F(MettaGridCppTest, GetOutput) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
 
   auto max_items_per_type = create_test_max_items_per_type();
   auto rewards = create_test_rewards();
@@ -337,31 +311,12 @@ TEST_F(MettaGridCppTest, GetOutput) {
 // ==================== Event System Tests ====================
 
 TEST_F(MettaGridCppTest, EventManager) {
-  std::vector<Layer> layer_for_type_id;
-  for (const auto& layer : ObjectLayers) {
-    layer_for_type_id.push_back(layer.second);
-  }
-
-  Grid grid(10, 10, layer_for_type_id);
+  Grid grid(10, 10);
   EventManager event_manager;
 
   // Test that event manager can be initialized
   // (This is a basic test - more complex event testing would require more setup)
   EXPECT_NO_THROW(event_manager.process_events(1));
-}
-
-// ==================== Object Type Tests ====================
-
-TEST_F(MettaGridCppTest, ObjectTypes) {
-  // Test that object type constants are properly defined
-  EXPECT_NE(ObjectType::AgentT, ObjectType::WallT);
-  EXPECT_NE(ObjectType::AgentT, ObjectType::GeneratorRedT);
-  EXPECT_NE(ObjectType::WallT, ObjectType::GeneratorRedT);
-
-  // Test that object layers are properly mapped
-  EXPECT_TRUE(ObjectLayers.find(ObjectType::AgentT) != ObjectLayers.end());
-  EXPECT_TRUE(ObjectLayers.find(ObjectType::WallT) != ObjectLayers.end());
-  EXPECT_TRUE(ObjectLayers.find(ObjectType::GeneratorRedT) != ObjectLayers.end());
 }
 
 // ==================== Wall/Block Tests ====================

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -367,7 +367,7 @@ TEST_F(MettaGridCppTest, ObjectTypes) {
 // ==================== Wall/Block Tests ====================
 
 TEST_F(MettaGridCppTest, WallCreation) {
-  ObjectConfig wall_cfg;
+  WallConfig wall_cfg;
 
   std::unique_ptr<Wall> wall(new Wall(2, 3, wall_cfg));
 


### PR DESCRIPTION
Reduces the complexity of layers. A lot of the purpose of this is to get rid of ObjectLayers, which was barely being used.

This reduces hardcoded aspects of object types.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210654218853832)