### PR TITLE
Stop pufferbox from overriding checkpoint interval

### DIFF
--- a/configs/hardware/pufferbox.yaml
+++ b/configs/hardware/pufferbox.yaml
@@ -6,5 +6,3 @@ trainer:
   num_workers: 16 # num cores
   async_factor: 2
   zero_copy: True
-  checkpoint:
-    checkpoint_interval: 300


### PR DESCRIPTION
If there's a good reason to do this then forget this PR. Otherwise, seems less annoying to override it in pufferbox. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210713171041728)