### PR TITLE
Make a GameConfig cpp object

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,5 +4,5 @@ defaults:
   - _self_
 
 seed: null
-run_id: 20250703.01
+run_id: 20250704.01
 run: ${oc.env:USER}.local.${run_id}

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -437,6 +437,7 @@ py::tuple MettaGrid::reset() {
   // Compute initial observations
   std::vector<ssize_t> shape = {static_cast<ssize_t>(_agents.size()), static_cast<ssize_t>(2)};
   auto zero_actions = py::array_t<int>(shape);
+  std::fill(zero_actions.mutable_data(), zero_actions.mutable_data() + zero_actions.size(), 0);
   _compute_observations(zero_actions);
 
   return py::make_tuple(_observations, py::dict());

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -32,17 +32,6 @@
 
 namespace py = pybind11;
 
-struct GameConfig {
-  int num_agents;
-  unsigned int max_steps;
-  unsigned short obs_width;
-  unsigned short obs_height;
-  std::vector<std::string> inventory_item_names;
-  unsigned int num_observation_tokens;
-  std::map<std::string, std::shared_ptr<ActionConfig>> actions;
-  std::map<std::string, std::shared_ptr<GridObjectConfig>> objects;
-};
-
 MettaGrid::MettaGrid(const GameConfig& cfg, py::list map, int seed)
     : max_steps(cfg.max_steps),
       obs_width(cfg.obs_width),

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -436,8 +436,10 @@ py::tuple MettaGrid::reset() {
 
   // Compute initial observations
   std::vector<ssize_t> shape = {static_cast<ssize_t>(_agents.size()), static_cast<ssize_t>(2)};
-  auto zero_actions = py::array_t<int>(shape);
-  std::fill(zero_actions.mutable_data(), zero_actions.mutable_data() + zero_actions.size(), 0);
+  auto zero_actions = py::array_t<ActionType, py::array::c_style>(shape);
+  std::fill(static_cast<ActionType*>(zero_actions.request().ptr),
+            static_cast<ActionType*>(zero_actions.request().ptr) + zero_actions.size(),
+            static_cast<ActionType>(0));
   _compute_observations(zero_actions);
 
   return py::make_tuple(_observations, py::dict());
@@ -488,6 +490,7 @@ void MettaGrid::set_buffers(const py::array_t<uint8_t, py::array::c_style>& obse
                             const py::array_t<bool, py::array::c_style>& terminals,
                             const py::array_t<bool, py::array::c_style>& truncations,
                             const py::array_t<float, py::array::c_style>& rewards) {
+  // These are initialized in reset()
   _observations = observations;
   _terminals = terminals;
   _truncations = truncations;

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -33,12 +33,13 @@ class GridObjectConfig;
 class ConverterConfig;
 class WallConfig;
 class AgentConfig;
+class GameConfig;
 
 namespace py = pybind11;
 
 class METTAGRID_API MettaGrid {
 public:
-  MettaGrid(py::dict env_cfg, py::list map, int seed);
+  MettaGrid(const GameConfig& cfg, py::list map, int seed);
   ~MettaGrid();
 
   unsigned short obs_width;

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -34,8 +34,20 @@ class ConverterConfig;
 class WallConfig;
 class AgentConfig;
 class GameConfig;
+class ActionConfig;
 
 namespace py = pybind11;
+
+struct GameConfig {
+  int num_agents;
+  unsigned int max_steps;
+  unsigned short obs_width;
+  unsigned short obs_height;
+  std::vector<std::string> inventory_item_names;
+  unsigned int num_observation_tokens;
+  std::map<std::string, std::shared_ptr<ActionConfig>> actions;
+  std::map<std::string, std::shared_ptr<GridObjectConfig>> objects;
+};
 
 class METTAGRID_API MettaGrid {
 public:

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict
+from typing import Any
 
 from metta.mettagrid.mettagrid_c import ActionConfig as ActionConfig_cpp
 from metta.mettagrid.mettagrid_c import AgentConfig as AgentConfig_cpp
@@ -12,7 +12,7 @@ from metta.mettagrid.mettagrid_config import GameConfig as GameConfig_py
 from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
 
 
-def from_mettagrid_config(mettagrid_config_dict: GameConfig_py) -> GameConfig_cpp:
+def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> GameConfig_cpp:
     """Convert a mettagrid_config.GameConfig to a mettagrid_c_config.GameConfig."""
 
     mettagrid_config = GameConfig_py(**mettagrid_config_dict)
@@ -128,14 +128,3 @@ def from_mettagrid_config(mettagrid_config_dict: GameConfig_py) -> GameConfig_cp
     game_config["objects"] = object_configs
 
     return GameConfig_cpp(**game_config)
-
-
-def cpp_config_dict(game_config_dict: Dict[str, Any]) -> Dict[str, Any]:
-    """Validates a config dict and returns a config_c dict.
-
-    In particular, this function converts from the style of config we have in yaml to the style of config we expect
-    in cpp; and validates along the way.
-    """
-    game_config = GameConfig_py(**game_config_dict)
-
-    return from_mettagrid_config(game_config).model_dump(by_alias=True, exclude_none=True)

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,49 +1,21 @@
 import copy
-from typing import Any, ClassVar, Dict, List
+from typing import Any, Dict
 
-from pydantic import ConfigDict, Field
-
-from metta.common.util.typed_config import BaseModelWithForbidExtra
 from metta.mettagrid.mettagrid_c import ActionConfig as ActionConfig_cpp
 from metta.mettagrid.mettagrid_c import AgentConfig as AgentConfig_cpp
 from metta.mettagrid.mettagrid_c import AttackActionConfig as AttackActionConfig_cpp
 from metta.mettagrid.mettagrid_c import ConverterConfig as ConverterConfig_cpp
+from metta.mettagrid.mettagrid_c import GameConfig as GameConfig_cpp
 from metta.mettagrid.mettagrid_c import WallConfig as WallConfig_cpp
 from metta.mettagrid.mettagrid_config import ConverterConfig as ConverterConfig_py
 from metta.mettagrid.mettagrid_config import GameConfig as GameConfig_py
 from metta.mettagrid.mettagrid_config import WallConfig as WallConfig_py
 
 
-class ActionsConfig_cpp(BaseModelWithForbidExtra):
-    """Actions configuration."""
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
-
-    noop: ActionConfig_cpp
-    move: ActionConfig_cpp
-    rotate: ActionConfig_cpp
-    put_items: ActionConfig_cpp
-    get_items: ActionConfig_cpp
-    attack: AttackActionConfig_cpp
-    swap: ActionConfig_cpp
-    change_color: ActionConfig_cpp
-
-
-class GameConfig_cpp(BaseModelWithForbidExtra):
-    """Game configuration."""
-
-    inventory_item_names: List[str]
-    num_agents: int = Field(ge=1)
-    max_steps: int = Field(ge=0)
-    obs_width: int = Field(ge=1)
-    obs_height: int = Field(ge=1)
-    num_observation_tokens: int = Field(ge=1)
-    actions: ActionsConfig_cpp
-    objects: Dict[str, Any]
-
-
-def from_mettagrid_config(mettagrid_config: GameConfig_py) -> GameConfig_cpp:
+def from_mettagrid_config(mettagrid_config_dict: GameConfig_py) -> GameConfig_cpp:
     """Convert a mettagrid_config.GameConfig to a mettagrid_c_config.GameConfig."""
+
+    mettagrid_config = GameConfig_py(**mettagrid_config_dict)
 
     inventory_item_names = list(mettagrid_config.inventory_item_names)
     inventory_item_ids = dict((name, i) for i, name in enumerate(inventory_item_names))

--- a/mettagrid/src/metta/mettagrid/mettagrid_env.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_env.py
@@ -19,7 +19,7 @@ from metta.common.profiling.stopwatch import Stopwatch, with_instance_timer
 from metta.mettagrid.curriculum.core import Curriculum
 from metta.mettagrid.level_builder import Level
 from metta.mettagrid.mettagrid_c import MettaGrid
-from metta.mettagrid.mettagrid_c_config import cpp_config_dict
+from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 from metta.mettagrid.replay_writer import ReplayWriter
 from metta.mettagrid.stats_writer import StatsWriter
 from metta.mettagrid.util.dict_utils import unroll_nested_dict
@@ -146,7 +146,7 @@ class MettaGridEnv(PufferEnv, GymEnv):
         # Convert string array to list of strings for C++ compatibility
         # TODO: push the not-numpy-array higher up the stack, and consider pushing not-a-sparse-list lower.
         with self.timer("_initialize_c_env.make_c_env"):
-            self._c_env = MettaGrid(cpp_config_dict(game_config_dict), level.grid.tolist(), self._current_seed)
+            self._c_env = MettaGrid(from_mettagrid_config(game_config_dict), level.grid.tolist(), self._current_seed)
 
         self._grid_env = self._c_env
 

--- a/mettagrid/tests/test_actions.py
+++ b/mettagrid/tests/test_actions.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from metta.mettagrid.mettagrid_c import MettaGrid
-from metta.mettagrid.mettagrid_c_config import cpp_config_dict
+from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 from metta.mettagrid.mettagrid_env import (
     dtype_observations,
     dtype_rewards,
@@ -93,9 +93,7 @@ def configured_env(base_config):
         if config_overrides:
             game_config.update(config_overrides)
 
-        print(cpp_config_dict(game_config))
-
-        env = MettaGrid(cpp_config_dict(game_config), game_map, 42)
+        env = MettaGrid(from_mettagrid_config(game_config), game_map, 42)
 
         # Set up buffers
         observations = np.zeros((1, NUM_OBS_TOKENS, OBS_TOKEN_SIZE), dtype=dtype_observations)

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from metta.mettagrid.mettagrid_c import MettaGrid
-from metta.mettagrid.mettagrid_c_config import cpp_config_dict
+from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 from metta.mettagrid.mettagrid_env import (
     dtype_actions,
     dtype_observations,
@@ -78,7 +78,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
 
         deep_merge(game_config, config_override)
 
-    return MettaGrid(cpp_config_dict(game_config), game_map.tolist(), 42)
+    return MettaGrid(from_mettagrid_config(game_config), game_map.tolist(), 42)
 
 
 class TestBuffers:

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -242,14 +242,18 @@ class TestGlobalTokens:
         LAST_REWARD = 11
 
         # Initial state checks
-        assert obs[0, 0, 1] == EPISODE_COMPLETION_PCT, "First token should be episode completion percentage"
-        assert obs[0, 0, 2] == 0, "Episode completion should start at 0%"
-        assert obs[0, 1, 1] == LAST_ACTION, "Second token should be last action"
-        assert obs[0, 1, 2] == 0, "Last action should be 0"
-        assert obs[0, 2, 1] == LAST_ACTION_ARG, "Third token should be last action arg"
-        assert obs[0, 2, 2] == 0, "Last action arg should start at 0"
-        assert obs[0, 3, 1] == LAST_REWARD, "Fourth token should be last reward"
-        assert obs[0, 3, 2] == 0, "Last reward should start at 0"
+        assert obs[0, 0, 1] == EPISODE_COMPLETION_PCT, (
+            f"First token should be episode completion percentage ({EPISODE_COMPLETION_PCT}). Was {obs[0, 0, 1]}"
+        )
+        assert obs[0, 0, 2] == 0, f"Episode completion should start at 0%. Was {obs[0, 0, 2]}"
+        assert obs[0, 1, 1] == LAST_ACTION, f"Second token should be last action ({LAST_ACTION}). Was {obs[0, 1, 1]}"
+        assert obs[0, 1, 2] == 0, f"Last action should be 0. Was {obs[0, 1, 2]}"
+        assert obs[0, 2, 1] == LAST_ACTION_ARG, (
+            f"Third token should be last action arg ({LAST_ACTION_ARG}). Was {obs[0, 2, 1]}"
+        )
+        assert obs[0, 2, 2] == 0, f"Last action arg should start at 0. Was {obs[0, 2, 2]}"
+        assert obs[0, 3, 1] == LAST_REWARD, f"Fourth token should be last reward ({LAST_REWARD}). Was {obs[0, 3, 1]}"
+        assert obs[0, 3, 2] == 0, f"Last reward should start at 0. Was {obs[0, 3, 2]}"
 
         # Take a step with a noop action
         noop_action_idx = c_env.action_names().index("noop")

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from metta.mettagrid.mettagrid_c import MettaGrid
-from metta.mettagrid.mettagrid_c_config import cpp_config_dict
+from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 from metta.mettagrid.mettagrid_env import dtype_actions
 
 NUM_AGENTS = 2
@@ -53,7 +53,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5):
         "agent": {},
     }
 
-    return MettaGrid(cpp_config_dict(game_config), game_map.tolist(), 42)
+    return MettaGrid(from_mettagrid_config(game_config), game_map.tolist(), 42)
 
 
 def test_grid_hash():

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from metta.mettagrid.mettagrid_c import MettaGrid
-from metta.mettagrid.mettagrid_c_config import cpp_config_dict
+from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 from metta.mettagrid.mettagrid_env import (
     dtype_actions,
     dtype_observations,
@@ -69,7 +69,7 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
         },
     }
 
-    return MettaGrid(cpp_config_dict(game_config), game_map, 42)
+    return MettaGrid(from_mettagrid_config(game_config), game_map, 42)
 
 
 def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENTS):
@@ -112,7 +112,7 @@ def create_reward_test_env(max_steps=10, width=5, height=5, num_agents=NUM_AGENT
         "agent": {"freeze_duration": 100, "rewards": {"heart": 1.0}},
     }
 
-    return MettaGrid(cpp_config_dict(game_config), game_map.tolist(), 42)
+    return MettaGrid(from_mettagrid_config(game_config), game_map.tolist(), 42)
 
 
 def perform_action(env, action_name, arg=0):

--- a/tests/test_validate_all_envs.py
+++ b/tests/test_validate_all_envs.py
@@ -64,4 +64,4 @@ class TestValidateAllEnvs:
         # uncomment for debugging
         print(OmegaConf.to_yaml(OmegaConf.create(game_config_dict)))
 
-        metta.mettagrid.mettagrid_c_config.cpp_config_dict(cast(dict[str, Any], game_config_dict))
+        metta.mettagrid.mettagrid_c_config.from_mettagrid_config(cast(dict[str, Any], game_config_dict))


### PR DESCRIPTION
Introduces a C++ `GameConfig` class to replace the Python dictionary-based configuration for MettaGrid.

This eliminates our usage of python dictionaries in the Mettagrid constructor, and thereby improves type safety. We're still obviously doing Python-cpp conversion, but now it's closer to "Python wrapping cpp", versus "cpp unwrapping Python".

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210721606600965)