### PR TITLE
Stop reinstalling jq

### DIFF
--- a/.github/actions/call-bencher-api/action.yml
+++ b/.github/actions/call-bencher-api/action.yml
@@ -20,10 +20,6 @@ runs:
     - name: Install Bencher CLI
       uses: bencherdev/bencher@main
 
-    - name: Install jq
-      shell: bash
-      run: sudo apt-get install -y jq
-
     - name: Check main branch status
       id: check-main
       shell: bash
@@ -33,11 +29,11 @@ runs:
         # Run the command and capture output
         if bencher branch view ${{ inputs.project_id }} main --token "$BENCHER_API_TOKEN" > /tmp/branch_output.json 2>/dev/null; then
           echo "Branch info retrieved, checking for benchmark data..."
-          
+
           # Debug: show what we got
           echo "Branch data:"
           cat /tmp/branch_output.json | jq '.'
-          
+
           # Check if branch has valid benchmark data
           if jq -e '.head != null' /tmp/branch_output.json > /dev/null; then
             # The key check: try to list reports on the main branch
@@ -45,7 +41,7 @@ runs:
             if bencher report list ${{ inputs.project_id }} \
                 --branch main \
                 --token "$BENCHER_API_TOKEN" > /tmp/reports.json 2>/dev/null; then
-              
+
               # Check if we actually have reports
               report_count=$(jq 'length' /tmp/reports.json)
               if [ "$report_count" -gt 0 ]; then
@@ -81,13 +77,13 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         if [ -f "${{ inputs.benchmark_file }}" ] && [ -s "${{ inputs.benchmark_file }}" ]; then
-          
+
           # Core throughput KPIs (higher is better - alert only on regressions)
           declare -A THROUGHPUT_METRICS=(
             ["agent_rate"]="Main agent performance KPI"
             ["env_rate"]="Main environment performance KPI"
           )
-          
+
           for metric in "${!THROUGHPUT_METRICS[@]}"; do
             echo "Setting regression threshold for ${THROUGHPUT_METRICS[$metric]}: $metric"
             echo "Will alert if performance drops by more than 20%"
@@ -104,7 +100,7 @@ runs:
               --github-actions "$GITHUB_TOKEN" \
               --file "${{ inputs.benchmark_file }}" || echo "⚠️  Could not set threshold for $metric"
           done
-          
+
           echo "✅ Regression thresholds configured (20% performance drop triggers alert)"
         else
           echo "⚠️ No benchmark file found: ${{ inputs.benchmark_file }}"
@@ -123,13 +119,13 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         echo "📊 Checking for performance improvements (informational only)..."
-        echo "- agent_rate: Checking for >20% improvements" 
+        echo "- agent_rate: Checking for >20% improvements"
         echo "- env_rate: Checking for >20% improvements"
 
         if [ -f "${{ inputs.benchmark_file }}" ]; then
           # Create a temporary branch name for improvement detection
           IMPROVEMENT_BRANCH="${GITHUB_HEAD_REF}-improvements"
-          
+
           # Run without --err to just report improvements
           bencher run \
             --project ${{ inputs.project_id }} \
@@ -146,7 +142,7 @@ runs:
             --adapter json \
             --github-actions "$GITHUB_TOKEN" \
             --file "${{ inputs.benchmark_file }}" || echo "📈 Performance improvements detected!"
-            
+
           echo "✅ Improvement check completed"
         else
           echo "⚠️  No benchmark file found: ${{ inputs.benchmark_file }}"
@@ -165,7 +161,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         echo "🚨 Checking for performance regressions (will fail if detected)..."
-        echo "- agent_rate: Will fail if >20% slower than baseline" 
+        echo "- agent_rate: Will fail if >20% slower than baseline"
         echo "- env_rate: Will fail if >20% slower than baseline"
 
         if [ -f "${{ inputs.benchmark_file }}" ]; then
@@ -182,7 +178,7 @@ runs:
             --adapter json \
             --github-actions "$GITHUB_TOKEN" \
             --file "${{ inputs.benchmark_file }}"
-            
+
           echo "✅ No performance regressions detected in KPIs"
         else
           echo "⚠️  No benchmark file found: ${{ inputs.benchmark_file }}"
@@ -214,7 +210,7 @@ runs:
             --adapter json \
             --github-actions "$GITHUB_TOKEN" \
             --file "${{ inputs.benchmark_file }}"
-            
+
           echo "✅ PR benchmark data uploaded successfully"
         else
           echo "⚠️  No benchmark file found: ${{ inputs.benchmark_file }}"

--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -19,16 +19,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Extract Assignees and Reviewers
         id: extract-assignees-reviewers
         run: |
-          assignees=$(echo '${{ toJSON(github.event.pull_request.assignees) }}' | jq -r '.[].login' | tr '\n' ',' | sed 's/,$//')
-          reviewers=$(echo '${{ toJSON(github.event.pull_request.requested_reviewers) }}' | jq -r '.[].login' | tr '\n' ',' | sed 's/,$//')
-          echo "assignees=$assignees" >> $GITHUB_OUTPUT
-          echo "reviewers=$reviewers" >> $GITHUB_OUTPUT
+          python3 -c "
+          import json
+
+          assignees_data = json.loads('${{ toJSON(github.event.pull_request.assignees) }}')
+          reviewers_data = json.loads('${{ toJSON(github.event.pull_request.requested_reviewers) }}')
+
+          assignees = ','.join([user['login'] for user in assignees_data])
+          reviewers = ','.join([user['login'] for user in reviewers_data])
+
+          print(f'assignees={assignees}')
+          print(f'reviewers={reviewers}')
+          " >> $GITHUB_OUTPUT
 
       - name: Ensure Asana Task
         id: ensure-asana-task

--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -22,18 +22,10 @@ jobs:
       - name: Extract Assignees and Reviewers
         id: extract-assignees-reviewers
         run: |
-          python3 -c "
-          import json
-
-          assignees_data = json.loads('${{ toJSON(github.event.pull_request.assignees) }}')
-          reviewers_data = json.loads('${{ toJSON(github.event.pull_request.requested_reviewers) }}')
-
-          assignees = ','.join([user['login'] for user in assignees_data])
-          reviewers = ','.join([user['login'] for user in reviewers_data])
-
-          print(f'assignees={assignees}')
-          print(f'reviewers={reviewers}')
-          " >> $GITHUB_OUTPUT
+          assignees=$(echo '${{ toJSON(github.event.pull_request.assignees) }}' | jq -r '.[].login' | tr '\n' ',' | sed 's/,$//')
+          reviewers=$(echo '${{ toJSON(github.event.pull_request.requested_reviewers) }}' | jq -r '.[].login' | tr '\n' ',' | sed 's/,$//')
+          echo "assignees=$assignees" >> $GITHUB_OUTPUT
+          echo "reviewers=$reviewers" >> $GITHUB_OUTPUT
 
       - name: Ensure Asana Task
         id: ensure-asana-task


### PR DESCRIPTION
Removes the unnecessary jq installation step from github actions / workflows.

The jq installation step is unnecessary as it's already available in the GitHub Actions runner environment. Removing this step reduces execution time. For bencher this might not matter, but for the Asana workflow, [not] installing jq accounted for 12s out of 24-27s.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210689997507275)