### PR TITLE
Add tag game mode and update curriculum structure in mettagrid

### DIFF
--- a/configs/env/mettagrid/arena/tag.yaml
+++ b/configs/env/mettagrid/arena/tag.yaml
@@ -37,6 +37,6 @@ game:
   objects:
     altar:
       input_resources:
-        heart: 1
+        blueprint: 1
       initial_resource_count: 1
       cooldown: 1

--- a/configs/env/mettagrid/arena/tag.yaml
+++ b/configs/env/mettagrid/arena/tag.yaml
@@ -27,7 +27,7 @@ game:
         objects:
           mine_red: 10
           generator_red: 5
-          altar: 10
+          altar: 2
           lasery: 2
           armory: 2
 

--- a/configs/env/mettagrid/arena/tag.yaml
+++ b/configs/env/mettagrid/arena/tag.yaml
@@ -1,0 +1,42 @@
+# Altars take hearts as input, so the only way to get more hearts is to freeze
+# other agents.
+
+defaults:
+  - /env/mettagrid/mettagrid@
+  - /env/mettagrid/game/objects@game.objects:
+      - basic
+      - mines
+      - generators
+      - combat
+  - _self_
+
+game:
+  num_agents: 24
+  map_builder:
+    _target_: metta.map.mapgen.MapGen
+
+    width: 25
+    height: 25
+    instances: 4
+    instance_border_width: 0
+
+    root:
+      type: metta.map.scenes.random.Random
+      params:
+        agents: 6
+        objects:
+          mine_red: 10
+          generator_red: 5
+          altar: 10
+          lasery: 2
+          armory: 2
+
+          block: 20
+          wall: 20
+
+  objects:
+    altar:
+      input_resources:
+        heart: 1
+      initial_resource_count: 1
+      cooldown: 1

--- a/configs/env/mettagrid/arena/tag_easy.yaml
+++ b/configs/env/mettagrid/arena/tag_easy.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - tag
+  - /env/mettagrid/game/objects/combat_easy@game.objects:
+  - _self_

--- a/configs/env/mettagrid/arena/tag_easy_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_easy_shaped.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - tag
+  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
+  - _self_

--- a/configs/env/mettagrid/arena/tag_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_shaped.yaml
@@ -1,0 +1,8 @@
+# Simple map with mines / generators / altar
+# But with converters that are easier to use.
+# And shaped rewards.
+
+defaults:
+  - tag
+  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
+  - _self_

--- a/configs/env/mettagrid/arena/tag_shaped.yaml
+++ b/configs/env/mettagrid/arena/tag_shaped.yaml
@@ -1,8 +1,0 @@
-# Simple map with mines / generators / altar
-# But with converters that are easier to use.
-# And shaped rewards.
-
-defaults:
-  - tag
-  - /env/mettagrid/game/agent/rewards/shaped@game.agent.rewards
-  - _self_

--- a/configs/env/mettagrid/curriculum/all.yaml
+++ b/configs/env/mettagrid/curriculum/all.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
-curricula_cfgs:
+tasks:
   /env/mettagrid/curriculum/arena: 5
   /env/mettagrid/curriculum/navigation/low_reward: 3
   /env/mettagrid/curriculum/object_use: 2

--- a/configs/env/mettagrid/curriculum/arena.yaml
+++ b/configs/env/mettagrid/curriculum/arena.yaml
@@ -12,3 +12,7 @@ tasks:
   /env/mettagrid/arena/advanced: 1
   /env/mettagrid/arena/advanced_easy: 1
   /env/mettagrid/arena/advanced_easy_shaped: 1
+
+  /env/mettagrid/arena/tag: 1
+  /env/mettagrid/arena/tag_easy: 1
+  /env/mettagrid/arena/tag_easy_shaped: 1

--- a/configs/env/mettagrid/curriculum/arena/learning_progress.yaml
+++ b/configs/env/mettagrid/curriculum/arena/learning_progress.yaml
@@ -1,0 +1,6 @@
+# Inherit from base progressive configuration
+defaults:
+  - random
+  - _self_
+
+_target_: metta.mettagrid.curriculum.learning_progress.LearningProgressCurriculum

--- a/configs/env/mettagrid/curriculum/arena/random.yaml
+++ b/configs/env/mettagrid/curriculum/arena/random.yaml
@@ -1,4 +1,4 @@
-_target_: metta.mettagrid.curriculum.learning_progress.LearningProgressCurriculum
+_target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 tasks:
   /env/mettagrid/arena/basic: 1

--- a/configs/env/mettagrid/curriculum/navigation/progressive.yaml
+++ b/configs/env/mettagrid/curriculum/navigation/progressive.yaml
@@ -14,7 +14,6 @@ tasks:
 
 # Navigation-specific env_overrides (extends base env_overrides)
 env_overrides:
