### PR TITLE
Add simple.easy.yaml config for mettagrid with multi-room setup

### DIFF
--- a/configs/env/mettagrid/curriculum/resources.yaml
+++ b/configs/env/mettagrid/curriculum/resources.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
 
-env_cfg_template: /env/mettagrid/simple
+env_cfg_template: /env/mettagrid/simple.easy
 
 buckets:
   game.agent.rewards.ore_red:

--- a/configs/env/mettagrid/simple.easy.yaml
+++ b/configs/env/mettagrid/simple.easy.yaml
@@ -1,0 +1,51 @@
+defaults:
+  - mettagrid
+  - game/objects:
+      - basic
+      - mines
+      - generators
+      - combat
+
+  - _self_
+
+game:
+  num_agents: 24
+  map_builder:
+    _target_: metta.mettagrid.room.multi_room.MultiRoom
+    num_rooms: ${div:${..num_agents},6}
+    border_width: 6
+
+    room:
+      _target_: metta.mettagrid.room.random.Random
+      width: 25
+      height: 25
+      border_width: 0
+
+      agents: 6
+
+      objects:
+        mine_red: 10
+        generator_red: 5
+        altar: 5
+
+        block: 20
+        wall: 20
+
+  objects:
+    altar:
+      input_battery_red: 1
+      initial_items: 1
+    mine_red:
+      initial_items: 1
+    generator_red:
+      initial_items: 1
+
+  agent:
+    rewards:
+      ore_red: 0.1
+      ore_red_max: 5
+
+      battery_red: 0.9
+      battery_red_max: 5
+
+      heart: 1


### PR DESCRIPTION
### TL;DR

Added a new simple.easy.yaml configuration file for the MettagGrid environment.

### What changed?

Added a new configuration file for MettagGrid that defines an easy version of the simple environment. The configuration:
- Sets up a multi-room environment with 24 agents distributed across 4 rooms
- Each room is 25x25 with 6 agents per room
- Includes various objects: red mines (10), red generators (5), altars (5), blocks (20), and walls (20)
- Configures object properties like initial items for altars, mines, and generators
- Defines agent rewards for collecting red ore (0.1), red batteries (0.9), and hearts (1)
- Sets maximum reward values for red ore (5) and red batteries (5)

### How to test?

1. Load the new configuration file using:
   ```
   python -m metta.run env=mettagrid/simple.easy
   ```
2. Verify that the environment initializes with the specified number of agents and objects
3. Check that the reward system works correctly for collecting the different items

### Why make this change?

This configuration provides an easier version of the MettagGrid environment, which is useful for initial testing, training, and debugging of agents. The simplified setup with clearly defined rewards makes it more accessible for new users and helps establish baseline agent performance.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210714476639481)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210714714875808)