### PR TITLE
Add tag game mode to mettagrid arena environments

### DIFF
--- a/configs/env/mettagrid/arena/tag.yaml
+++ b/configs/env/mettagrid/arena/tag.yaml
@@ -1,0 +1,42 @@
+# Altars take hearts as input, so the only way to get more hearts is to freeze
+# other agents.
+
+defaults:
+  - /env/mettagrid/mettagrid@
+  - /env/mettagrid/game/objects@game.objects:
+      - basic
+      - mines
+      - generators
+      - combat
+  - _self_
+
+game:
+  num_agents: 24
+  map_builder:
+    _target_: metta.map.mapgen.MapGen
+
+    width: 25
+    height: 25
+    instances: 4
+    instance_border_width: 0
+
+    root:
+      type: metta.map.scenes.random.Random
+      params:
+        agents: 6
+        objects:
+          mine_red: 10
+          generator_red: 5
+          altar: 10
+          lasery: 2
+          armory: 2
+
+          block: 20
+          wall: 20
+
+  objects:
+    altar:
+      input_resources:
+        heart: 1
+      initial_resource_count: 1
+      cooldown: 1

--- a/configs/env/mettagrid/arena/tag_easy.yaml
+++ b/configs/env/mettagrid/arena/tag_easy.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - tag
+  - /env/mettagrid/game/objects/combat_easy@game.objects:
+  - _self_

--- a/configs/env/mettagrid/arena/tag_easy_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_easy_shaped.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - tag
+  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
+  - _self_

--- a/configs/env/mettagrid/arena/tag_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_shaped.yaml
@@ -1,0 +1,8 @@
+# Simple map with mines / generators / altar
+# But with converters that are easier to use.
+# And shaped rewards.
+
+defaults:
+  - tag
+  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
+  - _self_

--- a/configs/env/mettagrid/arena/tag_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_shaped.yaml
@@ -1,8 +1,0 @@
-# Simple map with mines / generators / altar
-# But with converters that are easier to use.
-# And shaped rewards.
-
-defaults:
-  - tag
-  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
-  - _self_

--- a/configs/env/mettagrid/curriculum/arena.yaml
+++ b/configs/env/mettagrid/curriculum/arena.yaml
@@ -12,3 +12,7 @@ tasks:
   /env/mettagrid/arena/advanced: 1
   /env/mettagrid/arena/advanced_easy: 1
   /env/mettagrid/arena/advanced_easy_shaped: 1
+
+  /env/mettagrid/arena/tag: 1
+  /env/mettagrid/arena/tag_easy: 1
+  /env/mettagrid/arena/tag_easy_shaped: 1

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -11,3 +11,5 @@ simulations:
     env: /env/mettagrid/arena/combat
   arena/advanced:
     env: /env/mettagrid/arena/advanced
+  arena/tag:
+    env: /env/mettagrid/arena/tag

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -2,7 +2,7 @@ defaults:
   - sim_suite
   - _self_
 
-name: simple
+name: arena
 
 simulations:
   arena/basic:

--- a/recipes/arena.sh
+++ b/recipes/arena.sh
@@ -1,0 +1,7 @@
+
+./devops/skypilot/launch.py train \
+--gpus=4 \
+--nodes=8 \
+run=$USER.arena.baseline.8x4 \
+trainer.curriculum=/env/mettagrid/arena/basic_easy_shaped \
+trainer.simulation.evaluate_interval=50

--- a/recipes/arena.sh
+++ b/recipes/arena.sh
@@ -2,6 +2,8 @@
 ./devops/skypilot/launch.py train \
 --gpus=4 \
 --nodes=8 \
-run=$USER.arena.baseline.8x4 \
+--no-spot \
+run=$USER.recipes.arena.8x4 \
 trainer.curriculum=/env/mettagrid/arena/basic_easy_shaped \
-trainer.simulation.evaluate_interval=50
+trainer.simulation.evaluate_interval=50 \
+

--- a/recipes/nav_memory_sequence.sh
+++ b/recipes/nav_memory_sequence.sh
@@ -1,3 +1,3 @@
 
 #NAV-MEMORY-SEQUENCE
-./devops/skypilot/launch.py train run=$USER.nav_memory_sequence.baseline trainer.curriculum=env/mettagrid/curriculum/nav_memory_sequence --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.nav_memory_sequence trainer.curriculum=env/mettagrid/curriculum/nav_memory_sequence --gpus=4 --skip-git-check \

--- a/recipes/navigation.sh
+++ b/recipes/navigation.sh
@@ -1,2 +1,2 @@
 #NAVIGATION
-./devops/skypilot/launch.py train run=$USER.navigation.baseline  trainer.curriculum=env/mettagrid/curriculum/navigation --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.navigation  trainer.curriculum=env/mettagrid/curriculum/navigation --gpus=4 --skip-git-check \

--- a/recipes/object_use.sh
+++ b/recipes/object_use.sh
@@ -1,2 +1,1 @@
-
-./devops/skypilot/launch.py train run=$USER.object_use.baseline  trainer.curriculum=env/mettagrid/curriculum/object_use --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.object_use  trainer.curriculum=env/mettagrid/curriculum/object_use --gpus=4 --skip-git-check \

--- a/recipes/sequence.sh
+++ b/recipes/sequence.sh
@@ -1,1 +1,1 @@
-./devops/skypilot/launch.py train run=$USER.sequence.baseline  trainer.curriculum=env/mettagrid/curriculum/sequence --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.sequence  trainer.curriculum=env/mettagrid/curriculum/sequence --gpus=4 --skip-git-check \


### PR DESCRIPTION
# Add Tag Arena to MettagGrid

This PR introduces a new Tag Arena game mode to MettagGrid where agents can freeze other agents to collect hearts. The only way to get more hearts is by freezing other agents, and altars take hearts as input.

## Features

- Added `tag.yaml` configuration with 24 agents in a 25x25 grid with 4 instances
- Created easier variant `tag_easy.yaml` with simplified combat mechanics
- Added shaped rewards variant `tag_easy_shaped.yaml` for better learning
- Updated the arena curriculum to include the new tag variants
- Added tag to the arena simulation configuration
- Created a training recipe script for arena environments

The tag arena includes various objects like mines, generators, altars, lasers, and armories to create an engaging environment for agent interaction.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210737290445449)