### PR TITLE
Residual MLPs offered in nn_layer_library!

### DIFF
--- a/agent/src/metta/agent/lib/nn_layer_library.py
+++ b/agent/src/metta/agent/lib/nn_layer_library.py
@@ -123,7 +123,7 @@ class Swish(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.beta = nn.Parameter(torch.tensor(1.0), dtype=torch.float32)
+        self.beta = nn.Parameter(torch.tensor(1.0, dtype=torch.float32))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x * torch.sigmoid(self.beta * x)

--- a/agent/src/metta/agent/lib/nn_layer_library.py
+++ b/agent/src/metta/agent/lib/nn_layer_library.py
@@ -84,11 +84,77 @@ class Bilinear(LayerBase):
         return nn.Bilinear(**self._nn_params)
 
     def _forward(self, td: TensorDict):
-        # input_1 = td[self._input_source[0]]
-        # input_2 = td[self._input_source[1]]
         input_1 = td[self._sources[0]["name"]]
         input_2 = td[self._sources[1]["name"]]
         td[self._name] = self._net(input_1, input_2)
+        return td
+
+
+class ResidualBlock(nn.Module):
+    """
+    This class cannot be used as a layer in MettaAgent. It is a helper class for ResNetMLP.
+    """
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size),
+            nn.LayerNorm(hidden_size),
+            Swish(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.LayerNorm(hidden_size),
+            Swish(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.LayerNorm(hidden_size),
+            Swish(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.LayerNorm(hidden_size),
+            Swish(),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.block(x)
+
+
+class Swish(nn.Module):
+    """
+    This class cannot be used as a layer in MettaAgent. It is a helper class for ResidualBlock.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.beta = nn.Parameter(torch.tensor(1.0), dtype=torch.float32)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * torch.sigmoid(self.beta * x)
+
+
+class ResNetMLP(LayerBase):
+    """
+    Applies a residual dense connection to the incoming data: y = x + F(x)
+    Input and output shapes are the same. To scale, you need to create an initial and/or final linear layer separately
+    that maps to the hidden size you want.
+    """
+
+    def __init__(self, depth, **cfg):
+        super().__init__(**cfg)
+        self._depth = depth
+
+    def _make_net(self):
+        self._out_tensor_shape = self._in_tensor_shapes[0].copy()
+
+        if self._depth % 4 != 0:
+            raise ValueError("Depth must be a multiple of 4.")
+        self._num_blocks = self._depth // 4
+
+        hidden_size = self._in_tensor_shapes[0][0]
+
+        self.residual_layers = nn.Sequential(*[ResidualBlock(hidden_size) for _ in range(self._num_blocks)])
+
+    def _forward(self, td: TensorDict):
+        x = td[self._sources[0]["name"]]
+        x = self.residual_layers(x)
+        td[self._name] = x
         return td
 
 

--- a/configs/agent/prototypes/resmlp_value.yaml
+++ b/configs/agent/prototypes/resmlp_value.yaml
@@ -1,0 +1,103 @@
+# see reference_design.yaml for explanation of components
+_target_: metta.agent.metta_agent.MettaAgent
+
+observations:
+  obs_key: grid_obs
+
+clip_range: 0 # set to 0 to disable clipping
+analyze_weights_interval: 300
+l2_init_weight_update_interval: 0
+
+components:
+  #necessary layers: _core_, _action_embeds_, _action_, _value_
+  #necessary input_source: _obs_
+
+  _obs_:
+    _target_: metta.agent.lib.obs_tokenizers.ObsTokenPadStrip
+    sources:
+      null
+
+  obs_normalizer:
+    _target_: metta.agent.lib.obs_tokenizers.ObsAttrValNorm
+    sources:
+      - name: _obs_
+
+  obs_fourier:
+    _target_: metta.agent.lib.obs_tokenizers.ObsAttrEmbedFourier
+    num_freqs: 8
+    attr_embed_dim: 8
+    sources:
+      - name: obs_normalizer
+
+  obs_latent_query_attn:
+    _target_: metta.agent.lib.obs_enc.ObsLatentAttn
+    out_dim: 32
+    use_mask: true
+    num_query_tokens: 10
+    query_token_dim: 32
+    num_heads: 4
+    num_layers: 1
+    sources:
+      - name: obs_fourier
+
+  obs_latent_self_attn:
+    _target_: metta.agent.lib.obs_enc.ObsSelfAttn
+    out_dim: 128
+    num_heads: 4
+    num_layers: 2
+    qk_dim: 32
+    use_mask: false
+    use_cls_token: true
+    sources:
+      - name: obs_latent_query_attn
+
+  _core_:
+    _target_: metta.agent.lib.lstm.LSTM
+    sources:
+      - name: obs_latent_self_attn
+    output_size: 128
+    nn_params:
+      num_layers: 2
+
+  critic_1:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: _core_
+    nn_params:
+      out_features: 256
+    nonlinearity: nn.Tanh
+
+  critic_2:
+    _target_: metta.agent.lib.nn_layer_library.ResNetMLP
+    depth: 64
+    sources:
+      - name: critic_1
+
+  _value_:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: critic_2
+    nn_params:
+      out_features: 1
+    nonlinearity: null
+
+  actor_1:
+    _target_: metta.agent.lib.nn_layer_library.Linear
+    sources:
+      - name: _core_
+    nn_params:
+      out_features: 512
+
+  _action_embeds_:
+    _target_: metta.agent.lib.action.ActionEmbedding
+    sources:
+      null
+    nn_params:
+      num_embeddings: 100
+      embedding_dim: 16
+
+  _action_:
+    _target_: metta.agent.lib.actor.MettaActorSingleHead
+    sources:
+      - name: actor_1
+      - name: _action_embeds_


### PR DESCRIPTION
**Added very deep residual MLPs to the nn_layer_library.**
[https://arxiv.org/pdf/2503.14858](https://arxiv.org/pdf/2503.14858)

**Other work:**
- Added a prototypes folder under config/agent to keep things clean
- Added a config that generates an agent using a 64 layer MLP for the critic network.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210721194013322)