### PR TITLE
Support non-macos brew installs

### DIFF
--- a/metta/setup/components/system.py
+++ b/metta/setup/components/system.py
@@ -56,7 +56,7 @@ class SystemSetup(SetupModule):
         else:
             # NOTE: need to implement this at some point
             info("""
-                You will need to manage package installation manually.
+                You will need to install brew or can manage package installation manually.
                 See devops/macos/Brewfile for the full list of recommended packages.
 
                 If you are on a mettabox, you can run `./devops/mettabox/setup_machine.sh`.


### PR DESCRIPTION
Brew isn't just on macs! We should continue to install it for macs and not on other platforms, but if already present on non-macs, we should go ahead and use it to install system packages.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210692443001771)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210691431461825