### PR TITLE
Update training config to use arena sim with basic_easy_shaped curriculum

### DIFF
--- a/configs/train_job.yaml
+++ b/configs/train_job.yaml
@@ -2,7 +2,7 @@ defaults:
   - common
   - agent: fast
   - trainer: trainer
-  - sim: all
+  - sim: arena
   - wandb: metta_research
   - _self_
 
@@ -11,5 +11,8 @@ seed: 1
 train_job:
   map_preview_uri: s3://softmax-public/training_runs/${run}/map_preview.json.z
   evals: ${sim}
+
+trainer:
+  curriculum: /env/mettagrid/arena/basic_easy_shaped
 
 cmd: train

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -2,7 +2,7 @@ _target_: metta.rl.trainer.MettaTrainer
 
 num_workers: ???
 
-curriculum: /env/mettagrid/curriculum/arena
+curriculum: ???
 env_overrides: {}
 
 initial_policy:
@@ -31,7 +31,7 @@ optimizer:
   beta1: 0.9
   beta2: 0.999
   eps: 1e-12
-  learning_rate: 0.0004573146765703167
+  learning_rate: 0.000457
   weight_decay: 0
 
 lr_scheduler:


### PR DESCRIPTION
### TL;DR

Updated training configuration to use the arena simulation with a basic easy shaped curriculum.

### What changed?

- Changed the simulation configuration from `all` to `arena` in `train_job.yaml`
- Set a specific curriculum path `/env/mettagrid/arena/basic_easy_shaped` in `train_job.yaml`
- Made the `curriculum` field in `trainer.yaml` configurable with `???` instead of hardcoding it to `/env/mettagrid/curriculum/arena`
- Simplified the learning rate value from `0.0004573146765703167` to `0.000457` in `trainer.yaml`

### How to test?

1. Run a training job with the updated configuration:
   ```
   python train.py --config-name train_job
   ```
2. Verify that the arena simulation is used with the basic easy shaped curriculum
3. Check that the training progresses as expected with the simplified learning rate

### Why make this change?

This change focuses the training on the arena simulation with a more appropriate curriculum path that better matches the simulation type. Making the curriculum configurable in the trainer template provides more flexibility, while the learning rate simplification maintains the same effective value but improves readability.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210725182492621)