### PR TITLE
refactor agent config

### DIFF
--- a/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/central_table_layout.yaml
@@ -12,8 +12,9 @@ game:
   num_agents: 8
 
   agent:
-    default_item_max: 1
-    heart_max: 255
+    default_resource_limit: 1
+    resource_limits:
+      heart: 255
     rewards:
       ore_red: 0.005
       ore_blue: 0.005

--- a/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/confined_room_coord.yaml
@@ -12,8 +12,9 @@ game:
   num_agents: 8
 
   agent:
-    default_item_max: 1
-    heart_max: 255
+    default_resource_limit: 1
+    resource_limits:
+      heart: 255
     rewards:
       ore_red: 0.005
       ore_blue: 0.005

--- a/configs/env/mettagrid/cooperation/experimental/two_rooms_coord.yaml
+++ b/configs/env/mettagrid/cooperation/experimental/two_rooms_coord.yaml
@@ -9,9 +9,10 @@ sampling: 1
 
 game:
   agent:
-    ore_red_max: 1
-    battery_red_max: 1
-    heart_max: 255
+    resource_limits:
+      ore_red: 1
+      battery_red: 1
+      heart: 255
 
   max_steps: 1000
   num_agents: 8

--- a/configs/env/mettagrid/debug.yaml
+++ b/configs/env/mettagrid/debug.yaml
@@ -12,7 +12,7 @@ game:
   num_agents: 2
 
   agent:
-    default_item_max: 50
+    default_resource_limit: 50
     freeze_duration: 0
 
   actions:

--- a/configs/env/mettagrid/extended_sequence/backchain1.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain1.yaml
@@ -8,12 +8,13 @@ game:
   num_agents: 4
   max_steps: 200
   agent:
-    ore_red_max: 1
-    ore_blue_max: 1
-    ore_green_max: 1
-    battery_red_max: 1
-    battery_blue_max: 1
-    battery_green_max: 1
+    resource_limits:
+      ore_red: 1
+      ore_blue: 1
+      ore_green: 1
+      battery_red: 1
+      battery_blue: 1
+      battery_green: 1
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/extended_sequence/backchain1.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain1.yaml
@@ -16,7 +16,6 @@ game:
       battery_blue: 1
       battery_green: 1
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}
       battery_red: ${sampling:0.01,0.3,0.1}
       ore_blue: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/extended_sequence/backchain2.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain2.yaml
@@ -17,7 +17,6 @@ game:
       battery_blue: 1
       battery_green: 1
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}
       battery_red: ${sampling:0.01,0.3,0.1}
       ore_blue: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/extended_sequence/backchain2.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain2.yaml
@@ -9,12 +9,13 @@ game:
   max_steps: 200
   num_agents: 4
   agent:
-    ore_red_max: 1
-    ore_blue_max: 1
-    ore_green_max: 1
-    battery_red_max: 1
-    battery_blue_max: 1
-    battery_green_max: 1
+    resource_limits:
+      ore_red: 1
+      ore_blue: 1
+      ore_green: 1
+      battery_red: 1
+      battery_blue: 1
+      battery_green: 1
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/extended_sequence/backchain3.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain3.yaml
@@ -10,12 +10,13 @@ game:
   num_agents: 4
   max_steps: 200
   agent:
-    ore_red_max: 1
-    ore_blue_max: 1
-    ore_green_max: 1
-    battery_red_max: 1
-    battery_blue_max: 1
-    battery_green_max: 1
+    resource_limits:
+      ore_red: 1
+      ore_blue: 1
+      ore_green: 1
+      battery_red: 1
+      battery_blue: 1
+      battery_green: 1
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/extended_sequence/backchain3.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain3.yaml
@@ -18,7 +18,6 @@ game:
       battery_blue: 1
       battery_green: 1
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1,0.01}
       battery_red: ${sampling:0.01,0.3,0.1}
       ore_blue: ${sampling:0.005,0.1,0.01}

