### PR TITLE
Add profile for softmax docker installation

### DIFF
--- a/metta/setup/components/aws.py
+++ b/metta/setup/components/aws.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 
 from metta.setup.components.base import SetupModule
-from metta.setup.config import UserType
 from metta.setup.registry import register_module
 from metta.setup.utils import info
 
@@ -15,15 +14,13 @@ class AWSSetup(SetupModule):
 
     @property
     def setup_script_location(self) -> str | None:
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             return "devops/aws/setup_aws_profiles.sh"
         return None
 
     def is_applicable(self) -> bool:
-        return self.config.user_type in [
-            UserType.SOFTMAX,
-            UserType.CLOUD,
-        ] and self.config.is_component_enabled("aws")
+        # Skypilot is a dependency of AWS
+        return any(self.config.is_component_enabled(dep) for dep in ["aws", "skypilot"])
 
     def check_installed(self) -> bool:
         aws_config = Path.home() / ".aws" / "config"
@@ -33,7 +30,7 @@ class AWSSetup(SetupModule):
         return True
 
     def install(self) -> None:
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             info("""
                 Your AWS access should have been provisioned.
                 If you don't have access, contact your team lead.

--- a/metta/setup/components/skypilot.py
+++ b/metta/setup/components/skypilot.py
@@ -1,7 +1,6 @@
 import subprocess
 
 from metta.setup.components.base import SetupModule
-from metta.setup.config import UserType
 from metta.setup.registry import register_module
 from metta.setup.utils import info, success
 
@@ -13,11 +12,7 @@ class SkypilotSetup(SetupModule):
         return "SkyPilot cloud compute orchestration"
 
     def is_applicable(self) -> bool:
-        return (
-            self.config.user_type in [UserType.SOFTMAX, UserType.CLOUD]
-            and self.config.is_component_enabled("skypilot")
-            and self.config.is_component_enabled("aws")
-        )
+        return self.config.is_component_enabled("skypilot") and self.config.is_component_enabled("aws")
 
     def check_installed(self) -> bool:
         try:
@@ -35,7 +30,7 @@ class SkypilotSetup(SetupModule):
 
     @property
     def setup_script_location(self) -> str | None:
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             return "devops/skypilot/install.sh"
         return None
 
@@ -53,7 +48,7 @@ class SkypilotSetup(SetupModule):
                 info("GitHub authentication may have been cancelled or failed.")
                 info("You can complete it later with: gh auth login")
 
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             super().install()
             success("SkyPilot installed")
         else:
@@ -67,7 +62,7 @@ class SkypilotSetup(SetupModule):
         if not self.check_installed():
             return None
 
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             try:
                 result = subprocess.run(["sky", "api", "info"], capture_output=True, text=True)
                 softmax_url = "skypilot-api.softmax-research.net"

--- a/metta/setup/components/wandb.py
+++ b/metta/setup/components/wandb.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 from metta.setup.components.base import SetupModule
-from metta.setup.config import UserType
 from metta.setup.registry import register_module
 from metta.setup.utils import info, success, warning
 
@@ -34,7 +33,7 @@ class WandbSetup(SetupModule):
             success("W&B already configured")
             return
 
-        if self.config.user_type == UserType.SOFTMAX:
+        if self.config.user_type.is_softmax:
             info("""
                 Your Weights & Biases access should have been provisioned.
                 If you don't have access, contact your team lead.

--- a/metta/setup/config.py
+++ b/metta/setup/config.py
@@ -10,6 +10,20 @@ class UserType(Enum):
     EXTERNAL = "external"
     CLOUD = "cloud"
     SOFTMAX = "softmax"
+    SOFTMAX_DOCKER = "softmax-docker"
+
+    @property
+    def is_softmax(self) -> bool:
+        return self in (UserType.SOFTMAX, UserType.SOFTMAX_DOCKER)
+
+    def get_description(self) -> str:
+        descriptions = {
+            UserType.EXTERNAL: "External contributor",
+            UserType.CLOUD: "User with own cloud account",
+            UserType.SOFTMAX: "Softmax employee",
+            UserType.SOFTMAX_DOCKER: "Softmax (Docker)",
+        }
+        return descriptions.get(self, self.value)
 
 
 class ComponentConfig(TypedDict):
@@ -52,6 +66,21 @@ PROFILE_DEFINITIONS: dict[UserType, ProfileConfig] = {
             "aws": {"enabled": True},
             "wandb": {"enabled": True},
             "skypilot": {"enabled": True},
+            "tailscale": {"enabled": False},
+        }
+    },
+    UserType.SOFTMAX_DOCKER: {
+        "components": {
+            "system": {"enabled": True},
+            "core": {"enabled": True},
+            "githooks": {"enabled": True},
+            "mettascope": {"enabled": False},
+            "observatory-fe": {"enabled": False},
+            "observatory-cli": {"enabled": False},
+            "studio": {"enabled": False},
+            "aws": {"enabled": True, "expected_connection": "751442549699"},
+            "wandb": {"enabled": True, "expected_connection": "metta-research"},
+            "skypilot": {"enabled": False},
             "tailscale": {"enabled": False},
         }
     },


### PR DESCRIPTION
This PR:
- adds a config profile for softmax docker boxes
- makes a few things more maintainable for when we choose to add more profiles

Motivation:
Richard noticed that our docker images were failing to run devops/setup_dev.sh properly after the introduction of the new metta.sh setup wizard. This is because setup_dev.sh now just wraps the new setup process as if it were a softmax user, which results in it trying to build some of our node-dependent projects (mettascope), but the docker images aren't built with node. our usage of the docker containers doesn't rely on those node-dependent projects being built

A future enhancement would be to have a single source of truth for list of system packages across macos/docker/linux/etc, have support for installing that list across those platforms' preferred package management system (brew vs apt etc), and and to have the required system packages be inferred from the set of requested components. That's coming....soon....

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210692503821506)