### PR TITLE
Support storing torch traces locally or in config-specified urls

### DIFF
--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -83,7 +83,9 @@ update_epochs: 1
 cpu_offload: false
 compile: false
 compile_mode: reduce-overhead
-profiler_interval_epochs: 10000
+profiler:
+  interval_epochs: 10000
+  profile_dir: ${run_dir}/torch_traces
 
 forward_pass_minibatch_target_size: 4096
 async_factor: 2

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -85,7 +85,7 @@ compile: false
 compile_mode: reduce-overhead
 profiler:
   interval_epochs: 10000
-  profile_dir: ${run_dir}/torch_traces
+  profile_dir: s3://softmax-public/torch_traces/${run}
 
 forward_pass_minibatch_target_size: 4096
 async_factor: 2

--- a/metta/rl/torch_profiler.py
+++ b/metta/rl/torch_profiler.py
@@ -158,7 +158,7 @@ class TorchProfiler:
             logger.warning(f"Could not remove temporary trace file {input_path}: {e}")
 
     def _wandb_log_trace_link(self, upload_url) -> None:
-        """Logs the S3 link to the profile trace in WandB."""
+        """Logs the public url link to the profile trace in WandB."""
         link_summary = {
             "torch_traces/link": wandb.Html(f'<a href="{upload_url}">Torch Trace (Epoch {self._start_epoch})</a>')
         }

--- a/metta/rl/torch_profiler.py
+++ b/metta/rl/torch_profiler.py
@@ -7,7 +7,7 @@ import tempfile
 import torch.profiler
 import wandb
 
-from metta.mettagrid.util.file import http_url, write_file
+from metta.mettagrid.util.file import http_url, is_public_uri, write_file
 from metta.rl.trainer_config import TorchProfilerConfig
 
 logger = logging.getLogger(__name__)
@@ -131,7 +131,8 @@ class TorchProfiler:
             self._compress_trace(temp_json_path, final_gz_path)  # final_gz_path is a gzip compressed file
             write_file(upload_path, final_gz_path, content_type="application/gzip")
             upload_url = http_url(upload_path)
-            if upload_url and self._wandb_run:
+
+            if is_public_uri(upload_url) and self._wandb_run:
                 self._wandb_log_trace_link(upload_url)
 
         except Exception as e:

--- a/metta/rl/torch_profiler.py
+++ b/metta/rl/torch_profiler.py
@@ -1,10 +1,14 @@
 import gzip
 import logging
 import os
+import shutil
+import tempfile
 
-import boto3
 import torch.profiler
 import wandb
+
+from metta.mettagrid.util.file import http_url, write_file
+from metta.rl.trainer_config import TorchProfilerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -22,19 +26,16 @@ class TorchProfiler:
     which is fine) and select 'load'. Navigate traces using WASD on your
     keyboard.
 
