### PR TITLE
feat: prettier formatting tool for md

### DIFF
--- a/.cursor/commands.md
+++ b/.cursor/commands.md
@@ -1,6 +1,7 @@
 # Metta Testing Commands
 
-This file contains simple commands for testing the metta codebase. These commands are designed to run quickly and provide useful feedback about whether the system is working correctly.
+This file contains simple commands for testing the metta codebase. These commands are designed to run quickly and
+provide useful feedback about whether the system is working correctly.
 
 ## Prerequisites
 

--- a/.github/scripts/claude_tools/README.md
+++ b/.github/scripts/claude_tools/README.md
@@ -9,18 +9,21 @@ This directory contains specialized tools designed to assist Claude in code revi
 A type annotation analyzer that helps Claude identify missing type annotations in Python code.
 
 **Commands:**
+
 - `analyze <file.py>` - Analyze file(s) for missing type annotations
 - `mypy <file.py>` - Run mypy type checker
 - `pyright <file.py>` - Run pyright type checker
 - `check <file.py>` - Run all checks and provide comprehensive summary
 
 **Features:**
+
 - AST-based analysis to identify missing annotations
 - Smart filtering to only report high-value annotations
 - Structured JSON output for easy parsing
 - Respects coding conventions (skips private methods, properties, etc.)
 
 **Usage in Claude workflows:**
+
 ```bash
 # Analyze a single file
 .github/scripts/claude_tools/type_check.py analyze src/example.py
@@ -30,3 +33,4 @@ A type annotation analyzer that helps Claude identify missing type annotations i
 
 # Run comprehensive check
 .github/scripts/claude_tools/type_check.py check src/example.py
+```

--- a/.openhands/README.md
+++ b/.openhands/README.md
@@ -1,6 +1,7 @@
 # OpenHands Setup for Metta AI
 
-This directory contains setup scripts that automatically configure the Metta AI development environment when starting an OpenHands conversation.
+This directory contains setup scripts that automatically configure the Metta AI development environment when starting an
+OpenHands conversation.
 
 ## Files
 

--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -2,9 +2,14 @@
 
 ## Overview
 
-Metta AI is an open-source research project investigating the emergence of cooperation and alignment in multi-agent AI systems. The project creates a model organism for complex multi-agent gridworld environments to study the impact of social dynamics, such as kinship and mate selection, on learning and cooperative behaviors of AI agents.
+Metta AI is an open-source research project investigating the emergence of cooperation and alignment in multi-agent AI
+systems. The project creates a model organism for complex multi-agent gridworld environments to study the impact of
+social dynamics, such as kinship and mate selection, on learning and cooperative behaviors of AI agents.
 
-The core hypothesis is that social dynamics, akin to love in biological systems, play a crucial role in the development of cooperative AGI and AI alignment. The project introduces a novel reward-sharing mechanism mimicking familial bonds and mate selection, allowing researchers to observe the evolution of complex social behaviors and cooperation among AI agents.
+The core hypothesis is that social dynamics, akin to love in biological systems, play a crucial role in the development
+of cooperative AGI and AI alignment. The project introduces a novel reward-sharing mechanism mimicking familial bonds
+and mate selection, allowing researchers to observe the evolution of complex social behaviors and cooperation among AI
+agents.
 
 ## Repository Structure
 
@@ -48,6 +53,7 @@ To train a model:
 ```
 
 Parameters:
+
 - `run`: Names your experiment and controls where checkpoints are saved under `train_dir/<run>`
 - `+hardware=<preset>`: Tunes the trainer for your machine (options include macbook, desktop, etc.)
 - `+user=<n>`: Loads defaults from `configs/user/<n>.yaml`
@@ -61,7 +67,8 @@ To run the interactive simulation:
 ./tools/play.py run=my_experiment +hardware=macbook wandb=off
 ```
 
-This launches a human-controlled session using the same configuration flags as training. It's useful for quickly testing maps or policies on your local hardware.
+This launches a human-controlled session using the same configuration flags as training. It's useful for quickly testing
+maps or policies on your local hardware.
 
 To run the terminal simulation:
 
@@ -130,4 +137,5 @@ The project is designed for research in:
 - **Discord**: https://discord.gg/mQzrgwqmwy
 - **Short (5m) Talk**: https://www.youtube.com/watch?v=bt6hV73VA8I
 - **Talk**: https://foresight.org/summary/david-bloomin-metta-learning-love-is-all-you-need/
-- **Interactive Demo**: https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fandre_pufferbox_33%2Freplay.77200.json.z&play=true
+- **Interactive Demo**:
+  https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fandre_pufferbox_33%2Freplay.77200.json.z&play=true

--- a/.prettierrc
+++ b/.prettierrc
@@ -36,6 +36,15 @@
         "printWidth": 100,
         "singleQuote": true
       }
