### PR TITLE
change freeze_duration to a signed short

### DIFF
--- a/mettagrid/src/metta/mettagrid/action_handler.hpp
+++ b/mettagrid/src/metta/mettagrid/action_handler.hpp
@@ -43,10 +43,12 @@ public:
     Agent* actor = static_cast<Agent*>(_grid->object(actor_object_id));
 
     // Handle frozen status
-    if (actor->frozen > 0) {
+    if (actor->frozen != 0) {
       actor->stats.incr("status.frozen.ticks");
       actor->stats.incr("status.frozen.ticks." + actor->group_name);
-      actor->frozen -= 1;
+      if (actor->frozen > 0) {
+        actor->frozen -= 1;
+      }
       return false;
     }
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -690,7 +690,7 @@ py::list MettaGrid::inventory_item_names_py() {
 }
 
 AgentConfig MettaGrid::_create_agent_config(const py::dict& agent_group_cfg_py) {
-  unsigned char freeze_duration = agent_group_cfg_py["freeze_duration"].cast<unsigned char>();
+  short freeze_duration = agent_group_cfg_py["freeze_duration"].cast<short>();
   float action_failure_penalty = agent_group_cfg_py["action_failure_penalty"].cast<float>();
   std::map<InventoryItem, uint8_t> max_items_per_type =
       agent_group_cfg_py["max_items_per_type"].cast<std::map<InventoryItem, uint8_t>>();

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -57,7 +57,7 @@ class AgentGroupConfig_cpp(ObjectConfig_cpp):
     """Agent group configuration."""
 
     object_type: Literal["agent"] = "agent"
-    freeze_duration: int = Field(ge=0)
+    freeze_duration: int = Field(ge=-1)
     action_failure_penalty: float = Field(default=0, ge=0)
     max_items_per_type: Dict[FeatureId, int] = Field(default_factory=dict)
     resource_rewards: Dict[FeatureId, float] = Field(default_factory=dict)

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -35,7 +35,7 @@ class AgentConfig(BaseModelWithForbidExtra):
     """Agent configuration."""
 
     default_item_max: Optional[int] = Field(default=None, ge=0)
-    freeze_duration: Optional[int] = Field(default=None, ge=0)
+    freeze_duration: Optional[int] = Field(default=None, ge=-1)
     rewards: Optional[AgentRewards] = None
     ore_red_max: Optional[int] = Field(default=None, alias="ore.red_max")
     ore_blue_max: Optional[int] = Field(default=None, alias="ore.blue_max")

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -14,7 +14,7 @@
 struct AgentConfig {
   std::string group_name;
   unsigned char group_id;
-  unsigned char freeze_duration;
+  short freeze_duration;
   float action_failure_penalty;
   std::map<InventoryItem, uint8_t> max_items_per_type;
   std::map<InventoryItem, float> resource_rewards;
@@ -26,8 +26,8 @@ struct AgentConfig {
 class Agent : public MettaObject {
 public:
   unsigned char group;
-  unsigned char frozen;
-  unsigned char freeze_duration;
+  short frozen;
+  short freeze_duration;
   unsigned char orientation;
   // inventory is a map of item to amount.
   // keys should be deleted when the amount is 0, to keep iteration faster.
@@ -120,7 +120,7 @@ public:
     features.reserve(5 + this->inventory.size());
     features.push_back({ObservationFeature::TypeId, type_id});
     features.push_back({ObservationFeature::Group, group});
-    features.push_back({ObservationFeature::Frozen, frozen});
+    features.push_back({ObservationFeature::Frozen, static_cast<uint8_t>(frozen > 0 ? 1 : 0)});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});
     for (const auto& [item, amount] : this->inventory) {

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -120,7 +120,7 @@ public:
     features.reserve(5 + this->inventory.size());
     features.push_back({ObservationFeature::TypeId, type_id});
     features.push_back({ObservationFeature::Group, group});
-    features.push_back({ObservationFeature::Frozen, static_cast<uint8_t>(frozen > 0 ? 1 : 0)});
+    features.push_back({ObservationFeature::Frozen, static_cast<uint8_t>(frozen != 0 ? 1 : 0)});
     features.push_back({ObservationFeature::Orientation, orientation});
     features.push_back({ObservationFeature::Color, color});
     for (const auto& [item, amount] : this->inventory) {


### PR DESCRIPTION
Changes freeze_duration to a signed short and adds logic for negative freeze_duration's to result in a permanent freezing effect. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210701959974668)