### PR TITLE
Move type_id to config

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -93,6 +93,7 @@ game:
 
   objects:
     altar:
+      type_id: 8
       input_battery.red: 3
       output_heart: 1
       max_output: 5
@@ -101,6 +102,7 @@ game:
       initial_items: 1
 
     mine_red:
+      type_id: 2
       output_ore.red: 1
       color: 0
       max_output: 5
@@ -109,6 +111,7 @@ game:
       initial_items: 1
 
     mine_blue:
+      type_id: 3
       color: 1
       output_ore.blue: 1
       max_output: 5
@@ -117,6 +120,7 @@ game:
       initial_items: 1
 
     mine_green:
+      type_id: 4
       output_ore.green: 1
       color: 2
       max_output: 5
@@ -125,6 +129,7 @@ game:
       initial_items: 1
 
     generator_red:
+      type_id: 5
       input_ore.red: 1
       output_battery.red: 1
       color: 0
@@ -134,6 +139,7 @@ game:
       initial_items: 1
 
     generator_blue:
+      type_id: 6
       input_ore.blue: 1
       output_battery.blue: 1
       color: 1
@@ -143,6 +149,7 @@ game:
       initial_items: 1
 
     generator_green:
+      type_id: 7
       input_ore.green: 1
       output_battery.green: 1
       color: 2
@@ -152,6 +159,7 @@ game:
       initial_items: 1
 
     armory:
+      type_id: 9
       input_ore.red: 3
       output_armor: 1
       max_output: 5
@@ -160,6 +168,7 @@ game:
       initial_items: 1
 
     lasery:
+      type_id: 10
       input_ore.red: 1
       input_battery.red: 2
       output_laser: 1
@@ -169,6 +178,7 @@ game:
       initial_items: 1
 
     lab:
+      type_id: 11
       input_ore.red: 3
       input_battery.red: 3
       output_blueprint: 1
@@ -178,6 +188,7 @@ game:
       initial_items: 1
 
     factory:
+      type_id: 12
       input_blueprint: 1
       input_ore.red: 5
       input_battery.red: 5
@@ -189,6 +200,7 @@ game:
       initial_items: 1
 
     temple:
+      type_id: 13
       input_heart: 1
       input_blueprint: 1
       output_heart: 5
@@ -198,9 +210,11 @@ game:
       initial_items: 1
 
     wall:
+      type_id: 1
       swappable: false
 
     block:
+      type_id: 1
       swappable: true
 
   actions:

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -99,10 +99,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   py::dict wall_cfg, block_cfg, mine_cfg, generator_cfg, altar_cfg;
 
   objects_cfg["wall"] = wall_cfg;
-  objects_cfg["block"] = block_cfg;
-  objects_cfg["mine_red"] = mine_cfg;
-  objects_cfg["generator_red"] = generator_cfg;
-  objects_cfg["altar"] = altar_cfg;
+  objects_cfg["wall"]["type_id"] = 1;
 
   game_cfg["objects"] = objects_cfg;
 

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -116,6 +116,7 @@ game:
 
   objects:
     altar:
+      type_id: 8
       input_battery.red: 3
       output_heart: 1
       max_output: 5
@@ -124,6 +125,7 @@ game:
       initial_items: 1
 
     mine_red:
+      type_id: 2
       output_ore.red: 1
       color: 0
       max_output: 5
@@ -132,6 +134,7 @@ game:
       initial_items: 1
 
     mine_blue:
+      type_id: 3
       color: 1
       output_ore.blue: 1
       max_output: 5
@@ -140,6 +143,7 @@ game:
       initial_items: 1
 
     mine_green:
+      type_id: 4
       output_ore.green: 1
       color: 2
       max_output: 5
@@ -148,6 +152,7 @@ game:
       initial_items: 1
 
     generator_red:
+      type_id: 5
       input_ore.red: 1
       output_battery.red: 1
       color: 0
@@ -157,6 +162,7 @@ game:
       initial_items: 1
 
     generator_blue:
+      type_id: 6
       input_ore.blue: 1
       output_battery.blue: 1
       color: 1
@@ -166,6 +172,7 @@ game:
       initial_items: 1
 
     generator_green:
+      type_id: 7
       input_ore.green: 1
       output_battery.green: 1
       color: 2
@@ -175,6 +182,7 @@ game:
       initial_items: 1
 
     armory:
+      type_id: 9
       input_ore.red: 3
       output_armor: 1
       max_output: 5