-  desync_episodes: true
   game:
     num_agents: 4
 

--- a/configs/env/mettagrid/curriculum/navsequence/nav_backchain.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_backchain.yaml
@@ -1,5 +1,5 @@
 _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
-curricula_cfgs:
+tasks:
   /env/mettagrid/curriculum/navigation/low_reward: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1

--- a/configs/env/mettagrid/curriculum/navsequence/nav_backchain_mem.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_backchain_mem.yaml
@@ -2,7 +2,7 @@ _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 #train this pretrained on our best navigation policy
 #dd_navigation_curriculum:v54
-curricula_cfgs:
+tasks:
   /env/mettagrid/curriculum/navigation/low_reward: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1
   /env/mettagrid/curriculum/navsequence/mem_medium: 1

--- a/configs/env/mettagrid/curriculum/navsequence/nav_mem.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_mem.yaml
@@ -2,7 +2,7 @@ _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 #use this environment pretrained on a policy that is the best at navigation sequence already
 #gd_backchain_mem_pretained:v18
-curricula_cfgs:
+tasks:
   /env/mettagrid/curriculum/navigation/low_reward: 5
   /env/mettagrid/curriculum/navsequence/mem_medium: 5
   # /env/mettagrid/curriculum/navsequence/mem_hard: 2

--- a/configs/env/mettagrid/curriculum/navsequence/nav_navsequence_backchain.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_navsequence_backchain.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
-curricula_cfgs:
+tasks:
   /env/mettagrid/curriculum/navigation/low_reward: 1
   /env/mettagrid/curriculum/navsequence/navsequence_all: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1

--- a/configs/env/mettagrid/curriculum/progressive.yaml
+++ b/configs/env/mettagrid/curriculum/progressive.yaml
@@ -7,13 +7,12 @@ _target_: metta.mettagrid.curriculum.progressive.ProgressiveMultiTaskCurriculum
 performance_threshold: 0.8
 smoothing: 0.1
 progression_rate: 0.001
-progression_mode: "perf"  # 'time' or 'perf'
+progression_mode: "perf" # 'time' or 'perf'
 blending_smoothness: 0.5
-blending_mode: "logistic"  # 'logistic' or 'linear'
+blending_mode: "logistic" # 'logistic' or 'linear'
 
 # Placeholder tasks - should be overridden by specific configs
 tasks: ???
 
 # Default env_overrides - can be overridden by specific configs
-env_overrides:
-  desync_episodes: true
+env_overrides: {}

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -11,3 +11,5 @@ simulations:
     env: /env/mettagrid/arena/combat
   arena/advanced:
     env: /env/mettagrid/arena/advanced
+  arena/tag:
+    env: /env/mettagrid/arena/tag

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -2,7 +2,7 @@ defaults:
   - sim_suite
   - _self_
 
-name: simple
+name: arena
 
 simulations:
   arena/basic:

--- a/mettagrid/src/metta/mettagrid/curriculum/random.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/random.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 class RandomCurriculum(MultiTaskCurriculum):
     """Curriculum that samples from multiple environment types with fixed weights."""
 
-    def __init__(self, curricula_cfgs: Dict[str, float], env_overrides: DictConfig | None = None):
+    def __init__(self, tasks: Dict[str, float], env_overrides: DictConfig | None = None):
         self.env_overrides = env_overrides or OmegaConf.create({})
-        curricula = {t: self._curriculum_from_id(t) for t in curricula_cfgs.keys()}
-        self._task_weights = curricula_cfgs
+        curricula = {t: self._curriculum_from_id(t) for t in tasks.keys()}
+        self._task_weights = tasks
         super().__init__(curricula)
 
     def get_task(self) -> Task:

--- a/recipes/arena.sh
+++ b/recipes/arena.sh
@@ -1,0 +1,7 @@
+
+./devops/skypilot/launch.py train \
+--gpus=4 \
+--nodes=8 \
+run=$USER.arena.baseline.8x4 \
+trainer.curriculum=/env/mettagrid/arena/basic_easy_shaped \
+trainer.simulation.evaluate_interval=50

--- a/recipes/arena.sh
+++ b/recipes/arena.sh
@@ -6,4 +6,4 @@
 run=$USER.recipes.arena.8x4 \
 trainer.curriculum=/env/mettagrid/arena/basic_easy_shaped \
 trainer.simulation.evaluate_interval=50 \
-
+--heartbeat-timeout-seconds=0

--- a/recipes/arena.sh
+++ b/recipes/arena.sh
@@ -2,6 +2,8 @@
 ./devops/skypilot/launch.py train \
 --gpus=4 \
 --nodes=8 \
-run=$USER.arena.baseline.8x4 \
+--no-spot \
+run=$USER.recipes.arena.8x4 \
 trainer.curriculum=/env/mettagrid/arena/basic_easy_shaped \
