### PR TITLE
Correctly zero out zero_actions

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -437,6 +437,7 @@ py::tuple MettaGrid::reset() {
   // Compute initial observations
   std::vector<ssize_t> shape = {static_cast<ssize_t>(_agents.size()), static_cast<ssize_t>(2)};
   auto zero_actions = py::array_t<int>(shape);
+  std::fill(zero_actions.mutable_data(), zero_actions.mutable_data() + zero_actions.size(), 0);
   _compute_observations(zero_actions);
 
   return py::make_tuple(_observations, py::dict());

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -436,8 +436,10 @@ py::tuple MettaGrid::reset() {
 
   // Compute initial observations
   std::vector<ssize_t> shape = {static_cast<ssize_t>(_agents.size()), static_cast<ssize_t>(2)};
-  auto zero_actions = py::array_t<int>(shape);
-  std::fill(zero_actions.mutable_data(), zero_actions.mutable_data() + zero_actions.size(), 0);
+  auto zero_actions = py::array_t<ActionType, py::array::c_style>(shape);
+  std::fill(static_cast<ActionType*>(zero_actions.request().ptr),
+            static_cast<ActionType*>(zero_actions.request().ptr) + zero_actions.size(),
+            static_cast<ActionType>(0));
   _compute_observations(zero_actions);
 
   return py::make_tuple(_observations, py::dict());
@@ -488,6 +490,7 @@ void MettaGrid::set_buffers(const py::array_t<uint8_t, py::array::c_style>& obse
                             const py::array_t<bool, py::array::c_style>& terminals,
                             const py::array_t<bool, py::array::c_style>& truncations,
                             const py::array_t<float, py::array::c_style>& rewards) {
+  // These are initialized in reset()
   _observations = observations;
   _terminals = terminals;
   _truncations = truncations;

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -242,14 +242,18 @@ class TestGlobalTokens:
         LAST_REWARD = 11
 
         # Initial state checks
-        assert obs[0, 0, 1] == EPISODE_COMPLETION_PCT, "First token should be episode completion percentage"
-        assert obs[0, 0, 2] == 0, "Episode completion should start at 0%"
-        assert obs[0, 1, 1] == LAST_ACTION, "Second token should be last action"
-        assert obs[0, 1, 2] == 0, "Last action should be 0"
-        assert obs[0, 2, 1] == LAST_ACTION_ARG, "Third token should be last action arg"
-        assert obs[0, 2, 2] == 0, "Last action arg should start at 0"
-        assert obs[0, 3, 1] == LAST_REWARD, "Fourth token should be last reward"
-        assert obs[0, 3, 2] == 0, "Last reward should start at 0"
+        assert obs[0, 0, 1] == EPISODE_COMPLETION_PCT, (
+            f"First token should be episode completion percentage ({EPISODE_COMPLETION_PCT}). Was {obs[0, 0, 1]}"
+        )
+        assert obs[0, 0, 2] == 0, f"Episode completion should start at 0%. Was {obs[0, 0, 2]}"
+        assert obs[0, 1, 1] == LAST_ACTION, f"Second token should be last action ({LAST_ACTION}). Was {obs[0, 1, 1]}"
+        assert obs[0, 1, 2] == 0, f"Last action should be 0. Was {obs[0, 1, 2]}"
+        assert obs[0, 2, 1] == LAST_ACTION_ARG, (
+            f"Third token should be last action arg ({LAST_ACTION_ARG}). Was {obs[0, 2, 1]}"
+        )
+        assert obs[0, 2, 2] == 0, f"Last action arg should start at 0. Was {obs[0, 2, 2]}"
+        assert obs[0, 3, 1] == LAST_REWARD, f"Fourth token should be last reward ({LAST_REWARD}). Was {obs[0, 3, 1]}"
+        assert obs[0, 3, 2] == 0, f"Last reward should start at 0. Was {obs[0, 3, 2]}"
 
         # Take a step with a noop action
         noop_action_idx = c_env.action_names().index("noop")


### PR DESCRIPTION
Properly initializes the `zero_actions` array in the `reset()` method by filling it with zeros. Previously, the array was created but not initialized with values. The PR also improves test error messages by adding more detailed context when assertions fail.

Note that the test in question tended to pass when the fully test suite was run, but fail when the test was run individually. I assume this is because when the full test suite was run, memory happened to get cleared.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210721549334192)