### PR TITLE
Remove npc eval from all suite

### DIFF
--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -34,10 +34,6 @@ simulations:
   navigation/radialmaze:
     env: env/mettagrid/navigation/evals/radialmaze
     policy_agents_pct: 1.0
-  npc/simple:
-    env: env/mettagrid/simple
-    policy_agents_pct: 0.5
-    npc_policy_uri: wandb://run/b.daphne.npc_simple
   objectuse/altar_use_free:
     env: env/mettagrid/object_use/evals/altar_use_free
     policy_agents_pct: 1.0


### PR DESCRIPTION
## Summary
- remove `npc/simple` evaluation from `configs/sim/all.yaml`

## Testing
- `uv run ruff format`
- `uv run ruff check` *(fails: F821 undefined name, E501 line too long)*
- `uv run pytest -q` *(fails: 'xcxc' found in pufferlib/trainer.py)*


------
https://chatgpt.com/codex/tasks/task_e_68518b58704c832e80b95df2fa4eb54b