@@ -183,6 +191,7 @@ game:
       initial_items: 1
 
     lasery:
+      type_id: 10
       input_ore.red: 1
       input_battery.red: 2
       output_laser: 1
@@ -192,6 +201,7 @@ game:
       initial_items: 1
 
     lab:
+      type_id: 11
       input_ore.red: 3
       input_battery.red: 3
       output_blueprint: 1
@@ -201,6 +211,7 @@ game:
       initial_items: 1
 
     factory:
+      type_id: 12
       input_blueprint: 1
       input_ore.red: 5
       input_battery.red: 5
@@ -212,6 +223,7 @@ game:
       initial_items: 1
 
     temple:
+      type_id: 13
       input_heart: 1
       input_blueprint: 1
       output_heart: 5
@@ -221,9 +233,11 @@ game:
       initial_items: 1
 
     wall:
+      type_id: 1
       swappable: false
 
     block:
+      type_id: 1
       swappable: true
 
   actions:

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -50,18 +50,21 @@ game:
 
   objects:
     altar:
+      type_id: 8
       cooldown: 2
       max_output: 100
       conversion_ticks: 1
       initial_items: 100
 
     generator_red:
+      type_id: 2
       cooldown: 5
       max_output: 100
       conversion_ticks: 1
       initial_items: 30
 
-    wall: {}
+    wall:
+      type_id: 1
 
   actions:
     noop:

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -54,10 +54,10 @@ protected:
     bool was_frozen = false;
     if (agent_target) {
       // Track attack targets
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->_type_id]);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->_type_id] + "." +
+      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id]);
+      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
                         actor->group_name);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->_type_id] + "." +
+      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
                         actor->group_name + "." + agent_target->group_name);
 
       if (agent_target->group_name == actor->group_name) {

--- a/mettagrid/src/metta/mettagrid/actions/swap.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/swap.hpp
@@ -33,7 +33,7 @@ protected:
       return false;
     }
 
-    actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[target->_type_id]);
+    actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[target->type_id]);
 
     _grid->swap_objects(actor->id, target->id);
     return true;

