### PR TITLE
stop passing inventory_items to places that shouldn't need them

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -58,7 +58,7 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
   _feature_normalizations = _obs_encoder->feature_normalizations();
 
   _event_manager = std::make_unique<EventManager>();
-  _stats = std::make_unique<StatsTracker>(inventory_item_names);
+  _stats = std::make_unique<StatsTracker>();
   _stats->set_environment(this);
 
   _event_manager->init(_grid.get());
@@ -705,7 +705,6 @@ AgentConfig MettaGrid::_create_agent_config(const py::dict& agent_group_cfg_py) 
                      max_items_per_type,
                      resource_rewards,
                      resource_reward_max,
-                     inventory_item_names,
                      type_id};
 }
 
@@ -724,6 +723,11 @@ unsigned int StatsTracker::get_current_step() const {
   return static_cast<MettaGrid*>(_env)->current_step;
 }
 
+const std::string& StatsTracker::inventory_item_name(InventoryItem item) const {
+  if (!_env) return StatsTracker::NO_ENV_INVENTORY_ITEM_NAME;
+  return _env->inventory_item_names[item];
+}
+
 ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cfg_py) {
   std::map<InventoryItem, uint8_t> recipe_input =
       converter_cfg_py["recipe_input"].cast<std::map<InventoryItem, uint8_t>>();
@@ -736,16 +740,8 @@ ConverterConfig MettaGrid::_create_converter_config(const py::dict& converter_cf
   ObsType color = converter_cfg_py["color"].cast<ObsType>();
   TypeId type_id = converter_cfg_py["type_id"].cast<TypeId>();
   std::string type_name = converter_cfg_py["type_name"].cast<std::string>();
-  return ConverterConfig{recipe_input,
-                         recipe_output,
-                         max_output,
-                         conversion_ticks,
-                         cooldown,
-                         initial_items,
-                         color,
-                         inventory_item_names,
-                         type_id,
-                         type_name};
+  return ConverterConfig{
+      recipe_input, recipe_output, max_output, conversion_ticks, cooldown, initial_items, color, type_id, type_name};
 }
 
 WallConfig MettaGrid::_create_wall_config(const py::dict& wall_cfg_py) {

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -19,7 +19,6 @@ struct AgentConfig {
   std::map<InventoryItem, uint8_t> max_items_per_type;
   std::map<InventoryItem, float> resource_rewards;
   std::map<InventoryItem, float> resource_reward_max;
-  std::vector<std::string> inventory_item_names;
   TypeId type_id;
 };
 
@@ -53,7 +52,6 @@ public:
         group_name(config.group_name),
         color(0),
         current_resource_reward(0),
-        stats(config.inventory_item_names),
         frozen(0),
         orientation(0),
         reward(nullptr) {

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -21,7 +21,6 @@ struct ConverterConfig {
   unsigned short cooldown;
   unsigned char initial_items;
   ObsType color;
-  std::vector<std::string> inventory_item_names;
   TypeId type_id;
   std::string type_name;
 };
@@ -104,8 +103,7 @@ public:
         max_output(cfg.max_output),
         conversion_ticks(cfg.conversion_ticks),
         cooldown(cfg.cooldown),
-        color(cfg.color),
-        stats(cfg.inventory_item_names) {
+        color(cfg.color) {
     GridObject::init(cfg.type_id, cfg.type_name, GridLocation(r, c, GridLayer::Object_Layer));
     this->converting = false;
     this->cooling_down = false;

--- a/mettagrid/src/metta/mettagrid/stats_tracker.hpp
+++ b/mettagrid/src/metta/mettagrid/stats_tracker.hpp
@@ -56,6 +56,8 @@ private:
 public:
   inline static const std::string NO_ENV_INVENTORY_ITEM_NAME = "[unknown -- stats tracker not initialized]";
 
+  StatsTracker() : _env(nullptr) {}
+
   void set_environment(MettaGrid* env) {
     _env = env;
   }

--- a/mettagrid/src/metta/mettagrid/stats_tracker.hpp
+++ b/mettagrid/src/metta/mettagrid/stats_tracker.hpp
@@ -19,7 +19,6 @@ private:
   std::map<std::string, float> _min_value;
   std::map<std::string, float> _max_value;
   std::map<std::string, int> _update_count;
-  std::vector<std::string> _inventory_item_names;
   MettaGrid* _env;
 
   // Track timing for any update
@@ -55,18 +54,13 @@ private:
   friend class StatsTrackerTest;
 
 public:
-  explicit StatsTracker(const std::vector<std::string>& inventory_item_names)
-      : _env(nullptr), _inventory_item_names(inventory_item_names) {}
+  inline static const std::string NO_ENV_INVENTORY_ITEM_NAME = "[unknown -- stats tracker not initialized]";
 
   void set_environment(MettaGrid* env) {
     _env = env;
   }
 
-  // We expose this through stats since "what name will be meaningful" to people is a reasonable domain of stats.
-  // Implemented when mettagrid is complete.
-  const std::string& inventory_item_name(InventoryItem item) const {
-    return _inventory_item_names[item];
-  }
+  const std::string& inventory_item_name(InventoryItem item) const;
 
   void add(const std::string& key, float amount) {
     _stats[key] += amount;

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -56,10 +56,6 @@ protected:
     return resource_reward_max;
   }
 
-  std::vector<std::string> create_test_inventory_item_names() {
-    return {"ore", "laser", "armor", "heart"};
-  }
-
   AgentConfig create_test_agent_config() {
     AgentConfig agent_cfg;
     agent_cfg.group_name = "test_group";
@@ -69,7 +65,6 @@ protected:
     agent_cfg.max_items_per_type = create_test_max_items_per_type();
     agent_cfg.resource_rewards = create_test_rewards();
     agent_cfg.resource_reward_max = create_test_resource_reward_max();
-    agent_cfg.inventory_item_names = create_test_inventory_item_names();
     agent_cfg.type_id = 0;
     return agent_cfg;
   }
@@ -244,7 +239,6 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   generator_cfg.cooldown = 10;
   generator_cfg.initial_items = 0;
   generator_cfg.color = 0;
-  generator_cfg.inventory_item_names = create_test_inventory_item_names();
   generator_cfg.type_id = TestItems::CONVERTER;
   generator_cfg.type_name = "generator";
   EventManager event_manager;
@@ -297,7 +291,6 @@ TEST_F(MettaGridCppTest, GetOutput) {
   generator_cfg.cooldown = 10;
   generator_cfg.initial_items = 1;
   generator_cfg.color = 0;
-  generator_cfg.inventory_item_names = create_test_inventory_item_names();
   generator_cfg.type_id = TestItems::CONVERTER;
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg);
@@ -353,7 +346,6 @@ TEST_F(MettaGridCppTest, ConverterCreation) {
   converter_cfg.cooldown = 10;
   converter_cfg.initial_items = 0;
   converter_cfg.color = 0;
-  converter_cfg.inventory_item_names = create_test_inventory_item_names();
   converter_cfg.type_id = TestItems::CONVERTER;
   converter_cfg.type_name = "converter";
   std::unique_ptr<Converter> converter(new Converter(1, 2, converter_cfg));

--- a/mettagrid/tests/test_stats_tracker.cpp
+++ b/mettagrid/tests/test_stats_tracker.cpp
@@ -11,8 +11,7 @@ public:
 // Test fixture for StatsTracker
 class StatsTrackerTest : public ::testing::Test {
 protected:
-  std::vector<std::string> empty_inventory_item_names;
-  StatsTracker stats{empty_inventory_item_names};
+  StatsTracker stats;
 
   MockMettaGrid mock_env;
 


### PR DESCRIPTION
Refactors `StatsTracker` to remove dependency on inventory item names being passed during construction.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210677856768142)