### PR TITLE
Make attack configurable

### DIFF
--- a/configs/env/mettagrid/debug.yaml
+++ b/configs/env/mettagrid/debug.yaml
@@ -22,6 +22,10 @@ game:
       enabled: true
     attack:
       enabled: false
+      attack_resources:
+        laser: 1
+      defense_resources:
+        armor: 1
     swap:
       enabled: false
     change_color:

--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -230,6 +230,10 @@ game:
       enabled: true
     attack:
       enabled: true
+      attack_resources:
+        laser: 1
+      defense_resources:
+        armor: 1
     swap:
       enabled: true
     change_color:

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250619.02
+run_id: 20250630.01
 run: ${oc.env:USER}.local.${run_id}

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -37,8 +37,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   py::list inventory_item_names;
   inventory_item_names.append("ore");
   inventory_item_names.append("heart");
-  inventory_item_names.append("armor");
-  inventory_item_names.append("laser");
   game_cfg["inventory_item_names"] = inventory_item_names;
 
   // Actions configuration
@@ -49,6 +47,8 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   move_cfg["enabled"] = true;
   rotate_cfg["enabled"] = true;
   attack_cfg["enabled"] = true;
+  attack_cfg["attack_resources"] = py::dict();
+  attack_cfg["defense_resources"] = py::dict();
   swap_cfg["enabled"] = true;
   put_cfg["enabled"] = true;
   get_cfg["enabled"] = true;