--- a/configs/env/mettagrid/game/agent/hearts.yaml
+++ b/configs/env/mettagrid/game/agent/hearts.yaml
@@ -1,7 +1,8 @@
-default_item_max: 50
+default_resource_limit: 50
 # the agent should be able to pick up as many hearts as they want, even if
 # "normal" item limits are lower
-heart_max: 255
+resource_limits:
+  heart: 255
 freeze_duration: 10
 
 rewards:

--- a/configs/env/mettagrid/game/agent/hearts.yaml
+++ b/configs/env/mettagrid/game/agent/hearts.yaml
@@ -6,7 +6,5 @@ resource_limits:
 freeze_duration: 10
 
 rewards:
-  # action_failure_penalty: 0.00001
-  action_failure_penalty: 0
   heart: 1
   heart_max: 1000

--- a/configs/env/mettagrid/laser_tag.yaml
+++ b/configs/env/mettagrid/laser_tag.yaml
@@ -59,7 +59,7 @@ game:
                 team_2: 18
 
   agent:
-    default_item_max: 5
+    default_resource_limit: 5
 
   objects:
     altar:

--- a/configs/env/mettagrid/multiagent/experiments/defaults.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/defaults.yaml
@@ -8,7 +8,6 @@ game:
   num_agents: 32
   agent:
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       ore_red_max: 3
       battery_red: ${sampling:0.01,0.5, 0.1}

--- a/configs/env/mettagrid/multiagent/experiments/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/terrain_from_numpy.yaml
@@ -12,7 +12,6 @@ game:
   num_agents: 32
   agent:
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       ore_blue: ${sampling:0.005,0.1, 0.01}
       ore_green: ${sampling:0.005,0.1, 0.01}

--- a/configs/env/mettagrid/multiagent/experiments/varied_terrain.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/varied_terrain.yaml
@@ -7,7 +7,6 @@ game:
   num_agents: 32
   agent:
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       ore_blue: ${sampling:0.005,0.1, 0.01}
       ore_green: ${sampling:0.005,0.1, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/evals/defaults.yaml
@@ -17,7 +17,7 @@ game:
       heart: 1.0
       ore_red: 0
       battery_red: 0
-    default_item_max: 100
+    default_resource_limit: 100
     freeze_duration: 0
 
   objects:

--- a/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
@@ -17,7 +17,6 @@ game:
       battery_blue: ${sampling:1,2,3}
       battery_green: ${sampling:1,2,3}
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       battery_red: ${sampling:0.01,0.5, 0.1}
       battery_red_max: 5

--- a/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
@@ -9,12 +9,13 @@ sampling: 1
 game:
   num_agents: 4
   agent:
-    ore_red_max: ${sampling:1,2,3}
-    ore_blue_max: ${sampling:1,2,3}
-    ore_green_max: ${sampling:1,2,3}
-    battery_red_max: ${sampling:1,2,3}
-    battery_blue_max: ${sampling:1,2,3}
-    battery_green_max: ${sampling:1,2,3}
+    resource_limits:
+      ore_red: ${sampling:1,2,3}
+      ore_blue: ${sampling:1,2,3}
+      ore_green: ${sampling:1,2,3}
+      battery_red: ${sampling:1,2,3}
+      battery_blue: ${sampling:1,2,3}
+      battery_green: ${sampling:1,2,3}
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
@@ -15,8 +15,9 @@ labels:
 game:
   num_agents: 4
   agent:
-    ore_red_max: ${sampling:1,10,5}
-    battery_red_max: ${sampling:1,10,5}
+    resource_limits:
+      ore_red: ${sampling:1,10,5}
+      battery_red: ${sampling:1,10,5}
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.05, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
@@ -19,7 +19,6 @@ game:
       ore_red: ${sampling:1,10,5}
       battery_red: ${sampling:1,10,5}
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.05, 0.01}
       battery_red: ${sampling:0.01,0.1, 0.1}
       heart: 1

