### PR TITLE
Remove converter type_ids from cpp

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -102,6 +102,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
 
   objects_cfg["wall"] = wall_cfg;
   objects_cfg["wall"]["type_id"] = 1;
+  objects_cfg["wall"]["type_name"] = "wall";
+  objects_cfg["wall"]["object_type"] = "wall";
 
   game_cfg["objects"] = objects_cfg;
 

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -68,7 +68,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   game_cfg["actions"] = actions_cfg;
 
   // Groups configuration
-  py::dict agent_groups;
   py::dict agent_group1, agent_group2;
 
   agent_group1["freeze_duration"] = 0;
@@ -94,9 +93,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group2["type_id"] = 0;
   agent_group2["type_name"] = "agent";
   agent_group2["object_type"] = "agent";
-
-  agent_groups["agent.team1"] = agent_group1;
-  agent_groups["agent.team2"] = agent_group2;
 
   // Objects configuration
   py::dict objects_cfg;

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -79,8 +79,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group1["group_id"] = 0;
   agent_group1["group_reward_pct"] = 0.0f;
   agent_group1["type_id"] = 0;
-  agent_group2["type_name"] = "agent";
-  agent_group2["object_type"] = "agent";
+  agent_group1["type_name"] = "agent";
+  agent_group1["object_type"] = "agent";
 
   agent_group2["freeze_duration"] = 0;
   agent_group2["action_failure_penalty"] = 0;

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -80,6 +80,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group1["group_id"] = 0;
   agent_group1["group_reward_pct"] = 0.0f;
   agent_group1["type_id"] = 0;
+  agent_group2["type_name"] = "agent";
+  agent_group2["object_type"] = "agent";
 
   agent_group2["freeze_duration"] = 0;
   agent_group2["action_failure_penalty"] = 0;
@@ -90,11 +92,11 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group2["group_id"] = 1;
   agent_group2["group_reward_pct"] = 0.0f;
   agent_group2["type_id"] = 0;
+  agent_group2["type_name"] = "agent";
+  agent_group2["object_type"] = "agent";
 
   agent_groups["agent.team1"] = agent_group1;
   agent_groups["agent.team2"] = agent_group2;
-
-  game_cfg["agent_groups"] = agent_groups;
 
   // Objects configuration
   py::dict objects_cfg;
@@ -104,6 +106,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   objects_cfg["wall"]["type_id"] = 1;
   objects_cfg["wall"]["type_name"] = "wall";
   objects_cfg["wall"]["object_type"] = "wall";
+  objects_cfg["agent.team1"] = agent_group1;
+  objects_cfg["agent.team2"] = agent_group2;
 
   game_cfg["objects"] = objects_cfg;
 

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -54,11 +54,10 @@ protected:
     bool was_frozen = false;
     if (agent_target) {
       // Track attack targets
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id]);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
-                        actor->group_name);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
-                        actor->group_name + "." + agent_target->group_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name + "." + actor->group_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name + "." + actor->group_name + "." +
+                        agent_target->group_name);
 
       if (agent_target->group_name == actor->group_name) {
         actor->stats.incr("attack.own_team." + actor->group_name);

--- a/mettagrid/src/metta/mettagrid/actions/swap.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/swap.hpp
@@ -33,7 +33,7 @@ protected:
       return false;
     }
 
-    actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[target->type_id]);
+    actor->stats.incr("action." + _action_name + "." + target->type_name);
 
     _grid->swap_objects(actor->id, target->id);
     return true;

--- a/mettagrid/src/metta/mettagrid/grid_object.hpp
+++ b/mettagrid/src/metta/mettagrid/grid_object.hpp
@@ -59,11 +59,13 @@ public:
   GridObjectId id;
   GridLocation location;
   TypeId type_id;
+  std::string type_name;
 
   virtual ~GridObject() = default;
 
-  void init(TypeId type_id, const GridLocation& loc) {
+  void init(TypeId type_id, const std::string& type_name, const GridLocation& loc) {
     this->type_id = type_id;
+    this->type_name = type_name;
     this->location = loc;
   }
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -121,6 +121,10 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
       object_type_names[type_id] = key.cast<std::string>();
     }
 
