### PR TITLE
hotfix for cursor bckg

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -29,10 +29,14 @@ git config --global user.email "openhands@all-hands.dev" 2>/dev/null || true
 if ! command -v uv &> /dev/null; then
     echo "📦 Installing uv package manager..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
-    
-    # Add uv to PATH for current session
-    export PATH="$HOME/.cargo/bin:$PATH"
-    
+
+    # Add uv to PATH for current session - uv installs to ~/.local/bin
+    if [ -f "$HOME/.local/bin/env" ]; then
+        source "$HOME/.local/bin/env"
+    else
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+
     # Verify installation
     if ! command -v uv &> /dev/null; then
         echo "❌ Failed to install uv"
@@ -68,13 +72,13 @@ try:
         print('✅ Metta mettagrid module imported successfully')
     except ImportError as e:
         print(f'⚠️  Mettagrid module import issue: {e}')
-    
+
     try:
         import metta.rl.fast_gae
         print('✅ C++ extensions (fast_gae) imported successfully')
     except ImportError as e:
         print(f'⚠️  C++ extensions import issue: {e}')
-        
+
     print('✅ Setup verification completed - Metta is ready to use!')
 except ImportError as e:
     print(f'❌ Critical error - Metta package not found: {e}')

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -30,22 +30,12 @@ if ! command -v uv &> /dev/null; then
     echo "📦 Installing uv package manager..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
 