-    Set profiler_interval_epochs in the config to zero to turn it off.
+    Set profiler.interval_epochs in the config to zero to turn it off.
 
     Future work could include support for TensorBoard.
     """
 
-    def __init__(self, master, run_dir, cfg_profiler_interval_epochs, wandb_run):
+    def __init__(self, master: bool, profiler_config: TorchProfilerConfig, wandb_run, run_dir: str):
         self._master = master
-        self._cfg_profiler_interval_epochs = cfg_profiler_interval_epochs
+        self._profiler_config = profiler_config
         self._run_dir = run_dir
         self._wandb_run = wandb_run
-        self._profile_dir = os.path.join(self._run_dir, "torch_traces")
-        os.makedirs(self._profile_dir, exist_ok=True)
-        self._s3_client = boto3.client("s3")
         self._profiler = None
         self._active = False
         self._start_epoch = None
@@ -45,12 +46,12 @@ class TorchProfiler:
         # We may need to revisit if compiling models under "max-autotune".
         self._first_profile_epoch = 300
 
-    def on_epoch_end(self, epoch):
+    def on_epoch_end(self, epoch: int) -> None:
         should_profile_this_epoch = False
         if not self._active:
             should_profile_this_epoch = (
-                self._cfg_profiler_interval_epochs != 0
-                and (epoch % self._cfg_profiler_interval_epochs == 0 or epoch == self._first_profile_epoch)
+                self._profiler_config.enabled
+                and (epoch % self._profiler_config.interval_epochs == 0 or epoch == self._first_profile_epoch)
                 and self._master
             )
         if should_profile_this_epoch:
@@ -119,17 +120,24 @@ class TorchProfiler:
 
         output_filename_json = f"{self._profile_filename_base}.json"
         output_filename_gz = f"{output_filename_json}.gz"
-        temp_json_path = os.path.join(self._profile_dir, output_filename_json)  # for uncompressed, to be deleted
-        final_gz_path = os.path.join(self._profile_dir, output_filename_gz)  # compressed path
+        temp_dir = tempfile.mkdtemp(prefix="torch_profile_")
+        temp_json_path = os.path.join(temp_dir, output_filename_json)  # for uncompressed, to be deleted
+        final_gz_path = os.path.join(temp_dir, output_filename_gz)  # compressed path
+
+        upload_path = os.path.join(self._profiler_config.profile_dir, output_filename_gz)
 
         try:
             self._export_profile(prof, temp_json_path)  # temp_json_path is a Chrome trace format file
             self._compress_trace(temp_json_path, final_gz_path)  # final_gz_path is a gzip compressed file
-            s3_bucket, s3_path = self._s3_upload(final_gz_path, output_filename_gz)
-            self._wandb_log_trace_link(s3_bucket, s3_path)
+            write_file(upload_path, final_gz_path, content_type="application/gzip")
+            upload_url = http_url(upload_path)
+            if upload_url and self._wandb_run:
+                self._wandb_log_trace_link(upload_url)
 
         except Exception as e:
             logger.error(f"Error handling profile trace for epoch {self._start_epoch}: {e}", exc_info=True)
+        finally:
+            shutil.rmtree(temp_dir)
 
     # _save_profile() helper methods -----------------------------------------------------
     def _export_profile(self, prof, output_path):
@@ -148,19 +156,9 @@ class TorchProfiler:
         except OSError as e:
             logger.warning(f"Could not remove temporary trace file {input_path}: {e}")
 
-    def _s3_upload(self, local_path, filename_gz):
-        """Uploads the compressed trace to the predefined S3 bucket and returns bucket & key."""
-        s3_bucket = "softmax-public"
-        s3_path = f"torch_traces/{os.path.basename(self._run_dir)}/{filename_gz}"
-        logger.info(f"Uploading profile trace to S3: s3://{s3_bucket}/{s3_path}")
-        self._s3_client.upload_file(local_path, s3_bucket, s3_path)
-        logger.info("Successfully uploaded profile trace to S3.")
-        return s3_bucket, s3_path
-
-    def _wandb_log_trace_link(self, s3_bucket, s3_path):
+    def _wandb_log_trace_link(self, upload_url) -> None:
         """Logs the S3 link to the profile trace in WandB."""
-        link = f"https://{s3_bucket}.s3.us-east-1.amazonaws.com/{s3_path}"
         link_summary = {
-            "torch_traces/link": wandb.Html(f'<a href="{link}">Torch Trace (Epoch {self._start_epoch})</a>')
+            "torch_traces/link": wandb.Html(f'<a href="{upload_url}">Torch Trace (Epoch {self._start_epoch})</a>')
         }
         self._wandb_run.log(link_summary)

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -129,7 +129,7 @@ class MettaTrainer:
         self._batch_size = trainer_cfg.batch_size
         self._minibatch_size = trainer_cfg.minibatch_size
 
-        self.torch_profiler = TorchProfiler(self._master, cfg.run_dir, trainer_cfg.profiler_interval_epochs, wandb_run)
+        self.torch_profiler = TorchProfiler(self._master, trainer_cfg.profiler, wandb_run, cfg.run_dir)
         self.losses = Losses()
         self.stats = defaultdict(list)
         self.grad_stats = {}

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -115,6 +115,21 @@ class PPOConfig(BaseModelWithForbidExtra):
     target_kl: float | None = None
 
 
+class TorchProfilerConfig(BaseModelWithForbidExtra):
+    interval_epochs: int = Field(default=10000, ge=0)  # 0 to disable
+    # Upload location: None disables uploads, supports s3:// or local paths
+    profile_dir: str = Field(default="")
+
+    @property
+    def enabled(self) -> bool:
+        return self.interval_epochs > 0
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "TorchProfilerConfig":
+        assert self.profile_dir, "profile_dir must be set"
+        return self
+
+
 class TrainerConfig(BaseModelWithForbidExtra):
     # Target for hydra instantiation
     target: str = Field(default="metta.rl.trainer.MettaTrainer", alias="_target_")
@@ -166,7 +181,7 @@ class TrainerConfig(BaseModelWithForbidExtra):
     # Reduce-overhead mode: Best for training loops when compile is enabled
     compile_mode: Literal["default", "reduce-overhead", "max-autotune"] = "reduce-overhead"
     # Profile every 10K epochs: Infrequent to minimize overhead
-    profiler_interval_epochs: int = Field(default=10000, gt=0)
+    profiler: TorchProfilerConfig = Field(default_factory=TorchProfilerConfig)
 
     # Distributed training
     # Forward minibatch: Type 2 default chosen arbitrarily
@@ -254,5 +269,8 @@ def parse_trainer_config(
 
     if "replay_dir" not in config_dict.setdefault("simulation", {}):
         config_dict["simulation"]["replay_dir"] = f"s3://softmax-public/replays/{cfg.run}"
+
+    if "profile_dir" not in config_dict.setdefault("profiler", {}):
+        config_dict["profiler"]["profile_dir"] = f"{cfg.run_dir}/torch_traces"
 
     return TrainerConfig.model_validate(config_dict)

--- a/mettagrid/src/metta/mettagrid/util/file.py
+++ b/mettagrid/src/metta/mettagrid/util/file.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Union
+from urllib.parse import urlparse
 
 import boto3
 import wandb
@@ -204,6 +205,16 @@ def http_url(path: str) -> str:
     if path.startswith("wandb://"):
         return WandbURI.parse(path).http_url()
     return path
+
+
+def is_public_uri(url: str | None) -> bool:
+    """
+    Check if a URL is a public HTTP/HTTPS URL.
+    """
+    if not url:
+        return False
+    parsed = urlparse(url)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/rl/test_trainer_config.py
+++ b/tests/rl/test_trainer_config.py
@@ -33,7 +33,7 @@ valid_trainer_config = {
     "cpu_offload": False,
     "compile": False,
     "compile_mode": "reduce-overhead",
-    "profiler_interval_epochs": 10000,
+    "profiler": {"interval_epochs": 10000, "profile_dir": "/test/upload/dir"},
     "num_workers": 1,
     "env": "/env/mettagrid/simple",
     "curriculum": None,


### PR DESCRIPTION
And add a new typed config for it

Previously we'd fail on trying to torch profile if you weren't connected to our s3

This proved to be a pain point for Matteo

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210701900688561)