### PR TITLE
Clean up navigation training

### DIFF
--- a/configs/env/mettagrid/navigation/training/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation/training/cylinder_world.yaml
@@ -3,17 +3,7 @@ defaults:
   - _self_
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/cylinder-world_large,varied_terrain/cylinder-world_medium,varied_terrain/cylinder-world_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1
+

--- a/configs/env/mettagrid/navigation/training/large.yaml
+++ b/configs/env/mettagrid/navigation/training/large.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_large,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/medium.yaml
+++ b/configs/env/mettagrid/navigation/training/medium.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_medium,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/small.yaml
+++ b/configs/env/mettagrid/navigation/training/small.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_small,varied_terrain/maze_small,varied_terrain/sparse_small,varied_terrain/dense_small,varied_terrain/cylinder-world_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
@@ -3,17 +3,6 @@ defaults:
   - _self_
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: terrain_maps_nohearts
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_large,varied_terrain/balanced_medium,varied_terrain/balanced_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/dense_large,varied_terrain/dense_medium,varied_terrain/dense_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/maze_large,varied_terrain/maze_medium,varied_terrain/maze_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
@@ -5,20 +5,9 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
     num_rooms: ${..num_agents}
     border_width: 6
     room:
       dir: ${choose:varied_terrain/sparse_large,varied_terrain/sparse_medium,varied_terrain/sparse_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1


### PR DESCRIPTION
Simplifies navigation training configs by removing redundant agent and altar configurations. In particular, this removes settings that already exist in the defaults that the training configs are using.

I implicitly tested these as part of training a new model on the nav curriculum. I also ran in play mode and witnessed that the altars didn't obviously create any new hearts.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210760372028421)