-    # Add uv to PATH for current session - uv installs to ~/.local/bin
-    if [ -f "$HOME/.local/bin/env" ]; then
-        source "$HOME/.local/bin/env"
-    else
-        export PATH="$HOME/.local/bin:$PATH"
-    fi
+    # Add all common uv installation paths to PATH
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-    # Check if uv is still not found (might be installed via Homebrew)
-    if ! command -v uv &> /dev/null; then
-        # Check common Homebrew locations
-        if [ -f "/opt/homebrew/bin/uv" ]; then
-            export PATH="/opt/homebrew/bin:$PATH"
-        elif [ -f "/usr/local/bin/uv" ]; then
-            export PATH="/usr/local/bin:$PATH"
-        fi
-    fi
+    # Source env files if they exist
+    [ -f "$HOME/.local/bin/env" ] && source "$HOME/.local/bin/env"
+    [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
 
     # Verify installation
     if ! command -v uv &> /dev/null; then

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -37,6 +37,16 @@ if ! command -v uv &> /dev/null; then
         export PATH="$HOME/.local/bin:$PATH"
     fi
 
+    # Check if uv is still not found (might be installed via Homebrew)
+    if ! command -v uv &> /dev/null; then
+        # Check common Homebrew locations
+        if [ -f "/opt/homebrew/bin/uv" ]; then
+            export PATH="/opt/homebrew/bin:$PATH"
+        elif [ -f "/usr/local/bin/uv" ]; then
+            export PATH="/usr/local/bin:$PATH"
+        fi
+    fi
+
     # Verify installation
     if ! command -v uv &> /dev/null; then
         echo "❌ Failed to install uv"

--- a/install.sh
+++ b/install.sh
@@ -60,8 +60,15 @@ if ! check_cmd uv; then
     echo "\nuv is not installed. Installing uv..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
 
-    if [ -f "$HOME/.cargo/env" ]; then
+    # Source the correct environment file for uv
+    if [ -f "$HOME/.local/bin/env" ]; then
+        . "$HOME/.local/bin/env"
+    elif [ -f "$HOME/.cargo/env" ]; then
+        # Fallback to cargo env if uv was installed via cargo
         . "$HOME/.cargo/env"
+    else
+        # Manually add to PATH as a last resort
+        export PATH="$HOME/.local/bin:$PATH"
     fi
 
     if ! check_cmd uv; then

--- a/install.sh
+++ b/install.sh
@@ -60,26 +60,12 @@ if ! check_cmd uv; then
     echo "\nuv is not installed. Installing uv..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
 
-    # Source the correct environment file for uv
-    if [ -f "$HOME/.local/bin/env" ]; then
-        . "$HOME/.local/bin/env"
-    elif [ -f "$HOME/.cargo/env" ]; then
-        # Fallback to cargo env if uv was installed via cargo
-        . "$HOME/.cargo/env"
-    else
-        # Manually add to PATH as a last resort
-        export PATH="$HOME/.local/bin:$PATH"
-    fi
+    # Add all common uv installation paths to PATH
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-    # Check if uv is still not found (might be installed via Homebrew)
-    if ! check_cmd uv; then
-        # Check common Homebrew locations
-        if [ -f "/opt/homebrew/bin/uv" ]; then
-            export PATH="/opt/homebrew/bin:$PATH"
-        elif [ -f "/usr/local/bin/uv" ]; then
-            export PATH="/usr/local/bin:$PATH"
-        fi
-    fi
+    # Source env files if they exist
+    [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+    [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
     if ! check_cmd uv; then
         err "Failed to install uv. Please install it manually from https://github.com/astral-sh/uv"

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,16 @@ if ! check_cmd uv; then
         export PATH="$HOME/.local/bin:$PATH"
     fi
 
+    # Check if uv is still not found (might be installed via Homebrew)
+    if ! check_cmd uv; then
+        # Check common Homebrew locations
+        if [ -f "/opt/homebrew/bin/uv" ]; then
+            export PATH="/opt/homebrew/bin:$PATH"
+        elif [ -f "/usr/local/bin/uv" ]; then
+            export PATH="/usr/local/bin:$PATH"
+        fi
+    fi
+
     if ! check_cmd uv; then
         err "Failed to install uv. Please install it manually from https://github.com/astral-sh/uv"
     fi


### PR DESCRIPTION
## Summary
I've fixed the issue with the uv installation error in your background agents. The problem was that the installation scripts were looking for uv in the wrong location after installation.

## The Issue
The uv installer was installing to ~/.local/bin/, but the scripts were trying to source ~/.cargo/env to update the PATH. This caused the scripts to fail to find the installed uv binary even though it was successfully installed.

## The Fix
I updated two scripts:
install.sh (lines 62-72): Changed the PATH configuration to:
First check for $HOME/.local/bin/env (where uv installer puts its env file)
Fall back to $HOME/.cargo/env if uv was installed via cargo
As a last resort, manually add $HOME/.local/bin to PATH
.openhands/setup.sh (lines 33-38): Updated to use the same logic for finding and sourcing the correct env file.

## Result
Now when the scripts run:
They'll correctly find uv after installation by sourcing the right environment file
The "Failed to install uv" error should no longer appear
Your background agents should be able to continue with the setup process
The changes ensure compatibility with both the standard uv installation (to ~/.local/bin) and any alternative cargo-based installations.

> Allocating resources for this agent (request id: bc-0eb42af2-4e17-43fb-a9ea-4adc0e72cc8f)...
> 
> Error: Environment failed to start
> Details:
> Failed to execute install command  (system: false, user: None): Command failed with exit code 1: stderr: downloading uv 0.7.20 x86_64-unknown-linux-gnu
> downloading uv 0.7.20 x86_64-unknown-linux-gnu
> ERROR: Failed to install uv. Please install it manually from https://github.com/astral-sh/uv
> 
> Installing xvfb and related dependencies for ubuntu...
> Installing xvfb and related dependencies for ubuntu...
> Hit:1 http://archive.ubuntu.com/ubuntu plucky InRelease
> Get:2 http://security.ubuntu.com/ubuntu plucky-security InRelease [126 kB]
> Get:3 http://archive.ubuntu.com/ubuntu plucky-updates InRelease [126 kB]
> Get:4 http://security.ubuntu.com/ubuntu plucky-security/restricted amd64 Packages [99.5 kB]
> Get:5 http://archive.ubuntu.com/ubuntu plucky-backports InRelease [126 kB]
> Get:6 http://security.ubuntu.com/ubuntu plucky-security/universe amd64 Packages [114 kB]
> Get:7 http://security.ubuntu.com/ubuntu plucky-security/main amd64 Packages [162 kB]
> Get:8 http://archive.ubuntu.com/ubuntu plucky-updates/restricted amd64 Packages [99.5 kB]
> Get:9 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 Packages [269 kB]
> Get:10 http://archive.ubuntu.com/ubuntu plucky-updates/universe amd64 Packages [211 kB]
> Fetched 1,333 kB in 1s (1,421 kB/s)
> Reading package lists...
> Found libasound2t64 package, using it
> Reading package lists...
> Building dependency tree...
> Reading state information...
> curl is already the newest version (8.12.1-3ubuntu1).
> wget is already the newest version (1.24.5-2ubuntu1).
> xauth is already the newest version (1:1.1.2-1.1).
> tmux is already the newest version (3.5a-3).
> ca-certificates is already the newest version (20241223).
> libatk1.0-0t64 is already the newest version (2.56.1-1).
> libatk-bridge2.0-0t64 is already the newest version (2.56.1-1).
> libcups2t64 is already the newest version (2.4.12-0ubuntu1).
> libgtk-3-0t64 is already the newest version (3.24.49-2ubuntu1).
> libnss3 is already the newest version (2:3.108-1ubuntu1).
> The following additional packages will be installed:
>   git-man libasound2-data libgl1-mesa-dri libglx-mesa0 mesa-libgallium
>   mesa-vulkan-drivers xserver-common
> The following packages will be upgraded:
>   git git-man libasound2-data libasound2t64 libgbm1 libgl1-mesa-dri
>   libglx-mesa0 mesa-libgallium mesa-vulkan-drivers xserver-common xvfb
> 11 upgraded, 0 newly installed, 0 to remove and 49 not upgraded.
> Need to get 37.5 MB of archives.
> After this operation, 230 kB of additional disk space will be used.
> Get:1 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 git-man all 1:2.48.1-0ubuntu1.1 [1,149 kB]
> Get:2 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 git amd64 1:2.48.1-0ubuntu1.1 [4,786 kB]
> Get:3 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 libasound2t64 amd64 1.2.13-1ubuntu0.1 [443 kB]
> Get:4 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 libasound2-data all 1.2.13-1ubuntu0.1 [21.2 kB]
> Get:5 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 libgl1-mesa-dri amd64 25.0.7-0ubuntu0.25.04.1 [35.8 kB]
> Get:6 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 libglx-mesa0 amd64 25.0.7-0ubuntu0.25.04.1 [146 kB]
> Get:7 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 libgbm1 amd64 25.0.7-0ubuntu0.25.04.1 [33.4 kB]
> Get:8 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 mesa-libgallium amd64 25.0.7-0ubuntu0.25.04.1 [12.1 MB]
> Get:9 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 mesa-vulkan-drivers amd64 25.0.7-0ubuntu0.25.04.1 [17.8 MB]
> Get:10 http://archive.ubuntu.com/ubuntu plucky-updates/main amd64 xserver-common all 2:21.1.16-1ubuntu1.1 [34.8 kB]
> Get:11 http://archive.ubuntu.com/ubuntu plucky-updates/universe amd64 xvfb amd64 2:21.1.16-1ubuntu1.1 [973 kB]
> Fetched 37.5 MB in 3s (13.1 MB/s)
> (Reading database ... 60536 files and directories currently installed.)
> Preparing to unpack .../00-git-man_1%3a2.48.1-0ubuntu1.1_all.deb ...
> Unpacking git-man (1:2.48.1-0ubuntu1.1) over (1:2.48.1-0ubuntu1) ...
> Preparing to unpack .../01-git_1%3a2.48.1-0ubuntu1.1_amd64.deb ...
> Unpacking git (1:2.48.1-0ubuntu1.1) over (1:2.48.1-0ubuntu1) ...
> Preparing to unpack .../02-libasound2t64_1.2.13-1ubuntu0.1_amd64.deb ...
> Unpacking libasound2t64:amd64 (1.2.13-1ubuntu0.1) over (1.2.13-1build1) ...
> Preparing to unpack .../03-libasound2-data_1.2.13-1ubuntu0.1_all.deb ...
> Unpacking libasound2-data (1.2.13-1ubuntu0.1) over (1.2.13-1build1) ...
> Preparing to unpack .../04-libgl1-mesa-dri_25.0.7-0ubuntu0.25.04.1_amd64.deb ...
> Unpacking libgl1-mesa-dri:amd64 (25.0.7-0ubuntu0.25.04.1) over (25.0.3-1ubuntu2) ...
> Preparing to unpack .../05-libglx-mesa0_25.0.7-0ubuntu0.25.04.1_amd64.deb ...
> Unpacking libglx-mesa0:amd64 (25.0.7-0ubuntu0.25.04.1) over (25.0.3-1ubuntu2) ...
> Preparing to unpack .../06-libgbm1_25.0.7-0ubuntu0.25.04.1_amd64.deb ...
> Unpacking libgbm1:amd64 (25.0.7-0ubuntu0.25.04.1) over (25.0.3-1ubuntu2) ...
> Preparing to unpack .../07-mesa-libgallium_25.0.7-0ubuntu0.25.04.1_amd64.deb ...
> Unpacking mesa-libgallium:amd64 (25.0.7-0ubuntu0.25.04.1) over (25.0.3-1ubuntu2) ...
> Preparing to unpack .../08-mesa-vulkan-drivers_25.0.7-0ubuntu0.25.04.1_amd64.deb ...
> Unpacking mesa-vulkan-drivers:amd64 (25.0.7-0ubuntu0.25.04.1) over (25.0.3-1ubuntu2) ...
> Preparing to unpack .../09-xserver-common_2%3a21.1.16-1ubuntu1.1_all.deb ...
> Unpacking xserver-common (2:21.1.16-1ubuntu1.1) over (2:21.1.16-1ubuntu1) ...
> Preparing to unpack .../10-xvfb_2%3a21.1.16-1ubuntu1.1_amd64.deb ...
> Unpacking xvfb (2:21.1.16-1ubuntu1.1) over (2:21.1.16-1ubuntu1) ...
> Setting up mesa-vulkan-drivers:amd64 (25.0.7-0ubuntu0.25.04.1) ...
> Setting up mesa-libgallium:amd64 (25.0.7-0ubuntu0.25.04.1) ...
> Setting up libgbm1:amd64 (25.0.7-0ubuntu0.25.04.1) ...
> Setting up libgl1-mesa-dri:amd64 (25.0.7-0ubuntu0.25.04.1) ...
> Setting up libasound2-data (1.2.13-1ubuntu0.1) ...
> Setting up libasound2t64:amd64 (1.2.13-1ubuntu0.1) ...
> Setting up git-man (1:2.48.1-0ubuntu1.1) ...
> Setting up xserver-common (2:21.1.16-1ubuntu1.1) ...
> Setting up libglx-mesa0:amd64 (25.0.7-0ubuntu0.25.04.1) ...
> Setting up xvfb (2:21.1.16-1ubuntu1.1) ...
> Setting up git (1:2.48.1-0ubuntu1.1) ...
> Processing triggers for man-db (2.13.0-1) ...
> Processing triggers for libc-bin (2.41-6ubuntu1) ...
> Dependencies installed successfully.
> [Exit] Success (code: 0)
> Detected architecture: x86_64
> Setting architecture to x64
> Final architecture: x64
> Detected architecture: x86_64
> Setting architecture to x64
> Final architecture: x64
> Downloading vm-daemon from https://public-asphr-vm-daemon-bucket.s3.us-east-1.amazonaws.com/vm-daemon/vm-daemon-x64-ec81cb0f4878b7cb52fac23a1c814dcfbd3ec61ff18f7ed6bb714d186f8b514c.tar.gz
> vm-daemon.tar.gz: OK
> Running vm-daemon install command with cursor server commit: 031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0
> Installing vm-daemon...
> Installing extensions from devcontainer directory /workspace
> {"level":"info","time":"2025-07-09T21:12:04.696Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"DevContainerService","basePath":"/workspace","extensionsJsonPath":"/workspace/.vscode/extensions.json","message":"Found VSCode extensions configuration at /workspace/.vscode/extensions.json"}
> {"level":"info","time":"2025-07-09T21:12:04.697Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"DevContainerService","basePath":"/workspace","extensionCount":12,"extensions":["charliermarsh.ruff","streetsidesoftware.code-spell-checker","ms-python.python","ms-python.vscode-pylance","mechatroner.rainbow-csv","tamasfe.even-better-toml","ms-azuretools.vscode-docker","ms-python.debugpy","ms-vscode-remote.remote-containers","ms-vscode.cmake-tools","ms-vscode.cpptools-extension-pack","twxs.cmake"],"message":"Found 12 VSCode extensions to install"}
> Extensions to install from devcontainer: charliermarsh.ruff, streetsidesoftware.code-spell-checker, ms-python.python, ms-python.vscode-pylance, mechatroner.rainbow-csv, tamasfe.even-better-toml, ms-azuretools.vscode-docker, ms-python.debugpy, ms-vscode-remote.remote-containers, ms-vscode.cmake-tools, ms-vscode.cpptools-extension-pack, twxs.cmake
> Installing Cursor server for commit 031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0...
> {"level":"info","time":"2025-07-09T21:12:09.034Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"CursorServerService","commit":"031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0","finalDir":"/home/ubuntu/.cursor-server/bin/031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0","message":"Successfully downloaded server at /home/ubuntu/.cursor-server/bin/031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0"}
> Cursor server installed successfully.
> Reconciling extensions: charliermarsh.ruff, eamodio.gitlens, ktnrg45.vscode-cython, mechatroner.rainbow-csv, ms-azuretools.vscode-docker, ms-python.debugpy, ms-python.python, ms-python.vscode-pylance, ms-vscode.cmake-tools, ms-vscode.cpptools, ms-vscode.cpptools-extension-pack, ms-vscode.makefile-tools, streetsidesoftware.code-spell-checker, tamasfe.even-better-toml, twxs.cmake, charliermarsh.ruff, streetsidesoftware.code-spell-checker, ms-python.python, ms-python.vscode-pylance, mechatroner.rainbow-csv, tamasfe.even-better-toml, ms-azuretools.vscode-docker, ms-python.debugpy, ms-vscode-remote.remote-containers, ms-vscode.cmake-tools, ms-vscode.cpptools-extension-pack, twxs.cmake
> {"level":"info","time":"2025-07-09T21:12:09.035Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"CursorServerService","extensions":["charliermarsh.ruff","eamodio.gitlens","ktnrg45.vscode-cython","mechatroner.rainbow-csv","ms-azuretools.vscode-docker","ms-python.debugpy","ms-python.python","ms-python.vscode-pylance","ms-vscode.cmake-tools","ms-vscode.cpptools","ms-vscode.cpptools-extension-pack","ms-vscode.makefile-tools","streetsidesoftware.code-spell-checker","tamasfe.even-better-toml","twxs.cmake","ms-vscode-remote.remote-containers"],"targetPlatform":"linux-x64","commit":"031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0","message":"Reconciling extensions: charliermarsh.ruff, eamodio.gitlens, ktnrg45.vscode-cython, mechatroner.rainbow-csv, ms-azuretools.vscode-docker, ms-python.debugpy, ms-python.python, ms-python.vscode-pylance, ms-vscode.cmake-tools, ms-vscode.cpptools, ms-vscode.cpptools-extension-pack, ms-vscode.makefile-tools, streetsidesoftware.code-spell-checker, tamasfe.even-better-toml, twxs.cmake, ms-vscode-remote.remote-containers"}
> {"level":"info","time":"2025-07-09T21:12:09.036Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","extensionIds":["charliermarsh.ruff","eamodio.gitlens","ktnrg45.vscode-cython","mechatroner.rainbow-csv","ms-azuretools.vscode-docker","ms-python.debugpy","ms-python.python","ms-python.vscode-pylance","ms-vscode.cmake-tools","ms-vscode.cpptools","ms-vscode.cpptools-extension-pack","ms-vscode.makefile-tools","streetsidesoftware.code-spell-checker","tamasfe.even-better-toml","twxs.cmake","ms-vscode-remote.remote-containers"],"message":"Querying marketplace for extensions..."}
> {"level":"info","time":"2025-07-09T21:12:09.837Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","extensions":12,"message":"Found 12 extensions"}
> {"level":"info","time":"2025-07-09T21:12:09.837Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","outputDir":"/home/ubuntu/.cursor-server/extensions","message":"Cleaning up old extensions..."}
> {"level":"info","time":"2025-07-09T21:12:09.839Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","version":"1.0.5","message":"Installing v1.0.5..."}
> {"level":"info","time":"2025-07-09T21:12:09.839Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","version":"2025.6.0","message":"Installing v2025.6.0..."}
> {"level":"info","time":"2025-07-09T21:12:09.839Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","version":"2023.6.0","message":"Installing v2023.6.0..."}
> {"level":"info","time":"2025-07-09T21:12:09.839Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","version":"2025.24.0","message":"Installing v2025.24.0..."}
> {"level":"info","time":"2025-07-09T21:12:09.840Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","downloadUrl":"https://marketplace.cursorapi.com/downloads/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true","message":"Downloading..."}
> {"level":"info","time":"2025-07-09T21:12:09.840Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://marketplace.cursorapi.com/downloads/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true","filepath":"/home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix","message":"Downloading https://marketplace.cursorapi.com/downloads/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true to /home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix"}
> {"level":"info","time":"2025-07-09T21:12:09.841Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","downloadUrl":"https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/ms-python/debugpy/2025.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64","message":"Downloading..."}
> {"level":"info","time":"2025-07-09T21:12:09.841Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/ms-python/debugpy/2025.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix","message":"Downloading https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/ms-python/debugpy/2025.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64 to /home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:09.842Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","downloadUrl":"https://marketplace.cursorapi.com/downloads/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true","message":"Downloading..."}
> {"level":"info","time":"2025-07-09T21:12:09.842Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://marketplace.cursorapi.com/downloads/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix","message":"Downloading https://marketplace.cursorapi.com/downloads/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true to /home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:09.843Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","downloadUrl":"https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/charliermarsh/ruff/2025.24.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64","message":"Downloading..."}
> {"level":"info","time":"2025-07-09T21:12:09.843Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/charliermarsh/ruff/2025.24.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64","filepath":"/home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix","message":"Downloading https://marketplace.cursorapi.com/open-vsx-mirror/vscode/asset/charliermarsh/ruff/2025.24.0/Microsoft.VisualStudio.Services.VSIXPackage?redirect=true&targetPlatform=linux-x64 to /home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.231Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://downloads.cursor.com/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage","filepath":"/home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix","message":"Downloading https://downloads.cursor.com/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage to /home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.254Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://cursor-cdn.com/openvsx_v0/production/7cd26f457e04579d59f1dfe7678199fb68fb375f43c58d396a7d846f6d3d5444","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix","message":"Downloading https://cursor-cdn.com/openvsx_v0/production/7cd26f457e04579d59f1dfe7678199fb68fb375f43c58d396a7d846f6d3d5444 to /home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.319Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://cursor-cdn.com/openvsx_v0/production/d9757cd89263173a991f1227e7ac85ec426e6c2736b501419b355bbace6aa6a0","filepath":"/home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix","message":"Downloading https://cursor-cdn.com/openvsx_v0/production/d9757cd89263173a991f1227e7ac85ec426e6c2736b501419b355bbace6aa6a0 to /home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.341Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://downloads.cursor.com/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix","message":"Downloading https://downloads.cursor.com/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage to /home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.436Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://cursor-cdn.com/openvsx_v0/production/7cd26f457e04579d59f1dfe7678199fb68fb375f43c58d396a7d846f6d3d5444","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix","message":"Successfully downloaded https://cursor-cdn.com/openvsx_v0/production/7cd26f457e04579d59f1dfe7678199fb68fb375f43c58d396a7d846f6d3d5444 to /home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.436Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","filename":"ms-python.debugpy-2025.6.0.vsix","message":"Downloaded ms-python.debugpy-2025.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.436Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","message":"Extracting..."}
> {"level":"info","time":"2025-07-09T21:12:10.871Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://cursor-cdn.com/openvsx_v0/production/d9757cd89263173a991f1227e7ac85ec426e6c2736b501419b355bbace6aa6a0","filepath":"/home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix","message":"Successfully downloaded https://cursor-cdn.com/openvsx_v0/production/d9757cd89263173a991f1227e7ac85ec426e6c2736b501419b355bbace6aa6a0 to /home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.871Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","filename":"charliermarsh.ruff-2025.24.0.vsix","message":"Downloaded charliermarsh.ruff-2025.24.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:10.871Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","message":"Extracting..."}
> {"level":"info","time":"2025-07-09T21:12:11.051Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","finalDir":"/home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0","message":"Installed to /home/ubuntu/.cursor-server/extensions/ms-python.debugpy-2025.6.0"}
> {"level":"info","time":"2025-07-09T21:12:11.052Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.debugpy","message":"Removed VSIX file"}
> {"level":"info","time":"2025-07-09T21:12:11.102Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://downloads.cursor.com/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage","filepath":"/home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix","message":"Successfully downloaded https://downloads.cursor.com/production/extensions/d7f9f831-2239-4783-9d06-18d27f285818/1.0.5/Microsoft.VisualStudio.Services.VSIXPackage to /home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5.vsix"}
> {"level":"info","time":"2025-07-09T21:12:11.102Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","filename":"anysphere.cursorpyright-1.0.5.vsix","message":"Downloaded anysphere.cursorpyright-1.0.5.vsix"}
> {"level":"info","time":"2025-07-09T21:12:11.102Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","message":"Extracting..."}
> {"level":"info","time":"2025-07-09T21:12:11.500Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","url":"https://downloads.cursor.com/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage","filepath":"/home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix","message":"Successfully downloaded https://downloads.cursor.com/production/extensions/f1f59ae4-9318-4f3c-a9b5-81b2eaa5f8a5/2023.6.0/Microsoft.VisualStudio.Services.VSIXPackage to /home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:11.500Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","filename":"ms-python.python-2023.6.0.vsix","message":"Downloaded ms-python.python-2023.6.0.vsix"}
> {"level":"info","time":"2025-07-09T21:12:11.500Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","message":"Extracting..."}
> {"level":"info","time":"2025-07-09T21:12:11.632Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","finalDir":"/home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0","message":"Installed to /home/ubuntu/.cursor-server/extensions/charliermarsh.ruff-2025.24.0"}
> {"level":"info","time":"2025-07-09T21:12:11.634Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"charliermarsh.ruff","message":"Removed VSIX file"}
> {"level":"info","time":"2025-07-09T21:12:13.366Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","finalDir":"/home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0","message":"Installed to /home/ubuntu/.cursor-server/extensions/ms-python.python-2023.6.0"}
> {"level":"info","time":"2025-07-09T21:12:13.369Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"ms-python.python","message":"Removed VSIX file"}
> {"level":"info","time":"2025-07-09T21:12:14.006Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","finalDir":"/home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5","message":"Installed to /home/ubuntu/.cursor-server/extensions/anysphere.cursorpyright-1.0.5"}
> {"level":"info","time":"2025-07-09T21:12:14.007Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","displayId":"anysphere.cursorpyright","message":"Removed VSIX file"}
> {"level":"info","time":"2025-07-09T21:12:14.007Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","successCount":4,"failureCount":0,"message":"Installation complete: 4 successful, 0 failed"}
> {"level":"info","time":"2025-07-09T21:12:14.008Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","extensionsCount":4,"message":"Updated extensions.json with 4 extensions"}
> Extensions reconciled successfully.
> {"level":"info","time":"2025-07-09T21:12:14.008Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"ExtensionDownloader","message":"Download and extraction complete!"}
> {"level":"info","time":"2025-07-09T21:12:14.008Z","pid":531,"hostname":"cursor","service":"vm-daemon","process_id":531,"process_arch":"x64","process_platform":"linux","component":"CursorServerService","extensions":["charliermarsh.ruff","eamodio.gitlens","ktnrg45.vscode-cython","mechatroner.rainbow-csv","ms-azuretools.vscode-docker","ms-python.debugpy","ms-python.python","ms-python.vscode-pylance","ms-vscode.cmake-tools","ms-vscode.cpptools","ms-vscode.cpptools-extension-pack","ms-vscode.makefile-tools","streetsidesoftware.code-spell-checker","tamasfe.even-better-toml","twxs.cmake","ms-vscode-remote.remote-containers"],"targetPlatform":"linux-x64","commit":"031e7e0ff1e2eda9c1a0f5df67d44053b059c5d0","message":"Successfully reconciled extensions"}
> Installed vm-daemon.
> VM daemon installation complete
> [Exit] Success (code: 0)
> Refreshing GitHub access token...
> Refreshing GitHub access token...
> {"level":"info","time":"2025-07-09T21:12:14.299Z","pid":781,"hostname":"cursor","service":"vm-daemon","process_id":781,"process_arch":"x64","process_platform":"linux","message":"Successfully refreshed GitHub access token in git config."}
> {"level":"info","time":"2025-07-09T21:12:14.305Z","pid":781,"hostname":"cursor","service":"vm-daemon","process_id":781,"process_arch":"x64","process_platform":"linux","remoteName":"origin","message":"Successfully updated remote URL."}
> {"level":"info","time":"2025-07-09T21:12:14.308Z","pid":781,"hostname":"cursor","service":"vm-daemon","process_id":781,"process_arch":"x64","process_platform":"linux","remoteName":"origin","message":"Successfully updated remote URL."}
> Successfully refreshed GitHub access token
> [Exit] Success (code: 0)
> downloading uv 0.7.20 x86_64-unknown-linux-gnu
> downloading uv 0.7.20 x86_64-unknown-linux-gnu
> no checksums to verify
> installing to /home/ubuntu/.local/bin
>   uv
>   uvx
> everything's installed!
> 
> To add $HOME/.local/bin to your PATH, either restart your shell or run:
> 
>     source $HOME/.local/bin/env (sh, bash, zsh)
>     source $HOME/.local/bin/env.fish (fish)
> Welcome to Metta!
> 
> uv is not installed. Installing uv...
> downloading uv 0.7.20 x86_64-unknown-linux-gnu
> no checksums to verify
> installing to /home/ubuntu/.local/bin
>   uv
>   uvx
> everything's installed!
> ERROR: Failed to install uv. Please install it manually from https://github.com/astral-sh/uv
> [Exit] Failed (code: 1)
> 

Cursor background agents fail like this, I think this hotfix should fix it

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210757143367518)