### PR TITLE
Put type_id into config objects

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -126,9 +126,8 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map) {
       } else if (cell == "mine_red" || cell == "mine_blue" || cell == "mine_green" || cell == "generator_red" ||
                  cell == "generator_blue" || cell == "generator_green" || cell == "altar" || cell == "armory" ||
                  cell == "lasery" || cell == "lab" || cell == "factory" || cell == "temple") {
-        TypeId type_id = cfg["objects"][py::str(cell)]["type_id"].cast<TypeId>();
         auto converter_cfg = _create_converter_config(cfg["objects"][py::str(cell)]);
-        converter = new Converter(r, c, converter_cfg, type_id);
+        converter = new Converter(r, c, converter_cfg);
       } else if (cell.starts_with("agent.")) {
         auto agent_group_cfg_py = agent_groups[py::str(cell)].cast<py::dict>();
 
@@ -700,8 +699,16 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
   unsigned short cooldown = converter_cfg_py["cooldown"].cast<unsigned short>();
   unsigned char initial_items = converter_cfg_py["initial_items"].cast<unsigned char>();
   ObsType color = converter_cfg_py["color"].cast<ObsType>();
-  return ConverterConfig{
-      recipe_input, recipe_output, max_output, conversion_ticks, cooldown, initial_items, color, inventory_item_names};
+  TypeId type_id = converter_cfg_py["type_id"].cast<TypeId>();
+  return ConverterConfig{recipe_input,
+                         recipe_output,
+                         max_output,
+                         conversion_ticks,
+                         cooldown,
+                         initial_items,
+                         color,
+                         inventory_item_names,
+                         type_id};
 }
 
 WallConfig MettaGrid::_create_wall_config(const py::dict& wall_cfg_py) {

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -22,6 +22,7 @@ struct ConverterConfig {
   unsigned char initial_items;
   ObsType color;
   std::vector<std::string> inventory_item_names;
+  TypeId type_id;
 };
 
 class Converter : public HasInventory {
@@ -96,7 +97,7 @@ public:
   EventManager* event_manager;
   StatsTracker stats;
 
-  Converter(GridCoord r, GridCoord c, ConverterConfig cfg, TypeId type_id)
+  Converter(GridCoord r, GridCoord c, ConverterConfig cfg)
       : recipe_input(cfg.recipe_input),
         recipe_output(cfg.recipe_output),
         max_output(cfg.max_output),
@@ -104,7 +105,7 @@ public:
         cooldown(cfg.cooldown),
         color(cfg.color),
         stats(cfg.inventory_item_names) {
-    GridObject::init(type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(cfg.type_id, GridLocation(r, c, GridLayer::Object_Layer));
     this->converting = false;
     this->cooling_down = false;
 

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -234,8 +234,9 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.initial_items = 0;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
+  generator_cfg.type_id = TestItems::CONVERTER;
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg, TestItems::CONVERTER);
+  Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -288,8 +289,9 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator_cfg.initial_items = 1;
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
+  generator_cfg.type_id = TestItems::CONVERTER;
   EventManager event_manager;
-  Converter* generator = new Converter(0, 0, generator_cfg, TestItems::CONVERTER);
+  Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
   generator->set_event_manager(&event_manager);
 
@@ -343,7 +345,8 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.initial_items = 0;
   converter_cfg.color = 0;
   converter_cfg.inventory_item_names = create_test_inventory_item_names();
-  std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg, TestItems::CONVERTER));
+  converter_cfg.type_id = TestItems::CONVERTER;
+  std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg));
 
   ASSERT_NE(converter, nullptr);
   EXPECT_EQ(converter->location.r, 1);


### PR DESCRIPTION
Move `type_id` from `Converter` constructor to `ConverterConfig` struct to simplify object creation.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210657442094902)