### PR TITLE
generator -> generator_red in char encoder

### DIFF
--- a/mettagrid/src/metta/mettagrid/char_encoder.py
+++ b/mettagrid/src/metta/mettagrid/char_encoder.py
@@ -17,8 +17,7 @@ NAME_TO_CHAR: dict[str, list[str]] = {
     "mine_blue": ["b"],
     "mine_green": ["g"],
     # generators
-    "generator": ["n"],
-    "generator_red": ["R"],
+    "generator_red": ["n", "R"],
     "generator_blue": ["B"],
     "generator_green": ["G"],
     # other objects

--- a/mettagrid/tests/renderer/test_nethack.py
+++ b/mettagrid/tests/renderer/test_nethack.py
@@ -24,7 +24,7 @@ class TestNethackRenderer:
     @pytest.fixture
     def basic_renderer(self):
         """Create a basic renderer for testing."""
-        object_type_names = ["agent", "wall", "empty", "mine", "generator", "altar", "factory", "lab", "temple"]
+        object_type_names = ["agent", "wall", "empty", "mine_red", "generator_red", "altar", "factory", "lab", "temple"]
         return NethackRenderer(object_type_names)
 
     @pytest.fixture
@@ -396,12 +396,12 @@ class TestNetHackStyleSolution:
             "wall": "#",
             "agent": "@",
             "empty": ".",
-            "generator": "G",
+            "generator_red": "G",
             "altar": "_",
             "factory": "F",
             "lab": "L",
             "temple": "T",
-            "mine": "^",
+            "mine_red": "^",
             "converter": "*",
         }
 


### PR DESCRIPTION
Follow-up to #1179.

We have some ascii maps that use `n` character that are still producing maps with "generator" string. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210664825510718)