--- a/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
@@ -19,7 +19,6 @@ game:
       ore_red: ${sampling:5,20,15}
       battery_red: ${sampling:5,20,15}
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.05, 0.01}
       battery_red: ${sampling:0.01,0.1, 0.1}
       heart: 1

--- a/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
@@ -15,8 +15,9 @@ labels:
 game:
   num_agents: 4
   agent:
-    ore_red_max: ${sampling:5,20,15}
-    battery_red_max: ${sampling:5,20,15}
+    resource_limits:
+      ore_red: ${sampling:5,20,15}
+      battery_red: ${sampling:5,20,15}
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.05, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
@@ -21,7 +21,6 @@ game:
       ore_red: ${sampling:5,20,15}
       battery_red: ${sampling:5,20,15}
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       battery_red: ${sampling:0.01,0.3, 0.1}
       heart: 1

--- a/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
@@ -17,8 +17,9 @@ labels:
 game:
   num_agents: 4
   agent:
-    ore_red_max: ${sampling:5,20,15}
-    battery_red_max: ${sampling:5,20,15}
+    resource_limits:
+      ore_red: ${sampling:5,20,15}
+      battery_red: ${sampling:5,20,15}
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
@@ -11,8 +11,9 @@ sampling: 1
 game:
   num_agents: 4
   agent:
-    ore_red_max: ${sampling:5,25,15}
-    battery_red_max: ${sampling:5,25,15}
+    resource_limits:
+      ore_red: ${sampling:5,25,15}
+      battery_red: ${sampling:5,25,15}
     rewards:
       action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}

--- a/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
@@ -15,7 +15,6 @@ game:
       ore_red: ${sampling:5,25,15}
       battery_red: ${sampling:5,25,15}
     rewards:
-      action_failure_penalty: 0
       ore_red: ${sampling:0.005,0.1, 0.01}
       battery_red: ${sampling:0.01,0.3, 0.1}
       heart: 1

--- a/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
+++ b/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
@@ -13,8 +13,6 @@ game:
   agent:
     default_resource_limit: 5
     rewards:
-      # action_failure_penalty: 0.00001
-      action_failure_penalty: 0
       ore_red: 0.01
       battery_red: 0.1
       battery_red_max: 5

--- a/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
+++ b/configs/env/mettagrid/object_use/training/easy_all_objects.yaml
@@ -11,7 +11,7 @@ sampling: 1
 game:
   num_agents: 4
   agent:
-    default_item_max: 5
+    default_resource_limit: 5
     rewards:
       # action_failure_penalty: 0.00001
       action_failure_penalty: 0

--- a/configs/env/mettagrid/puffer.yaml
+++ b/configs/env/mettagrid/puffer.yaml
@@ -13,7 +13,7 @@ game:
   num_agents: 24
 
   agent:
-    default_item_max: 50
+    default_resource_limit: 50
     freeze_duration: 10
 
   map_builder:

