### PR TITLE
Mettabox train script relies on updated python to determine num_workers

### DIFF
--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -1,5 +1,5 @@
 _target_: metta.rl.trainer.MettaTrainer
-num_workers: ???  # determined by create_trainer_config if not specified
+num_workers: null  # determined by train.py if not specified
 
 curriculum: ???
 env_overrides: {}

--- a/devops/train.sh
+++ b/devops/train.sh
@@ -21,20 +21,6 @@ else
 fi
 export HEARTBEAT_FILE
 
-# System configuration
-if [ -z "$NUM_CPUS" ]; then
-  if command -v lscpu &> /dev/null; then
-    # Linux
-    NUM_CPUS=$(lscpu | grep "CPU(s)" | awk '{print $NF}' | head -n1)
-    NUM_CPUS=$((NUM_CPUS / 2))
-  elif command -v sysctl &> /dev/null; then
-    # macOS
-    NUM_CPUS=$(sysctl -n hw.ncpu)
-    NUM_CPUS=$((NUM_CPUS / 2))
-  else
-    NUM_CPUS=1  # fallback
-  fi
-fi
 
 # Auto-detect GPUs if not set
 if [ -z "$NUM_GPUS" ]; then
@@ -52,7 +38,6 @@ NODE_INDEX=${NODE_INDEX:-0}
 
 # Display configuration
 echo "[CONFIG] Training configuration:"
-echo "  - CPUs: $NUM_CPUS"
 echo "  - GPUs: $NUM_GPUS"
 echo "  - Nodes: $NUM_NODES"
 echo "  - Master address: $MASTER_ADDR"
@@ -70,7 +55,7 @@ PYTHONPATH=$PYTHONPATH:. uv run torchrun \
   --master-port=$MASTER_PORT \
   --node-rank=$NODE_INDEX \
   tools/train.py \
-  trainer.num_workers=$((NUM_CPUS / NUM_GPUS)) \
+  trainer.num_workers=null \
   wandb.enabled=true \
   $args
 EXIT_CODE=$?

--- a/tools/train.py
+++ b/tools/train.py
@@ -50,10 +50,8 @@ def _calculate_default_num_workers(is_serial: bool) -> int:
 
 
 def train(cfg: ListConfig | DictConfig, wandb_run: WandbRun | None, logger: Logger):
-    if OmegaConf.is_missing(cfg.trainer, "num_workers") or cfg.trainer.num_workers is None:
-        OmegaConf.set_struct(cfg, False)
+    if not cfg.trainer.num_workers:
         cfg.trainer.num_workers = _calculate_default_num_workers(cfg.vectorization == "serial")
-        OmegaConf.set_struct(cfg, True)
     cfg = load_train_job_config_with_overrides(cfg)
 
     if os.environ.get("RANK", "0") == "0":


### PR DESCRIPTION
Update _calculate_default_num_workers to account for gpus. update train.sh to defer to the _calculate_default_num_workers

https://app.asana.com/1/1209016784099267/project/1209805539287945/task/1210746464522539?focus=true

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210748632091088)