### PR TITLE
remove inter-team reward sharing configuration

### DIFF
--- a/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
@@ -79,13 +79,3 @@ game:
       conversion_ticks: 1
       initial_items: 1
 
-  reward_sharing:
-    groups:
-      team_1:
-        team_1: 1
-      team_2:
-        team_2: 1
-      team_3:
-        team_3: 1
-      team_4:
-        team_4: 1

--- a/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
@@ -80,13 +80,3 @@ game:
       conversion_ticks: 1
       initial_items: 1
 
-  reward_sharing:
-    groups:
-      team_1:
-        team_1: 1
-      team_2:
-        team_2: 1
-      team_3:
-        team_3: 1
-      team_4:
-        team_4: 1

--- a/configs/env/mettagrid/cooperation/experimental/two_rooms_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/two_rooms_coord.yaml
@@ -73,13 +73,3 @@ game:
       conversion_ticks: 1
       initial_items: 1
 
-  reward_sharing:
-    groups:
-      team_1:
-        team_1: 1
-      team_2:
-        team_2: 1
-      team_3:
-        team_3: 1
-      team_4:
-        team_4: 1

--- a/metta/api.py
+++ b/metta/api.py
@@ -315,7 +315,6 @@ def _get_default_env_config(num_agents: int = 4, width: int = 32, height: int = 
                 "wall": {"type_id": TYPE_WALL, "swappable": False},
                 "block": {"type_id": TYPE_BLOCK, "swappable": True},
             },
-            "reward_sharing": {"groups": {}},
             "map_builder": {
                 "_target_": "metta.mettagrid.room.multi_room.MultiRoom",
                 "num_rooms": num_agents,

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -256,14 +256,3 @@ game:
       enabled: true
     change_color:
       enabled: true
-
-  reward_sharing:
-    groups:
-      team_1:
-        team_1: 0.5
-      team_2:
-        team_2: 0.5
-      team_3:
-        team_3: 0.5
-      team_4:
-        team_4: 0.5

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,7 +1,7 @@
 import copy
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
-from pydantic import Field, RootModel, conint
+from pydantic import Field, conint
 
 from metta.common.util.typed_config import BaseModelWithForbidExtra
 from metta.mettagrid.mettagrid_c import AgentConfig as AgentConfig_cpp

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -56,18 +56,6 @@ class ObjectConfig_cpp(BaseModelWithForbidExtra):
     type_name: str
 
 
-class RewardSharingGroup_cpp(RootModel[Dict[str, float]]):
-    """Reward sharing configuration for a group."""
-
-    pass
-
-
-class RewardSharingConfig_cpp(BaseModelWithForbidExtra):
-    """Reward sharing configuration."""
-
-    groups: Optional[Dict[str, RewardSharingGroup_cpp]] = None
-
-
 class GameConfig_cpp(BaseModelWithForbidExtra):
     """Game configuration."""
 
@@ -79,7 +67,6 @@ class GameConfig_cpp(BaseModelWithForbidExtra):
     num_observation_tokens: int = Field(ge=1)
     actions: ActionsConfig_cpp
     objects: Dict[str, Any]
-    reward_sharing: Optional[RewardSharingConfig_cpp] = None
 
 
 def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -137,18 +137,6 @@ class ConverterConfig(BaseModelWithForbidExtra):
     color: Optional[int] = Field(default=None, ge=0, le=255)
 
 
-class RewardSharingGroup(RootModel[Dict[str, float]]):
-    """Reward sharing configuration for a group."""
-
-    pass
-
-
-class RewardSharingConfig(BaseModelWithForbidExtra):
-    """Reward sharing configuration."""
-
-    groups: Optional[Dict[str, RewardSharingGroup]] = None
-
-
 class GameConfig(BaseModelWithForbidExtra):
     """Game configuration."""
 
@@ -164,4 +152,3 @@ class GameConfig(BaseModelWithForbidExtra):
     groups: Dict[str, GroupConfig] = Field(min_length=1)
     actions: ActionsConfig
     objects: Dict[str, ConverterConfig | WallConfig]
-    reward_sharing: Optional[RewardSharingConfig] = None

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -223,22 +223,6 @@
         "enabled": true
       }
     },
-    "reward_sharing": {
-      "groups": {
-        "team_1": {
-          "team_1": 0.5
-        },
-        "team_2": {
-          "team_2": 0.5
-        },
-        "team_3": {
-          "team_3": 0.5
-        },
-        "team_4": {
-          "team_4": 0.5
-        }
-      }
-    },
     "map_builder": {
       "num_rooms": 4,
       "border_width": 6,


### PR DESCRIPTION
Removes the `reward_sharing` configuration from various YAML files and related code structures. This specifies inter-team reward sharing, but the configuration currently isn't in use. Since I'm working on locking down configuration, it seems sensible to remove it (since it's not used), and add it back once it's clear what and where it should be.

Tested by searching for "reward_sharing"

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210718411937444)