--- a/mettagrid/src/metta/mettagrid/grid_object.hpp
+++ b/mettagrid/src/metta/mettagrid/grid_object.hpp
@@ -58,12 +58,12 @@ class GridObject {
 public:
   GridObjectId id;
   GridLocation location;
-  TypeId _type_id;
+  TypeId type_id;
 
   virtual ~GridObject() = default;
 
   void init(TypeId type_id, const GridLocation& loc) {
-    this->_type_id = type_id;
+    this->type_id = type_id;
     this->location = loc;
   }
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -123,42 +123,12 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map) {
         Wall* wall = new Wall(r, c, wall_cfg);
         _grid->add_object(wall);
         _stats->incr("objects." + cell);
-      } else if (cell == "mine_red") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["mine_red"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::MineRedT);
-      } else if (cell == "mine_blue") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["mine_blue"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::MineBlueT);
-      } else if (cell == "mine_green") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["mine_green"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::MineGreenT);
-      } else if (cell == "generator_red") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["generator_red"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::GeneratorRedT);
-      } else if (cell == "generator_blue") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["generator_blue"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::GeneratorBlueT);
-      } else if (cell == "generator_green") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["generator_green"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::GeneratorGreenT);
-      } else if (cell == "altar") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["altar"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::AltarT);
-      } else if (cell == "armory") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["armory"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::ArmoryT);
-      } else if (cell == "lasery") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["lasery"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::LaseryT);
-      } else if (cell == "lab") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["lab"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::LabT);
-      } else if (cell == "factory") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["factory"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::FactoryT);
-      } else if (cell == "temple") {
-        auto converter_cfg = _create_converter_config(cfg["objects"]["temple"]);
-        converter = new Converter(r, c, converter_cfg, ObjectType::TempleT);
+      } else if (cell == "mine_red" || cell == "mine_blue" || cell == "mine_green" || cell == "generator_red" ||
+                 cell == "generator_blue" || cell == "generator_green" || cell == "altar" || cell == "armory" ||
+                 cell == "lasery" || cell == "lab" || cell == "factory" || cell == "temple") {
+        TypeId type_id = cfg["objects"][py::str(cell)]["type_id"].cast<TypeId>();
+        auto converter_cfg = _create_converter_config(cfg["objects"][py::str(cell)]);
+        converter = new Converter(r, c, converter_cfg, type_id);
       } else if (cell.starts_with("agent.")) {
         auto agent_group_cfg_py = agent_groups[py::str(cell)].cast<py::dict>();
 
@@ -532,7 +502,7 @@ py::dict MettaGrid::grid_objects() {
 
     py::dict obj_dict;
     obj_dict["id"] = obj_id;
-    obj_dict["type"] = obj->_type_id;
+    obj_dict["type"] = obj->type_id;
     obj_dict["r"] = obj->location.r;
     obj_dict["c"] = obj->location.c;
     obj_dict["layer"] = obj->location.layer;
@@ -623,7 +593,7 @@ py::dict MettaGrid::get_episode_stats() {
     Converter* converter = dynamic_cast<Converter*>(obj);
     if (converter) {
       // Add metadata to the converter's stats tracker BEFORE converting to dict
-      converter->stats.set("type_id", static_cast<int>(converter->_type_id));
+      converter->stats.set("type_id", static_cast<int>(converter->type_id));
       converter->stats.set("location.r", static_cast<int>(converter->location.r));
       converter->stats.set("location.c", static_cast<int>(converter->location.c));
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -50,6 +50,7 @@ class WallConfig_cpp(BaseModelWithForbidExtra):
     """Wall/Block configuration."""
 
     swappable: Optional[bool] = None
+    type_id: Byte
 
 
 class ConverterConfig_cpp(BaseModelWithForbidExtra):

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -62,6 +62,7 @@ class ConverterConfig_cpp(BaseModelWithForbidExtra):
     cooldown: int = Field(ge=0)
     initial_items: int = Field(ge=0)
     color: Byte = Field(default=0)
+    type_id: Byte
 
 
 class ObjectsConfig_cpp(BaseModelWithForbidExtra):

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -88,6 +88,7 @@ class ActionsConfig(BaseModelWithForbidExtra):
 class WallConfig(BaseModelWithForbidExtra):
     """Wall/Block configuration."""
 
+    type_id: int
     swappable: Optional[bool] = None
 
 
@@ -119,6 +120,7 @@ class ConverterConfig(BaseModelWithForbidExtra):
     output_blueprint: Optional[int] = Field(default=None, alias="output_blueprint", ge=0, le=255)
 
     # Converter properties
+    type_id: int
     max_output: int = Field(ge=-1)
     conversion_ticks: int = Field(ge=0)
     cooldown: int = Field(ge=0)

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -114,7 +114,7 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.reserve(5 + this->inventory.size());
-    features.push_back({ObservationFeature::TypeId, _type_id});
+    features.push_back({ObservationFeature::TypeId, type_id});
     features.push_back({ObservationFeature::Group, group});
     features.push_back({ObservationFeature::Frozen, frozen});
     features.push_back({ObservationFeature::Orientation, orientation});

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -166,7 +166,7 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.reserve(5 + this->inventory.size());
-    features.push_back({ObservationFeature::TypeId, _type_id});
+    features.push_back({ObservationFeature::TypeId, type_id});
     features.push_back({ObservationFeature::Color, color});
     features.push_back({ObservationFeature::ConvertingOrCoolingDown, this->converting || this->cooling_down});
     for (const auto& [item, amount] : this->inventory) {

--- a/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
@@ -18,7 +18,7 @@ public:
     }
 
     converter->finish_converting();
-    converter->stats.incr(ObjectTypeNames[converter->_type_id] + ".produced");
+    converter->stats.incr(ObjectTypeNames[converter->type_id] + ".produced");
   }
 };
 

--- a/mettagrid/src/metta/mettagrid/objects/wall.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/wall.hpp
@@ -24,7 +24,7 @@ public:
   virtual vector<PartialObservationToken> obs_features() const override {
     vector<PartialObservationToken> features;
     features.reserve(2);
-    features.push_back({ObservationFeature::TypeId, _type_id});
+    features.push_back({ObservationFeature::TypeId, type_id});
     if (_swappable) {
       // Only emit the token if it's swappable, to reduce the number of tokens.
       features.push_back({ObservationFeature::Swappable, 1});

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -42,7 +42,10 @@ def base_config():
             "change_color": {"enabled": True},
         },
         "groups": {"red": {"id": 0, "props": {}}},
-        "objects": {"wall": {}, "altar": {"max_output": -1, "conversion_ticks": 1, "cooldown": 10, "initial_items": 0}},
+        "objects": {
+            "wall": {"type_id": 1},
+            "altar": {"type_id": 8, "max_output": -1, "conversion_ticks": 1, "cooldown": 10, "initial_items": 0},
+        },
         "agent": {"rewards": {}},
     }
 

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -60,8 +60,8 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
         },
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {
-            "wall": {},
-            "block": {},
+            "wall": {"type_id": 1},
+            "block": {"type_id": 1},
         },
         "agent": {},
     }

