### PR TITLE
More reliably attach Github widgets to Asana tasks

### DIFF
--- a/.github/actions/asana/ensure-task/action.yml
+++ b/.github/actions/asana/ensure-task/action.yml
@@ -44,7 +44,9 @@ inputs:
   asana_email_field_id:
     description: "The Asana custom field ID for the 'Asana Email' field in the roster project. This is used to map GitHub logins to Asana emails."
     required: true
-
+  asana_attachment_secret:
+    description: "The Asana attachment secret. This is used to authenticate the Asana attachment action."
+    required: true
 
 outputs:
   task_url:
@@ -80,4 +82,5 @@ runs:
         INPUT_GH_LOGIN_FIELD_ID: ${{ inputs.gh_login_field_id }}
         INPUT_ASANA_EMAIL_FIELD_ID: ${{ inputs.asana_email_field_id }}
         INPUT_PR_AUTHOR_FIELD_ID: ${{ inputs.pr_author_field_id }}
+        INPUT_ASANA_ATTACHMENT_SECRET: ${{ inputs.asana_attachment_secret }}
 

--- a/.github/actions/asana/ensure-task/action.yml
+++ b/.github/actions/asana/ensure-task/action.yml
@@ -44,6 +44,9 @@ inputs:
   asana_email_field_id:
     description: "The Asana custom field ID for the 'Asana Email' field in the roster project. This is used to map GitHub logins to Asana emails."
     required: true
+  pr_author_field_id:
+    description: "The Asana custom field ID for the 'PR Author' field in the roster project."
+    required: true
   asana_attachment_secret:
     description: "The Asana attachment secret. This is used to authenticate the Asana attachment action."
     required: true

--- a/.github/actions/asana/ensure-task/main.py
+++ b/.github/actions/asana/ensure-task/main.py
@@ -453,8 +453,7 @@ def ensure_github_url_in_asana_task(
     payload = {
         "allowedProjects": [project_id],
         "blockedProjects": [],
-        # Unclear why this is needed. The Asana endpoint wants it. It doesn't seem like it need to
-        # be correct, but may as well?
+        # This is used in the created attachment story.
         "pullRequestName": title,
         # This we fake, since we want Asana to find the right task in the description.
         "pullRequestDescription": task_url,

--- a/.github/actions/asana/ensure-task/main.py
+++ b/.github/actions/asana/ensure-task/main.py
@@ -200,6 +200,7 @@ def create_asana_task(
     asana_token: str,
     pr_author_field_id: str,
     pr_author_asana: str | None,
+    asana_attachment_secret: str,
 ) -> str:
     """Create a new Asana task with the GitHub URL field populated."""
     url = "https://app.asana.com/api/1.0/tasks"
@@ -237,7 +238,11 @@ def create_asana_task(
 
     response = requests.post(url, json=payload, headers=headers, timeout=30)
     if response.status_code == 201:
-        return response.json()["data"]["permalink_url"]
+        task_url = response.json()["data"]["permalink_url"]
+        # For the most part, create_asana_task should do the same work as update_asana_task. This
+        # is a specific exception, since it's an extra call and this should be effectively immutable.
+        ensure_github_url_in_asana_task(asana_attachment_secret, project_id, task_url, title, github_url)
+        return task_url
     else:
         print(f"Asana API Error: {response.status_code} - {response.text}")
         sys.exit(1)
@@ -357,6 +362,7 @@ def ensure_asana_task_exists(
     asana_token: str,
     pr_author_field_id: str,
     pr_author_asana: str | None,
+    asana_attachment_secret: str,
 ) -> str:
     """Ensure an Asana task exists with the given GitHub URL. Return existing or create new."""
 
@@ -415,6 +421,7 @@ def ensure_asana_task_exists(
         asana_token,
         pr_author_field_id,
         pr_author_asana,
+        asana_attachment_secret,
     )
     print(f"Created new Asana task: {new_task_url}")
     return new_task_url
@@ -427,6 +434,12 @@ def ensure_github_url_in_asana_task(
     title: str,
     github_url: str,
 ) -> dict | None:
+    """Ensure the GitHub URL is in the Asana task.
+
+    Asana provides this via https://github.com/Asana/create-app-attachment-github-action, but their
+    workflow only runs in limited contexts. In particular, we don't trust it to pick up the task url
+    from the description when we've added it within the same workflow. So we'll just do it manually.
+    """
     github_url_number = github_url.split("pull/")[-1]
     if not github_url_number.isdigit():
         print(f"Invalid GitHub URL: {github_url}")
@@ -510,9 +523,8 @@ if __name__ == "__main__":
         asana_token,
         pr_author_field_id,
         pr_author_asana,
+        asana_attachment_secret,
     )
-
-    ensure_github_url_in_asana_task(asana_attachment_secret, project_id, task_url, title, github_url)
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         f.write(f"task_url={task_url}\n")

--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -46,6 +46,7 @@ jobs:
           gh_login_field_id: ${{ vars.ASANA_GH_LOGIN_FIELD_GID }}
           asana_email_field_id: ${{ vars.ASANA_EMAIL_FIELD_GID }}
           pr_author_field_id: ${{ vars.ASANA_PR_AUTHOR_FIELD_GID }}
+          asana-attachment-secret: ${{ secrets.ASANA_ATTACHMENT_SECRET }}
 
       - name: Update PR Description
         uses: ./.github/actions/asana/update-pr-description
@@ -54,12 +55,3 @@ jobs:
           repo: ${{ github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
           task_url: ${{ steps.ensure-asana-task.outputs.task_url }}
-
-      - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@latest
-        id: postAttachment
-        with:
-          asana-secret: ${{ secrets.ASANA_ATTACHMENT_SECRET }}
-
-      - name: Log output status
-        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"

--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -46,7 +46,7 @@ jobs:
           gh_login_field_id: ${{ vars.ASANA_GH_LOGIN_FIELD_GID }}
           asana_email_field_id: ${{ vars.ASANA_EMAIL_FIELD_GID }}
           pr_author_field_id: ${{ vars.ASANA_PR_AUTHOR_FIELD_GID }}
-          asana-attachment-secret: ${{ secrets.ASANA_ATTACHMENT_SECRET }}
+          asana_attachment_secret: ${{ secrets.ASANA_ATTACHMENT_SECRET }}
 
       - name: Update PR Description
         uses: ./.github/actions/asana/update-pr-description


### PR DESCRIPTION
Adds GitHub PR attachment functionality to our custom Asana integration, replacing the official Asana GitHub action. The official integration works by reading a PR description; but the PR description doesn't have the Asana task URL we want at the time the PR is created.

By making the endpoint call manually, we can get around this.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210714869008517)