--- a/metta/api.py
+++ b/metta/api.py
@@ -265,7 +265,6 @@ def _get_default_env_config(num_agents: int = 4, width: int = 32, height: int = 
                 },
                 "freeze_duration": 10,
                 "rewards": {
-                    "action_failure_penalty": 0,
                     "ore_red": 0.01,
                     "battery_red": 0.02,
                     "heart": 1,

--- a/metta/api.py
+++ b/metta/api.py
@@ -259,8 +259,10 @@ def _get_default_env_config(num_agents: int = 4, width: int = 32, height: int = 
             ],
             "groups": {"agent": {"id": 0, "sprite": 0}},
             "agent": {
-                "default_item_max": 50,
-                "heart_max": 255,
+                "default_resource_limit": 50,
+                "resource_limits": {
+                    "heart": 255,
+                },
                 "freeze_duration": 10,
                 "rewards": {
                     "action_failure_penalty": 0,

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -55,8 +55,6 @@ game:
     freeze_duration: 10
 
     rewards:
-      # action_failure_penalty: 0.00001
-      action_failure_penalty: 0
       ore_red: 0.005
       ore_blue: 0.005
       ore_green: 0.005

--- a/mettagrid/configs/benchmark.yaml
+++ b/mettagrid/configs/benchmark.yaml
@@ -51,7 +51,7 @@ game:
   max_steps: 1000
 
   agent:
-    default_item_max: 50
+    default_resource_limit: 50
     freeze_duration: 10
 
     rewards:

--- a/mettagrid/configs/test_basic.yaml
+++ b/mettagrid/configs/test_basic.yaml
@@ -42,8 +42,9 @@ game:
       props: {}
 
   agent:
-    default_item_max: 5
-    heart_max: 255
+    default_resource_limit: 5
+    resource_limits:
+      heart: 255
     freeze_duration: 10
     rewards:
       heart: 1

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -780,7 +780,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
            py::arg("group_name"),
            py::arg("freeze_duration") = 0,
            py::arg("action_failure_penalty") = 0,
-           py::arg("max_items_per_type") = std::map<InventoryItem, uint8_t>(),
+           py::arg("resource_limits") = std::map<InventoryItem, uint8_t>(),
            py::arg("resource_rewards") = std::map<InventoryItem, float>(),
            py::arg("resource_reward_max") = std::map<InventoryItem, float>(),
            py::arg("group_reward_pct") = 0)
@@ -790,7 +790,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def_readwrite("group_id", &AgentConfig::group_id)
       .def_readwrite("freeze_duration", &AgentConfig::freeze_duration)
       .def_readwrite("action_failure_penalty", &AgentConfig::action_failure_penalty)
-      .def_readwrite("max_items_per_type", &AgentConfig::max_items_per_type)
+      .def_readwrite("resource_limits", &AgentConfig::resource_limits)
       .def_readwrite("resource_rewards", &AgentConfig::resource_rewards)
       .def_readwrite("resource_reward_max", &AgentConfig::resource_reward_max)
       .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct);

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -43,15 +43,13 @@ def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> GameConfig_c
             "freeze_duration": merged_config.get("freeze_duration", 0),
             "group_id": group_config.id,
             "group_name": group_name,
-            "action_failure_penalty": merged_config.get("rewards", {}).get("action_failure_penalty", 0),
-            "max_resources": dict(
+            "action_failure_penalty": merged_config.get("action_failure_penalty", 0),
+            "resource_limits": dict(
                 (resource_id, merged_config.get("resource_limits", {}).get(resource_name, default_resource_limit))
                 for (resource_id, resource_name) in enumerate(resource_names)
             ),
             "resource_rewards": dict(
-                (resource_ids[k], v)
-                for k, v in merged_config.get("rewards", {}).items()
-                if not k.endswith("_max") and k != "action_failure_penalty"
+                (resource_ids[k], v) for k, v in merged_config.get("rewards", {}).items() if not k.endswith("_max")
             ),
             "resource_reward_max": dict(
                 (resource_ids[k[:-4]], v) for k, v in merged_config.get("rewards", {}).items() if k.endswith("_max")

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -34,19 +34,10 @@ class AgentRewards(BaseModelWithForbidExtra):
 class AgentConfig(BaseModelWithForbidExtra):
     """Agent configuration."""
 
-    default_item_max: Optional[int] = Field(default=None, ge=0)
+    default_resource_limit: Optional[int] = Field(default=None, ge=0)
+    resource_limits: Optional[Dict[str, int]] = Field(default_factory=dict)
     freeze_duration: Optional[int] = Field(default=None, ge=-1)
     rewards: Optional[AgentRewards] = None
-    ore_red_max: Optional[int] = Field(default=None)
-    ore_blue_max: Optional[int] = Field(default=None)
-    ore_green_max: Optional[int] = Field(default=None)
-    battery_red_max: Optional[int] = Field(default=None)
-    battery_blue_max: Optional[int] = Field(default=None)
-    battery_green_max: Optional[int] = Field(default=None)
-    heart_max: Optional[int] = Field(default=None)
-    armor_max: Optional[int] = Field(default=None)
-    laser_max: Optional[int] = Field(default=None)
-    blueprint_max: Optional[int] = Field(default=None)
 
 
 class GroupProps(RootModel[Dict[str, Any]]):

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -8,7 +8,6 @@ from metta.common.util.typed_config import BaseModelWithForbidExtra
 class AgentRewards(BaseModelWithForbidExtra):
     """Agent reward configuration."""
 
-    action_failure_penalty: Optional[float] = Field(default=None, ge=0)
     ore_red: Optional[float] = Field(default=None)
     ore_blue: Optional[float] = Field(default=None)
     ore_green: Optional[float] = Field(default=None)
@@ -38,6 +37,7 @@ class AgentConfig(BaseModelWithForbidExtra):
     resource_limits: Optional[Dict[str, int]] = Field(default_factory=dict)
     freeze_duration: Optional[int] = Field(default=None, ge=-1)
     rewards: Optional[AgentRewards] = None
+    action_failure_penalty: Optional[float] = Field(default=None, ge=0)
 
 
 class GroupProps(RootModel[Dict[str, Any]]):

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -19,7 +19,7 @@ struct AgentConfig : public GridObjectConfig {
               const std::string& group_name,
               unsigned char freeze_duration,
               float action_failure_penalty,
-              const std::map<InventoryItem, uint8_t>& max_items_per_type,
+              const std::map<InventoryItem, uint8_t>& resource_limits,
               const std::map<InventoryItem, float>& resource_rewards,
               const std::map<InventoryItem, float>& resource_reward_max,
               float group_reward_pct)
@@ -28,7 +28,7 @@ struct AgentConfig : public GridObjectConfig {
         group_id(group_id),
         freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
-        max_items_per_type(max_items_per_type),
+        resource_limits(resource_limits),
         resource_rewards(resource_rewards),
         resource_reward_max(resource_reward_max),
         group_reward_pct(group_reward_pct) {}
@@ -37,7 +37,7 @@ struct AgentConfig : public GridObjectConfig {
   unsigned char group_id;
   short freeze_duration;
   float action_failure_penalty;
-  std::map<InventoryItem, uint8_t> max_items_per_type;
+  std::map<InventoryItem, uint8_t> resource_limits;
   std::map<InventoryItem, float> resource_rewards;
   std::map<InventoryItem, float> resource_reward_max;
   float group_reward_pct;
@@ -66,7 +66,7 @@ public:
   Agent(GridCoord r, GridCoord c, const AgentConfig& config)
       : freeze_duration(config.freeze_duration),
         action_failure_penalty(config.action_failure_penalty),
-        max_items_per_type(config.max_items_per_type),
+        resource_limits(config.resource_limits),
         resource_rewards(config.resource_rewards),
         resource_reward_max(config.resource_reward_max),
         group(config.group_id),
@@ -86,7 +86,7 @@ public:
   int update_inventory(InventoryItem item, short amount) {
     int current_amount = this->inventory[item];
     int new_amount = current_amount + amount;
-    new_amount = std::clamp(new_amount, 0, static_cast<int>(this->max_items_per_type[item]));
+    new_amount = std::clamp(new_amount, 0, static_cast<int>(this->resource_limits[item]));
 
     int delta = new_amount - current_amount;
     if (new_amount > 0) {
@@ -150,7 +150,7 @@ public:
   }
 
 private:
-  std::map<InventoryItem, uint8_t> max_items_per_type;
+  std::map<InventoryItem, uint8_t> resource_limits;
 };
 
 #endif  // OBJECTS_AGENT_HPP_

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -20,7 +20,7 @@
       "blueprint"
     ],
     "agent": {
-      "default_item_max": 50,
+      "default_resource_limit": 50,
       "freeze_duration": 10,
       "rewards": {
         "action_failure_penalty": 0,

--- a/mettagrid/tests/mettagrid_test_args_env_cfg.json
+++ b/mettagrid/tests/mettagrid_test_args_env_cfg.json
@@ -23,7 +23,6 @@
       "default_resource_limit": 50,
       "freeze_duration": 10,
       "rewards": {
-        "action_failure_penalty": 0,
         "ore_red": 0.005,
         "ore_blue": 0.005,
         "ore_green": 0.005,

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -26,14 +26,14 @@ protected:
 
   void TearDown() override {}
 
-  // Helper function to create test max_items_per_type map
-  std::map<uint8_t, uint8_t> create_test_max_items_per_type() {
-    std::map<uint8_t, uint8_t> max_items_per_type;
-    max_items_per_type[TestItems::ORE] = 50;
-    max_items_per_type[TestItems::LASER] = 50;
-    max_items_per_type[TestItems::ARMOR] = 50;
-    max_items_per_type[TestItems::HEART] = 50;
-    return max_items_per_type;
+  // Helper function to create test resource_limits map
+  std::map<uint8_t, uint8_t> create_test_resource_limits() {
+    std::map<uint8_t, uint8_t> resource_limits;
+    resource_limits[TestItems::ORE] = 50;
+    resource_limits[TestItems::LASER] = 50;
+    resource_limits[TestItems::ARMOR] = 50;
+    resource_limits[TestItems::HEART] = 50;
+    return resource_limits;
   }
 
   // Helper function to create test rewards map
@@ -62,8 +62,8 @@ protected:
                        1,                                  // group_id
                        "test_group",                       // group_name
                        100,                                // freeze_duration
-                       0.1f,                               // action_failure_penalty
-                       create_test_max_items_per_type(),   // max_items_per_type
+                       0.0f,                               // action_failure_penalty
+                       create_test_resource_limits(),      // resource_limits
                        create_test_rewards(),              // resource_rewards
                        create_test_resource_reward_max(),  // resource_reward_max
                        0.0f);                              // group_reward_pct
@@ -106,10 +106,10 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   // check that the item is not in the inventory
   EXPECT_EQ(agent->inventory.find(TestItems::ORE), agent->inventory.end());
 
-  // Test hitting max_items_per_type limit
+  // Test hitting resource_limits limit
   agent->update_inventory(TestItems::ORE, 30);
-  delta = agent->update_inventory(TestItems::ORE, 50);  // max_items_per_type is 50
-  EXPECT_EQ(delta, 20);                                 // Should only add up to max_items_per_type
+  delta = agent->update_inventory(TestItems::ORE, 50);  // resource_limits is 50
+  EXPECT_EQ(delta, 20);                                 // Should only add up to resource_limits
   EXPECT_EQ(agent->inventory[TestItems::ORE], 50);
 }
 

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -64,7 +64,7 @@ def create_heart_reward_test_env(max_steps=50, num_agents=NUM_AGENTS):
             },
         },
         "agent": {
-            "default_item_max": 10,
+            "default_resource_limit": 10,
             "rewards": {"heart": 1.0},  # This gives 1.0 reward per heart collected
         },
     }


### PR DESCRIPTION
This is a partial refactor / rearrangement of agent config. This:

* Pushes item limits under a `resource_limits` setting, letting us drop the `_max` suffix, and letting us stop polluting the namespace in a weird way.
* Removes the hardcoding of expected names for resource_limits.
  * Right now we won't catch if people set limits on things that don't exist.
* Moves `invalid_action_penalty` out of `rewards`, since it doesn't match everything else there. Also, deletes it from all configs since it's not being used.
  * I do worry this is deceptive, since if people want to set it, they'll most naturally set it in the wrong place. Hopefully the error messages will be clear enough for them to figure it out!
* Renames some amount of "items" to "resources".

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210722120063864)