+    if (!object_cfg.contains("object_type")) {
+      throw std::runtime_error("Object type not specified for " + key.cast<std::string>());
+    }
+
     auto object_type = object_cfg["object_type"].cast<std::string>();
     if (object_type == "agent") {
       unsigned int id = object_cfg["group_id"].cast<unsigned int>();

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -686,7 +686,6 @@ Agent* MettaGrid::create_agent(int r, int c, const py::dict& agent_group_cfg_py)
   std::string group_name = agent_group_cfg_py["group_name"].cast<std::string>();
   unsigned int group_id = agent_group_cfg_py["group_id"].cast<unsigned int>();
   TypeId type_id = agent_group_cfg_py["type_id"].cast<TypeId>();
-  std::string type_name = agent_group_cfg_py["type_name"].cast<std::string>();
   return new Agent(r,
                    c,
                    freeze_duration,
@@ -697,8 +696,7 @@ Agent* MettaGrid::create_agent(int r, int c, const py::dict& agent_group_cfg_py)
                    group_name,
                    group_id,
                    inventory_item_names,
-                   type_id,
-                   type_name);
+                   type_id);
 }
 
 py::array_t<unsigned int> MettaGrid::get_agent_groups() const {

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -141,8 +141,13 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
       // Add cell position and type to hash data
       grid_hash_data += std::to_string(r) + "," + std::to_string(c) + ":" + cell + ";";
 
-      if (cell == "empty") {
+      // #HardCodedConfig
+      if (cell == "empty" || cell == "." || cell == " ") {
         continue;
+      }
+
+      if (!object_configs.contains(py_cell)) {
+        throw std::runtime_error("Unknown object type: " + cell);
       }
 
       auto object_cfg = object_configs[py_cell].cast<py::dict>();

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -108,11 +108,16 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
 
   for (const auto& [key, value] : object_configs) {
     auto object_cfg = value.cast<py::dict>();
+    TypeId type_id = object_cfg["type_id"].cast<TypeId>();
 
-    if (object_type_names[object_cfg["type_id"].cast<int>()] == "") {
+    if (type_id >= object_type_names.size()) {
+      object_type_names.resize(type_id + 1);
+    }
+
+    if (object_type_names[type_id] == "") {
       // #HardCodedConfig
       // The guard here is to avoid overwriting the type_name for the wall object with the block object.
-      object_type_names[object_cfg["type_id"].cast<int>()] = key.cast<std::string>();
+      object_type_names[type_id] = key.cast<std::string>();
     }
 
     auto object_type = object_cfg["object_type"].cast<std::string>();

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -111,6 +111,7 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
     TypeId type_id = object_cfg["type_id"].cast<TypeId>();
 
     if (type_id >= object_type_names.size()) {
+      // Sometimes the type_ids are not contiguous, so we need to resize the vector.
       object_type_names.resize(type_id + 1);
     }
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -44,6 +44,7 @@ public:
   unsigned int max_steps;
 
   std::vector<std::string> inventory_item_names;
+  std::vector<std::string> object_type_names;
 
   // Python API methods
   py::tuple reset();
@@ -68,7 +69,7 @@ public:
   py::object observation_space();
   py::list action_success();
   py::list max_action_args();
-  py::list object_type_names();
+  py::list object_type_names_py();
   py::list inventory_item_names_py();
   py::array_t<unsigned int> get_agent_groups() const;
   Agent* create_agent(int r, int c, const py::dict& agent_group_cfg_py);

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import Field, RootModel, conint
 
@@ -10,20 +10,6 @@ from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
 
 Byte = conint(ge=0, le=255)
 FeatureId = Byte
-
-
-class AgentGroupConfig_cpp(BaseModelWithForbidExtra):
-    """Agent group configuration."""
-
-    freeze_duration: int = Field(ge=0)
-    action_failure_penalty: float = Field(default=0, ge=0)
-    max_items_per_type: Dict[FeatureId, int] = Field(default_factory=dict)
-    resource_rewards: Dict[FeatureId, float] = Field(default_factory=dict)
-    resource_reward_max: Dict[FeatureId, float] = Field(default_factory=dict)
-    group_name: str
-    group_id: int
-    group_reward_pct: float = Field(ge=0, le=1)
-    type_id: int = 0
 
 
 class ActionConfig_cpp(BaseModelWithForbidExtra):
@@ -47,16 +33,43 @@ class ActionsConfig_cpp(BaseModelWithForbidExtra):
     armor_item_id: FeatureId
 
 
-class WallConfig_cpp(BaseModelWithForbidExtra):
+class ObjectConfig_cpp(BaseModelWithForbidExtra):
+    """Object configuration."""
+
+    object_type: Literal["agent", "converter", "wall"]
+    # type_id is meant for consumption by the agents, and it should show up in features.
+    type_id: int
+    # type_name is meant for consumption by humans, and will be used in stats and the viewer.
+    type_name: str
+
+
+class AgentGroupConfig_cpp(ObjectConfig_cpp):
+    """Agent group configuration."""
+
+    object_type: Literal["agent"] = "agent"
+    freeze_duration: int = Field(ge=0)
+    action_failure_penalty: float = Field(default=0, ge=0)
+    max_items_per_type: Dict[FeatureId, int] = Field(default_factory=dict)
+    resource_rewards: Dict[FeatureId, float] = Field(default_factory=dict)
+    resource_reward_max: Dict[FeatureId, float] = Field(default_factory=dict)
+    group_name: str
+    group_id: int
+    group_reward_pct: float = Field(ge=0, le=1)
+    type_id: int = 0
+
+
+class WallConfig_cpp(ObjectConfig_cpp):
     """Wall/Block configuration."""
 
+    object_type: Literal["wall"] = "wall"
     swappable: Optional[bool] = None
     type_id: Byte
 
 
-class ConverterConfig_cpp(BaseModelWithForbidExtra):
+class ConverterConfig_cpp(ObjectConfig_cpp):
     """Converter configuration for objects that convert items."""
 
+    object_type: Literal["converter"] = "converter"
     recipe_input: Dict[FeatureId, int] = Field(default_factory=dict)
     recipe_output: Dict[FeatureId, int] = Field(default_factory=dict)
     max_output: int = Field(ge=-1)
@@ -65,25 +78,6 @@ class ConverterConfig_cpp(BaseModelWithForbidExtra):
     initial_items: int = Field(ge=0)
     color: Byte = Field(default=0)
     type_id: Byte
-
-
-class ObjectsConfig_cpp(BaseModelWithForbidExtra):
-    """Objects configuration."""
-
-    altar: Optional[ConverterConfig_cpp] = None
-    mine_red: Optional[ConverterConfig_cpp] = None
-    mine_blue: Optional[ConverterConfig_cpp] = None
-    mine_green: Optional[ConverterConfig_cpp] = None
-    generator_red: Optional[ConverterConfig_cpp] = None
-    generator_blue: Optional[ConverterConfig_cpp] = None
-    generator_green: Optional[ConverterConfig_cpp] = None
-    armory: Optional[ConverterConfig_cpp] = None
-    lasery: Optional[ConverterConfig_cpp] = None
-    lab: Optional[ConverterConfig_cpp] = None
-    factory: Optional[ConverterConfig_cpp] = None
-    temple: Optional[ConverterConfig_cpp] = None
-    wall: Optional[WallConfig_cpp] = None
-    block: Optional[WallConfig_cpp] = None
 
 
 class RewardSharingGroup_cpp(RootModel[Dict[str, float]]):
@@ -107,9 +101,8 @@ class GameConfig_cpp(BaseModelWithForbidExtra):
     obs_width: int = Field(ge=1)
     obs_height: int = Field(ge=1)
     num_observation_tokens: int = Field(ge=1)
-    agent_groups: Dict[str, AgentGroupConfig_cpp] = Field(min_length=1)
     actions: ActionsConfig_cpp
-    objects: ObjectsConfig_cpp
+    objects: Dict[str, AgentGroupConfig_cpp | ConverterConfig_cpp | WallConfig_cpp]
     reward_sharing: Optional[RewardSharingConfig_cpp] = None
 
 
@@ -119,7 +112,7 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
     inventory_item_names = list(mettagrid_config.inventory_item_names)
     inventory_item_ids = dict((name, i) for i, name in enumerate(inventory_item_names))
 
-    agent_group_configs = {}
+    object_configs = {}
 
     # these are the baseline settings for all agents
     agent_default_config_dict = mettagrid_config.agent.model_dump(by_alias=True, exclude_unset=True)
@@ -160,14 +153,17 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
             "group_reward_pct": group_config.group_reward_pct or 0,
         }
 
+        # #HardCodedConfig
         # these defaults should be moved elsewhere!
         for k in agent_group_config["resource_rewards"]:
             if k not in agent_group_config["resource_reward_max"]:
                 agent_group_config["resource_reward_max"][k] = 1000
 
-        agent_group_configs["agent." + group_name] = AgentGroupConfig_cpp(**agent_group_config)
+        # #HardCodedConfig
+        agent_group_config["type_id"] = 0
+        agent_group_config["type_name"] = "agent"
+        object_configs["agent." + group_name] = AgentGroupConfig_cpp(**agent_group_config)
 
-    object_configs = {}
     for object_type, object_config in mettagrid_config.objects.items():
         if isinstance(object_config, ConverterConfig_py):
             converter_config_dict = object_config.model_dump(by_alias=True, exclude_unset=True)
@@ -182,18 +178,21 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
                     converter_config_cpp_dict["recipe_output"][inventory_item_ids[k[7:]]] = v
                 else:
                     converter_config_cpp_dict[k] = v
+            converter_config_cpp_dict["type_name"] = object_type
             object_configs[object_type] = ConverterConfig_cpp(**converter_config_cpp_dict)
         elif isinstance(object_config, WallConfig_py):
-            object_configs[object_type] = WallConfig_cpp(**object_config.model_dump(by_alias=True, exclude_unset=True))
+            object_config_dict = object_config.model_dump(by_alias=True, exclude_unset=True)
+            object_config_dict["type_name"] = object_type
+            object_configs[object_type] = WallConfig_cpp(**object_config_dict)
         else:
             raise ValueError(f"Unknown object type: {object_type}")
 
     game_config = mettagrid_config.model_dump(by_alias=True, exclude_none=True)
-    game_config["agent_groups"] = agent_group_configs
     del game_config["agent"]
     del game_config["groups"]
     game_config["objects"] = object_configs
     # TODO: make this configurable at a higher level
+    # #HardCodedConfig
     game_config["actions"]["laser_item_id"] = inventory_item_ids["laser"]
     game_config["actions"]["armor_item_id"] = inventory_item_ids["armor"]
 

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -40,8 +40,7 @@ public:
         std::string group_name,
         unsigned char group_id,
         const std::vector<std::string>& inventory_item_names,
-        TypeId type_id,
-        std::string type_name)
+        TypeId type_id)
       : freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
         max_items_per_type(max_items_per_type),
@@ -52,7 +51,8 @@ public:
         color(0),
         current_resource_reward(0),
         stats(inventory_item_names) {
-    GridObject::init(type_id, type_name, GridLocation(r, c, GridLayer::Agent_Layer));
+    // #HardCodedConfig -- "agent" is hard coded.
+    GridObject::init(type_id, "agent", GridLocation(r, c, GridLayer::Agent_Layer));
 
     this->frozen = 0;
     this->orientation = 0;

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -40,7 +40,8 @@ public:
         std::string group_name,
         unsigned char group_id,
         const std::vector<std::string>& inventory_item_names,
-        TypeId type_id)
+        TypeId type_id,
+        std::string type_name)
       : freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
         max_items_per_type(max_items_per_type),
