### PR TITLE
Add internal_id column to episodes table

### DIFF
--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -152,8 +152,10 @@ MIGRATIONS = [
         description="Add heatmap performance indexes",
         sql_statements=[
             # Critical index for episode_agent_metrics main query
-            """CREATE INDEX idx_episode_agent_metrics_episode_metric
-               ON episode_agent_metrics(episode_id, metric)""",
+            """ALTER TABLE episode_agent_metrics DROP CONSTRAINT episode_agent_metrics_pkey""",
+            """CREATE INDEX idx_episode_agent_metrics_metric_episode_value
+                ON episode_agent_metrics(metric, episode_id)
+                INCLUDE (value)""",
             # Composite index for episodes eval filtering and joins
             """CREATE INDEX idx_episodes_eval_category_env_policy
                ON episodes(eval_category, env_name, primary_policy_id)""",
@@ -178,6 +180,14 @@ MIGRATIONS = [
         description="Add tags field to training_runs table",
         sql_statements=[
             """ALTER TABLE training_runs ADD COLUMN tags TEXT[]""",
+        ],
+    ),
+    SqlMigration(
+        version=9,
+        description="Add internal_id field to episodes table and episode_agent_metrics table",
+        sql_statements=[
+            """ALTER TABLE episodes ADD COLUMN internal_id SERIAL UNIQUE""",
+            """ALTER TABLE episode_agent_metrics ADD COLUMN episode_internal_id INTEGER""",
         ],
     ),
 ]
@@ -337,7 +347,7 @@ class MettaRepo:
                     attributes
                 ) VALUES (
                     %s, %s, %s, %s, %s, %s, %s, %s
-                ) RETURNING id
+                ) RETURNING id, internal_id
                 """,
                 (
                     replay_url,
@@ -354,6 +364,7 @@ class MettaRepo:
             if row is None:
                 raise RuntimeError("Failed to insert episode record")
             episode_id = row[0]
+            episode_internal_id = row[1]
 
             # Insert agent policies
             for agent_id, policy_id in agent_policies.items():
@@ -369,15 +380,16 @@ class MettaRepo:
                 )
 
             # Insert agent metrics in bulk
-            rows: List[Tuple[uuid.UUID, int, str, float]] = []
+            rows: List[Tuple[uuid.UUID, int, int, str, float]] = []
             for agent_id, metrics in agent_metrics.items():
                 for metric_name, value in metrics.items():
-                    rows.append((episode_id, agent_id, metric_name, value))
+                    rows.append((episode_id, episode_internal_id, agent_id, metric_name, value))
 
             async with con.cursor() as cursor:
                 await cursor.executemany(
                     """
-                  INSERT INTO episode_agent_metrics (episode_id, agent_id, metric, value) VALUES (%s, %s, %s, %s)
+                  INSERT INTO episode_agent_metrics (episode_id, episode_internal_id, agent_id, metric, value)
+                  VALUES (%s, %s, %s, %s, %s)
                   """,
                     rows,
                 )


### PR DESCRIPTION
This is step #1 of 3 to moving episode_agent_metrics onto INT ids instead of UUIDS.  We are doing this for two reasons:
1. The episode_agent_metrics table is already 4GB, and the index on it is another 4GB
2. I want sequential episode ids for cache invalidation

The steps are as follows:
1. This PR: add required columns and start writing episode_internal_id to episode_agent_metrics for new data
2. Backfill the episode_internal_ids on existing data
3. Switch to using the episode_internal_id column and drop the episode_id column from episode_agent_metrics

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210747406901717)