### PR TITLE
fetch artifacts action

### DIFF
--- a/.github/actions/fetch-artifacts/action.yml
+++ b/.github/actions/fetch-artifacts/action.yml
@@ -1,0 +1,56 @@
+name: 'Fetch Artifacts'
+description: 'Downloads zipped artifacts from previous successful workflow runs'
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: false
+    default: ${{ github.token }}
+  workflow-name:
+    description: 'Name of the workflow file to search (e.g., "build.yml")'
+    required: true
+  artifact-name-pattern:
+    description: 'Pattern to match artifact names (supports wildcards like "build-*" or exact names)'
+    required: true
+  num-artifacts:
+    description: 'Number of artifacts to collect'
+    required: false
+    default: '5'
+  output-directory:
+    description: 'Directory to save downloaded artifacts'
+    required: false
+    default: 'downloaded-artifacts'
+outputs:
+  artifacts-found:
+    description: 'Number of artifacts found and downloaded'
+    value: ${{ steps.fetch-artifacts.outputs.artifacts-found }}
+  success:
+    description: 'Whether the operation completed successfully'
+    value: ${{ steps.fetch-artifacts.outputs.success }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11.7"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "0.7.3"
+        enable-cache: true
+
+    - name: Fetch Artifacts
+      id: fetch-artifacts
+      shell: bash
+      env:
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        INPUT_ARTIFACT_NAME_PATTERN: ${{ inputs.artifact-name-pattern }}
+        INPUT_NUM_ARTIFACTS: ${{ inputs.num-artifacts }}
+        INPUT_OUTPUT_DIRECTORY: ${{ inputs.output-directory }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+      run: |
+        uv run ${{ github.action_path }}/fetch_artifacts.py

--- a/.github/actions/fetch-artifacts/fetch_artifacts.py
+++ b/.github/actions/fetch-artifacts/fetch_artifacts.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "PyGithub>=2.1.1",
+#   "requests>=2.31.0",
+# ]
+# ///
+"""
+Fetch Artifacts Script
+
+Downloads zipped artifacts from previous workflow runs and saves them to disk.
+Simple and focused - just gets the ZIP files for you to process as needed.
+"""
+
+import fnmatch
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from github import Github
+
+
+class GitHubActionsOutput:
+    """Helper for setting GitHub Actions outputs safely."""
+
+    def __init__(self):
+        self.github_output = os.environ.get("GITHUB_OUTPUT")
+
+    def set_output(self, name: str, value: str) -> None:
+        """Set a GitHub Actions output value."""
+        if self.github_output:
+            with open(self.github_output, "a", encoding="utf-8") as f:
+                # Use delimiter for multiline content
+                if "\n" in value:
+                    delimiter = f"EOF_{hash(value) % 10000}"
+                    f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+                else:
+                    f.write(f"{name}={value}\n")
+        print(f"::set-output name={name}::{value[:100]}{'...' if len(value) > 100 else ''}")
+
+
+class GitHubAPI:
+    """GitHub API client using PyGithub for fetching workflow runs and artifacts."""
+
+    def __init__(self, token: str, repo: str):
+        self.token = token
+        self.github = Github(token)
+        self.repo = self.github.get_repo(repo)
+
+    def get_workflow_runs(self, workflow_filename: str, exclude_run_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Get successful workflow runs for the specified workflow."""
+        try:
+            workflow = self.repo.get_workflow(workflow_filename)
+            runs = workflow.get_runs(status="completed", conclusion="success")
+
+            result = []
+            # Paginate through runs to ensure we get all of them
+            page = 0
+            max_pages = 10  # Reasonable limit to avoid infinite loops
+
+            while page < max_pages:
+                try:
+                    runs_page = runs.get_page(page)
+                    if not runs_page:
+                        break
+
+                    for run in runs_page:
+                        # Exclude current run if specified
+                        if exclude_run_id and str(run.id) == str(exclude_run_id):
+                            continue
+
+                        result.append(
+                            {
+                                "id": run.id,
+                                "created_at": run.created_at.isoformat(),
+                                "url": run.html_url,
+                            }
+                        )
+
+                    page += 1
+
+                    # If we have enough runs for reasonable searching, break early
+                    if len(result) >= 100:
+                        break
+
+                except Exception:
+                    # No more pages available
+                    break
+
+            return result
+        except Exception as e:
+            print(f"❌ Error fetching workflow runs: {e}")
+            return []
+
+    def get_run_artifacts(self, run_id: int) -> List[Dict[str, Any]]:
+        """Get artifacts for a specific workflow run."""
+        try:
+            run = self.repo.get_workflow_run(run_id)
+            artifacts = run.get_artifacts()
+
+            result = []
+            # Paginate through artifacts to ensure we get all of them
+            page = 0
+            max_pages = 5  # Artifacts are usually fewer, so lower limit
+
+            while page < max_pages:
+                try:
+                    artifacts_page = artifacts.get_page(page)
+                    if not artifacts_page:
+                        break
+
+                    for artifact in artifacts_page:
+                        result.append(
+                            {
+                                "id": artifact.id,
+                                "name": artifact.name,
+                                "size": artifact.size_in_bytes,
+                                "created_at": artifact.created_at.isoformat(),
+                                "expires_at": artifact.expires_at.isoformat() if artifact.expires_at else None,
+                                "download_url": artifact.archive_download_url,
+                            }
+                        )
+
+                    page += 1
+
+                except Exception:
+                    # No more pages available
+                    break
+
+            return result
+        except Exception as e:
+            print(f"❌ Error fetching artifacts for run {run_id}: {e}")
+            return []
+
+    def download_artifact(self, download_url: str, output_path: Path) -> bool:
+        """Download an artifact ZIP file."""
+        try:
+            import requests
+
+            # Use the stored token for download
+            headers = {"Authorization": f"Bearer {self.token}"}
+
+            response = requests.get(download_url, headers=headers, stream=True)
+            response.raise_for_status()
+
+            with open(output_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+
+            return True
+        except Exception as e:
+            print(f"❌ Error downloading artifact: {e}")
+            return False
+
+
+class ArtifactFetcher:
+    """Main class for fetching artifacts and saving them as ZIP files."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self.github_api = GitHubAPI(config["github_token"], config["repo"])
+        self.output = GitHubActionsOutput()
+        self.current_run_id = os.environ.get("GITHUB_RUN_ID")
+
+    def matches_pattern(self, artifact_name: str, pattern: str) -> bool:
+        """Check if artifact name matches the pattern."""
+        return fnmatch.fnmatch(artifact_name.lower(), pattern.lower())
+
+    def find_and_collect_artifacts(self) -> tuple[List[Dict[str, Any]], int]:
+        """Find artifacts matching the specified pattern, collecting until we have num_artifacts."""
+        print(
+            f"🔍 Searching for {self.config['num_artifacts']} artifacts matching '{self.config['artifact_name_pattern']}'"
+        )
+        print(f"📋 Workflow: {self.config['workflow_name']}")
+
+        try:
+            # Get all successful workflow runs
+            runs = self.github_api.get_workflow_runs(self.config["workflow_name"], exclude_run_id=self.current_run_id)
+
+            print(f"📊 Found {len(runs)} successful workflow runs to search")
+
+            matching_artifacts = []
+            runs_searched = 0
+            target_count = self.config["num_artifacts"]
+
+            for run in runs:
+                runs_searched += 1
+                run_id = run["id"]
+                run_date = run["created_at"]
+
+                print(
+                    f"🔍 Searching run {run_id} ({run_date[:10]}) - {len(matching_artifacts)}/{target_count} artifacts found"
+                )
+
+                try:
+                    artifacts = self.github_api.get_run_artifacts(run_id)
+
+                    for artifact in artifacts:
+                        if self.matches_pattern(artifact["name"], self.config["artifact_name_pattern"]):
+                            artifact_info = {
+                                "artifact_id": artifact["id"],
+                                "artifact_name": artifact["name"],
+                                "size_bytes": artifact["size"],
+                                "created_at": artifact["created_at"],
+                                "run_id": run_id,
+                                "run_date": run_date,
+                                "workflow_url": run["url"],
+                                "expires_at": artifact["expires_at"],
+                                "download_url": artifact["download_url"],
+                            }
+                            matching_artifacts.append(artifact_info)
+                            print(f"✅ Found matching artifact: {artifact['name']} ({artifact['size']:,} bytes)")
+
+                            # Check if we've collected enough artifacts
+                            if len(matching_artifacts) >= target_count:
+                                print(f"🎯 Collected {target_count} artifacts, stopping search")
+                                return matching_artifacts, runs_searched
+
+                except Exception as e:
+                    print(f"⚠️ Error fetching artifacts for run {run_id}: {e}")
+                    continue
+
+            print(f"🎯 Search complete: found {len(matching_artifacts)} artifacts after searching {runs_searched} runs")
+            return matching_artifacts, runs_searched
+
+        except Exception as e:
+            print(f"❌ Error fetching workflow runs: {e}")
+            return [], 0
+
+    def download_artifact(self, artifact_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Download a single artifact as a ZIP file."""
+        artifact_name = artifact_info["artifact_name"]
+        run_id = artifact_info["run_id"]
+        download_url = artifact_info["download_url"]
+
+        # Create output directory
+        output_dir = Path(self.config["output_directory"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create unique filename: artifact-name_run-id.zip
+        zip_filename = f"{artifact_name}_{run_id}.zip"
+        zip_path = output_dir / zip_filename
+
+        print(f"📦 Downloading {artifact_name} to {zip_path}")
+
+        try:
+            success = self.github_api.download_artifact(download_url, zip_path)
+
+            if success and zip_path.exists():
+                file_size = zip_path.stat().st_size
+                print(f"✅ Downloaded successfully: {file_size:,} bytes")
+
+                return {
+                    **artifact_info,
+                    "status": "downloaded",
+                    "local_path": str(zip_path),
+                    "local_filename": zip_filename,
+                    "downloaded_size_bytes": file_size,
+                }
+            else:
+                print("❌ Download failed - file not created")
+                return {**artifact_info, "status": "failed", "error": "File not created"}
+
+        except Exception as e:
+            print(f"❌ Error downloading artifact {artifact_name}: {e}")
+            return {**artifact_info, "status": "error", "error": str(e)}
+
+    def run(self) -> Dict[str, Any]:
+        """Main execution method."""
+        # Find and collect the requested number of artifacts
+        matching_artifacts, runs_searched = self.find_and_collect_artifacts()
+
+        if not matching_artifacts:
+            self.output.set_output("success", "true")
+            self.output.set_output("artifacts-found", "0")
+            print("ℹ️ No matching artifacts found")
+            return {"success": True, "artifacts_found": 0, "message": "No matching artifacts found"}
+
+        # Download artifacts
+        downloaded_artifacts = []
+        successful_downloads = 0
+
+        for artifact_info in matching_artifacts:
+            result = self.download_artifact(artifact_info)
+            downloaded_artifacts.append(result)
+
+            if result["status"] == "downloaded":
+                successful_downloads += 1
+
+        # Set outputs
+        self.output.set_output("success", "true")
+        self.output.set_output("artifacts-found", str(successful_downloads))
+
+        # Print summary
+        self._print_summary(downloaded_artifacts, runs_searched)
+
+        return {"success": True, "artifacts_found": successful_downloads, "downloaded_artifacts": downloaded_artifacts}
+
+    def _print_summary(self, downloaded_artifacts: List[Dict[str, Any]], runs_searched: int) -> None:
+        """Print a summary of the download operation."""
+        print("\n📊 Download Summary:")
+        print(f"{'Artifact Name':<30} {'Run ID':<12} {'Date':<12} {'Size':<12} {'Status'}")
+        print("-" * 80)
+
+        total_size = 0
+        successful = 0
+
+        for artifact in downloaded_artifacts:
+            name = artifact["artifact_name"][:28]
+            run_id = str(artifact["run_id"])[-8:]  # Last 8 chars
+            date = artifact["run_date"][:10]  # Just the date
+            size = f"{artifact['size_bytes']:,}B"
+            status = artifact.get("status", "unknown")
+
+            if status == "downloaded":
+                successful += 1
+                total_size += artifact.get("downloaded_size_bytes", 0)
+
+            print(f"{name:<30} {run_id:<12} {date:<12} {size:<12} {status}")
+
+        print(f"\n✅ Successfully downloaded {successful}/{len(downloaded_artifacts)} artifacts")
+        print(f"📁 Total size: {total_size:,} bytes")
+        print(f"🔍 Runs searched: {runs_searched}")
+        print(f"💾 Files saved to: {self.config['output_directory']}/")
+
+        if successful > 0:
+            print("\n📂 Downloaded files:")
+            for artifact in downloaded_artifacts:
+                if artifact.get("status") == "downloaded":
+                    print(f"  • {artifact['local_filename']}")
+
+
+def parse_config() -> Dict[str, Any]:
+    """Parse configuration from environment variables."""
+    config = {
+        "github_token": os.environ.get("INPUT_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+        "workflow_name": os.environ.get("INPUT_WORKFLOW_NAME"),
+        "artifact_name_pattern": os.environ.get("INPUT_ARTIFACT_NAME_PATTERN"),
+        "num_artifacts": int(os.environ.get("INPUT_NUM_ARTIFACTS", "5")),
+        "output_directory": os.environ.get("INPUT_OUTPUT_DIRECTORY", "downloaded-artifacts"),
+        "repo": os.environ.get("GITHUB_REPOSITORY"),
+    }
+
+    # Validation
+    required_fields = ["github_token", "workflow_name", "artifact_name_pattern", "repo"]
+    missing_fields = [field for field in required_fields if not config[field]]
+
+    if missing_fields:
+        print(f"❌ Missing required configuration: {', '.join(missing_fields)}")
+        sys.exit(1)
+
+    if config["num_artifacts"] < 1 or config["num_artifacts"] > 100:
+        print("❌ num_artifacts must be between 1 and 100")
+        sys.exit(1)
+
+    return config
+
+
+def main():
+    """Main entry point."""
+    print("🚀 Starting Fetch Artifacts action")
+
+    try:
+        config = parse_config()
+
+        print("📋 Configuration:")
+        print(f"  • Repository: {config['repo']}")
+        print(f"  • Workflow: {config['workflow_name']}")
+        print(f"  • Artifact pattern: {config['artifact_name_pattern']}")
+        print(f"  • Number of artifacts to collect: {config['num_artifacts']}")
+        print(f"  • Output directory: {config['output_directory']}")
+
+        fetcher = ArtifactFetcher(config)
+        result = fetcher.run()
+
+        if result["success"]:
+            print(f"🎉 Completed successfully: {result['artifacts_found']} artifacts downloaded")
+        else:
+            print(f"❌ Operation failed: {result.get('message', 'Unknown error')}")
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"💥 Fatal error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-fetch-artifacts.yml
+++ b/.github/workflows/test-fetch-artifacts.yml
@@ -1,0 +1,73 @@
+name: 'Test Fetch Artifacts Action'
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/actions/fetch-artifacts/**'
+      - '.github/workflows/test-fetch-artifacts.yml'
+
+jobs:
+  test-fetch-artifacts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch newsletter artifacts
+        uses: ./.github/actions/fetch-artifacts
+        with:
+          workflow-name: 'generate-newsletter.yml'
+          artifact-name-pattern: 'newsletter-*'
+          num-artifacts: '2'
+          output-directory: 'newsletter-artifacts'
+
+      - name: List downloaded artifacts
+        run: |
+          echo "📦 Downloaded artifacts:"
+          ls -la newsletter-artifacts/
+          echo ""
+
+      - name: Unzip and examine artifacts
+        run: |
+          echo "🔍 Examining artifact contents..."
+
+          for zip_file in newsletter-artifacts/*.zip; do
+            if [ -f "$zip_file" ]; then
+              echo "=========================================="
+              echo "📄 Processing: $(basename "$zip_file")"
+              echo "=========================================="
+
+              # Create directory for this artifact
+              artifact_dir="unzipped/$(basename "$zip_file" .zip)"
+              mkdir -p "$artifact_dir"
+
+              # Unzip the artifact
+              unzip -q "$zip_file" -d "$artifact_dir"
+
+              # Show the directory structure
+              echo "📂 Directory structure:"
+              find "$artifact_dir" -type f -exec ls -lh {} \; | head -20
+              echo ""
+
+              # Show some sample content if there are text files
+              echo "📝 Sample content (first few files):"
+              find "$artifact_dir" -name "*.txt" -o -name "*.md" -o -name "*.json" -o -name "*.yml" -o -name "*.yaml" | head -3 | while read file; do
+                echo "--- Content of $file (first 10 lines) ---"
+                head -10 "$file" 2>/dev/null || echo "Unable to read file"
+                echo ""
+              done
+
+              echo "=========================================="
+              echo ""
+            fi
+          done
+
+      - name: Summary
+        run: |
+          echo "✅ Test completed!"
+          echo "📊 Summary:"
+          echo "  • Artifacts downloaded: $(ls newsletter-artifacts/*.zip 2>/dev/null | wc -l)"
+          echo "  • Total size: $(du -sh newsletter-artifacts/ 2>/dev/null | cut -f1 || echo '0')"
+          echo "  • Unzipped files: $(find unzipped/ -type f 2>/dev/null | wc -l || echo '0')"


### PR DESCRIPTION
# Add Fetch Artifacts Action

## Overview
This PR adds a new reusable GitHub action that downloads artifacts from previous successful workflow runs. The action searches backward through workflow history to collect a specified number of matching artifacts.

## What's Added

### 📦 New Action: `.github/actions/fetch-artifacts`
- **Purpose**: Download ZIP artifacts from previous workflow runs
- **Language**: Python with PyGithub + requests
- **Dependency Management**: Uses `uv` for fast, reliable package installation

### 🔧 Key Features
- **Smart Search**: Searches backward through workflow runs until it finds the requested number of artifacts
- **Pattern Matching**: Supports wildcards (e.g., `newsletter-*`, `build-*`) or exact names
- **Robust Pagination**: Handles repositories with many workflow runs and artifacts
- **Clean Output**: Downloads artifacts as ZIP files with clear naming: `{artifact-name}_{run-id}.zip`
- **Early Termination**: Stops searching once the target number of artifacts is reached

### 📝 Inputs
- `workflow-name` (required): Workflow file to search (e.g., "build.yml")
- `artifact-name-pattern` (required): Pattern to match artifact names
- `num-artifacts` (optional): Number of artifacts to collect (default: 5)
- `output-directory` (optional): Where to save downloads (default: "downloaded-artifacts")
- `github-token` (optional): Defaults to `${{ github.token }}`

### 📤 Outputs
- `artifacts-found`: Number of artifacts successfully downloaded
- `success`: Whether the operation completed successfully

### 🧪 Test Workflow
Added `test-fetch-artifacts.yml` that:
- Fetches 2 `newsletter-*` artifacts from `generate-newsletter.yml`
- Unzips and examines their contents
- Provides detailed summary of what was downloaded

## Usage Example
```yaml
- name: Fetch previous build artifacts
  uses: ./.github/actions/fetch-artifacts
  with:
    workflow-name: 'generate-newsletter.yml'
    artifact-name-pattern: 'newsletter-*'
    num-artifacts: '3'
    output-directory: 'previous-newsletters'
```

This action will be used to improve newsletter continuity.