### PR TITLE
Move a little more towards type_names being configurable

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -102,6 +102,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
 
   objects_cfg["wall"] = wall_cfg;
   objects_cfg["wall"]["type_id"] = 1;
+  objects_cfg["wall"]["type_name"] = "wall";
 
   game_cfg["objects"] = objects_cfg;
 

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -54,11 +54,10 @@ protected:
     bool was_frozen = false;
     if (agent_target) {
       // Track attack targets
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id]);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
-                        actor->group_name);
-      actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[agent_target->type_id] + "." +
-                        actor->group_name + "." + agent_target->group_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name + "." + actor->group_name);
+      actor->stats.incr("action." + _action_name + "." + agent_target->type_name + "." + actor->group_name + "." +
+                        agent_target->group_name);
 
       if (agent_target->group_name == actor->group_name) {
         actor->stats.incr("attack.own_team." + actor->group_name);

--- a/mettagrid/src/metta/mettagrid/actions/swap.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/swap.hpp
@@ -33,7 +33,7 @@ protected:
       return false;
     }
 
-    actor->stats.incr("action." + _action_name + "." + ObjectTypeNames[target->type_id]);
+    actor->stats.incr("action." + _action_name + "." + target->type_name);
 
     _grid->swap_objects(actor->id, target->id);
     return true;

--- a/mettagrid/src/metta/mettagrid/grid_object.hpp
+++ b/mettagrid/src/metta/mettagrid/grid_object.hpp
@@ -59,11 +59,13 @@ public:
   GridObjectId id;
   GridLocation location;
   TypeId type_id;
+  std::string type_name;
 
   virtual ~GridObject() = default;
 
-  void init(TypeId type_id, const GridLocation& loc) {
+  void init(TypeId type_id, const std::string& type_name, const GridLocation& loc) {
     this->type_id = type_id;
+    this->type_name = type_name;
     this->location = loc;
   }
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -712,6 +712,8 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
   unsigned char initial_items = converter_cfg_py["initial_items"].cast<unsigned char>();
   ObsType color = converter_cfg_py["color"].cast<ObsType>();
   TypeId type_id = converter_cfg_py["type_id"].cast<TypeId>();
+  std::string type_name = converter_cfg_py["type_name"].cast<std::string>();
+
   return ConverterConfig{recipe_input,
                          recipe_output,
                          max_output,
@@ -720,13 +722,15 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
                          initial_items,
                          color,
                          inventory_item_names,
-                         type_id};
+                         type_id,
+                         type_name};
 }
 
 WallConfig MettaGrid::_create_wall_config(const py::dict& wall_cfg_py) {
   bool swappable = wall_cfg_py.contains("swappable") ? wall_cfg_py["swappable"].cast<bool>() : false;
   TypeId type_id = wall_cfg_py["type_id"].cast<TypeId>();
-  return WallConfig{type_id, swappable};
+  std::string type_name = wall_cfg_py["type_name"].cast<std::string>();
+  return WallConfig{type_id, type_name, swappable};
 }
 
 // Pybind11 module definition

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -52,6 +52,7 @@ class WallConfig_cpp(BaseModelWithForbidExtra):
 
     swappable: Optional[bool] = None
     type_id: Byte
+    type_name: str
 
 
 class ConverterConfig_cpp(BaseModelWithForbidExtra):
@@ -65,7 +66,7 @@ class ConverterConfig_cpp(BaseModelWithForbidExtra):
     initial_items: int = Field(ge=0)
     color: Byte = Field(default=0)
     type_id: Byte
-
+    type_name: str
 
 class ObjectsConfig_cpp(BaseModelWithForbidExtra):
     """Objects configuration."""
@@ -182,9 +183,9 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
                     converter_config_cpp_dict["recipe_output"][inventory_item_ids[k[7:]]] = v
                 else:
                     converter_config_cpp_dict[k] = v
-            object_configs[object_type] = ConverterConfig_cpp(**converter_config_cpp_dict)
+            object_configs[object_type] = ConverterConfig_cpp(type_name=object_type, **converter_config_cpp_dict)
         elif isinstance(object_config, WallConfig_py):
-            object_configs[object_type] = WallConfig_cpp(**object_config.model_dump(by_alias=True, exclude_unset=True))
+            object_configs[object_type] = WallConfig_cpp(type_name=object_type, **object_config.model_dump(by_alias=True, exclude_unset=True))
         else:
             raise ValueError(f"Unknown object type: {object_type}")
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -68,6 +68,7 @@ class ConverterConfig_cpp(BaseModelWithForbidExtra):
     type_id: Byte
     type_name: str
 
