### PR TITLE
fix replay generation in training

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -762,7 +762,7 @@ class MettaTrainer:
     @with_instance_timer("_generate_and_upload_replay", log_level=logging.INFO)
     def _generate_and_upload_replay(self):
         replay_sim_config = SingleEnvSimulationConfig(
-            env="/env/mettagrid/arena/advanced",
+            env="/env/mettagrid/mettagrid",  # won't be used, dynamic `env_cfg()` should override all of it
             num_episodes=1,
             env_overrides=self._curriculum.get_task().env_cfg(),
         )


### PR DESCRIPTION
Replay generation is currently crashing on some curricula because env_overrides can be incompatible with arena env:

```
        replay_sim_config = SingleEnvSimulationConfig(
            env="/env/mettagrid/arena/advanced",
            num_episodes=1,
            env_overrides=self._curriculum.get_task().env_cfg(),
        )
```

The entire approach seems confused, `env_cfg()` contains the full env, and env is there just because `Simulation` requires it.

This PR changes to `/env/mettagrid/mettagrid` which should be minimal & compatible with all other env configs, but I think we should reconsider Simulation APIs to clean this up.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210733149351946)