### PR TITLE
Give blocks their own type_id

### DIFF
--- a/configs/env/mettagrid/game/objects/basic.yaml
+++ b/configs/env/mettagrid/game/objects/basic.yaml
@@ -12,5 +12,5 @@ wall:
   swappable: false
 
 block:
-  type_id: 1
+  type_id: 14
   swappable: true

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -232,7 +232,7 @@ game:
       swappable: false
 
     block:
-      type_id: 1
+      type_id: 14
       swappable: true
 
   actions:

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -114,17 +114,14 @@ MettaGrid::MettaGrid(py::dict cfg, py::list map, int seed) {
       object_type_names.resize(type_id + 1);
     }
 
-    if (object_type_names[type_id] == "") {
-      // #HardCodedConfig
-      // The guard here is to avoid overwriting the type_name for the wall object with the block object.
-      object_type_names[type_id] = key.cast<std::string>();
-    }
+    std::string object_type = object_cfg["object_type"].cast<std::string>();
 
-    if (!object_cfg.contains("object_type")) {
-      throw std::runtime_error("Object type not specified for " + key.cast<std::string>());
+    if (object_type_names[type_id] != "" && object_type_names[type_id] != object_type) {
+      throw std::runtime_error("Object type_id " + std::to_string(type_id) + " already exists with type_name " +
+                               object_type_names[type_id] + ". Trying to add " + object_type + ".");
     }
+    object_type_names[type_id] = object_type;
 
-    auto object_type = object_cfg["object_type"].cast<std::string>();
     if (object_type == "agent") {
       unsigned int id = object_cfg["group_id"].cast<unsigned int>();
       _group_sizes[id] = 0;

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -61,7 +61,6 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {
             "wall": {"type_id": 1},
-            "block": {"type_id": 1},
         },
         "agent": {},
     }

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -49,7 +49,6 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
         "groups": {"red": {"id": 0, "props": {}}},
         "objects": {
             "wall": {"type_id": 1},
-            "block": {"type_id": 1},
         },
         "agent": {},
     }

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -108,7 +108,6 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
         },
         "objects": {
             "wall": {"type_id": 1},
-            "block": {"type_id": 1},
         },
         "agent": {"freeze_duration": 100, "rewards": {"heart": 1.0}},
     }


### PR DESCRIPTION
Changed the `type_id` for block objects from 1 to 14 and improved type ID validation to prevent duplicate IDs with different object types.

This also switches us back from using the object's key-in-configuration to using its object_type property. These should be the same except in the case of agents, where we distinguish different types of agents in the config, but they all share the object_type "agent".

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210691972996641)