+
 class ObjectsConfig_cpp(BaseModelWithForbidExtra):
     """Objects configuration."""
 
@@ -185,7 +186,9 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
                     converter_config_cpp_dict[k] = v
             object_configs[object_type] = ConverterConfig_cpp(type_name=object_type, **converter_config_cpp_dict)
         elif isinstance(object_config, WallConfig_py):
-            object_configs[object_type] = WallConfig_cpp(type_name=object_type, **object_config.model_dump(by_alias=True, exclude_unset=True))
+            object_configs[object_type] = WallConfig_cpp(
+                type_name=object_type, **object_config.model_dump(by_alias=True, exclude_unset=True)
+            )
         else:
             raise ValueError(f"Unknown object type: {object_type}")
 

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -51,7 +51,7 @@ public:
         color(0),
         current_resource_reward(0),
         stats(inventory_item_names) {
-    GridObject::init(type_id, GridLocation(r, c, GridLayer::Agent_Layer));
+    GridObject::init(type_id, "agent", GridLocation(r, c, GridLayer::Agent_Layer));
 
     this->frozen = 0;
     this->orientation = 0;

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -23,6 +23,7 @@ struct ConverterConfig {
   ObsType color;
   std::vector<std::string> inventory_item_names;
   TypeId type_id;
+  std::string type_name;
 };
 
 class Converter : public HasInventory {
@@ -105,7 +106,7 @@ public:
         cooldown(cfg.cooldown),
         color(cfg.color),
         stats(cfg.inventory_item_names) {
-    GridObject::init(cfg.type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(cfg.type_id, cfg.type_name, GridLocation(r, c, GridLayer::Object_Layer));
     this->converting = false;
     this->cooling_down = false;
 

--- a/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/production_handler.hpp
@@ -18,7 +18,7 @@ public:
     }
 
     converter->finish_converting();
-    converter->stats.incr(ObjectTypeNames[converter->type_id] + ".produced");
+    converter->stats.incr(converter->type_name + ".produced");
   }
 };
 

--- a/mettagrid/src/metta/mettagrid/objects/wall.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/wall.hpp
@@ -9,7 +9,8 @@
 #include "metta_object.hpp"
 
 struct WallConfig {
-  int type_id;
+  TypeId type_id;
+  std::string type_name;
   bool swappable;
 };
 
@@ -18,7 +19,7 @@ public:
   bool _swappable;
 
   Wall(GridCoord r, GridCoord c, WallConfig cfg) {
-    GridObject::init(cfg.type_id, GridLocation(r, c, GridLayer::Object_Layer));
+    GridObject::init(cfg.type_id, cfg.type_name, GridLocation(r, c, GridLayer::Object_Layer));
     this->_swappable = cfg.swappable;
   }
 

--- a/mettagrid/tests/test_grid_object.cpp
+++ b/mettagrid/tests/test_grid_object.cpp
@@ -61,9 +61,10 @@ protected:
 // Test init with GridLocation
 TEST_F(GridObjectTest, InitWithLocation) {
   GridLocation loc(5, 10, 2);
-  obj.init(1, loc);
+  obj.init(1, "object", loc);
 
   EXPECT_EQ(1, obj.type_id);
+  EXPECT_EQ("object", obj.type_name);
   EXPECT_EQ(5, obj.location.r);
   EXPECT_EQ(10, obj.location.c);
   EXPECT_EQ(2, obj.location.layer);

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -235,6 +235,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.color = 0;
   generator_cfg.inventory_item_names = inventory_item_names;
   generator_cfg.type_id = TestItems::CONVERTER;
+  generator_cfg.type_name = "generator";
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
@@ -346,10 +347,12 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.color = 0;
   converter_cfg.inventory_item_names = create_test_inventory_item_names();
   converter_cfg.type_id = TestItems::CONVERTER;
+  converter_cfg.type_name = "converter";
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg));
 
   ASSERT_NE(converter, nullptr);
   EXPECT_EQ(converter->location.r, 1);
   EXPECT_EQ(converter->location.c, 2);
   EXPECT_EQ(converter->type_id, TestItems::CONVERTER);
+  EXPECT_EQ(converter->type_name, "converter");
 }


### PR DESCRIPTION
My full diff is hitting heap corruption errors; so here I am bisecting again.

This moves to making objects responsible for their own type_names. We pull these names from configuration automatically for non-agents.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210664392729431)