--- a/mettagrid/tests/test_grid_object.cpp
+++ b/mettagrid/tests/test_grid_object.cpp
@@ -63,7 +63,7 @@ TEST_F(GridObjectTest, InitWithLocation) {
   GridLocation loc(5, 10, 2);
   obj.init(1, loc);
 
-  EXPECT_EQ(1, obj._type_id);
+  EXPECT_EQ(1, obj.type_id);
   EXPECT_EQ(5, obj.location.r);
   EXPECT_EQ(10, obj.location.c);
   EXPECT_EQ(2, obj.location.layer);

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -234,9 +234,8 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.initial_items = 0;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
-  generator_cfg.type_id = TestItems::CONVERTER;
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg);
+  Converter* generator = new Converter(0, 0, generator_cfg, TestItems::CONVERTER);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -289,10 +288,8 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator_cfg.initial_items = 1;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
-  generator_cfg.type_id = TestItems::CONVERTER;
-  generator_cfg.type_name = "generator";
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg);
+  Converter* generator = new Converter(0, 0, generator_cfg, TestItems::CONVERTER);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -346,7 +343,6 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.initial_items = 0;
   converter_cfg.color = 0;
   converter_cfg.inventory_item_names = create_test_inventory_item_names();
-  converter_cfg.type_id = TestItems::CONVERTER;
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, TestItems::CONVERTER));
 
   ASSERT_NE(converter, nullptr);

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -16,6 +16,7 @@ constexpr uint8_t ORE = 0;
 constexpr uint8_t LASER = 1;
 constexpr uint8_t ARMOR = 2;
 constexpr uint8_t HEART = 3;
+constexpr uint8_t CONVERTER = 4;
 }  // namespace TestItems
 
 // Pure C++ tests without any Python/pybind dependencies - we will test those with pytest
@@ -233,8 +234,9 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.initial_items = 0;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
+  generator_cfg.type_id = TestItems::CONVERTER;
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorRedT);
+  Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -287,8 +289,10 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator_cfg.initial_items = 1;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
+  generator_cfg.type_id = TestItems::CONVERTER;
+  generator_cfg.type_name = "generator";
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg, ObjectType::GeneratorRedT);
+  Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -342,9 +346,11 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.initial_items = 0;
   converter_cfg.color = 0;
   converter_cfg.inventory_item_names = create_test_inventory_item_names();
-  std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, ObjectType::GeneratorRedT));
+  converter_cfg.type_id = TestItems::CONVERTER;
+  std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, TestItems::CONVERTER));
 
   ASSERT_NE(converter, nullptr);
   EXPECT_EQ(converter->location.r, 1);
   EXPECT_EQ(converter->location.c, 2);
+  EXPECT_EQ(converter->type_id, TestItems::CONVERTER);
 }

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -48,8 +48,8 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
         },
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {
-            "wall": {},
-            "block": {},
+            "wall": {"type_id": 1},
+            "block": {"type_id": 1},
         },
         "agent": {},
     }

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -53,8 +53,9 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
         },
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {
-            "wall": {},
+            "wall": {"type_id": 1},
             "altar": {
+                "type_id": 8,
                 "output_heart": 1,
                 "initial_items": 5,  # Start with some hearts
                 "max_output": 50,
@@ -106,8 +107,8 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
             "blue": {"id": 2, "group_reward_pct": 0.0},
         },
         "objects": {
-            "wall": {},
-            "block": {},
+            "wall": {"type_id": 1},
+            "block": {"type_id": 1},
         },
         "agent": {"freeze_duration": 100, "rewards": {"heart": 1.0}},
     }


### PR DESCRIPTION
Moves type_id to configuration files.

This is a portion of #1196, which I'm having trouble getting to pass tests.

Medium term, we should expect type_ids to be auto-generated rather than specified. At the moment we're keeping it stable since I expect that having them shift around is more likely to break things like visualizers that depend on type_ids being consistent.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210657050874854)