@@ -62,8 +62,6 @@ py::dict CreateBenchmarkConfig(int num_agents) {
   actions_cfg["put_items"] = put_cfg;
   actions_cfg["get_items"] = get_cfg;
   actions_cfg["change_color"] = change_color_cfg;
-  actions_cfg["armor_item_id"] = 2;
-  actions_cfg["laser_item_id"] = 3;
 
   game_cfg["actions"] = actions_cfg;
 
@@ -96,7 +94,7 @@ py::dict CreateBenchmarkConfig(int num_agents) {
 
   // Objects configuration
   py::dict objects_cfg;
-  py::dict wall_cfg, block_cfg, mine_cfg, generator_cfg, altar_cfg;
+  py::dict wall_cfg;
 
   objects_cfg["wall"] = wall_cfg;
   objects_cfg["wall"]["type_id"] = 1;

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -253,6 +253,10 @@ game:
       enabled: true
     attack:
       enabled: true
+      attack_resources:
+        laser: 1
+      defense_resources:
+        armor: 1
     swap:
       enabled: true
     change_color:

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -79,6 +79,10 @@ game:
       enabled: true
     attack:
       enabled: true
+      attack_resources:
+        laser: 1
+      defense_resources:
+        armor: 1
     swap:
       enabled: true
     change_color:

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -14,10 +14,10 @@
 class Attack : public ActionHandler {
 public:
   explicit Attack(const ActionConfig& cfg,
-                  InventoryItem laser_item_id,
-                  InventoryItem armor_item_id,
+                  const std::map<InventoryItem, int>& attack_resources,
+                  const std::map<InventoryItem, int>& defense_resources,
                   const std::string& action_name = "attack")
-      : ActionHandler(cfg, action_name), _laser_item_id(laser_item_id), _armor_item_id(armor_item_id) {
+      : ActionHandler(cfg, action_name), _attack_resources(attack_resources), _defense_resources(defense_resources) {
     priority = 1;
   }
 
@@ -26,16 +26,23 @@ public:
   }
 
 protected:
-  InventoryItem _laser_item_id;
-  InventoryItem _armor_item_id;
+  std::map<InventoryItem, int> _attack_resources;
+  std::map<InventoryItem, int> _defense_resources;
 
   bool _handle_action(Agent* actor, ActionArg arg) override {
     if (arg > 9 || arg < 1) {
       return false;
     }
 
-    if (actor->update_inventory(_laser_item_id, -1) == 0) {
-      return false;
+    for (const auto& [item, amount] : _attack_resources) {
+      if (actor->inventory[item] < amount) {
+        return false;
+      }
+    }
+
+    for (const auto& [item, amount] : _attack_resources) {
+      int used_amount = std::abs(actor->update_inventory(item, -amount));
+      assert(used_amount == amount);
     }
 
     short distance = 1 + (arg - 1) / 3;
@@ -67,9 +74,24 @@ protected:
 
       was_frozen = agent_target->frozen > 0;
 
-      if (agent_target->update_inventory(_armor_item_id, -1)) {
+      bool blocked = _defense_resources.size() > 0;
+      for (const auto& [item, amount] : _defense_resources) {
+        if (agent_target->inventory[item] < amount) {
+          blocked = false;
+          break;
+        }
+      }
+
+      if (blocked) {
+        // Consume the defense resources
+        for (const auto& [item, amount] : _defense_resources) {
+          int used_amount = std::abs(agent_target->update_inventory(item, -amount));
+          assert(used_amount == amount);
+        }
+
         actor->stats.incr("attack.blocked." + agent_target->group_name);
         actor->stats.incr("attack.blocked." + agent_target->group_name + "." + actor->group_name);
+        return true;
       } else {
         agent_target->frozen = agent_target->freeze_duration;
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -90,10 +90,10 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
         cfg["actions"]["attack"]["attack_resources"].cast<std::map<InventoryItem, int>>();
     std::map<InventoryItem, int> defense_resources =
         cfg["actions"]["attack"]["defense_resources"].cast<std::map<InventoryItem, int>>();
-    _action_handlers.push_back(
-        std::make_unique<Attack>(cfg["actions"]["attack"].cast<ActionConfig>(), attack_resources, defense_resources));
-    _action_handlers.push_back(std::make_unique<AttackNearest>(
-        cfg["actions"]["attack"].cast<ActionConfig>(), attack_resources, defense_resources));
+
+    ActionConfig attack_cfg;
+    _action_handlers.push_back(std::make_unique<Attack>(attack_cfg, attack_resources, defense_resources));
+    _action_handlers.push_back(std::make_unique<AttackNearest>(attack_cfg, attack_resources, defense_resources));
   }
   if (cfg["actions"]["swap"]["enabled"].cast<bool>()) {
     _action_handlers.push_back(std::make_unique<Swap>(cfg["actions"]["swap"].cast<ActionConfig>()));

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -86,12 +86,14 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
     _action_handlers.push_back(std::make_unique<Rotate>(cfg["actions"]["rotate"].cast<ActionConfig>()));
   }
   if (cfg["actions"]["attack"]["enabled"].cast<bool>()) {
-    _action_handlers.push_back(std::make_unique<Attack>(cfg["actions"]["attack"].cast<ActionConfig>(),
-                                                        cfg["actions"]["laser_item_id"].cast<InventoryItem>(),
-                                                        cfg["actions"]["armor_item_id"].cast<InventoryItem>()));
-    _action_handlers.push_back(std::make_unique<AttackNearest>(cfg["actions"]["attack"].cast<ActionConfig>(),
-                                                               cfg["actions"]["laser_item_id"].cast<InventoryItem>(),
-                                                               cfg["actions"]["armor_item_id"].cast<InventoryItem>()));
+    std::map<InventoryItem, int> attack_resources =
+        cfg["actions"]["attack"]["attack_resources"].cast<std::map<InventoryItem, int>>();
+    std::map<InventoryItem, int> defense_resources =
+        cfg["actions"]["attack"]["defense_resources"].cast<std::map<InventoryItem, int>>();
+    _action_handlers.push_back(
+        std::make_unique<Attack>(cfg["actions"]["attack"].cast<ActionConfig>(), attack_resources, defense_resources));
+    _action_handlers.push_back(std::make_unique<AttackNearest>(
+        cfg["actions"]["attack"].cast<ActionConfig>(), attack_resources, defense_resources));
   }
   if (cfg["actions"]["swap"]["enabled"].cast<bool>()) {
     _action_handlers.push_back(std::make_unique<Swap>(cfg["actions"]["swap"].cast<ActionConfig>()));

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -194,14 +194,17 @@ def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
         else:
             raise ValueError(f"Unknown object type: {object_type}")
 
-    attack_resources = dict((inventory_item_ids[k], v) for k, v in mettagrid_config.actions.attack.attack_resources.items())
+    attack_resources = dict(
+        (inventory_item_ids[k], v) for k, v in mettagrid_config.actions.attack.attack_resources.items()
+    )
     defense_resources = dict(
         (inventory_item_ids[k], v) for k, v in mettagrid_config.actions.attack.defense_resources.items()
     )
+
+    game_config = mettagrid_config.model_dump(by_alias=True, exclude_none=True)
     game_config["actions"]["attack"]["attack_resources"] = attack_resources
     game_config["actions"]["attack"]["defense_resources"] = defense_resources
 
-    game_config = mettagrid_config.model_dump(by_alias=True, exclude_none=True)
     del game_config["agent"]
     del game_config["groups"]
     game_config["objects"] = object_configs

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -72,6 +72,13 @@ class ActionConfig(BaseModelWithForbidExtra):
     enabled: bool
 
 
+class AttackActionConfig(ActionConfig):
+    """Attack action configuration."""
+
+    attack_resources: Dict[str, int]
+    defense_resources: Dict[str, int]
+
+
 class ActionsConfig(BaseModelWithForbidExtra):
     """Actions configuration."""
 
@@ -80,7 +87,7 @@ class ActionsConfig(BaseModelWithForbidExtra):
     rotate: ActionConfig
     put_items: ActionConfig
     get_items: ActionConfig
-    attack: ActionConfig
+    attack: AttackActionConfig
     swap: ActionConfig
     change_color: ActionConfig
 

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -208,7 +208,13 @@
         "enabled": true
       },
       "attack": {
-        "enabled": true
+        "enabled": true,
+        "attack_resources": {
+          "laser": 1
+        },
+        "defense_resources": {
+          "armor": 1
+        }
       },
       "swap": {
         "enabled": true

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -36,7 +36,7 @@ def base_config():
             "move": {"enabled": True},
             "rotate": {"enabled": True},
             "get_items": {"enabled": True},  # maps to get_output
-            "attack": {"enabled": True},
+            "attack": {"enabled": True, "attack_resources": {"laser": 1}, "defense_resources": {"armor": 1}},
             "put_items": {"enabled": True},  # maps to get_recipe_items
             "swap": {"enabled": True},
             "change_color": {"enabled": True},

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -52,7 +52,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
             "noop": {"enabled": True},
             "move": {"enabled": True},
             "rotate": {"enabled": True},
-            "attack": {"enabled": False},
+            "attack": {"enabled": False, "attack_resources": {"laser": 1}, "defense_resources": {"armor": 1}},
             "put_items": {"enabled": False},
             "get_items": {"enabled": False},
             "swap": {"enabled": False},

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -172,13 +172,13 @@ TEST_F(MettaGridCppTest, AttackAction) {
   grid.add_object(target);
 
   // Give attacker a laser
-  attacker->update_inventory(TestItems::LASER, 1);
-  EXPECT_EQ(attacker->inventory[TestItems::LASER], 1);
+  attacker->update_inventory(TestItems::LASER, 2);
+  EXPECT_EQ(attacker->inventory[TestItems::LASER], 2);
 
-  // Give target some items
-  target->update_inventory(TestItems::ORE, 2);
+  // Give target some items and armor
+  target->update_inventory(TestItems::ARMOR, 5);
   target->update_inventory(TestItems::HEART, 3);
-  EXPECT_EQ(target->inventory[TestItems::ORE], 2);
+  EXPECT_EQ(target->inventory[TestItems::ARMOR], 5);
   EXPECT_EQ(target->inventory[TestItems::HEART], 3);
 
   // Verify attacker orientation
@@ -186,24 +186,37 @@ TEST_F(MettaGridCppTest, AttackAction) {
 
   // Create attack action handler
   ActionConfig attack_cfg;
-  Attack attack(attack_cfg, TestItems::LASER, TestItems::ARMOR);
+  std::map<InventoryItem, int> attack_resources;
+  std::map<InventoryItem, int> defense_resources;
+  attack_resources[TestItems::LASER] = 1;
+  // In this case, defense takes 3 armor!
+  defense_resources[TestItems::ARMOR] = 3;
+  Attack attack(attack_cfg, attack_resources, defense_resources);
   attack.init(&grid);
 
   // Perform attack (arg 5 targets directly in front)
   bool success = attack.handle_action(attacker->id, 5);
+  // Hitting a target with armor counts as success
   EXPECT_TRUE(success);
 
-  // Verify laser was consumed
-  EXPECT_EQ(attacker->inventory[TestItems::LASER], 0);
+  // Verify that the combat material was consumed
+  EXPECT_EQ(attacker->inventory[TestItems::LASER], 1);
+  EXPECT_EQ(target->inventory[TestItems::ARMOR], 2);
 
-  // Verify target was frozen
-  EXPECT_GT(target->frozen, 0);
+  // Verify target was not frozen or robbed
+  EXPECT_EQ(target->frozen, 0);
+  EXPECT_EQ(target->inventory[TestItems::HEART], 3);
+
+  // Attack again, now that armor is gone
+  success = attack.handle_action(attacker->id, 5);
+  EXPECT_TRUE(success);
 
   // Verify target's inventory was stolen
-  EXPECT_EQ(target->inventory[TestItems::ORE], 0);
   EXPECT_EQ(target->inventory[TestItems::HEART], 0);
-  EXPECT_EQ(attacker->inventory[TestItems::ORE], 2);
   EXPECT_EQ(attacker->inventory[TestItems::HEART], 3);
+  // Humorously, the defender's armor was also stolen!
+  EXPECT_EQ(target->inventory[TestItems::ARMOR], 0);
+  EXPECT_EQ(attacker->inventory[TestItems::ARMOR], 2);
 }
 
 TEST_F(MettaGridCppTest, PutRecipeItems) {

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -40,7 +40,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
             "noop": {"enabled": True},
             "move": {"enabled": True},
             "rotate": {"enabled": True},
-            "attack": {"enabled": False},
+            "attack": {"enabled": False, "attack_resources": {"laser": 1}, "defense_resources": {"armor": 1}},
             "put_items": {"enabled": False},
             "get_items": {"enabled": False},
             "swap": {"enabled": False},

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -96,7 +96,7 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
             "noop": {"enabled": True},
             "move": {"enabled": True},
             "rotate": {"enabled": False},
-            "attack": {"enabled": False},
+            "attack": {"enabled": False, "attack_resources": {"laser": 1}, "defense_resources": {"armor": 1}},
             "put_items": {"enabled": False},
             "get_items": {"enabled": False},
             "swap": {"enabled": False},

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -47,7 +47,7 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
             "move": {"enabled": True},
             "rotate": {"enabled": True},
             "put_items": {"enabled": True},
-            "attack": {"enabled": True},
+            "attack": {"enabled": True, "attack_resources": {"laser": 1}, "defense_resources": {"armor": 1}},
             "swap": {"enabled": True},
             "change_color": {"enabled": True},
         },


### PR DESCRIPTION
Support configurable resource requirements for both attackers and defenders.

This removes special casing for "laser" and "armor". This configuration doesn't extend to actions in general, since the "armor" concept seems really specific to attacking ("laser" seems generic as "consumed resources").

This also changes what success counts are for attacking -- attacking an agent that has armor now counts as success, since you've successfully destroyed their armor. If we want this to be failure, I think we need to clarify what "fail" means.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210680522227726)