### PR TITLE
Fix for changes with input_resources.

### DIFF
--- a/mettascope/src/hoverpanels.ts
+++ b/mettascope/src/hoverpanels.ts
@@ -170,30 +170,56 @@ function updateDom(htmlPanel: HTMLElement, object: any) {
   let displayedResources = 0
   if (objectConfig != null) {
     recipeArea.classList.remove('hidden')
-    // Configs have input_{resource} and output_{resource}.
-    for (let key in objectConfig) {
-      if (key.startsWith('input_')) {
-        let resource = key.replace('input_', '')
-        let amount = objectConfig[key]
+
+    // If config has input_resources or output_resources use that,
+    // otherwise use input_{resource} and output_{resource}.
+    if (objectConfig.hasOwnProperty('input_resources') || objectConfig.hasOwnProperty('output_resources')) {
+      // input_resources is a object like {heart: 1, blueprint: 1}
+      for (let resource in objectConfig.input_resources) {
         let item = itemTemplate.cloneNode(true) as HTMLElement
-        item.querySelector('.amount')!.textContent = amount
+        item.querySelector('.amount')!.textContent = objectConfig.input_resources[resource]
         item.querySelector('.icon')!.setAttribute('src', 'data/atlas/resources/' + resource + '.png')
         recipe.appendChild(item)
         displayedResources++
       }
-    }
-    // Add the arrow.
-    recipe.appendChild(recipeArrow.cloneNode(true))
-    // Add the output.
-    for (let key in objectConfig) {
-      if (key.startsWith('output_')) {
-        let resource = key.replace('output_', '')
-        let amount = objectConfig[key]
-        let item = itemTemplate.cloneNode(true) as HTMLElement
-        item.querySelector('.amount')!.textContent = amount
-        item.querySelector('.icon')!.setAttribute('src', 'data/atlas/resources/' + resource + '.png')
-        recipe.appendChild(item)
-        displayedResources++
+      // Add the arrow.
+      recipe.appendChild(recipeArrow.cloneNode(true))
+      // Add the output.
+      if (objectConfig.hasOwnProperty('output_resources')) {
+        for (let resource in objectConfig.output_resources) {
+          let item = itemTemplate.cloneNode(true) as HTMLElement
+          item.querySelector('.amount')!.textContent = objectConfig.output_resources[resource]
+          item.querySelector('.icon')!.setAttribute('src', 'data/atlas/resources/' + resource + '.png')
+          recipe.appendChild(item)
+          displayedResources++
+        }
+      }
+    } else {
+      // Configs have input_{resource} and output_{resource}.
+      for (let key in objectConfig) {
+        if (key.startsWith('input_')) {
+          let resource = key.replace('input_', '')
+          let amount = objectConfig[key]
+          let item = itemTemplate.cloneNode(true) as HTMLElement
+          item.querySelector('.amount')!.textContent = amount
+          item.querySelector('.icon')!.setAttribute('src', 'data/atlas/resources/' + resource + '.png')
+          recipe.appendChild(item)
+          displayedResources++
+        }
+      }
+      // Add the arrow.
+      recipe.appendChild(recipeArrow.cloneNode(true))
+      // Add the output.
+      for (let key in objectConfig) {
+        if (key.startsWith('output_')) {
+          let resource = key.replace('output_', '')
+          let amount = objectConfig[key]
+          let item = itemTemplate.cloneNode(true) as HTMLElement
+          item.querySelector('.amount')!.textContent = amount
+          item.querySelector('.icon')!.setAttribute('src', 'data/atlas/resources/' + resource + '.png')
+          recipe.appendChild(item)
+          displayedResources++
+        }
       }
     }
   }


### PR DESCRIPTION
The way we configure input and output resources has changed. I need to update mettascope for the new format as well as supporting old format.

If config has input_resources or output_resources use that, otherwise use input_{resource} and output_{resource}.

```
input_heart: 1
input_blurprint: 1
```

```
input_resources: {heart: 1, blueprint: 1}
```