@@ -51,7 +52,7 @@ public:
         color(0),
         current_resource_reward(0),
         stats(inventory_item_names) {
-    GridObject::init(type_id, GridLocation(r, c, GridLayer::Agent_Layer));
+    GridObject::init(type_id, type_name, GridLocation(r, c, GridLayer::Agent_Layer));
 
     this->frozen = 0;
     this->orientation = 0;

--- a/mettagrid/src/metta/mettagrid/objects/constants.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/constants.hpp
@@ -52,50 +52,6 @@ enum ObservationFeatureEnum : uint8_t {
 
 const uint8_t InventoryFeatureOffset = ObservationFeature::ObservationFeatureCount;
 
-// There should be a one-to-one mapping between ObjectType and ObjectTypeNames.
-// ObjectTypeName is mostly used for human-readability, but may be used as a key
-// in config files, etc. Agents will be able to see an object's type_id.
-//
-// Note that ObjectType does _not_ have to correspond to an object's class (which
-// is a C++ concept). In particular, multiple ObjectTypes may correspond to the
-// same class.
-enum ObjectType {
-  AgentT = 0,
-  WallT = 1,
-  MineRedT = 2,
-  MineBlueT = 3,
-  MineGreenT = 4,
-  GeneratorRedT = 5,
-  GeneratorBlueT = 6,
-  GeneratorGreenT = 7,
-  AltarT = 8,
-  ArmoryT = 9,
-  LaseryT = 10,
-  LabT = 11,
-  FactoryT = 12,
-  TempleT = 13,
-  GenericConverterT = 14,
-  ObjectTypeCount
-};
-
-constexpr std::array<const char*, ObjectTypeCount> ObjectTypeNamesArray = {{"agent",
-                                                                            "wall",
-                                                                            "mine_red",
-                                                                            "mine_blue",
-                                                                            "mine_green",
-                                                                            "generator_red",
-                                                                            "generator_blue",
-                                                                            "generator_green",
-                                                                            "altar",
-                                                                            "armory",
-                                                                            "lasery",
-                                                                            "lab",
-                                                                            "factory",
-                                                                            "temple",
-                                                                            "converter"}};
-
-const std::vector<std::string> ObjectTypeNames(ObjectTypeNamesArray.begin(), ObjectTypeNamesArray.end());
-
 const std::map<uint8_t, std::string> FeatureNames = {
     {ObservationFeature::TypeId, "type_id"},
     {ObservationFeature::Group, "agent:group"},

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -22,7 +22,7 @@ struct ConverterConfig {
   unsigned char initial_items;
   ObsType color;
   std::vector<std::string> inventory_item_names;
-  int type_id;
+  TypeId type_id;
   std::string type_name;
 };
 

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -22,7 +22,8 @@ struct ConverterConfig {
   unsigned char initial_items;
   ObsType color;
   std::vector<std::string> inventory_item_names;
-  TypeId type_id;
+  int type_id;
+  std::string type_name;
 };
 
 class Converter : public HasInventory {
@@ -105,7 +106,7 @@ public:
         cooldown(cfg.cooldown),
         color(cfg.color),
         stats(cfg.inventory_item_names) {
-    GridObject::init(cfg.type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(cfg.type_id, cfg.type_name, GridLocation(r, c, GridLayer::Object_Layer));
     this->converting = false;
     this->cooling_down = false;
 

--- a/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
@@ -18,7 +18,7 @@ public:
     }
 
     converter->finish_converting();
-    converter->stats.incr(ObjectTypeNames[converter->type_id] + ".produced");
+    converter->stats.incr(converter->type_name + ".produced");
   }
 };
 

--- a/mettagrid/src/metta/mettagrid/objects/wall.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/wall.hpp
@@ -9,7 +9,8 @@
 #include "metta_object.hpp"
 
 struct WallConfig {
-  int type_id;
+  TypeId type_id;
+  std::string type_name;
   bool swappable;
 };
 
@@ -18,7 +19,7 @@ public:
   bool _swappable;
 
   Wall(GridCoord r, GridCoord c, WallConfig cfg) {
-    GridObject::init(cfg.type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(cfg.type_id, cfg.type_name, GridLocation(r, c, GridLayer::Object_Layer));
     this->_swappable = cfg.swappable;
   }
 

--- a/mettagrid/tests/test_grid_object.cpp
+++ b/mettagrid/tests/test_grid_object.cpp
@@ -61,9 +61,10 @@ protected:
 // Test init with GridLocation
 TEST_F(GridObjectTest, InitWithLocation) {
   GridLocation loc(5, 10, 2);
-  obj.init(1, loc);
+  obj.init(1, "object", loc);
 
   EXPECT_EQ(1, obj.type_id);
+  EXPECT_EQ("object", obj.type_name);
   EXPECT_EQ(5, obj.location.r);
   EXPECT_EQ(10, obj.location.c);
   EXPECT_EQ(2, obj.location.layer);

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -69,18 +69,8 @@ TEST_F(MettaGridCppTest, AgentRewards) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(new Agent(0,
-                                         0,
-                                         100,
-                                         0.1f,
-                                         max_items_per_type,
-                                         rewards,
-                                         resource_reward_max,
-                                         "test_group",
-                                         1,
-                                         inventory_item_names,
-                                         0,
-                                         "agent"));
+  std::unique_ptr<Agent> agent(new Agent(
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
 
   // Test reward values
   EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ORE], 0.125f);
@@ -95,18 +85,8 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(new Agent(0,
-                                         0,
-                                         100,
-                                         0.1f,
-                                         max_items_per_type,
-                                         rewards,
-                                         resource_reward_max,
-                                         "test_group",
-                                         1,
-                                         inventory_item_names,
-                                         0,
-                                         "agent"));
+  std::unique_ptr<Agent> agent(new Agent(
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
 
   float dummy_reward = 0.0f;
   agent->init(&dummy_reward);
@@ -151,18 +131,8 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
-  Agent* agent = new Agent(2,
-                           3,
-                           100,
-                           0.1f,
-                           max_items_per_type,
-                           rewards,
-                           resource_reward_max,
-                           "test_group",
-                           1,
-                           inventory_item_names,
-                           0,
-                           "agent");
+  Agent* agent = new Agent(
+      2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0);
 
   grid.add_object(agent);
 
@@ -190,10 +160,10 @@ TEST_F(MettaGridCppTest, AttackAction) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   // Create attacker and target
-  Agent* attacker = new Agent(
-      2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
-  Agent* target = new Agent(
-      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names, 0, "agent");
+  Agent* attacker =
+      new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
+  Agent* target =
+      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names, 0);
 
   float attacker_reward = 0.0f;
   float target_reward = 0.0f;
@@ -246,8 +216,8 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent = new Agent(
-      1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
+  Agent* agent =
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -302,8 +272,8 @@ TEST_F(MettaGridCppTest, GetOutput) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent = new Agent(
-      1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
+  Agent* agent =
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -69,8 +69,18 @@ TEST_F(MettaGridCppTest, AgentRewards) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(new Agent(
-      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
+  std::unique_ptr<Agent> agent(new Agent(0,
+                                         0,
+                                         100,
+                                         0.1f,
+                                         max_items_per_type,
+                                         rewards,
+                                         resource_reward_max,
+                                         "test_group",
+                                         1,
+                                         inventory_item_names,
+                                         0,
+                                         "agent"));
 
   // Test reward values
   EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ORE], 0.125f);
@@ -85,8 +95,18 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  std::unique_ptr<Agent> agent(new Agent(
-      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
+  std::unique_ptr<Agent> agent(new Agent(0,
+                                         0,
+                                         100,
+                                         0.1f,
+                                         max_items_per_type,
+                                         rewards,
+                                         resource_reward_max,
+                                         "test_group",
+                                         1,
+                                         inventory_item_names,
+                                         0,
+                                         "agent"));
 
   float dummy_reward = 0.0f;
   agent->init(&dummy_reward);
@@ -131,8 +151,18 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
   auto rewards = create_test_rewards();
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
-  Agent* agent = new Agent(
-      2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0);
+  Agent* agent = new Agent(2,
+                           3,
+                           100,
+                           0.1f,
+                           max_items_per_type,
+                           rewards,
+                           resource_reward_max,
+                           "test_group",
+                           1,
+                           inventory_item_names,
+                           0,
+                           "agent");
 
   grid.add_object(agent);
 
@@ -160,10 +190,10 @@ TEST_F(MettaGridCppTest, AttackAction) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   // Create attacker and target
-  Agent* attacker =
-      new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
-  Agent* target =
-      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names, 0);
+  Agent* attacker = new Agent(
+      2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
+  Agent* target = new Agent(
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names, 0, "agent");
 
   float attacker_reward = 0.0f;
   float target_reward = 0.0f;
@@ -216,8 +246,8 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent =
-      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
+  Agent* agent = new Agent(
+      1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -235,6 +265,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
   generator_cfg.type_id = TestItems::CONVERTER;
+  generator_cfg.type_name = "generator";
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
@@ -271,8 +302,8 @@ TEST_F(MettaGridCppTest, GetOutput) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
 
-  Agent* agent =
-      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
+  Agent* agent = new Agent(
+      1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0, "agent");
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -346,10 +377,12 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.color = 0;
   converter_cfg.inventory_item_names = create_test_inventory_item_names();
   converter_cfg.type_id = TestItems::CONVERTER;
+  converter_cfg.type_name = "converter";
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg));
 
   ASSERT_NE(converter, nullptr);
   EXPECT_EQ(converter->location.r, 1);
   EXPECT_EQ(converter->location.c, 2);
   EXPECT_EQ(converter->type_id, TestItems::CONVERTER);
+  EXPECT_EQ(converter->type_name, "converter");
 }

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -136,7 +136,7 @@ def test_grid_objects():
     for obj in objects.values():
         if obj.get("type_id") == 1:
             # Walls
-            assert set(obj) == {"type_id"} | common_properties
+            assert set(obj) == {"type_id", "type_name"} | common_properties
         if obj.get("type_id") == 0:
             # Agents
             assert set(obj).issuperset(


### PR DESCRIPTION
Adds explicit type_id fields to all object configurations in the MettagGrid environment. This change decouples the object type identification from hardcoded enums.

Right now the type_ids are explicit in config files, which seems probably not where we want to end; but we need them for the moment because we want the type_ids to be stable. Happily, the iteration on getting rid of this should now let most of this iteration be moved out of cpp.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210654310008279)