### PR TITLE
Fix action disabling

### DIFF
--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -30,9 +30,9 @@ GameConfig CreateBenchmarkConfig(int num_agents) {
   std::vector<std::string> inventory_item_names = {"ore", "heart"};
 
   std::shared_ptr<ActionConfig> action_cfg =
-      std::make_shared<ActionConfig>(true, std::map<InventoryItem, int>(), std::map<InventoryItem, int>());
+      std::make_shared<ActionConfig>(std::map<InventoryItem, int>(), std::map<InventoryItem, int>());
   std::shared_ptr<AttackActionConfig> attack_cfg = std::make_shared<AttackActionConfig>(
-      true, std::map<InventoryItem, int>(), std::map<InventoryItem, int>(), std::map<InventoryItem, int>());
+      std::map<InventoryItem, int>(), std::map<InventoryItem, int>(), std::map<InventoryItem, int>());
 
   std::map<std::string, std::shared_ptr<ActionConfig>> actions_cfg;
 

--- a/mettagrid/src/metta/mettagrid/action_handler.hpp
+++ b/mettagrid/src/metta/mettagrid/action_handler.hpp
@@ -11,14 +11,12 @@
 #include "objects/constants.hpp"
 #include "types.hpp"
 struct ActionConfig {
-  bool enabled;
   std::map<InventoryItem, int> required_resources;
   std::map<InventoryItem, int> consumed_resources;
 
-  ActionConfig(bool enabled,
-               const std::map<InventoryItem, int>& required_resources,
+  ActionConfig(const std::map<InventoryItem, int>& required_resources,
                const std::map<InventoryItem, int>& consumed_resources)
-      : enabled(enabled), required_resources(required_resources), consumed_resources(consumed_resources) {}
+      : required_resources(required_resources), consumed_resources(consumed_resources) {}
 
   virtual ~ActionConfig() {}
 };

--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -14,11 +14,10 @@
 struct AttackActionConfig : public ActionConfig {
   std::map<InventoryItem, int> defense_resources;
 
-  AttackActionConfig(bool enabled,
-                     const std::map<InventoryItem, int>& required_resources,
+  AttackActionConfig(const std::map<InventoryItem, int>& required_resources,
                      const std::map<InventoryItem, int>& consumed_resources,
                      const std::map<InventoryItem, int>& defense_resources)
-      : ActionConfig(enabled, required_resources, consumed_resources), defense_resources(defense_resources) {}
+      : ActionConfig(required_resources, consumed_resources), defense_resources(defense_resources) {}
 };
 
 class Attack : public ActionHandler {

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -853,20 +853,17 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def_readwrite("color", &ConverterConfig::color);
 
   py::class_<ActionConfig, std::shared_ptr<ActionConfig>>(m, "ActionConfig")
-      .def(py::init<bool, const std::map<InventoryItem, int>&, const std::map<InventoryItem, int>&>(),
-           py::arg("enabled") = true,
+      .def(py::init<const std::map<InventoryItem, int>&, const std::map<InventoryItem, int>&>(),
            py::arg("required_resources") = std::map<InventoryItem, int>(),
            py::arg("consumed_resources") = std::map<InventoryItem, int>())
-      .def_readwrite("enabled", &ActionConfig::enabled)
       .def_readwrite("required_resources", &ActionConfig::required_resources)
       .def_readwrite("consumed_resources", &ActionConfig::consumed_resources);
 
   py::class_<AttackActionConfig, ActionConfig, std::shared_ptr<AttackActionConfig>>(m, "AttackActionConfig")
-      .def(py::init<bool,
-                    const std::map<InventoryItem, int>&,
+      .def(py::init<const std::map<InventoryItem, int>&,
                     const std::map<InventoryItem, int>&,
                     const std::map<InventoryItem, int>&>(),
-           py::arg("enabled") = true,
+
            py::arg("required_resources") = std::map<InventoryItem, int>(),
            py::arg("consumed_resources") = std::map<InventoryItem, int>(),
            py::arg("defense_resources") = std::map<InventoryItem, int>())

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -93,6 +93,8 @@ def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> GameConfig_c
     actions_config_cpp = {}
     # Add required and consumed resources to the attack action
     for action_name, action_config in game_config["actions"].items():
+        if not action_config["enabled"]:
+            continue
         action_config_cpp_params = {}
         action_config_cpp_params["consumed_resources"] = dict(
             (resource_ids[k], v) for k, v in action_config["consumed_resources"].items()

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -213,7 +213,7 @@ TEST_F(MettaGridCppTest, AttackAction) {
   EXPECT_EQ(attacker->orientation, Orientation::Up);
 
   // Create attack action handler
-  AttackActionConfig attack_cfg(true, {{TestItems::LASER, 1}}, {{TestItems::LASER, 1}}, {{TestItems::ARMOR, 3}});
+  AttackActionConfig attack_cfg({{TestItems::LASER, 1}}, {{TestItems::LASER, 1}}, {{TestItems::ARMOR, 3}});
   Attack attack(attack_cfg);
   attack.init(&grid);
 
@@ -274,7 +274,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   agent->update_inventory(TestItems::HEART, 1);
 
   // Create put_recipe_items action handler
-  ActionConfig put_cfg(true, {}, {});
+  ActionConfig put_cfg({}, {});
   PutRecipeItems put(put_cfg);
   put.init(&grid);
 
@@ -323,7 +323,7 @@ TEST_F(MettaGridCppTest, GetOutput) {
   agent->update_inventory(TestItems::ORE, 1);
 
   // Create get_output action handler
-  ActionConfig get_cfg(true, {}, {});
+  ActionConfig get_cfg({}, {});
   GetOutput get(get_cfg);
   get.init(&grid);
 

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -83,6 +83,12 @@ def test_truncation_at_max_steps():
             assert not np.any(terminals), f"Terminals should remain False at max_steps (step {step_num})"
 
 
+def test_action_config_disabled():
+    """Test that disabled actions are not available."""
+    c_env = create_minimal_mettagrid_c_env()
+    assert "attack" not in c_env.action_names()
+
+
 class TestObservations:
     """Test observation functionality and formats."""
 


### PR DESCRIPTION
Removes the `enabled` flag from `ActionConfig` class and moved action filtering to the Python configuration layer. We were previously failing to filter out disabled actions at all.

Added a new test to ensure that actions marked as `disabled` at the Python layer don't show up at the cpp layer.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210757723794610)