-trainer.simulation.evaluate_interval=50
+trainer.simulation.evaluate_interval=50 \
+

--- a/recipes/nav_memory_sequence.sh
+++ b/recipes/nav_memory_sequence.sh
@@ -1,3 +1,3 @@
 
 #NAV-MEMORY-SEQUENCE
-./devops/skypilot/launch.py train run=$USER.nav_memory_sequence.baseline trainer.curriculum=env/mettagrid/curriculum/nav_memory_sequence --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.nav_memory_sequence trainer.curriculum=env/mettagrid/curriculum/nav_memory_sequence --gpus=4 --skip-git-check \

--- a/recipes/navigation.sh
+++ b/recipes/navigation.sh
@@ -1,2 +1,2 @@
 #NAVIGATION
-./devops/skypilot/launch.py train run=$USER.navigation.baseline  trainer.curriculum=env/mettagrid/curriculum/navigation --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.navigation  trainer.curriculum=env/mettagrid/curriculum/navigation --gpus=4 --skip-git-check \

--- a/recipes/object_use.sh
+++ b/recipes/object_use.sh
@@ -1,2 +1,1 @@
-
-./devops/skypilot/launch.py train run=$USER.object_use.baseline  trainer.curriculum=env/mettagrid/curriculum/object_use --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.object_use  trainer.curriculum=env/mettagrid/curriculum/object_use --gpus=4 --skip-git-check \

--- a/recipes/sequence.sh
+++ b/recipes/sequence.sh
@@ -1,1 +1,1 @@
-./devops/skypilot/launch.py train run=$USER.sequence.baseline  trainer.curriculum=env/mettagrid/curriculum/sequence --gpus=4 --skip-git-check \
+./devops/skypilot/launch.py train run=$USER.recipes.sequence  trainer.curriculum=env/mettagrid/curriculum/sequence --gpus=4 --skip-git-check \

--- a/tests/rl/test_trainer_config.py
+++ b/tests/rl/test_trainer_config.py
@@ -168,7 +168,6 @@ class TestTypedConfigs:
         test_config_dict = {
             **valid_trainer_config,
             "env_overrides": {
-                "desync_episodes": True,
                 "max_steps": 1000,
                 "num_agents": 4,
             },
@@ -187,7 +186,6 @@ class TestTypedConfigs:
         # Test that env_overrides can be converted to DictConfig
         env_overrides_dict = DictConfig(validated_config.env_overrides)
         assert isinstance(env_overrides_dict, DictConfig)
-        assert env_overrides_dict.desync_episodes is True
         assert env_overrides_dict.max_steps == 1000
         assert env_overrides_dict.num_agents == 4
 
@@ -195,7 +193,6 @@ class TestTypedConfigs:
         config_dict = validated_config.model_dump(by_alias=True)
         assert config_dict["_target_"] == "metta.rl.trainer.MettaTrainer"
         assert config_dict["batch_size"] == 1024
-        assert config_dict["env_overrides"]["desync_episodes"] is True
         assert config_dict["env_overrides"]["max_steps"] == 1000
 
     def test_runtime_path_overrides(self):

--- a/tools/train.py
+++ b/tools/train.py
@@ -67,7 +67,6 @@ def main(cfg: DictConfig) -> int:
     record_heartbeat()
 
     logger = get_metta_logger()
-    logger.info(f"Train job config: {OmegaConf.to_yaml(cfg, resolve=True)}")
 
     logger.info(
         f"Training {cfg.run} on "
@@ -83,6 +82,7 @@ def main(cfg: DictConfig) -> int:
 
     logger.info(f"Training {cfg.run} on {cfg.device}")
     if os.environ.get("RANK", "0") == "0":
+        logger.info(f"Train job config: {OmegaConf.to_yaml(cfg, resolve=True)}")
         with WandbContext(cfg.wandb, cfg) as wandb_run:
             train(cfg, wandb_run, logger)
     else:


### PR DESCRIPTION
# Add Tag Arena Environment and Update Curriculum Structure

This PR introduces a new "Tag" arena environment where agents can freeze each other and collect hearts. The environment comes in three variants: standard, easy, and easy with shaped rewards.

## Curriculum Updates

- Renamed `curricula_cfgs` to `tasks` in RandomCurriculum for consistency
- Added Tag environments to the arena curriculum
- Created a new learning progress curriculum for arena environments
- Removed `desync_episodes` from progressive curriculum configurations

## Recipe Improvements

- Added a new arena.sh recipe for training with the arena environments
- Updated naming convention in recipe scripts to use `$USER.recipes.X` format
- Fixed configuration paths in existing recipe scripts

## Simulation Configuration

- Added Tag environment to the arena simulation suite
- Renamed simulation from "simple" to "arena" for clarity

## Logging Improvements

- Modified train.py to only log full config on rank 0 to reduce log clutter