### PR TITLE
include all agent subpackages in setuptools configuration

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -22,11 +22,11 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["metta.agent"]
+include = ["metta", "metta.*"]
 
 [tool.setuptools.package-data]
 "metta" = ["__init__.py"]
-"metta.agent" = ["py.typed"]
+"metta.agent" = ["py.typed", "**/*.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 [manifest]
 members = [
     "metta",
+    "metta-agent",
     "metta-app-backend",
     "metta-common",
     "metta-mettagrid",
@@ -712,6 +713,7 @@ dependencies = [
     { name = "imageio" },
     { name = "jmespath" },
     { name = "matplotlib" },
+    { name = "metta-agent" },
     { name = "metta-app-backend" },
     { name = "metta-common" },
     { name = "metta-mettagrid" },
@@ -771,6 +773,7 @@ requires-dist = [
     { name = "imageio", specifier = ">=2.37.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "matplotlib", specifier = ">=3.10.3" },
+    { name = "metta-agent", editable = "agent" },
     { name = "metta-app-backend", editable = "app_backend" },
     { name = "metta-common", editable = "common" },
     { name = "metta-mettagrid", editable = "mettagrid" },
@@ -812,6 +815,27 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "skypilot", specifier = "==0.9.3" }]
+
+[[package]]
+name = "metta-agent"
+version = "0.1.0"
+source = { editable = "agent" }
+dependencies = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", specifier = ">=1.1.401" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "ruff", specifier = ">=0.11.13" },
+]
 
 [[package]]
 name = "metta-app-backend"


### PR DESCRIPTION
his fixes ModuleNotFoundError for metta.agent.util.debug and similar imports after metta.agent namespace move

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210702087366976)