+    },
+    {
+      "files": ["*.md"],
+      "options": {
+        "parser": "markdown",
+        "printWidth": 120,
+        "proseWrap": "always",
+        "tabWidth": 2
+      }
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,19 +3,23 @@
 Codex agents working in this repository should follow these guidelines:
 
 ## Commit messages
+
 - Keep them short and present tense.
 - Describe the change clearly.
 
 ## Quality checks
+
 - Run `ruff format` and `ruff check` on Python files before committing.
 - Run the unit tests with `uv run pytest` or by activating the venv and running `pytest`.
 
 ## Type Annotations
+
 - Always add type annotations to function parameters
 - Add return type annotations to public API functions
 - Follow selective annotation guidelines (see CLAUDE.md for details)
 - Run mypy to check type consistency before committing
 
 ## Pull request notes
+
 - Mention relevant file paths when describing changes.
 - Include test output or note why tests were skipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Metta AI is a reinforcement learning project focusing on the emergence of cooperation and alignment in multi-agent AI systems. It creates a model organism for complex multi-agent gridworld environments to study the impact of social dynamics (like kinship and mate selection) on learning and cooperative behaviors.
+Metta AI is a reinforcement learning project focusing on the emergence of cooperation and alignment in multi-agent AI
+systems. It creates a model organism for complex multi-agent gridworld environments to study the impact of social
+dynamics (like kinship and mate selection) on learning and cooperative behaviors.
 
 The codebase consists of:
 
@@ -169,7 +171,8 @@ The workflow automatically determines the appropriate base branch:
 
 - **From PR Comments**: New branches are created from the current PR's branch
 - **From Issue Comments**: New branches are created from the main branch
-- **Example**: If you comment `@claude open-pr` in PR #657 (branch: `robb/0525-agent-type-changes`), Claude will create a new branch based on `robb/0525-agent-type-changes`, not main
+- **Example**: If you comment `@claude open-pr` in PR #657 (branch: `robb/0525-agent-type-changes`), Claude will create
+  a new branch based on `robb/0525-agent-type-changes`, not main
 
 ### Branch Naming Convention
 

--- a/README.md
+++ b/README.md
@@ -20,30 +20,46 @@ A reinforcement learning codebase focusing on the emergence of cooperation and a
 <a href="https://metta-ai.github.io/metta/?replayUrl=https%3A%2F%2Fsoftmax-public.s3.us-east-1.amazonaws.com%2Freplays%2Fandre_pufferbox_33%2Freplay.77200.json.z&play=true">Interactive demo</a>
 </p>
 
-Metta AI is an open-source research project investigating the emergence of cooperation and alignment in multi-agent AI systems. By creating a model organism for complex multi-agent gridworld environments, the project aims to study the impact of social dynamics, such as kinship and mate selection, on learning and cooperative behaviors of AI agents.
+Metta AI is an open-source research project investigating the emergence of cooperation and alignment in multi-agent AI
+systems. By creating a model organism for complex multi-agent gridworld environments, the project aims to study the
+impact of social dynamics, such as kinship and mate selection, on learning and cooperative behaviors of AI agents.
 
-Metta AI explores the hypothesis that social dynamics, akin to love in biological systems, play a crucial role in the development of cooperative AGI and AI alignment. The project introduces a novel reward-sharing mechanism mimicking familial bonds and mate selection, allowing researchers to observe the evolution of complex social behaviors and cooperation among AI agents. By investigating this concept in a controlled multi-agent setting, the project seeks to contribute to the broader discussion on the path towards safe and beneficial AGI.
+Metta AI explores the hypothesis that social dynamics, akin to love in biological systems, play a crucial role in the
+development of cooperative AGI and AI alignment. The project introduces a novel reward-sharing mechanism mimicking
+familial bonds and mate selection, allowing researchers to observe the evolution of complex social behaviors and
+cooperation among AI agents. By investigating this concept in a controlled multi-agent setting, the project seeks to
+contribute to the broader discussion on the path towards safe and beneficial AGI.
 
 ## Introduction
 
-Metta is a simulation environment (game) designed to train AI agents capable of meta-learning general intelligence. The core idea is to create an environment where incremental intelligence is rewarded, fostering the development of generally intelligent agents.
+Metta is a simulation environment (game) designed to train AI agents capable of meta-learning general intelligence. The
+core idea is to create an environment where incremental intelligence is rewarded, fostering the development of generally
+intelligent agents.
 
 ### Motivation and Approach
 
-1. **Agents and Environment**: Agents are shaped by their environment, learning policies that enhance their fitness. To develop general intelligence, agents need an environment where increasing intelligence is continually rewarded.
+1. **Agents and Environment**: Agents are shaped by their environment, learning policies that enhance their fitness. To
+   develop general intelligence, agents need an environment where increasing intelligence is continually rewarded.
 
-2. **Competitive and Cooperative Dynamics**: A game with multiple agents and some competition creates an evolving environment where challenges increase with agent intelligence. Purely competitive games often reach a Nash equilibrium, where locally optimal strategies are hard to deviate from. Adding cooperative dynamics introduces more behavioral possibilities and smooths the behavioral space.
+2. **Competitive and Cooperative Dynamics**: A game with multiple agents and some competition creates an evolving
+   environment where challenges increase with agent intelligence. Purely competitive games often reach a Nash
+   equilibrium, where locally optimal strategies are hard to deviate from. Adding cooperative dynamics introduces more
+   behavioral possibilities and smooths the behavioral space.
 
-3. **Kinship Structures**: The game features a flexible kinship structure, simulating a range of relationships from close kin to strangers. Agents must learn to coordinate with close kin, negotiate with more distant kin, and compete with strangers. This diverse social environment encourages continuous learning and intelligence growth.
+3. **Kinship Structures**: The game features a flexible kinship structure, simulating a range of relationships from
+   close kin to strangers. Agents must learn to coordinate with close kin, negotiate with more distant kin, and compete
+   with strangers. This diverse social environment encourages continuous learning and intelligence growth.
 
 The game is designed to evolve with the agents, providing unlimited learning opportunities despite simple rules.
 
 ### Game Overview
 
-The current version of the game can be found [here](https://huggingface.co/metta-ai/baseline.v0.1.0). It's a grid world with the following dynamics:
+The current version of the game can be found [here](https://huggingface.co/metta-ai/baseline.v0.1.0). It's a grid world
+with the following dynamics:
 
 - **Agents and Vision**: Agents can see a limited number of squares around them.
-- **Resources**: Agents harvest diamonds, convert them to energy at charger stations, and use energy to power the "heart altar" for rewards.
+- **Resources**: Agents harvest diamonds, convert them to energy at charger stations, and use energy to power the "heart
+  altar" for rewards.
 - **Energy Management**: All actions cost energy, so agents learn to manage their energy budgets efficiently.
 - **Combat**: Agents can attack others, temporarily freezing the target and stealing resources.
 - **Defense**: Agents can toggle shields, which drain energy but absorb attacks.
@@ -53,8 +69,10 @@ The current version of the game can be found [here](https://huggingface.co/metta
 
 The game offers numerous possibilities for exploration, including:
 
-1. **Diverse Energy Profiles**: Assigning different energy profiles to agents, essentially giving them different bodies and policies.
-2. **Dynamic Energy Profiles**: Allowing agents to change their energy profiles, reflecting different postures or emotions.
+1. **Diverse Energy Profiles**: Assigning different energy profiles to agents, essentially giving them different bodies
+   and policies.
+2. **Dynamic Energy Profiles**: Allowing agents to change their energy profiles, reflecting different postures or
+   emotions.
 3. **Resource Types and Conversions**: Introducing different resource types and conversion mechanisms.
 4. **Environment Modification**: Enabling agents to modify the game board by creating, destroying, or altering objects.
 
@@ -66,37 +84,48 @@ The game explores various kinship structures:
 2. **Teams**: Agents belong to teams with symmetric kinship among team members.
 3. **Hives/Clans/Families**: Structuring agents into larger kinship groups.
 
-Future plans include incorporating mate-selection dynamics, where agents share future rewards at a cost, potentially leading to intelligence gains through a signaling arms race.
+Future plans include incorporating mate-selection dynamics, where agents share future rewards at a cost, potentially
+leading to intelligence gains through a signaling arms race.
 
-Metta aims to create a rich, evolving environment where AI agents can develop general intelligence through continuous learning and adaptation.
+Metta aims to create a rich, evolving environment where AI agents can develop general intelligence through continuous
+learning and adaptation.
 
 ## Research Explorations
 
-The project's modular design and open-source nature make it easy for researchers to adapt and extend the platform to investigate their own hypotheses in this domain. The highly performant, open-ended game rules provide a rich environment for studying these behaviors and their potential implications for AI alignment.
+The project's modular design and open-source nature make it easy for researchers to adapt and extend the platform to
+investigate their own hypotheses in this domain. The highly performant, open-ended game rules provide a rich environment
+for studying these behaviors and their potential implications for AI alignment.
 
 Some areas of research interest:
 
 #### 1. Environment Development
 
-Develop rich and diverse gridworld environments with complex dynamics, such as resource systems, agent diversity, procedural terrain generation, support for various environment types, population dynamics, and kinship schemes.
+Develop rich and diverse gridworld environments with complex dynamics, such as resource systems, agent diversity,
+procedural terrain generation, support for various environment types, population dynamics, and kinship schemes.
 
 #### 2. Agent Architecture Research
 
-Incorporate techniques like dense learning signals, surprise minimization, exploration strategies, and blending reinforcement and imitation learning.
+Incorporate techniques like dense learning signals, surprise minimization, exploration strategies, and blending
+reinforcement and imitation learning.
 
 #### 3. Scalable Training Infrastructure
 
-Investigate scalable training approaches, including distributed reinforcement learning, student-teacher architectures, and blending reinforcement learning with imitation learning, to enable efficient training of large-scale multi-agent systems.
+Investigate scalable training approaches, including distributed reinforcement learning, student-teacher architectures,
+and blending reinforcement learning with imitation learning, to enable efficient training of large-scale multi-agent
+systems.
 
 #### 4. Intelligence Evaluations for Gridworld Agents
 
-Design and implement a comprehensive suite of intelligence evaluations for gridworld agents, covering navigation tasks, maze solving, in-context learning, cooperation, and competition scenarios.
+Design and implement a comprehensive suite of intelligence evaluations for gridworld agents, covering navigation tasks,
+maze solving, in-context learning, cooperation, and competition scenarios.
 
 #### 5. DevOps and Tooling
 
-Develop tools and infrastructure for efficient management, tracking, and deployment of experiments, such as cloud cluster management, experiment tracking and visualization, and continuous integration and deployment pipelines.
+Develop tools and infrastructure for efficient management, tracking, and deployment of experiments, such as cloud
+cluster management, experiment tracking and visualization, and continuous integration and deployment pipelines.
 
-This README provides only a brief overview of research explorations. Visit the [research roadmap](https://github.com/Metta-AI/metta/blob/main/roadmap.md) for more details.
+This README provides only a brief overview of research explorations. Visit the
+[research roadmap](https://github.com/Metta-AI/metta/blob/main/roadmap.md) for more details.
 
 ## Installation
 
@@ -111,6 +140,7 @@ cd metta
 ```
 
 After installation, you can use metta commands directly:
+
 ```bash
 metta status       # Check component status
 metta install      # Install additional components
@@ -127,7 +157,8 @@ metta configure    # Reconfigure for a different profile
 
 ## Usage
 
-The repository contains command-line tools in the `tools/` directory. Most of these tools use [Hydra](https://hydra.cc/) for configuration management, which allows flexible parameter overrides and composition.
+The repository contains command-line tools in the `tools/` directory. Most of these tools use [Hydra](https://hydra.cc/)
+for configuration management, which allows flexible parameter overrides and composition.
 
 - **Override parameters**: `param=value` sets configuration values directly
 - **Compose configs**: `+group=option` loads additional configuration files from `configs/group/option.yaml`
@@ -140,6 +171,7 @@ The repository contains command-line tools in the `tools/` directory. Most of th
 ```
 
 Parameters:
+
 - `run=my_experiment` - Names your experiment and controls where checkpoints are saved under `train_dir/<run>`
 - `+hardware=macbook` - Loads hardware-specific settings from `configs/hardware/macbook.yaml`
 - `wandb=off` - Disables Weights & Biases logging
@@ -158,10 +190,11 @@ To use WandB with your personal account:
    ```
 3. Edit `configs/wandb/external_user.yaml` and replace `???` with your WandB username:
    ```yaml
-   entity: ???  # Replace with your WandB username
+   entity: ??? # Replace with your WandB username
    ```
 
 Now you can run training with your personal WandB config:
+
 ```
 ./tools/train.py run=local.yourname.123 +hardware=macbook wandb=user
 ```
@@ -170,7 +203,8 @@ Now you can run training with your personal WandB config:
 
 ### Mettascope: in-browser viewer
 
-Mettascope allows you to run and view episodes in the environment you specify. It goes beyond just spectator mode, and allows taking over an agent and controlling it manually.
+Mettascope allows you to run and view episodes in the environment you specify. It goes beyond just spectator mode, and
+allows taking over an agent and controlling it manually.
 
 For more information, see [./mettascope/README.md](./mettascope/README.md).
 
@@ -181,9 +215,12 @@ For more information, see [./mettascope/README.md](./mettascope/README.md).
 ```
 
 Arguments:
+
 - `run=<name>` - **Required**. Experiment identifier
-- `policy_uri=<path>` - Specify the policy the models follow when not manually controller with a model checkpoint (`.pt` file).
-  - For local files, supply the path: `./train_dir/<run_name>/checkpoints/<checkpoint_name>.pt`. These  checkpoint files are created during training
+- `policy_uri=<path>` - Specify the policy the models follow when not manually controller with a model checkpoint (`.pt`
+  file).
+  - For local files, supply the path: `./train_dir/<run_name>/checkpoints/<checkpoint_name>.pt`. These checkpoint files
+    are created during training
   - For wandb artifacts, prefix with `wandb://`
 - `+hardware=<config>` - Hardware configuration (see [Training a Model](#training-a-model))
 
@@ -196,7 +233,8 @@ renderer_job.environment.uri="configs/env/mettagrid/maps/debug/simple_obstacles.
 
 ### Evaluating a Model
 
-When you run training, if you have WandB enabled, then you will be able to see in your WandB run page results for the eval suites.
+When you run training, if you have WandB enabled, then you will be able to see in your WandB run page results for the
+eval suites.
 
 However, this will not apply for anything trained before April 8th.
 
@@ -215,7 +253,8 @@ To add your policy to the existing navigation evals DB:
     device=cpu
 ```
 
-This will run your policy through the `configs/eval/navigation` eval_suite and then save it to the `navigation_db` artifact on WandB.
+This will run your policy through the `configs/eval/navigation` eval_suite and then save it to the `navigation_db`
+artifact on WandB.
 
 Then, to see the results in the heatmap along with the other policies in the database, you can run:
 
@@ -234,12 +273,12 @@ pyright metta  # optional, some stubs are missing
 pytest
 ```
 
-Running these commands mirrors our CI configuration and helps keep the codebase
-consistent.
+Running these commands mirrors our CI configuration and helps keep the codebase consistent.
 
 ## Third-party Content
 
-Some sample map patterns in `scenes/dcss` were adapted from the open-source game [Dungeon Crawl Stone Soup (DCSS)](https://github.com/crawl/crawl),
-specifically from the file [`simple.des`](https://github.com/crawl/crawl/blob/master/crawl-ref/source/dat/des/arrival/simple.des).
+Some sample map patterns in `scenes/dcss` were adapted from the open-source game
+[Dungeon Crawl Stone Soup (DCSS)](https://github.com/crawl/crawl), specifically from the file
+[`simple.des`](https://github.com/crawl/crawl/blob/master/crawl-ref/source/dat/des/arrival/simple.des).
 
 DCSS is licensed under the [GNU General Public License v2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).

--- a/app_backend/README.md
+++ b/app_backend/README.md
@@ -10,8 +10,8 @@ In the parent directory run the command
 docker build -t metta-app-backend:latest -f app_backend/Dockerfile .
 ```
 
-This will build the Docker image tagged as `metta-app-backend:latest`.
-The command must be run from the parent directory because we are using the parent `uv.lock` file.
+This will build the Docker image tagged as `metta-app-backend:latest`. The command must be run from the parent directory
+because we are using the parent `uv.lock` file.
 
 ## Running the Container
 
@@ -28,8 +28,8 @@ If you are running a postgres instance locally, use `host.docker.internal` as ho
 - `STATS_DB_URI`: PostgreSQL connection string (default: `postgres://postgres:password@127.0.0.1/postgres`)
 - `HOST`: Server host (default: `127.0.0.1`)
 - `PORT`: Server port (default: `8000`)
-- `DEBUG_USER_EMAIL` : In production, your auth token is managed by oauth2_proxy. This is a way to run locally
-without the oauth2_proxy.
+- `DEBUG_USER_EMAIL` : In production, your auth token is managed by oauth2_proxy. This is a way to run locally without
+  the oauth2_proxy.
 
 ## Development
 

--- a/configs/agent/README.md
+++ b/configs/agent/README.md
@@ -1,41 +1,46 @@
 # Architecture Overview 06-18-2025
+
 ## CNN-based Encoder Models
+
 fast.yaml uses a token-to-box converter that takes environment-generated tokens, converts them into a tensor that
-represents the tokens in a box with channels, width, and height, and then passes it to a CNN encoder stack. It's
-super fast and expressive but not quite as expressive as the attention-based architectures and is not robust when
-the features in the environment change - you'll have to train a new model.
+represents the tokens in a box with channels, width, and height, and then passes it to a CNN encoder stack. It's super
+fast and expressive but not quite as expressive as the attention-based architectures and is not robust when the features
+in the environment change - you'll have to train a new model.
 
 ## Attention-based Encoder Models
-latent_attn_med, latent_attn_small, and latent_attn_tiny are all fully robust agents, flexible to changing
-observation features and changing action spaces. All use the same action policy network. Their memory units are also
-all the same. Their observation encoders also use the same initial stack: stripping some padding tokens from the
-environment tokens and using a Fourier feature representation for position encoding, which perform better than
-learnable encodings. Finally, they pass the encoded sequence of environment tokens to attention mechanisms, all of
-which are multi-headed.
+
+latent_attn_med, latent_attn_small, and latent_attn_tiny are all fully robust agents, flexible to changing observation
+features and changing action spaces. All use the same action policy network. Their memory units are also all the same.
+Their observation encoders also use the same initial stack: stripping some padding tokens from the environment tokens
+and using a Fourier feature representation for position encoding, which perform better than learnable encodings.
+Finally, they pass the encoded sequence of environment tokens to attention mechanisms, all of which are multi-headed.
 Their differences are in their size and complexity which affect their speed and sample-efficiency.
 
 ### latent_attn_tiny.yaml
+
 Uses a single learnable token as a query against the entire sequence of encoded observations. It's the fastest to run
 and is robust to changing environments but is not as expressive as any of the other models including fast.yaml.
 
 ### latent_attn_small.yaml
+
 This is the sweet spot of performance and expressivity. It uses latent attention: a small number of learnable tokens
-attend to the entire sequence of encoded obs tokens in a cross attention layer. Those latent outputs then all attend
-to each other in a self-attention layer. We inject a classifier token and then output it as the summary output to
-the LSTM. It runs a bit slower than latent_attn_tiny.yaml.
+attend to the entire sequence of encoded obs tokens in a cross attention layer. Those latent outputs then all attend to
+each other in a self-attention layer. We inject a classifier token and then output it as the summary output to the LSTM.
+It runs a bit slower than latent_attn_tiny.yaml.
 
 ### latent_attn_med.yaml
-Same as above but with more layers. It seems to be the most sample efficient model but suffers from the worst
-wall-clock performance for obvious reasons. It runs at roughly half the speed of latent_attn_tiny.yaml.
+
+Same as above but with more layers. It seems to be the most sample efficient model but suffers from the worst wall-clock
+performance for obvious reasons. It runs at roughly half the speed of latent_attn_tiny.yaml.
 
 # Hard-earned Lessons
+
 - Embedding representations with more than roughly 48 dimensions struggle to learn at our sparsity. Try to keep dims
-around that or below before moving into higher layers. For instance, run a couple of layers at 32 then try to move to
-another block with higher representation dim. This may not be true if kickstarting is used.
-- Positional encoding is high-yield. We don't have enough samples to quickly infer position from learnable
-embeddings. In experiments, the prior injected by Fourier features significantly improved performance over both
-learnable embeddings and RoPE. Further, moving from four frequencies up to eight also helped although this is
-confounded by the expanded size of the observation embedding.
+  around that or below before moving into higher layers. For instance, run a couple of layers at 32 then try to move to
+  another block with higher representation dim. This may not be true if kickstarting is used.
+- Positional encoding is high-yield. We don't have enough samples to quickly infer position from learnable embeddings.
+  In experiments, the prior injected by Fourier features significantly improved performance over both learnable
+  embeddings and RoPE. Further, moving from four frequencies up to eight also helped although this is confounded by the
+  expanded size of the observation embedding.
 
 This architecture search is far from complete; there are a number of additional techniques to try!
-

--- a/devops/charts/README.md
+++ b/devops/charts/README.md
@@ -26,6 +26,8 @@ Refer to [helmfile documentation](https://helmfile.readthedocs.io/en/latest/) fo
 
 ### Observatory
 
-Observatory charts (`./observatory` and `./observatory-backend`) are deployed by CI/CD pipelines powered by GitHub Actions.
+Observatory charts (`./observatory` and `./observatory-backend`) are deployed by CI/CD pipelines powered by GitHub
+Actions.
 
-Image tag values are updated on each build, so we can't describe these charts with all up-to-date values statically in `helmfile.yaml`.
+Image tag values are updated on each build, so we can't describe these charts with all up-to-date values statically in
+`helmfile.yaml`.

--- a/devops/charts/skypilot/README.md
+++ b/devops/charts/skypilot/README.md
@@ -1,4 +1,5 @@
-This is a copy of [upstream chart](https://github.com/skypilot-org/skypilot/tree/master/charts/skypilot) with patches for:
+This is a copy of [upstream chart](https://github.com/skypilot-org/skypilot/tree/master/charts/skypilot) with patches
+for:
 
 1. `--host 0.0.0.0` bug
 2. `cert-manager` support

--- a/devops/skypilot/README.md
+++ b/devops/skypilot/README.md
@@ -7,9 +7,11 @@ This script provides a convenient way to launch training jobs on AWS using SkyPi
 - AWS credentials configured with `softmax` profile
 - SkyPilot CLI installed and configured. This results in a ~/.sky/config.yaml
 
-If you have successfully run  `./devops/skypilot/install.sh` or the appropriate setup_machine script for your operating system, these should be handled.
+If you have successfully run `./devops/skypilot/install.sh` or the appropriate setup_machine script for your operating
+system, these should be handled.
 
-You can run this command to confirm your connectivity to the Softmax skypilot server, its health, and if you are authenticated.
+You can run this command to confirm your connectivity to the Softmax skypilot server, its health, and if you are
+authenticated.
 
 ```bash
 sky api info
@@ -40,7 +42,8 @@ Note that launching jobs requires a repo with pushed commits (unless using `--sk
 
 There's a [web dashboard](https://skypilot-api.softmax-research.net/) that displays the status of all clusters and jobs.
 
-You will be prompted for username/password credentials. These can be extracted from your Skypilot config with this command:
+You will be prompted for username/password credentials. These can be extracted from your Skypilot config with this
+command:
 
 ```bash
 grep -o 'https://[^:]*:[^@]*@' ~/.sky/config.yaml | sed 's|https://||; s|@||' | sed 's|:| |' | while read username password; do
@@ -194,16 +197,18 @@ Jobs can have the following statuses:
 
 ## Shell Aliases
 
-To streamline your workflow, we provide a script to set shell aliases for common SkyPilot operations. It also sets `AWS_PROFILE=softmax` automatically.
+To streamline your workflow, we provide a script to set shell aliases for common SkyPilot operations. It also sets
+`AWS_PROFILE=softmax` automatically.
 
 To add these aliases temporarily:
+
 ```bash
 source ./devops/skypilot/setup_shell.sh
 ```
 
 To add them permanently, add the source command to your shell profile:
 
-```bash
+````bash
 # For bash users:
 echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.bashrc
 
@@ -238,8 +243,7 @@ echo "source /path/to/your/project/devops/skypilot/setup_shell.sh" >> ~/.config/
 - `lt run=<NAME>` - Quick launch training jobs
   ```bash
   lt run=my_experiment_001  # Equivalent to: ./devops/skypilot/launch.py train run=my_experiment_001
-  ```
-
+````
 
 ## Sandboxes
 
@@ -325,7 +329,8 @@ sky jobs queue -a
 
 2. **Set appropriate timeouts**: Always use `---max-runtime-hours` to prevent runaway costs
 
-3. **Use confirmation for important jobs**: Add `--confirm` to review the job details including GPU allocation, spot instance usage, and all command arguments
+3. **Use confirmation for important jobs**: Add `--confirm` to review the job details including GPU allocation, spot
+   instance usage, and all command arguments
 
 4. **Monitor actively**: Check job status regularly, especially for long-running jobs
 

--- a/devops/tf/README.md
+++ b/devops/tf/README.md
@@ -2,13 +2,16 @@
 
 OpenTofu (Terraform) configs are managed by [Spacelift](https://spacelift.io/).
 
-This directory contains [stacks](https://docs.spacelift.io/concepts/stack/creating-a-stack): Terraform configurations for different parts of the infrastructure.
+This directory contains [stacks](https://docs.spacelift.io/concepts/stack/creating-a-stack): Terraform configurations
+for different parts of the infrastructure.
 
-Note that `spacelift` stack configures Spacelift, but not the individual stacks in it (see `spacelift/README.md` for details).
+Note that `spacelift` stack configures Spacelift, but not the individual stacks in it (see `spacelift/README.md` for
+details).
 
 ## Common workflow
 
-Terraform works in two stages: first, `plan`, and then `apply`. Planning is relatively safe, so it can be done automatically, or even locally without pushing to the repo.
+Terraform works in two stages: first, `plan`, and then `apply`. Planning is relatively safe, so it can be done
+automatically, or even locally without pushing to the repo.
 
 Applying should ideally happen only from the `main` branch, but see below for the possible loopholes.
 
@@ -24,10 +27,12 @@ General workflow:
 
 - Read **Creating a stack** in the [Spacelift docs](https://docs.spacelift.io/concepts/stack/creating-a-stack).
 - Use the latest OpenTofu instead of Terraform.
-- If the stack includes AWS resources, don't forget to "Attach cloud" during stack creation, or later in **Stack Settings → Integrations**.
+- If the stack includes AWS resources, don't forget to "Attach cloud" during stack creation, or later in **Stack
+  Settings → Integrations**.
 - (Optional) Enable **Local Preview** under **Stack Settings → Behavior** for faster iteration.
 
-When working on a PR that adds a new stack, you can enable **Run Promotion** (see [Applying without merging](#applying-without-merging) below) and iterate on it before the PR is merged.
+When working on a PR that adds a new stack, you can enable **Run Promotion** (see
+[Applying without merging](#applying-without-merging) below) and iterate on it before the PR is merged.
 
 ## Previewing plans without pushing to GitHub
 

--- a/devops/tf/spacelift/README.md
+++ b/devops/tf/spacelift/README.md
@@ -1,5 +1,8 @@
 This stack configures the Spacelift itself.
 
-It intentionally doesn't create stacks as [resources](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack), though it could.
+It intentionally doesn't create stacks as
+[resources](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack), though it
+could.
 
-The reason is that we want to deploy stacks on commits to `main` branch, but it's impossible to test stacks before the PR is merged.
+The reason is that we want to deploy stacks on commits to `main` branch, but it's impossible to test stacks before the
+PR is merged.

--- a/devops/tools/format_md.sh
+++ b/devops/tools/format_md.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+EXCLUDE_PATTERN=""
+
+# Note that this script assumes that a .prettierrc is present with appropriate settings for
+# markdown files
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --exclude)
+      EXCLUDE_PATTERN="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--exclude \"pattern\"]"
+      exit 1
+      ;;
+  esac
+done
+
+# Check if npx and prettier are available
+if ! command -v npx &> /dev/null; then
+  echo "Error: npx not found. Please install Node.js and npm."
+  echo "On Mac, you can install it using:"
+  echo "  brew install node"
+  echo "Or download from https://nodejs.org/"
+  exit 1
+fi
+
+# Check if prettier is installed
+if ! npx prettier --version &> /dev/null; then
+  echo "Prettier not found. Would you like to install it? (y/n)"
+  read -r answer
+  if [[ "$answer" =~ ^[Yy]$ ]]; then
+    echo "Installing prettier..."
+    npm install --save-dev prettier
+    echo "Prettier installed successfully."
+  else
+    echo "Prettier is required for this script. Exiting."
+    exit 1
+  fi
+fi
+
+# Function to format files with exclusion
+format_files() {
+  local file_ext="$1"
+  echo "Formatting *.$file_ext files..."
+  if [ -n "$EXCLUDE_PATTERN" ]; then
+    # Use grep -v to exclude files matching the pattern
+    find . -name "*.$file_ext" -type f | grep -v "$EXCLUDE_PATTERN" | xargs npx prettier --write
+  else
+    # Format all files if no exclusion pattern
+    find . -name "*.$file_ext" -type f | xargs npx prettier --write
+  fi
+}
+
+# Format markdown files
+format_files "md"
+
+# Also format README files without extension (if any)
+echo "Checking for README files without extension..."
+if [ -n "$EXCLUDE_PATTERN" ]; then
+  find . -name "README" -type f | grep -v "$EXCLUDE_PATTERN" | xargs -r npx prettier --write --parser markdown
+else
+  find . -name "README" -type f | xargs -r npx prettier --write --parser markdown
+fi
+
+echo "All Markdown files (except excluded ones) have been formatted with Prettier."

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,7 +156,8 @@ The `metta.api` module exports:
 
 **Training**: `perform_rollout_step`, `process_minibatch_update`, `accumulate_rollout_stats`, `compute_advantage`
 
-**Distributed**: `setup_device_and_distributed`, `setup_distributed_vars`, `wrap_agent_distributed`, `cleanup_distributed`
+**Distributed**: `setup_device_and_distributed`, `setup_distributed_vars`, `wrap_agent_distributed`,
+`cleanup_distributed`
 
 **Checkpointing**: `save_checkpoint`, `load_checkpoint`
 
@@ -164,4 +165,5 @@ The `metta.api` module exports:
 
 **Components**: `Experience`, `Kickstarter`, `Losses`, `Stopwatch`
 
-**Utilities**: `setup_run_directories`, `save_experiment_config`, `create_evaluation_config_suite`, `create_replay_config`
+**Utilities**: `setup_run_directories`, `save_experiment_config`, `create_evaluation_config_suite`,
+`create_replay_config`

--- a/docs/mapgen.md
+++ b/docs/mapgen.md
@@ -40,6 +40,9 @@ Same heuristics about detecting if the URI is a file apply here.
 
 ### Loading maps in map_builder configs
 
-You can load a random map from an S3 directory in your YAML configs by using `metta.map.load_random.LoadRandom` as a map builder.
+You can load a random map from an S3 directory in your YAML configs by using `metta.map.load_random.LoadRandom` as a map
+builder.
 
-`LoadRandom` allows you to modify the map by applying additional scenes to it. Check out `configs/env/mettagrid/map_builder/load_random.yaml` for an example config that modifies the number of agents in the map.
+`LoadRandom` allows you to modify the map by applying additional scenes to it. Check out
+`configs/env/mettagrid/map_builder/load_random.yaml` for an example config that modifies the number of agents in the
+map.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,14 +1,17 @@
 # Workflow Documentation
 
-This directory contains detailed documentation for our GitHub Actions workflows. Each document provides comprehensive information about specific workflows, their configuration, and usage.
+This directory contains detailed documentation for our GitHub Actions workflows. Each document provides comprehensive
+information about specific workflows, their configuration, and usage.
 
 ## Available Documentation
 
 ### 📊 [PR Summary Workflow](./pr-summary.md)
 
-Comprehensive documentation for the automated PR summary system that generates weekly summaries of merged pull requests and posts them to Discord.
+Comprehensive documentation for the automated PR summary system that generates weekly summaries of merged pull requests
+and posts them to Discord.
 
 **Key Topics:**
+
 - Two-phase AI summary generation using Google Gemini models
 - Intelligent caching strategy to minimize API calls
 - Custom GitHub Actions for PR fetching and Discord posting
@@ -16,6 +19,7 @@ Comprehensive documentation for the automated PR summary system that generates w
 - Configuration options and usage examples
 
 **Components Covered:**
+
 - Main workflow (`pr_summary.yml`)
 - PR Digest Action (`pr-digest/`)
 - Summary Generation Script (`generate_pr_summary.py`)
@@ -23,9 +27,11 @@ Comprehensive documentation for the automated PR summary system that generates w
 
 ### 🔍 [Claude Review System](./claude-review-system.md)
 
-Comprehensive documentation for our AI-powered code review system that provides targeted, actionable feedback on pull requests.
+Comprehensive documentation for our AI-powered code review system that provides targeted, actionable feedback on pull
+requests.
 
 **Key Topics:**
+
 - Four specialized review types (README, Comments, Einops, Type Annotations)
 - "Silent on no issues" philosophy
 - Two-stage review process with conditional output
@@ -33,6 +39,7 @@ Comprehensive documentation for our AI-powered code review system that provides 
 - Best practices and troubleshooting
 
 **Components Covered:**
+
 - Base workflow system (`claude-review-base.yml`)
 - Individual review workflows
 - JSON output format and GitHub review creation
@@ -40,9 +47,11 @@ Comprehensive documentation for our AI-powered code review system that provides 
 
 ### 🤖 [Claude Assistant](./claude-assistant.md)
 
-Documentation for the interactive Claude bot that responds to mentions in comments and can automatically create pull requests.
+Documentation for the interactive Claude bot that responds to mentions in comments and can automatically create pull
+requests.
 
 **Key Topics:**
+
 - Two modes: comment responses and PR creation
 - Natural language understanding for code changes
 - Smart branch targeting for iterative development
@@ -50,6 +59,7 @@ Documentation for the interactive Claude bot that responds to mentions in commen
 - Error handling and debugging
 
 **Components Covered:**
+
 - Main workflow (`claude.yml`)
 - Comment detection and routing
 - Branch creation and management
@@ -59,18 +69,22 @@ Documentation for the interactive Claude bot that responds to mentions in commen
 ## Workflow Categories
 
 ### 🤖 AI-Powered Workflows
+
 - **[PR Summary](./pr-summary.md)**: Automated weekly summaries using Gemini AI
 - **[Claude Reviews](./claude-review-system.md)**: Targeted code review system using Claude AI
 - **[Claude Assistant](./claude-assistant.md)**: Interactive bot for questions and automated PR creation
 
 ### 💬 Interactive Workflows
+
 - **[Claude Assistant](./claude-assistant.md)**: Responds to @claude mentions for help and PR creation
 
 ### 📝 Documentation Workflows
+
 - **[PR Summary](./pr-summary.md)**: Generates comprehensive PR summaries
 - **[Claude README Review](./claude-review-system.md#1-📝-readme-accuracy-review)**: Ensures documentation accuracy
 
 ### 🔍 Code Quality Workflows
+
 - **[Claude Type Annotations](./claude-review-system.md#4-🏷️-type-annotations-review)**: Python type coverage
 - **[Claude Comments Review](./claude-review-system.md#2-💬-code-comments-review)**: Comment cleanup
 - **[Claude Einops](./claude-review-system.md#3-🔄-einops-suggestions-review)**: Tensor operation improvements
@@ -81,6 +95,7 @@ When adding new workflow documentation:
 
 1. **File Naming**: Use kebab-case (e.g., `workflow-name.md`)
 2. **Structure**: Include sections for:
+
    - Overview
    - Architecture diagram (if applicable)
    - Components breakdown

--- a/docs/workflows/claude-assistant.md
+++ b/docs/workflows/claude-assistant.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The Claude Assistant is an AI-powered GitHub bot that responds to mentions in comments and can automatically create pull requests based on natural language instructions. It leverages Anthropic's Claude AI to understand requests, analyze code, and implement changes.
+The Claude Assistant is an AI-powered GitHub bot that responds to mentions in comments and can automatically create pull
+requests based on natural language instructions. It leverages Anthropic's Claude AI to understand requests, analyze
+code, and implement changes.
 
 ## Architecture
 
@@ -36,11 +38,13 @@ The Claude Assistant is an AI-powered GitHub bot that responds to mentions in co
 Responds to general questions, provides code analysis, and offers suggestions.
 
 **Triggers**:
+
 - Any comment containing `@claude` (without `open-pr`)
 - Works on issues and pull requests
 - Responds to PR review comments
 
 **Capabilities**:
+
 - Code review and analysis
 - Explanations and documentation
 - Architecture suggestions
@@ -48,6 +52,7 @@ Responds to general questions, provides code analysis, and offers suggestions.
 - Running linters (ruff for Python)
 
 **Available Tools**:
+
 - `Bash`: Git commands, Python scripts, linters
 - `View`: Read file contents
 - `GlobTool`: Find files by pattern
@@ -58,10 +63,12 @@ Responds to general questions, provides code analysis, and offers suggestions.
 Automatically implements requested changes and creates a pull request.
 
 **Triggers**:
+
 - Comments containing `@claude open-pr`
 - Works on both issues and existing PRs
 
 **Capabilities**:
+
 - Implements code changes based on natural language
 - Creates feature branches automatically
 - Commits changes with descriptive messages
@@ -69,10 +76,12 @@ Automatically implements requested changes and creates a pull request.
 - Targets appropriate branches (not always main)
 
 **Smart Branch Targeting**:
+
 - **From Issue**: Creates PR targeting the default branch (usually main)
 - **From PR**: Creates PR targeting the PR's feature branch (iterative development)
 
 **Available Tools**:
+
 - All comment mode tools plus:
 - `Edit`: Modify existing files
 - `Replace`: Replace code sections
@@ -106,6 +115,7 @@ Claude will analyze the context and provide explanations.
 
 ```markdown
 @claude open-pr Refactor the authentication module to:
+
 1. Use async/await instead of callbacks
 2. Add proper error handling for network failures
 3. Include retry logic with exponential backoff
@@ -115,8 +125,10 @@ Claude will analyze the context and provide explanations.
 ### Iterative Development on PR
 
 When commenting on an existing PR:
+
 ```markdown
 @claude open-pr Based on the review feedback, please:
+
 - Extract the validation logic into a separate function
 - Add unit tests for the edge cases mentioned
 - Update the docstrings
@@ -136,17 +148,17 @@ GITHUB_TOKEN       # Usually provided automatically
 ### Environment Variables
 
 ```yaml
-CLAUDE_MODEL: "claude-sonnet-4-20250514"  # Model version
+CLAUDE_MODEL: 'claude-sonnet-4-20250514' # Model version
 ```
 
 ### Permissions Required
 
 ```yaml
 permissions:
-  contents: write      # For creating branches and commits
+  contents: write # For creating branches and commits
   pull-requests: write # For creating PRs and comments
-  issues: write        # For commenting on issues
-  id-token: write      # For authentication
+  issues: write # For commenting on issues
+  id-token: write # For authentication
 ```
 
 ## Workflow Details
@@ -154,6 +166,7 @@ permissions:
 ### 1. Detection Phase
 
 The workflow detects the type of request:
+
 - Searches for `@claude open-pr` to determine PR creation mode
 - Falls back to comment mode for general `@claude` mentions
 
@@ -192,18 +205,21 @@ Example: `claude/auto-123-2024-01-15T10-30-45`
 🤖 **Automated PR created by Claude**
 
 **Original request:**
+
 > [User's @claude open-pr comment]
 
-**Context:** This PR addresses the request from [issue/PR #X]
-**Target:** This PR will merge into `branch-name` (not main)
+**Context:** This PR addresses the request from [issue/PR #X] **Target:** This PR will merge into `branch-name` (not
+main)
 
 **Changes made:**
+
 - X commit(s) with: [commit message]
 
 **Branch flow:** `claude/auto-X-timestamp` → `target-branch`
 
 ---
-*This PR was automatically created by Claude Code Assistant.*
+
+_This PR was automatically created by Claude Code Assistant._
 ```
 
 ## Error Handling
@@ -211,10 +227,12 @@ Example: `claude/auto-123-2024-01-15T10-30-45`
 ### Common Issues and Solutions
 
 1. **No commits created**
+
    - Claude may have failed to use the commit tool
    - Solution: Ensure request is clear and specific
 
 2. **Branch push failed**
+
    - Permissions or conflict issues
    - Solution: Check GitHub token permissions
 
@@ -225,6 +243,7 @@ Example: `claude/auto-123-2024-01-15T10-30-45`
 ### Debug Information
 
 The workflow provides extensive debugging:
+
 - Git state before and after Claude runs
 - Branch information and commit counts
 - Success/failure messages with context
@@ -232,21 +251,24 @@ The workflow provides extensive debugging:
 ### Failure Comments
 
 When PR creation fails, Claude posts a diagnostic comment:
+
 ```markdown
 ⚠️ **Unable to create PR**
 
 **Reason:** No changes were committed
 
 **Debug info:**
+
 - Expected branch: `claude/auto-123-...`
 - Target branch: `main`
 - Has commits: false
 - Claude execution: success
 
 **Possible solutions:**
+
 - Try a simpler, more specific request
 - Check if the changes conflict with existing code
-- Ensure Claude used mcp__github_file_ops__commit_files
+- Ensure Claude used mcp**github_file_ops**commit_files
 ```
 
 ## Best Practices
@@ -254,12 +276,14 @@ When PR creation fails, Claude posts a diagnostic comment:
 ### 1. Writing Requests
 
 **DO:**
+
 - Be specific about what changes you want
 - Break complex requests into numbered steps
 - Mention specific files when possible
 - Provide context about the goal
 
 **DON'T:**
+
 - Make vague requests like "improve this code"
 - Ask for massive refactors in one go
 - Request changes to protected files
@@ -296,6 +320,7 @@ When PR creation fails, Claude posts a diagnostic comment:
 ### Custom Instructions
 
 The workflow accepts custom instructions through the `CLAUDE.md` file:
+
 - Coding standards
 - Project-specific patterns
 - Forbidden practices
@@ -304,6 +329,7 @@ The workflow accepts custom instructions through the `CLAUDE.md` file:
 ### Tool Restrictions
 
 For security, certain bash commands are limited:
+
 - Network operations restricted
 - No system modifications
 - Read-only access to most areas

--- a/docs/workflows/claude-review-system.md
+++ b/docs/workflows/claude-review-system.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The Claude Review System is a suite of AI-powered code review workflows that automatically analyze pull
-requests for specific improvements. Built on Anthropic's Claude AI, these workflows provide targeted,
-actionable feedback without the noise of traditional linters.
+The Claude Review System is a suite of AI-powered code review workflows that automatically analyze pull requests for
+specific improvements. Built on Anthropic's Claude AI, these workflows provide targeted, actionable feedback without the
+noise of traditional linters.
 
 **Key Philosophy**: Only comment when there are genuine improvements to suggest. If everything looks good, stay silent.
 
@@ -45,6 +45,7 @@ actionable feedback without the noise of traditional linters.
 ### 1. Orchestrator Workflow (`claude-review-orchestrator.yml`)
 
 The main entry point that:
+
 - Validates PR context (fails fast if no valid PR number)
 - Runs all review types in parallel
 - Consolidates results into a single GitHub review
@@ -53,6 +54,7 @@ The main entry point that:
 ### 2. Base Workflow (`claude-review-base.yml`)
 
 Shared foundation for all review types:
+
 - Handles PR checkout and file filtering
 - Sets up optional Python environment
 - Runs Claude analysis with specialized prompts
@@ -61,6 +63,7 @@ Shared foundation for all review types:
 ### 3. Individual Review Workflows
 
 Four specialized review types, each a thin wrapper around the base:
+
 - `claude-review-readme.yml` - Documentation accuracy
 - `claude-review-comments.yml` - Comment cleanup
 - `claude-review-einops.yml` - Tensor operation improvements
@@ -69,6 +72,7 @@ Four specialized review types, each a thin wrapper around the base:
 ### 4. Consolidation Script (`claude_review.py`)
 
 Single Python script that:
+
 - Downloads all review artifacts
 - Merges suggestions
 - Creates unified GitHub review with inline comments
@@ -81,10 +85,12 @@ Single Python script that:
 **Purpose**: Ensures documentation stays accurate when code changes.
 
 **Triggers**:
+
 - Pull request opened or reopened
 - Manual workflow dispatch
 
 **What it checks**:
+
 - Commands or CLI usage that no longer work
 - Installation instructions that are now incorrect
 - Removed dependencies still documented
@@ -93,6 +99,7 @@ Single Python script that:
 - Examples that would throw errors
 
 **What it ignores**:
+
 - Missing documentation (doesn't suggest additions)
 - Style or formatting issues
 - Opportunities for better documentation
@@ -102,10 +109,12 @@ Single Python script that:
 **Purpose**: Identifies and removes unnecessary comments that clutter code.
 
 **Triggers**:
+
 - Pull request opened or reopened
 - Manual workflow dispatch
 
 **Comments flagged for removal**:
+
 - Restating obvious code (e.g., `# increment counter` before `counter += 1`)
 - Explaining self-evident operations
 - Outdated comments that don't match implementation
@@ -113,6 +122,7 @@ Single Python script that:
 - Stating obvious commands
 
 **Comments preserved**:
+
 - Explaining WHY something is done
 - Important context or warnings
 - TODO/FIXME comments (unless obsolete)
@@ -124,10 +134,12 @@ Single Python script that:
 **Purpose**: Suggests using `einops.rearrange` for complex tensor operations.
 
 **Triggers**:
+
 - Pull request opened or reopened (Python files only)
 - Manual workflow dispatch
 
 **Good candidates for einops**:
+
 ```python
 # Complex and unclear:
 x = x.permute(0, 2, 1).reshape(batch_size, -1)
@@ -136,6 +148,7 @@ x = rearrange(x, 'b h w -> b (w h)')
 ```
 
 **Ignored operations**:
+
 - Simple, clear operations (`x.transpose(0, 1)`)
 - When existing code is already readable
 - Performance-critical sections
@@ -146,15 +159,18 @@ x = rearrange(x, 'b h w -> b (w h)')
 **Purpose**: Identifies missing type annotations that would improve code quality.
 
 **Triggers**:
+
 - Pull request opened or reopened (Python files only)
 - Manual workflow dispatch
 
 **Priority levels**:
+
 - **High**: Missing parameter types, public API return types, Optional returns
 - **Medium**: Complex functions, non-obvious returns, empty collections
 - **Ignored**: Private methods, obvious getters, simple functions, clear inference
 
 **Modern syntax preferred**:
+
 - `list[str]` over `List[str]`
 - `type | None` over `Optional[type]`
 - `dict[str, int]` over `Dict[str, int]`
@@ -164,6 +180,7 @@ x = rearrange(x, 'b h w -> b (w h)')
 ### 1. PR Validation
 
 The orchestrator first validates that a PR number exists:
+
 ```yaml
 validate-pr:
   steps:
@@ -179,6 +196,7 @@ validate-pr:
 ### 2. Parallel Review Execution
 
 All review types run simultaneously for efficiency:
+
 - Each review only processes relevant files (based on file patterns)
 - Reviews that find no issues create no artifacts
 - Claude is instructed to respond with "No issues found" when appropriate
@@ -186,6 +204,7 @@ All review types run simultaneously for efficiency:
 ### 3. Artifact-Based Communication
 
 Reviews communicate through artifacts:
+
 - Only created when issues are found
 - Contains `claude-review-analysis.json` with suggestions
 - Artifacts are downloaded and consolidated by the Python script
@@ -193,6 +212,7 @@ Reviews communicate through artifacts:
 ### 4. Unified Review Creation
 
 The consolidation script:
+
 1. Downloads all artifacts from the workflow run
 2. Merges suggestions from all review types
 3. Creates a single GitHub review with inline comments
@@ -218,9 +238,7 @@ When issues are found, Claude creates:
       "suggested_code": "improved code"
     }
   ],
-  "tldr": [
-    "Quick summary of changes"
-  ]
+  "tldr": ["Quick summary of changes"]
 }
 ```
 
@@ -229,7 +247,7 @@ When issues are found, Claude creates:
 ### Required Secrets
 
 ```yaml
-ANTHROPIC_API_KEY  # Claude API access key
+ANTHROPIC_API_KEY # Claude API access key
 ```
 
 ### Required Python Dependencies
@@ -242,18 +260,19 @@ requests>=2.31.0
 ### Base Workflow Inputs
 
 ```yaml
-review_name: string        # Display name for the review
-review_type: string        # Unique identifier for artifact naming
-file_pattern: string       # Regex for file filtering (default: ".*")
-setup_python: boolean      # Whether to setup Python (default: false)
-tools: string             # Comma-separated Claude tools
-prompt: string            # Review-specific instructions
-pr_number: string         # PR number to review
+review_name: string # Display name for the review
+review_type: string # Unique identifier for artifact naming
+file_pattern: string # Regex for file filtering (default: ".*")
+setup_python: boolean # Whether to setup Python (default: false)
+tools: string # Comma-separated Claude tools
+prompt: string # Review-specific instructions
+pr_number: string # PR number to review
 ```
 
 ## Usage Examples
 
 ### Manual Trigger
+
 ```bash
 # Using GitHub CLI
 gh workflow run "Claude Review: Orchestrator" -f pr_number=123
@@ -263,6 +282,7 @@ gh workflow run "Claude Review: Orchestrator" -f pr_number=123
 ```
 
 ### Direct Review Type Trigger
+
 ```bash
 # Run only the type annotations review
 gh workflow run "Claude Review: Types" -f pr_number=123
@@ -271,8 +291,9 @@ gh workflow run "Claude Review: Types" -f pr_number=123
 ### Creating a Custom Review
 
 1. Create workflow file: `.github/workflows/claude-review-security.yml`
+
 ```yaml
-name: "Claude Review: Security"
+name: 'Claude Review: Security'
 on:
   workflow_call:
     inputs:
@@ -284,10 +305,10 @@ jobs:
   review:
     uses: ./.github/workflows/claude-review-base.yml
     with:
-      review_name: "Security Analysis"
-      review_type: "security"
+      review_name: 'Security Analysis'
+      review_type: 'security'
       file_pattern: "\\.(py|js|ts)$"
-      tools: "Edit,Replace,Bash(git diff HEAD~1)"
+      tools: 'Edit,Replace,Bash(git diff HEAD~1)'
       pr_number: ${{ inputs.pr_number }}
       prompt: |
         Review code for security vulnerabilities.
@@ -319,6 +340,7 @@ jobs:
 ### 1. Writing Review Prompts
 
 **DO:**
+
 - Start with clear "no issues found" instructions
 - Define specific criteria for flagging issues
 - Provide concrete examples of patterns to find
@@ -326,6 +348,7 @@ jobs:
 - Use severity levels appropriately
 
 **DON'T:**
+
 - Ask for general "improvements"
 - Flag style preferences
 - Suggest additions (only fixes)
@@ -335,6 +358,7 @@ jobs:
 ### 2. File Pattern Strategy
 
 Use specific patterns to reduce analysis time:
+
 ```yaml
 file_pattern: "\\.py$"           # Python files only
 file_pattern: "\\.(js|ts)$"      # JavaScript and TypeScript
@@ -344,6 +368,7 @@ file_pattern: "^src/.*\\.py$"    # Python files in src/ directory
 ### 3. Tool Selection
 
 **Common tool combinations:**
+
 ```yaml
 # Basic code review
 tools: "Edit,Replace,Bash(git diff HEAD~1)"
@@ -368,10 +393,12 @@ tools: "Edit,Replace,Bash(git diff HEAD~1),Bash(python -m mypy --version)"
 ### No Review Appearing
 
 1. **Check PR validation**:
+
    - Ensure PR number is valid
    - Check orchestrator logs for validation errors
 
 2. **Verify issues were found**:
+
    - Check individual review job logs
    - Look for "No issues found" responses
    - Verify artifacts were created
@@ -384,11 +411,13 @@ tools: "Edit,Replace,Bash(git diff HEAD~1),Bash(python -m mypy --version)"
 ### Suggestions Not Inline
 
 Common causes:
+
 - File not in PR diff
 - Incorrect line numbers
 - GitHub API validation failure
 
 Debug by checking:
+
 - Skipped suggestions in review body
 - Script output for specific errors
 - PR file list vs suggestion files
@@ -431,14 +460,16 @@ Potential improvements:
 ### Updating Claude Model
 
 Change in `claude-review-base.yml`:
+
 ```yaml
 env:
-  CLAUDE_MODEL: "claude-sonnet-4-20250514"
+  CLAUDE_MODEL: 'claude-sonnet-4-20250514'
 ```
 
 ### Monitoring Usage
 
 Track in GitHub Actions:
+
 - Review frequency per type
 - Issues found vs PRs reviewed
 - Time to complete reviews

--- a/docs/workflows/pr-summary.md
+++ b/docs/workflows/pr-summary.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-This workflow automatically generates newsletters summarizing merged pull requests and posts them to Discord. It uses a two-phase approach with Google's Gemini AI models and implements smart caching to minimize API calls.
+This workflow automatically generates newsletters summarizing merged pull requests and posts them to Discord. It uses a
+two-phase approach with Google's Gemini AI models and implements smart caching to minimize API calls.
 
 ## Schedule
 
@@ -16,7 +17,7 @@ The newsletter runs on a **Monday/Wednesday/Friday** schedule at 5 PM PST (1 AM 
 
 ```yaml
 schedule:
-  - cron: "0 1 * * 2,4,6" # Tue/Thu/Sat at 1 AM GMT = Mon/Wed/Fri at 5 PM PST
+  - cron: '0 1 * * 2,4,6' # Tue/Thu/Sat at 1 AM GMT = Mon/Wed/Fri at 5 PM PST
 ```
 
 The cron runs on Tuesday/Thursday/Saturday GMT because 1 AM GMT corresponds to 5 PM PST the previous day.
@@ -39,23 +40,28 @@ The cron runs on Tuesday/Thursday/Saturday GMT because 1 AM GMT corresponds to 5
 ## Key Features
 
 ### Smart Caching System
+
 - **PR-level caching**: Individual PR summaries are cached to avoid re-analyzing
 - **Incremental fetching**: Only new PRs since last run are fetched from GitHub
 - **Cache pruning**: Automatic removal of entries older than 60 days
 - **Per-PR summary files**: Each PR gets its own summary file in `pr-summaries/`
 
 ### Variable Lookback Period
+
 The workflow automatically adjusts the lookback period based on the day:
+
 - Monday runs analyze 3 days of PRs (to cover the weekend)
 - Wednesday and Friday runs analyze 2 days of PRs
 
 ### Newsletter Continuity
+
 - References previous newsletters for context
 - Tracks recent shout-outs to distribute recognition
 - Maintains narrative continuity across newsletters
 - Shows progression and trends over time
 
 ### AI-Powered Analysis
+
 - **Phase 1**: Individual PR summaries using `gemini-2.5-flash` (fast, efficient)
 - **Phase 2**: Collection synthesis using `gemini-2.5-pro` (comprehensive analysis)
 - Parallel processing for efficiency
@@ -68,9 +74,9 @@ You can manually trigger the workflow with custom parameters:
 ```yaml
 workflow_dispatch:
   inputs:
-    days_to_scan: "1"      # Options: 1, 7, 14, 30
-    force_refresh: false   # Bypass cache
-    skip_discord: false    # Test mode without posting
+    days_to_scan: '1' # Options: 1, 7, 14, 30
+    force_refresh: false # Bypass cache
+    skip_discord: false # Test mode without posting
 ```
 
 ## Configuration
@@ -86,7 +92,7 @@ DISCORD_WEBHOOK_URL # Discord webhook for posting
 ### Repository Variables (Optional)
 
 ```yaml
-PR_NEWSLETTER_HISTORY_DAYS  # Override default days for scheduled runs
+PR_NEWSLETTER_HISTORY_DAYS # Override default days for scheduled runs
 ```
 
 ## Output Files
@@ -136,14 +142,16 @@ Cache keys include run numbers to ensure proper invalidation while maintaining h
 **Purpose**: Downloads zipped artifacts from previous successful workflow runs.
 
 **Key Features**:
+
 - Searches through workflow history for matching artifacts
 - Downloads artifacts as ZIP files for local processing
 - Supports pattern matching for artifact names
 - Excludes current run to avoid self-reference
 
 **Inputs**:
+
 - `workflow-name`: Name of the workflow file (e.g., "generate-newsletter.yml")
-- `artifact-name-pattern`: Pattern to match (e.g., "newsletter-*")
+- `artifact-name-pattern`: Pattern to match (e.g., "newsletter-\*")
 - `num-artifacts`: Number of artifacts to collect (default: 5)
 - `output-directory`: Where to save downloads (default: "downloaded-artifacts")
 
@@ -152,6 +160,7 @@ Cache keys include run numbers to ensure proper invalidation while maintaining h
 **Purpose**: Posts content to Discord with automatic message splitting.
 
 **Key Features**:
+
 - Automatic splitting at 2000 character Discord limit
 - Smart boundaries (paragraphs/lines) for readability
 - Rate limiting protection (0.5s delay between messages)
@@ -159,6 +168,7 @@ Cache keys include run numbers to ensure proper invalidation while maintaining h
 - Supports both direct content and file input
 
 **Inputs**:
+
 - `webhook-url`: Discord webhook URL (required)
 - `content`: Direct content to post
 - `content-file`: Path to file containing content
@@ -187,15 +197,20 @@ Cache keys include run numbers to ensure proper invalidation while maintaining h
 ## Troubleshooting
 
 ### No PRs Found
+
 If no PRs are found for the time period, the workflow creates minimal output files and posts a simple notification.
 
 ### Cache Issues
+
 To force a complete refresh:
+
 1. Manually trigger with `force_refresh: true`
 2. Or delete the `pr-summaries/` directory in your repository
 
 ### Time Zone Confusion
+
 Remember: The cron schedule runs in GMT. The day-of-week detection happens at runtime:
+
 - Tuesday 1 AM GMT = Monday 5 PM PST
 - Thursday 1 AM GMT = Wednesday 5 PM PST
 - Saturday 1 AM GMT = Friday 5 PM PST
@@ -203,16 +218,19 @@ Remember: The cron schedule runs in GMT. The day-of-week detection happens at ru
 ## Example Manual Runs
 
 ### Test without posting to Discord
+
 ```bash
 gh workflow run generate-newsletter.yml -f skip_discord=true
 ```
 
 ### Generate a weekly summary
+
 ```bash
 gh workflow run generate-newsletter.yml -f days_to_scan=7
 ```
 
 ### Force refresh all caches
+
 ```bash
 gh workflow run generate-newsletter.yml -f force_refresh=true
 ```

--- a/metta/sweep/README.md
+++ b/metta/sweep/README.md
@@ -1,6 +1,7 @@
 # Protein Hyperparameter Optimization
 
-A Bayesian hyperparameter optimization system using Gaussian Processes for efficient hyperparameter search with WandB integration.
+A Bayesian hyperparameter optimization system using Gaussian Processes for efficient hyperparameter search with WandB
+integration.
 
 ## Components
 
@@ -73,11 +74,13 @@ optimizer.record_observation(objective=0.95, cost=120.0)
 ## Configuration
 
 ### Protein Settings (`sweep.protein`)
+
 - `max_suggestion_cost`: Maximum cost per suggestion
 - `num_random_samples`: Initial random samples
 - `global_search_scale`: Search exploration scale
 
 ### Parameters (`sweep.parameters`)
+
 - `metric`: Objective metric name
 - `goal`: "maximize" or "minimize"
 - Parameter definitions with distributions and required fields:
@@ -85,56 +88,62 @@ optimizer.record_observation(objective=0.95, cost=120.0)
 #### Available Distributions
 
 **`uniform`** - Linear uniform distribution
+
 ```yaml
 learning_rate:
-  distribution: "uniform"
+  distribution: 'uniform'
   min: 0.001
   max: 0.01
-  scale: "auto"  # or numeric value, controls search width
-  mean: 0.005    # search center point
+  scale: 'auto' # or numeric value, controls search width
+  mean: 0.005 # search center point
 ```
 
 **`int_uniform`** - Integer uniform distribution
+
 ```yaml
 batch_size:
-  distribution: "int_uniform"
+  distribution: 'int_uniform'
   min: 16
   max: 128
-  scale: "auto"
+  scale: 'auto'
   mean: 64
 ```
 
 **`log_normal`** - Log-normal distribution (good for learning rates, regularization)
+
 ```yaml
 learning_rate:
-  distribution: "log_normal"
+  distribution: 'log_normal'
   min: 1e-5
   max: 1e-2
-  scale: "auto"  # or "time" for time-based scaling
+  scale: 'auto' # or "time" for time-based scaling
   mean: 3e-4
 ```
 
 **`uniform_pow2`** - Power-of-2 uniform distribution (for memory sizes, batch sizes)
+
 ```yaml
 hidden_size:
-  distribution: "uniform_pow2"
+  distribution: 'uniform_pow2'
   min: 64
   max: 1024
-  scale: "auto"
+  scale: 'auto'
   mean: 256
 ```
 
 **`logit_normal`** - Logit-normal distribution (good for probabilities, dropout rates)
+
 ```yaml
 dropout_rate:
-  distribution: "logit_normal"
+  distribution: 'logit_normal'
   min: 0.1
   max: 0.9
-  scale: "auto"
+  scale: 'auto'
   mean: 0.5
 ```
 
 #### Scale Options
+
 - `"auto"`: Default scale of 0.5
 - `"time"`: For log distributions, scale = 1/(log2(max) - log2(min))
 - Numeric value: Custom search width around the mean

--- a/mettagrid/README.md
+++ b/mettagrid/README.md
@@ -1,17 +1,24 @@
 # MettaGrid Environment
 
-MettaGrid is a multi-agent gridworld environment for studying the emergence of cooperation and social behaviors in reinforcement learning agents. The environment features a variety of objects and actions that agents can interact with to manage resources, engage in combat, share with others, and optimize their rewards.
+MettaGrid is a multi-agent gridworld environment for studying the emergence of cooperation and social behaviors in
+reinforcement learning agents. The environment features a variety of objects and actions that agents can interact with
+to manage resources, engage in combat, share with others, and optimize their rewards.
 
 ## Overview
 
-In MettaGrid, agents navigate a gridworld and interact with various objects to manage their energy, harvest resources, engage in combat, and cooperate with other agents. The key dynamics include:
+In MettaGrid, agents navigate a gridworld and interact with various objects to manage their energy, harvest resources,
+engage in combat, and cooperate with other agents. The key dynamics include:
 
-- **Energy Management**: Agents must efficiently manage their energy, which is required for all actions. They can harvest resources and convert them to energy at charger stations.
+- **Energy Management**: Agents must efficiently manage their energy, which is required for all actions. They can
+  harvest resources and convert them to energy at charger stations.
 - **Resource Gathering**: Agents can gather resources from generator objects scattered throughout the environment.
-- **Cooperation and Sharing**: Agents have the ability to share resources with other agents and use energy to power the heart altar, which provides rewards.
-- **Combat**: Agents can attack other agents to temporarily freeze them and steal their resources. They can also use shields to defend against attacks.
+- **Cooperation and Sharing**: Agents have the ability to share resources with other agents and use energy to power the
+  heart altar, which provides rewards.
+- **Combat**: Agents can attack other agents to temporarily freeze them and steal their resources. They can also use
+  shields to defend against attacks.
 
-The environment is highly configurable, allowing for experimentation with different world layouts, object placements, and agent capabilities.
+The environment is highly configurable, allowing for experimentation with different world layouts, object placements,
+and agent capabilities.
 
 ## Objects
 
@@ -19,25 +26,29 @@ The environment is highly configurable, allowing for experimentation with differ
 
 <img src="https://github.com/daveey/Griddly/blob/develop/resources/images/oryx/oryx_tiny_galaxy/tg_sliced/tg_monsters/tg_monsters_astronaut_u1.png?raw=true" width="32"/>
 
-The `Agent` object represents an individual agent in the environment. Agents can move, rotate, attack, and interact with other objects. Each agent has energy, resources, and shield properties that govern its abilities and interactions.
+The `Agent` object represents an individual agent in the environment. Agents can move, rotate, attack, and interact with
+other objects. Each agent has energy, resources, and shield properties that govern its abilities and interactions.
 
 ### Altar
 
 <img src="https://github.com/daveey/Griddly/blob/develop/resources/images/oryx/oryx_tiny_galaxy/tg_sliced/tg_items/tg_items_heart_full.png?raw=true" width="32"/>
 
-The `Altar` object allows agents to spend energy to gain rewards. Agents can power the altar by using the `use` action when near it. The altar has a cooldown period between uses.
+The `Altar` object allows agents to spend energy to gain rewards. Agents can power the altar by using the `use` action
+when near it. The altar has a cooldown period between uses.
 
-- Using the heart altar costs `altar.use_cost energy`. So, no matter how much energy you have, you are always dumping the same amount of energy in it and getting the same amount of reward.
+- Using the heart altar costs `altar.use_cost energy`. So, no matter how much energy you have, you are always dumping
+  the same amount of energy in it and getting the same amount of reward.
 - After the heart altar is used, it is unable to be used for altar.cooldown timesteps.
-- A single use of the heart altar gives you a single unit of reward:
-  if `target._type_id == ObjectType.AltarT:
-self.env._rewards[actor_id] += 1`
+- A single use of the heart altar gives you a single unit of reward: if
+  `target._type_id == ObjectType.AltarT: self.env._rewards[actor_id] += 1`
 
 ### Converter
 
 <img src="https://github.com/daveey/Griddly/blob/develop/resources/images/oryx/oryx_tiny_galaxy/tg_sliced/tg_items/tg_items_pda_A.png?raw=true" width="32"/>
 
-The `Converter` object allows agents to convert their harvested resources into energy. Agents can use converters by moving to them and taking the `use` action. Each use of a converter provides a specified amount of energy and has a cooldown period.
+The `Converter` object allows agents to convert their harvested resources into energy. Agents can use converters by
+moving to them and taking the `use` action. Each use of a converter provides a specified amount of energy and has a
+cooldown period.
 
 - Using the converter does not cost any energy.
 - Using the converter outputs `converter.energy_output.r1` energy
@@ -50,7 +61,8 @@ The `Converter` object allows agents to convert their harvested resources into e
 
 <img src="https://github.com/daveey/Griddly/blob/develop/resources/images/oryx/oryx_fantasy/ore-0.png?raw=true" width="32"/>
 
-The `Generator` object produces resources that agents can harvest. Agents can gather resources from generators by moving to them and taking the `use` action. Generators have a specified capacity and replenish resources over time.
+The `Generator` object produces resources that agents can harvest. Agents can gather resources from generators by moving
+to them and taking the `use` action. Generators have a specified capacity and replenish resources over time.
 
 - Using the generator once gives one resource 1
 - After the generator is used, it is unable to be used for `generator.cooldown` timesteps
@@ -69,25 +81,35 @@ The `cooldown` property determines how long before objects can be used again.
 
 ### Move / Rotate
 
-The `move` action allows agents to move to an adjacent cell in the gridworld. The action has two modes: moving forward and moving backward relative to the agent's current orientation.
+The `move` action allows agents to move to an adjacent cell in the gridworld. The action has two modes: moving forward
+and moving backward relative to the agent's current orientation.
 
-The `rotate` action enables agents to change their orientation within the gridworld. Agents can rotate to face in four directions: down, left, right, and up.
+The `rotate` action enables agents to change their orientation within the gridworld. Agents can rotate to face in four
+directions: down, left, right, and up.
 
 ### Attack
 
-The `attack` action allows agents to attack other agents or objects within their attack range. Successful attacks freeze the target for `freeze_duration` timesteps and allow the attacker to steal resources. Further, the attacked agent's energy is set to `0`. Attacks have a cost and inflict a damage value. The agent selects from one of nine coordinates within its attack range.
+The `attack` action allows agents to attack other agents or objects within their attack range. Successful attacks freeze
+the target for `freeze_duration` timesteps and allow the attacker to steal resources. Further, the attacked agent's
+energy is set to `0`. Attacks have a cost and inflict a damage value. The agent selects from one of nine coordinates
+within its attack range.
 
 ### Shield (Toggle)
 
-The `shield` action turns on a shield. When the shield is active, the agent is protected from attacks by other agents. The shield consumes energy defined by `upkeep.shield` while active. Attack damage is subtracted from the agent's energy, rather than freezing the agent.
+The `shield` action turns on a shield. When the shield is active, the agent is protected from attacks by other agents.
+The shield consumes energy defined by `upkeep.shield` while active. Attack damage is subtracted from the agent's energy,
+rather than freezing the agent.
 
 ### Transfer
 
-The `transfer` action enables agents to share resources with other agents. Agents can choose to transfer specific resources to another agent in an adjacent cell. It is currently not implemented.
+The `transfer` action enables agents to share resources with other agents. Agents can choose to transfer specific
+resources to another agent in an adjacent cell. It is currently not implemented.
 
 ### Use
 
-The `use` action allows agents to interact with objects such as altars, converters, and generators. The specific effects of the `use` action depend on the target object and can include converting resources to energy, powering the altar for rewards, or harvesting resources from generators.
+The `use` action allows agents to interact with objects such as altars, converters, and generators. The specific effects
+of the `use` action depend on the target object and can include converting resources to energy, powering the altar for
+rewards, or harvesting resources from generators.
 
 ### Swap
 
@@ -95,30 +117,24 @@ The `swap` action allows agents to swap positions with other agents. It is curre
 
 ## Configuration
 
-The MettaGrid environment is highly configurable through the use of YAML configuration files. These files specify the layout of the gridworld, the placement of objects, and various properties of the objects and agents.
+The MettaGrid environment is highly configurable through the use of YAML configuration files. These files specify the
+layout of the gridworld, the placement of objects, and various properties of the objects and agents.
 
 **Current settings:**
 
-1. Ore
-     - Base resource obtained from mines. Mines produce one ore when used. No resource requirements for use.
-     - Reward value: 0.005 per unit (max 2)
-     - Used to create batteries and lasers
-2. Battery
-     - Intermediate resource created from ore at a generator. Generator turns one ore into one battery.
-     - Reward value: 0.01 per unit (max 2)
-     - Used to create hearts and lasers
-3. Heart / heart altar
-     - High value reward, requires 3 batteries to be converted into a heart at a heart altar.
-4. Laser
-     - Weapon resource created from ore and batteries. Requires 1 ore and 2 batteries. Created at the lasery.
+1. Ore   - Base resource obtained from mines. Mines produce one ore when used. No resource requirements for use.   -
+   Reward value: 0.005 per unit (max 2)   - Used to create batteries and lasers
+2. Battery   - Intermediate resource created from ore at a generator. Generator turns one ore into one battery.   -
+   Reward value: 0.01 per unit (max 2)   - Used to create hearts and lasers
+3. Heart / heart altar   - High value reward, requires 3 batteries to be converted into a heart at a heart altar.
+4. Laser   - Weapon resource created from ore and batteries. Requires 1 ore and 2 batteries. Created at the lasery.
 
-- Consumed on use. When hitting an unarmored agent: freezes them and steals their whole inventory. When hitting an armoured agent, destroys their armor.
-  **Inventory System**
+- Consumed on use. When hitting an unarmored agent: freezes them and steals their whole inventory. When hitting an
+  armoured agent, destroys their armor. **Inventory System**
 - Agents have limited inventory space (default max: 50 items)
 - Resources provide rewards just by being in inventory (up to their max reward value)
-- Resources can be stolen through attacks
-  Objects
-  Various buildings: Mine, Generator, Armory, Lasery, Altar, Lab, Factory, Temple.
+- Resources can be stolen through attacks Objects Various buildings: Mine, Generator, Armory, Lasery, Altar, Lab,
+  Factory, Temple.
 - HP — hitpoints, the number of times something can be hit before destruction.
 - Cooldown between uses (varies by building)
 - Can be damaged and destroyed by attacks
@@ -129,7 +145,8 @@ For local development, refer to the top-level [README.md](../README.md) in this 
 
 ### CMake
 
-By default, `uv sync` will run the CMake build in an isolated environment, so if you need to run C++ tests and benchmarks, you'll need to invoke `cmake` directly.
+By default, `uv sync` will run the CMake build in an isolated environment, so if you need to run C++ tests and
+benchmarks, you'll need to invoke `cmake` directly.
 
 Build C++ tests and benchmarks in debug mode:
 

--- a/mettagrid/configs/README.md
+++ b/mettagrid/configs/README.md
@@ -1,3 +1,4 @@
-Configs in this directory are loaded with OmegaConf, without Hydra. So you can't use `defaults` lists in them or other Hydra-specific features.
+Configs in this directory are loaded with OmegaConf, without Hydra. So you can't use `defaults` lists in them or other
+Hydra-specific features.
 
 They are used in tests.

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,14 +5,16 @@
 ### 1.1. Game Dynamics
 
 - 1.1.1. Resource System
-	- Resource generation rates
-	- Rarity
-	- Mining cost
-	- Probabilistic mining
+
+  - Resource generation rates
+  - Rarity
+  - Mining cost
+  - Probabilistic mining
 
 - 1.1.2. Metabolism and Energy Costs
-	- Converting between resources
-	- Converting to energy
+
+  - Converting between resources
+  - Converting to energy
 
 - 1.1.3. Object Interactions and Crafting
 - 1.1.4. Open-ended Game Rules
@@ -21,29 +23,30 @@
 
 - 1.2.1. Species with different energy costs
 - 1.2.2. Upgradable Traits and Skills
-	- Reduced energy costs
-	- Increased damage / shield / attack range
-	- Noise reduction of observations
-	- Energy regen
-	- Explicit upgrade vs experience
-	- Balancing upgrade costs
+  - Reduced energy costs
+  - Increased damage / shield / attack range
+  - Noise reduction of observations
+  - Energy regen
+  - Explicit upgrade vs experience
+  - Balancing upgrade costs
 - 1.2.3. Equipment and Inventory Management
-	- Items provide upgrades and are tradeable
+  - Items provide upgrades and are tradeable
 
 ### 1.3. Terrain Generation
 
 - 1.3.1. Procedural World Generation
 - 1.3.2. Environmental Hazards and Obstacles
-	- Energy costs for travel
-	- Attack / defense bonus
+  - Energy costs for travel
+  - Attack / defense bonus
 - 1.3.3. Seasonal Changes and Dynamic Weather
-	- Night can reduce visibility
-	- Bonuses / Penalties in different weather
+  - Night can reduce visibility
+  - Bonuses / Penalties in different weather
 - 1.3.4. Agents can change terrain type
 
 ### 1.4. Support for Many Environment Types
 
-Developing a flexible and extensible framework for integrating Metta AI with various gridworld environments and supporting the easy addition of new environment types.
+Developing a flexible and extensible framework for integrating Metta AI with various gridworld environments and
+supporting the easy addition of new environment types.
 
 - 1.4.1. New objects, rules, interactions can be easily added
 - 1.4.2. Customizable Environment Configuration
@@ -53,7 +56,8 @@ Developing a flexible and extensible framework for integrating Metta AI with var
 
 ### 1.5. Population Dynamics
 
-Investigating the dynamics of population growth, clustering behaviors, and behavioral diversity in complex multi-agent environments, and developing tools for studying these phenomena.
+Investigating the dynamics of population growth, clustering behaviors, and behavioral diversity in complex multi-agent
+environments, and developing tools for studying these phenomena.
 
 - 1.5.1. Tools for Studying Population Dynamics
 - 1.5.2. Clustering Behaviors and Group Formation
@@ -61,7 +65,8 @@ Investigating the dynamics of population growth, clustering behaviors, and behav
 
 ### 1.6. Kinship Schemes
 
-Implementing and comparing various kinship schemes, such as family structures and random kinship markers, and exploring their impact on the emergence of cooperative behaviors and social structures.
+Implementing and comparing various kinship schemes, such as family structures and random kinship markers, and exploring
+their impact on the emergence of cooperative behaviors and social structures.
 
 - 1.6.1. Family Structures and Inheritance
 - 1.6.2. Kinship Markers
@@ -70,7 +75,8 @@ Implementing and comparing various kinship schemes, such as family structures an
 
 ### 1.7. Mate Selection Schemes
 
-Designing mate selection mechanisms based on behavioral observation and reward sharing, and studying the emergent mating strategies and population dynamics in the presence of these mechanisms.
+Designing mate selection mechanisms based on behavioral observation and reward sharing, and studying the emergent mating
+strategies and population dynamics in the presence of these mechanisms.
 
 - 1.7.1. Behavioral Observation and Evaluation
 - 1.7.2. Reward Sharing Based on Mate Selection
@@ -80,9 +86,12 @@ Designing mate selection mechanisms based on behavioral observation and reward s
 
 Developing a robust, universal gridworld agent architecture capable of adapting to new game rules and environments.
 
-Evaluating the effectiveness of blending reinforcement learning and imitation learning for accelerating agent training and performance.
+Evaluating the effectiveness of blending reinforcement learning and imitation learning for accelerating agent training
+and performance.
 
-Studying the scalability and efficiency of distributed reinforcement learning algorithms for training large-scale multi-agent systems.
+Studying the scalability and efficiency of distributed reinforcement learning algorithms for training large-scale
+multi-agent systems.
+
 ### 2.1. Robust Universal GridWorld Agent
 
 - 2.1.1. Adaptable Neural Network Architecture
@@ -102,7 +111,8 @@ Studying the scalability and efficiency of distributed reinforcement learning al
 
 ### 2.4. Exploration and Curiosity
 
-Exploring the role of intrinsic motivation and curiosity in driving efficient exploration and learning in open-ended environments.
+Exploring the role of intrinsic motivation and curiosity in driving efficient exploration and learning in open-ended
+environments.
 
 - 2.4.1. Intrinsic Motivation Signals
 - 2.4.2. Novelty-based Exploration
@@ -130,7 +140,9 @@ Exploring the role of intrinsic motivation and curiosity in driving efficient ex
 
 ## 4. Intelligence Evaluations for Gridworld Agents
 
-Designing and implementing a comprehensive suite of intelligence evaluations for gridworld agents, covering navigation, maze solving, in-context learning, cooperation, and competition.
+Designing and implementing a comprehensive suite of intelligence evaluations for gridworld agents, covering navigation,
+maze solving, in-context learning, cooperation, and competition.
+
 ### 4.1. Navigation Tasks
 
 - 4.1.1. Path Planning and Shortest Path Finding
@@ -151,11 +163,13 @@ Designing and implementing a comprehensive suite of intelligence evaluations for
 
 ### 4.4. Cooperation and Competition
 
- Investigating the impact of reward-sharing mechanisms on the emergence of cooperative behaviors in multi-agent environments.
+Investigating the impact of reward-sharing mechanisms on the emergence of cooperative behaviors in multi-agent
+environments.
 
 - 4.4.1. Emergent Communication and Signaling
 - 4.4.2. Cooperative Goal Achievement
 - 4.4.3. Strategic Decision Making in Competitive Scenarios
+
 ## 5. DevOps and Tooling
 
 ### 5.1. Cloud Cluster Management

--- a/scenes/dcss/README.md
+++ b/scenes/dcss/README.md
@@ -1,4 +1,5 @@
-These scenes were generated from the file [`simple.des`](https://github.com/crawl/crawl/blob/master/crawl-ref/source/dat/des/arrival/simple.des).
+These scenes were generated from the file
+[`simple.des`](https://github.com/crawl/crawl/blob/master/crawl-ref/source/dat/des/arrival/simple.des).
 
 To regenerate these scenes, run the following command:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,22 +1,28 @@
 # Testing Philosophy
 
 Follow generic best practices. With help from our friend Claude, here are some generic points
-* Tests should be independent and idempotent. Tests shouldn't pass or fail based on other tests.
-* Tests should be focused. Test one thing per test.
-* Tests should be fast and efficient.
-* Tests should cover edge cases and boundary conditions, not just the happy path.
-* External dependencies should be appropriately mocked, so your test can be focused on what it's testing.
-* Tests should be readable by humans.
+
+- Tests should be independent and idempotent. Tests shouldn't pass or fail based on other tests.
+- Tests should be focused. Test one thing per test.
+- Tests should be fast and efficient.
+- Tests should cover edge cases and boundary conditions, not just the happy path.
+- External dependencies should be appropriately mocked, so your test can be focused on what it's testing.
+- Tests should be readable by humans.
 
 In addition to these generic points, here are some other thoughts:
-* If you need to fix a bug or a regression, you should first try to reproduce the bug as a test, and then fix it. Second best is to fix it and then write a test that would have caught it.
-* Unit tests are better because they're faster. Integration tests are better because they're more directly connected to usage (e.g., actually training).
-* LLMs should be writing most of your tests, but you should review them to make sure they're covering what they should be.
+
+- If you need to fix a bug or a regression, you should first try to reproduce the bug as a test, and then fix it. Second
+  best is to fix it and then write a test that would have caught it.
+- Unit tests are better because they're faster. Integration tests are better because they're more directly connected to
+  usage (e.g., actually training).
+- LLMs should be writing most of your tests, but you should review them to make sure they're covering what they should
+  be.
 
 # Testing Structure
 
-* Tests should be in `tests/`, with there being a single such directory at the root of the project.
-* Tests should start with `test_`. Other files should not start with `test_`.
-* The test directory should mirror the directory structure of the project, including subdirectories. So, for example, tests for `package_name/your/favorite/file.py` should be in `tests/your/favorite/test_file.py`.
+- Tests should be in `tests/`, with there being a single such directory at the root of the project.
+- Tests should start with `test_`. Other files should not start with `test_`.
+- The test directory should mirror the directory structure of the project, including subdirectories. So, for example,
+  tests for `package_name/your/favorite/file.py` should be in `tests/your/favorite/test_file.py`.
 
 If tests are not structured this way, we should migrate them.


### PR DESCRIPTION

This PR adds Prettier support for Markdown files to improve consistency and readability across our documentation. All `.md` files have been formatted according to our new Prettier configuration.

### Changes

#### Configuration
- **Added Markdown settings to `.prettierrc`**:
  - Line width: 120 characters (wider than default 80 for better code block handling)
  - Prose wrap: `always` (ensures consistent line wrapping)
  - Tab width: 2 spaces
  - Parser: `markdown`

#### New tooling
- **Added `devops/tools/format_md.sh`** script for formatting Markdown files
  - Follows the same pattern as our existing `format_json.sh`
  - Supports `--exclude` patterns for skipping files
  - Handles both `.md` files and `README` files without extensions
  - Includes Prettier installation check

#### Formatted files
- 28 Markdown files reformatted for consistency
- Primary changes include:
  - Consistent line wrapping at 120 characters
  - Proper list formatting and indentation
  - Standardized spacing around headers and code blocks
  - No content changes - only formatting
