### PR TITLE
Remove usage of ObjectType for agents

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -79,6 +79,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group1["group_name"] = "team1";
   agent_group1["group_id"] = 0;
   agent_group1["group_reward_pct"] = 0.0f;
+  agent_group1["type_id"] = 0;
 
   agent_group2["freeze_duration"] = 0;
   agent_group2["action_failure_penalty"] = 0;
@@ -88,6 +89,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   agent_group2["group_name"] = "team2";
   agent_group2["group_id"] = 1;
   agent_group2["group_reward_pct"] = 0.0f;
+  agent_group2["type_id"] = 0;
 
   agent_groups["agent.team1"] = agent_group1;
   agent_groups["agent.team2"] = agent_group2;

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -671,6 +671,7 @@ Agent* MettaGrid::create_agent(int r, int c, const py::dict& agent_group_cfg_py)
       agent_group_cfg_py["resource_reward_max"].cast<std::map<InventoryItem, float>>();
   std::string group_name = agent_group_cfg_py["group_name"].cast<std::string>();
   unsigned int group_id = agent_group_cfg_py["group_id"].cast<unsigned int>();
+  TypeId type_id = agent_group_cfg_py["type_id"].cast<TypeId>();
 
   return new Agent(r,
                    c,
@@ -681,7 +682,8 @@ Agent* MettaGrid::create_agent(int r, int c, const py::dict& agent_group_cfg_py)
                    resource_reward_max,
                    group_name,
                    group_id,
-                   inventory_item_names);
+                   inventory_item_names,
+                   type_id);
 }
 
 py::array_t<unsigned int> MettaGrid::get_agent_groups() const {

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -23,6 +23,7 @@ class AgentGroupConfig_cpp(BaseModelWithForbidExtra):
     group_name: str
     group_id: int
     group_reward_pct: float = Field(ge=0, le=1)
+    type_id: int = 0
 
 
 class ActionConfig_cpp(BaseModelWithForbidExtra):

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -39,7 +39,8 @@ public:
         std::map<InventoryItem, float> resource_reward_max,
         std::string group_name,
         unsigned char group_id,
-        const std::vector<std::string>& inventory_item_names)
+        const std::vector<std::string>& inventory_item_names,
+        TypeId type_id)
       : freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
         max_items_per_type(max_items_per_type),
@@ -50,7 +51,7 @@ public:
         color(0),
         current_resource_reward(0),
         stats(inventory_item_names) {
-    GridObject::init(ObjectType::AgentT, GridLocation(r, c, GridLayer::Agent_Layer));
+    GridObject::init(type_id, GridLocation(r, c, GridLayer::Agent_Layer));
 
     this->frozen = 0;
     this->orientation = 0;

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -70,7 +70,7 @@ TEST_F(MettaGridCppTest, AgentRewards) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   std::unique_ptr<Agent> agent(new Agent(
-      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names));
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
 
   // Test reward values
   EXPECT_FLOAT_EQ(agent->resource_rewards[TestItems::ORE], 0.125f);
@@ -86,7 +86,7 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   std::unique_ptr<Agent> agent(new Agent(
-      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names));
+      0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0));
 
   float dummy_reward = 0.0f;
   agent->init(&dummy_reward);
@@ -132,7 +132,7 @@ TEST_F(MettaGridCppTest, GridObjectManagement) {
   auto resource_reward_max = create_test_resource_reward_max();
   auto inventory_item_names = create_test_inventory_item_names();
   Agent* agent = new Agent(
-      2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names);
+      2, 3, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "test_group", 1, inventory_item_names, 0);
 
   grid.add_object(agent);
 
@@ -161,9 +161,9 @@ TEST_F(MettaGridCppTest, AttackAction) {
 
   // Create attacker and target
   Agent* attacker =
-      new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
+      new Agent(2, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
   Agent* target =
-      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names);
+      new Agent(0, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "blue", 2, inventory_item_names, 0);
 
   float attacker_reward = 0.0f;
   float target_reward = 0.0f;
@@ -217,7 +217,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   Agent* agent =
-      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 
@@ -272,7 +272,7 @@ TEST_F(MettaGridCppTest, GetOutput) {
   auto inventory_item_names = create_test_inventory_item_names();
 
   Agent* agent =
-      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names);
+      new Agent(1, 0, 100, 0.1f, max_items_per_type, rewards, resource_reward_max, "red", 1, inventory_item_names, 0);
   float agent_reward = 0.0f;
   agent->init(&agent_reward);
 


### PR DESCRIPTION
This pushes Agent to use outside-of-cpp type_ids, and removes usage of ObjectType.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210660677208037)