### PR TITLE
feat: generate test run description

### DIFF
--- a/app_backend/config.py
+++ b/app_backend/config.py
@@ -2,6 +2,25 @@ import os
 
 stats_db_uri = os.getenv("STATS_DB_URI", "postgres://postgres:password@127.0.0.1/postgres")
 debug_user_email = os.getenv("DEBUG_USER_EMAIL")
+debug = os.getenv("DEBUG", "").lower() in ["true", "1", "yes"]
 
 host = os.getenv("HOST", "127.0.0.1")
 port = int(os.getenv("PORT", "8000"))
+
+# LLM API configuration
+openai_api_key = os.getenv("OPENAI_API_KEY")
+anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+
+# Optional API URL overrides
+openai_api_base = os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1/chat/completions")
+openrouter_api_base = os.getenv("OPENROUTER_API_BASE", "https://openrouter.ai/api/v1/chat/completions")
+anthropic_api_url = os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages")
+
+# Optional model name overrides
+openai_model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+anthropic_model = os.getenv("ANTHROPIC_MODEL", "claude-3-5-haiku-20241022")
+openrouter_model = os.getenv("OPENROUTER_MODEL", "openrouter/auto")
+
+# Git client configuration
+git_client_mode = os.getenv("GIT_CLIENT_MODE", "auto")

--- a/app_backend/description_generator.py
+++ b/app_backend/description_generator.py
@@ -1,0 +1,654 @@
+import logging
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+import httpx
+
+from app_backend.git_client import GitClient, GitCommit, GitError
+from app_backend.github_client import GitHubClient
+from app_backend.llm_client import LLMClient
+
+logger = logging.getLogger("description_generator")
+
+
+class TrainingRunInput(NamedTuple):
+    """Input data for training run description generation."""
+
+    commits: List[GitCommit]
+    diff_stats: str
+    diff_content: str
+
+
+class GitDataProvider:
+    """Wrapper that provides git data with configurable fallback between local and GitHub clients."""
+
+    def __init__(self, http_client: httpx.Client, mode: str = "auto"):
+        """
+        Initialize the git data provider.
+
+        Args:
+            http_client: HTTP client for GitHub operations
+            mode: Operation mode - "auto", "local_only", "github_only"
+        """
+        if mode not in ("auto", "local_only", "github_only"):
+            raise ValueError(f"Invalid git client mode: {mode}")
+
+        # Assign clients based on mode
+        if mode == "github_only":
+            self.git_client = None
+            self.github_client = GitHubClient(http_client)
+        elif mode == "local_only":
+            self.git_client = GitClient()
+            self.github_client = None
+        else:  # mode == "auto"
+            self.git_client = GitClient()
+            self.github_client = GitHubClient(http_client)
+
+    def get_commit_data(self, commit_hash: str) -> Tuple[List[GitCommit], str, str]:
+        """
+        Get commit data (commits, diff_stats, diff_content) with fallback.
+
+        Args:
+            commit_hash: The git commit hash
+
+        Returns:
+            Tuple of (commits, diff_stats, diff_content)
+
+        Raises:
+            ValueError: If data cannot be retrieved from any configured source
+        """
+        # Try git client first if available
+        if self.git_client is not None:
+            try:
+                commits = self.git_client.get_commit_range(commit_hash)
+                diff_stats = self.git_client.get_range_diff_stats(commit_hash)
+                diff_content = self.git_client.get_range_diff(commit_hash)
+                return commits, diff_stats, diff_content
+            except (GitError, ValueError):
+                pass
+
+        # Try GitHub client if available
+        if self.github_client is not None:
+            try:
+                _, commits, diff_stats, diff_content = self.github_client.get_all_commit_data(commit_hash)
+                return commits, diff_stats, diff_content
+            except Exception:
+                pass
+
+        raise ValueError(f"Commit {commit_hash} not found with any configured git client")
+
+
+class TrainingRunDescriptionGenerator:
+    """
+    Generator for training run descriptions using LLM APIs.
+    Follows the existing client pattern with dependency injection.
+    """
+
+    def __init__(self, git_data_provider: GitDataProvider, llm_client: Optional[LLMClient] = None):
+        """
+        Initialize the training run description generator.
+
+        Args:
+            git_data_provider: Provider for git data with configurable fallback
+            llm_client: Optional LLM client for generating descriptions
+        """
+        self.git_data_provider = git_data_provider
+        self.llm_client = llm_client
+
+        # Check if LLM client is available
+        if llm_client is None or not llm_client.is_available():
+            logger.warning("No LLM client available - will fall back to git logs only")
+
+    def generate_description(self, commit_hash: str, has_uncommitted_changes: bool = False) -> str:
+        """
+        Generate a training run description based on git commit history.
+
+        Args:
+            commit_hash: The git commit hash for this training run
+            has_uncommitted_changes: Whether the commit had uncommitted changes
+
+        Returns:
+            Generated description text
+
+        Raises:
+            Various exceptions propagated from git/github operations
+        """
+        commits, diff_stats, diff_content = self.git_data_provider.get_commit_data(commit_hash)
+
+        if not commits:
+            raise ValueError(f"No commits found for hash {commit_hash}")
+
+        # Build input data
+        input_data = TrainingRunInput(commits=commits, diff_stats=diff_stats, diff_content=diff_content)
+
+        # Check if LLM is available
+        if self.llm_client and self.llm_client.is_available():
+            # Use LLM to generate description
+            messages = self._build_llm_messages(input_data)
+            logger.debug(f"Using LLM to generate description for commit {commit_hash[:8]}")
+            logger.debug(f"LLM conversation with {len(messages)} messages")
+
+            try:
+                result = self.llm_client.generate_text_with_messages(messages)
+                logger.debug(f"LLM generation successful, result length: {len(result)}")
+                return self._add_uncommitted_changes_disclaimer(result, commit_hash, has_uncommitted_changes)
+            except Exception as e:
+                logger.warning(f"LLM generation failed, falling back to git logs: {e}")
+                # Fall through to git logs fallback
+
+        # Fallback to formatted git logs
+        logger.debug(f"Using git logs fallback for commit {commit_hash[:8]} (LLM not available)")
+        result = self._build_git_summary(commits)
+
+        return self._add_uncommitted_changes_disclaimer(result, commit_hash, has_uncommitted_changes)
+
+    def _format_user_message(self, input_data: TrainingRunInput) -> str:
+        """
+        Format a user message from training run input data.
+
+        Args:
+            input_data: TrainingRunInput containing commits, diff_stats, and diff_content
+
+        Returns:
+            Formatted user message string
+        """
+        # Build commit history section without hashes
+        commit_details = []
+        for commit in input_data.commits:
+            commit_details.append(f"- {commit.message} (by {commit.author} on {commit.date})")
+
+        commit_history = "\n".join(commit_details)
+
+        # Limit actual diff to reasonable size (50KB max)
+        MAX_DIFF_SIZE = 50000
+        diff_content = input_data.diff_content
+        if len(diff_content) > MAX_DIFF_SIZE:
+            # Keep first part and add truncation notice
+            diff_content = diff_content[:MAX_DIFF_SIZE] + "\n... (diff truncated for brevity)"
+            logger.debug(f"Actual diff truncated to {MAX_DIFF_SIZE} chars")
+
+        return (
+            "COMMIT HISTORY:\n"
+            f"{commit_history}\n"
+            "\n"
+            "FILE STATISTICS:\n"
+            f"{input_data.diff_stats}\n"
+            "\n"
+            "CODE CHANGES:\n"
+            f"{diff_content}"
+        )
+
+    def _build_llm_messages(self, input_data: TrainingRunInput) -> List[Dict[str, str]]:
+        """
+        Build the conversation messages for LLM based on training run input data.
+
+        Args:
+            input_data: TrainingRunInput containing commits, diff_stats, and diff_content
+
+        Returns:
+            List of messages for conversation
+        """
+        # Get few-shot examples
+        examples = TRAINING_EXAMPLES
+
+        # Build messages
+        messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+
+        # Add examples
+        for example_input, expected_response in examples:
+            user_message = self._format_user_message(example_input)
+            messages.append({"role": "user", "content": user_message})
+            messages.append({"role": "assistant", "content": expected_response})
+
+        # Add current request
+        current_message = self._format_user_message(input_data)
+        messages.append({"role": "user", "content": current_message})
+
+        return messages
+
+    def _build_git_summary(self, commits: List[GitCommit]) -> str:
+        """
+        Build a git-based summary when LLM is not available.
+
+        Args:
+            commits: List of commits in the branch
+
+        Returns:
+            Formatted git summary string
+
+        Raises:
+            ValueError: If no commits are provided
+        """
+        if not commits:
+            raise ValueError("No commits found in this training run.")
+
+        # Build commit history section
+        commit_details = []
+        for commit in commits:
+            commit_details.append(f"- {commit.hash[:8]}: {commit.message} (by {commit.author} on {commit.date})")
+
+        commit_count = len(commits)
+        commit_summary = f"Training run based on {commit_count} commit{'s' if commit_count != 1 else ''}:\n\n"
+        commit_summary += "\n".join(commit_details)
+
+        return commit_summary
+
+    def _add_uncommitted_changes_disclaimer(
+        self, description: str, commit_hash: str, has_uncommitted_changes: bool
+    ) -> str:
+        """
+        Add disclaimer about uncommitted changes if present.
+
+        Args:
+            description: The generated description
+            commit_hash: The commit hash
+            has_uncommitted_changes: Whether there were uncommitted changes
+
+        Returns:
+            Description with disclaimer prepended if needed
+        """
+        if has_uncommitted_changes:
+            disclaimer = f"WARNING: Training run {commit_hash[:8]} included uncommitted changes\n\n"
+            return disclaimer + description
+        return description
+
+
+# System prompt with context and instructions
+SYSTEM_PROMPT = (
+    "You are tasked with creating concise, informative descriptions for machine learning training runs.\n\n"
+    "CONTEXT:\n"
+    "This is a reinforcement learning project called 'Metta AI' that focuses on the emergence of cooperation "
+    "and alignment in multi-agent AI systems. It creates a model organism for complex multi-agent gridworld "
+    "environments to study the impact of social dynamics (like kinship and mate selection) on learning and "
+    "cooperative behaviors.\n\n"
+    "The codebase consists of:\n"
+    "- Core Python implementation for agents, maps, RL algorithms, simulation\n"
+    "- C++/Python grid environment implementation\n"
+    "- Visualization and replay tools\n\n"
+    "TASK:\n"
+    "Produce exactly one paragraph (≤ 80 words) summarising the entire run. Never mention commit ids, hashes, "
+    "file names, or headings. Focus on the scientific/experimental aspects that a researcher would care about "
+    "when reviewing results - highlight the main features, experiments, or improvements that were being tested "
+    "using technical language appropriate for ML researchers."
+)
+
+# Training examples for few-shot learning
+TRAINING_EXAMPLES: List[tuple[TrainingRunInput, str]] = [
+    # Example 1: Enhanced Progressive Curriculum (commit 748bff35)
+    (
+        TrainingRunInput(
+            commits=[
+                GitCommit(
+                    hash="748bff3503d234414f9ed507762d641727529277",
+                    message="Enhanced Progressive Curriculum (#1178)",
+                    author="mstormbull",
+                    date="2025-06-27",
+                )
+            ],
+            diff_stats=""" .../learning_progress.yaml}                        |   0
+ .../curriculum/navigation/progressive.yaml         |  24 ++++-
+ configs/env/mettagrid/curriculum/progressive.yaml  |  19 ++++
+ configs/user/bullm.yaml                            |  37 +++++++
+ configs/user/bullm_lp.yaml                         |  36 -------
+ mettagrid/src/metta/mettagrid/curriculum/core.py   |   4 +
+ .../src/metta/mettagrid/curriculum/progressive.py  | 117 +++++++++++++++------
+ mettagrid/src/metta/mettagrid/mettagrid_env.py     |   5 +
+ 8 files changed, 172 insertions(+), 70 deletions(-)""",
+            diff_content="""diff --git a/configs/env/mettagrid/curriculum/navigation/progressive.yaml \\
+b/configs/env/mettagrid/curriculum/navigation/progressive.yaml
+index 720422717..f15291846 100644
+--- a/configs/env/mettagrid/curriculum/navigation/progressive.yaml
++++ b/configs/env/mettagrid/curriculum/navigation/progressive.yaml
+@@ -1,7 +1,23 @@
+-_target_: metta.mettagrid.curriculum.progressive.ProgressiveMultiTaskCurriculum
++# Inherit from base progressive configuration
++defaults:
++  - /env/mettagrid/curriculum/progressive@
++  - _self_
+
++# Navigation-specific tasks
+ tasks:
+-  /env/mettagrid/navigation/training/small: 1
+-  /env/mettagrid/navigation/training/medium: 1
+-  /env/mettagrid/navigation/training/large: 1
+   /env/mettagrid/navigation/training/terrain_from_numpy: 1
++  /env/mettagrid/navigation/training/cylinder_world: 1
++  /env/mettagrid/navigation/training/varied_terrain_sparse: 1
++  /env/mettagrid/navigation/training/varied_terrain_balanced: 1
++  /env/mettagrid/navigation/training/varied_terrain_maze: 1
++  /env/mettagrid/navigation/training/varied_terrain_dense: 1
++
++# Navigation-specific env_overrides (extends base env_overrides)
++env_overrides:
++  desync_episodes: true
++  game:
++    num_agents: 4
++
++# Navigation-specific progressive parameters (overrides base defaults)
++performance_threshold: 0.95
++progression_rate: 0.001
+diff --git a/mettagrid/src/metta/mettagrid/curriculum/progressive.py \\
+b/mettagrid/src/metta/mettagrid/curriculum/progressive.py
+index b188e60b0..4ce2e74e2 100644
+--- a/mettagrid/src/metta/mettagrid/curriculum/progressive.py
++++ b/mettagrid/src/metta/mettagrid/curriculum/progressive.py
+@@ -34,56 +35,112 @@ class ProgressiveCurriculum(SamplingCurriculum):
+
+
+ class ProgressiveMultiTaskCurriculum(RandomCurriculum):
+-    \"\"\"Curriculum that starts with higher probabilities for earlier tasks
+-    and gradually shifts to favor later tasks over time.\"\"\"
++    \"\"\"Curriculum that blends multiple tasks using gating mechanisms and advances progression based on
++    smoothed performance or time.\"\"\"
+
+     def __init__(
+         self,
+         tasks: Dict[str, float],
+-        env_overrides: DictConfig,
+-        progression_rate: float = 0.00001,
+-        initial_skew: float = 5.0,
++        env_overrides: Optional[DictConfig] = None,
++        performance_threshold: float = 0.8,
++        smoothing: float = 0.1,
++        progression_rate: float = 0.01,
++        progression_mode: str = "perf",
++        blending_smoothness: float = 0.5,
++        blending_mode: str = "logistic",
+     ):
++        if env_overrides is None:
++            env_overrides = DictConfig({})
+         super().__init__(tasks, env_overrides)
+-        self._task_order = list(tasks.keys())  # Preserve order from dict
+-        self._progression_rate = progression_rate  # How fast to shift probabilities
+-        self._initial_skew = initial_skew  # How much to favor early tasks initially
++        if progression_mode not in ["time", "perf"]:
++            raise ValueError("progression_mode must be either 'time' or 'perf'")
++        if blending_mode not in ["logistic", "linear"]:
++            raise ValueError("blending_mode must be either 'logistic' or 'linear'")
++        self._task_order = list(tasks.keys())
++        self._performance_threshold = performance_threshold
++        self._smoothing = smoothing
++        self._progression_rate = progression_rate
++        self._progression_mode = progression_mode
++        self._blending_smoothness = blending_smoothness
++        self._blending_mode = blending_mode
++        self._progress = 0.0  # initialization of the progress value parameterizing the trajectory
++        self._smoothed_performance = 0.0
+         self._step_count = 0
+-
+-        # Initialize weights heavily skewed toward beginning
++        self._last_score = None
+         self._update_progressive_weights()""",
+        ),
+        (
+            "Adds a performance-driven progressive curriculum: task weights are blended via logistic or linear gates,"
+            "progression speed is tunable, and smoothed performance must reach 0.95 before advancing. Extends the"
+            "navigation suite with terrain_from_numpy, cylinder_world, and varied_terrain tasks and enables"
+            "desync_episodes overrides."
+        ),
+    ),
+    # Example 2: MettaConf Multi-commit (commits 34313ae4..f4c91a71)
+    (
+        TrainingRunInput(
+            commits=[
+                GitCommit(
+                    hash="34313ae4e0433a09b5eb63aa7757ea669f9c560c",
+                    message="mettaconf - experimental implementation",
+                    author="Vyacheslav Matyukhin",
+                    date="2025-04-24",
+                ),
+                GitCommit(
+                    hash="c4139ec3bb9377a82b808c650900643bc68ec557",
+                    message="bugfix",
+                    author="Vyacheslav Matyukhin",
+                    date="2025-04-24",
+                ),
+                GitCommit(
+                    hash="f4c91a71984a421d2ddac00a70247a40c2c72622",
+                    message="patch nested configs",
+                    author="Vyacheslav Matyukhin",
+                    date="2025-04-24",
+                ),
+            ],
+            diff_stats=""" metta/sweep/README.md                      | 149 ++++++++++
+ metta/sweep/__init__.py                    |   7 +
+ metta/sweep/protein.py                     | 419 +++++++++++++++++++++++++++++
+ metta/sweep/protein_metta.py               |  36 +++
+ metta/sweep/protein_wandb.py               | 272 +++++++++++++++++++
+ metta/util/__init__.py                     |   1 +
+ metta/util/numpy/__init__.py               |   5 +
+ metta/util/numpy/clean_numpy_types.py      |  14 +
+ pyproject.toml                             |   2 +
+ tests/sweep/__init__.py                    |   1 +
+ tests/sweep/test_protein_metta.py          | 197 ++++++++++++++
+ tests/sweep/test_protein_wandb.py          | 273 +++++++++++++++++++
+ tests/util/__init__.py                     |   1 +
+ tests/util/numpy/__init__.py               |   1 +
+ tests/util/numpy/test_clean_numpy_types.py | 153 +++++++++++
+ uv.lock                                    |   4 +
+ 16 files changed, 1535 insertions(+)""",
+            diff_content="""diff --git a/metta/sweep/protein.py b/metta/sweep/protein.py
+new file mode 100644
+index 000000000..8c9e4bb27
+--- /dev/null
++++ b/metta/sweep/protein.py
+@@ -0,0 +1,419 @@
++\"\"\"
++Protein: A Bayesian hyperparameter optimization system using Gaussian Processes.
++
++This module implements a sophisticated hyperparameter optimization framework with:
++- Gaussian Process models for sample-efficient search
++- Multiple parameter distribution support (log_normal, uniform, logit_normal, uniform_pow2)
++- Acquisition function optimization using Expected Improvement
++- Multi-objective optimization capabilities
++- Cost-aware optimization with budget constraints
++\"\"\"
++
++import logging
++import math
++from typing import Any, Dict, List, Optional, Tuple, Union
++
++import numpy as np
++import torch
++import torch.nn as nn
++from botorch.acquisition import ExpectedImprovement
++from botorch.models import SingleTaskGP
++from botorch.optim import optimize_acqf
++from gpytorch.kernels import ScaleKernel, RBFKernel
++from gpytorch.mlls import ExactMarginalLogLikelihood
++
++logger = logging.getLogger(__name__)
++
++
++class ParameterDistribution:
++    \"\"\"Base class for parameter distributions in hyperparameter space.\"\"\"
++
++    def __init__(self, min_val: float, max_val: float, scale: Union[str, float] = "auto"):
++        self.min_val = min_val
++        self.max_val = max_val
++        self.scale = scale
++
++    def sample(self) -> float:
++        \"\"\"Sample a value from this distribution.\"\"\"
++        raise NotImplementedError
++
++    def transform_to_unit(self, value: float) -> float:
++        \"\"\"Transform value from parameter space to [0,1] unit space.\"\"\"
++        raise NotImplementedError
++
++    def transform_from_unit(self, unit_value: float) -> float:
++        \"\"\"Transform value from [0,1] unit space to parameter space.\"\"\"
++        raise NotImplementedError
++
++
++class LogNormalDistribution(ParameterDistribution):
++    \"\"\"Log-normal distribution for parameters like learning rates.\"\"\"
++
++    def sample(self) -> float:
++        log_min = math.log(self.min_val)
++        log_max = math.log(self.max_val)
++        log_val = np.random.uniform(log_min, log_max)
++        return math.exp(log_val)
++
++    def transform_to_unit(self, value: float) -> float:
++        log_val = math.log(max(value, self.min_val))
++        log_min = math.log(self.min_val)
++        log_max = math.log(self.max_val)
++        return (log_val - log_min) / (log_max - log_min)
++
++    def transform_from_unit(self, unit_value: float) -> float:
++        log_min = math.log(self.min_val)
++        log_max = math.log(self.max_val)
++        log_val = log_min + unit_value * (log_max - log_min)
++        return math.exp(log_val)""",
+        ),
+        (
+            "Replaces CARBS with 'Protein', a Bayesian HPO engine using single-task Gaussian Processes with RBF"
+            "kernels, Expected Improvement acquisition, and multi-objective, cost-aware search. Supports flexible"
+            "parameter distributions (log_normal, uniform_pow2, etc.) and streams results to WandB."
+        ),
+    ),
+    # Example 3: Architecture change (commit ca4b293c)
+    (
+        TrainingRunInput(
+            commits=[
+                GitCommit(
+                    hash="ca4b293c026521af9d0123eaaffa303bc0d34a5a",
+                    message="Vicious deletion of the post-lstm relu (#1221)",
+                    author="Alex Vardakostas",
+                    date="2025-06-27",
+                )
+            ],
+            diff_stats=""" configs/agent/fast.yaml              | 9 ++-------
+ configs/agent/latent_attn_med.yaml   | 9 ++-------
+ configs/agent/latent_attn_small.yaml | 9 ++-------
+ configs/agent/latent_attn_tiny.yaml  | 9 ++-------
+ configs/user/alex.yaml               | 4 ++--
+ 5 files changed, 10 insertions(+), 30 deletions(-)""",
+            diff_content="""diff --git a/configs/agent/fast.yaml b/configs/agent/fast.yaml
+index 4354c6fd0..6fee692f5 100644
+--- a/configs/agent/fast.yaml
++++ b/configs/agent/fast.yaml
+@@ -72,15 +72,10 @@ components:
+     nn_params:
+       num_layers: 2
+
+-  core_relu:
+-    _target_: metta.agent.lib.nn_layer_library.ReLU
+-    sources:
+-      - name: _core_
+-
+   critic_1:
+     _target_: metta.agent.lib.nn_layer_library.Linear
+     sources:
+-      - name: core_relu
++      - name: _core_
+     nn_params:
+       out_features: 1024
+     nonlinearity: nn.Tanh
+@@ -97,7 +92,7 @@ components:
+   actor_1:
+     _target_: metta.agent.lib.nn_layer_library.Linear
+     sources:
+-      - name: core_relu
++      - name: _core_
+     nn_params:
+       out_features: 512""",
+        ),
+        (
+            "Deletes the intermediate 'core_relu' so LSTM outputs feed critic and actor linear layers directly across"
+            "agents, testing whether trimming activations improves gradient flow and sample efficiency."
+        ),
+    ),
+    # Example 4: MettaConf patching (multi-commit)
+    (
+        TrainingRunInput(
+            commits=[
+                GitCommit(
+                    "34313ae4e0433a09b5eb63aa7757ea669f9c560c",
+                    "mettaconf - experimental implementation",
+                    "Vyacheslav Matyukhin",
+                    "2025-04-24",
+                ),
+                GitCommit("c4139ec3bb9377a82b808c650900643bc68ec557", "bugfix", "Vyacheslav Matyukhin", "2025-04-24"),
+                GitCommit(
+                    "f4c91a71984a421d2ddac00a70247a40c2c72622",
+                    "patch nested configs",
+                    "Vyacheslav Matyukhin",
+                    "2025-04-24",
+                ),
+            ],
+            diff_stats="""
+  deps/mettagrid/mettaconf/__init__.py   | 78 ++++++++++++++++++++++++++++++++
+  deps/mettagrid/tests/mettaconf_test.py | 83 ++++++++++++++++++++++++++++++++++
+  2 files changed, 161 insertions(+)
+""",
+            diff_content="""
+diff --git a/deps/mettagrid/mettaconf/__init__.py b/deps/mettagrid/mettaconf/__init__.py
+new file mode 100644
+index 000000000..c574acb11
+--- /dev/null
++++ b/deps/mettagrid/mettaconf/__init__.py
+@@ -0,0 +1,78 @@
++import os
++import pathlib
++from typing import IO, Any, Union
++
++from omegaconf import OmegaConf
++from omegaconf.base import DictKeyType
++from omegaconf.dictconfig import DictConfig
++from omegaconf.listconfig import ListConfig
++
++
++class PatchedDictConfig(DictConfig):
++    def _get_impl(self, key: DictKeyType, default_value: Any, validate_key: bool = True) -> Any:
++        if not isinstance(key, str):
++            # `key$load` feature is only supported for string keys
++            return super()._get_impl(key, default_value, validate_key)
++
++        source_file = self._metadata._source_file  # type: ignore
++
++        if key.endswith("$load"):
++            val = super()._get_impl(key, default_value, validate_key)
++            if isinstance(val, (ListConfig, DictConfig)):
++                val = patch_cfg(val, source_file)
++            return val
++
++        load_key = f"{key}$load"
++        load_val = None
++        if load_key in self:
++            load_val = MettaConf.load(os.path.join(os.path.dirname(source_file), self[load_key]))
++
++        if load_val is None:
++            # no load key, fall back to the default implementation
++            val = super()._get_impl(key, default_value, validate_key)
++            if isinstance(val, (ListConfig, DictConfig)):
++                val = patch_cfg(val, source_file)
++            return val
++
++        if key not in self:
++            # we have `key$load` but no `key`
++            return load_val
++
++        # both `key` and `key$load` exist
++        val = super()._get_impl(key, default_value, validate_key)
++        val = OmegaConf.merge(load_val, val)
++
++        if isinstance(val, (ListConfig, DictConfig)):
++            val = patch_cfg(val, source_file)
++        return val
++
++
++class PatchedListConfig(ListConfig):
++    # TODO
++    pass
++
++
+""",
+        ),
+        (
+            "Implements experimental MettaConf with patched OmegaConf classes supporting key$load syntax for "
+            "modular configuration composition. Tests dynamic file inclusion and nested config loading to "
+            "enable more flexible experiment configuration management in multi-agent training pipelines."
+        ),
+    ),
+]

--- a/app_backend/git_client.py
+++ b/app_backend/git_client.py
@@ -1,0 +1,134 @@
+# NOTE: This file duplicates functionality with common/src/metta/common/util/git.py
+# Both files implement similar git operations but with different interfaces.
+# TODO: Extract common git functionality into a shared library to avoid duplication.
+
+import logging
+import subprocess
+from typing import List
+
+from app_backend.github_client import GitCommit
+
+logger = logging.getLogger("git_client")
+
+
+class GitError(Exception):
+    """Custom exception for git-related errors."""
+
+
+def run_git(*args: str) -> str:
+    """Run a git command and return its output."""
+    try:
+        result = subprocess.run(["git", *args], capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise GitError(f"Git command failed ({e.returncode}): {e.stderr.strip()}") from e
+    except FileNotFoundError as e:
+        raise GitError("Git is not installed!") from e
+
+
+class GitClient:
+    """Client for git operations, mimicking the existing metta git utilities."""
+
+    DEFAULT_BRANCH = "main"
+
+    def get_current_commit(self) -> str:
+        """Get the current git commit hash."""
+        return run_git("rev-parse", "HEAD")
+
+    def get_current_branch(self) -> str:
+        """Get the current git branch name."""
+        try:
+            return run_git("symbolic-ref", "--short", "HEAD")
+        except GitError as e:
+            if "not a git repository" in str(e):
+                raise ValueError("Not in a git repository") from e
+            elif "HEAD is not a symbolic ref" in str(e):
+                return self.get_current_commit()
+            raise
+
+    def commit_exists(self, commit_hash: str) -> bool:
+        """Check if commit exists locally."""
+        try:
+            run_git("cat-file", "-e", commit_hash)
+            return True
+        except GitError:
+            return False
+
+    def get_merge_base(self, commit_hash: str, base_branch: str = DEFAULT_BRANCH) -> str:
+        """Get merge base between commit and base branch."""
+        try:
+            return run_git("merge-base", base_branch, commit_hash)
+        except GitError:
+            # Fallback to base branch
+            logger.warning(f"Could not find merge base for {commit_hash}, using {base_branch}")
+            return base_branch
+
+    def _parse_commit_line(self, line: str) -> GitCommit:
+        """Parse a single commit line in format 'hash|message|author|date'."""
+        parts = line.split("|", 3)
+        if len(parts) == 4:
+            hash_val, message, author, date = parts
+            return GitCommit(hash_val, message, author, date)
+        raise ValueError(f"Invalid commit line format: {line}")
+
+    def get_commit_range(self, commit_hash: str, base_branch: str = DEFAULT_BRANCH) -> List[GitCommit]:
+        """Get commits from merge base to specified commit."""
+        # Handle edge case where commit_hash equals base_branch
+        if commit_hash == base_branch:
+            # Return the single commit itself
+            try:
+                result = run_git("log", "--pretty=format:%H|%s|%an|%ad", "--date=short", "-1", commit_hash)
+                lines = result.strip().split("\n")
+                if lines and lines[0]:
+                    return [self._parse_commit_line(lines[0])]
+            except GitError:
+                pass
+            return []
+
+        merge_base = self.get_merge_base(commit_hash, base_branch)
+        commit_range = f"{merge_base}..{commit_hash}"
+
+        try:
+            result = run_git("log", "--pretty=format:%H|%s|%an|%ad", "--date=short", "--reverse", commit_range)
+
+            if not result.strip():
+                # Single commit case
+                result = run_git("log", "--pretty=format:%H|%s|%an|%ad", "--date=short", "-n", "1", commit_hash)
+
+            commits = []
+            for line in result.strip().split("\n"):
+                if line:
+                    try:
+                        commits.append(self._parse_commit_line(line))
+                    except ValueError:
+                        # Skip invalid lines
+                        continue
+
+            return commits
+
+        except GitError as e:
+            raise ValueError(f"Could not retrieve commit history: {str(e)}") from e
+
+    def get_range_diff_stats(self, commit_hash: str, base_branch: str = DEFAULT_BRANCH) -> str:
+        """Get the diff file statistics for the entire range from merge base to commit."""
+        merge_base = self.get_merge_base(commit_hash, base_branch)
+
+        try:
+            # Get the diff with file stats
+            result = run_git("diff", "--stat", f"{merge_base}..{commit_hash}")
+            return result
+        except GitError as e:
+            logger.warning(f"Could not get range diff stats: {str(e)}")
+            return ""
+
+    def get_range_diff(self, commit_hash: str, base_branch: str = DEFAULT_BRANCH) -> str:
+        """Get the actual diff content for the entire range from merge base to commit."""
+        merge_base = self.get_merge_base(commit_hash, base_branch)
+
+        try:
+            # Get the actual diff with + and - lines
+            result = run_git("diff", f"{merge_base}..{commit_hash}")
+            return result
+        except GitError as e:
+            logger.warning(f"Could not get range diff: {str(e)}")
+            return ""

--- a/app_backend/github_client.py
+++ b/app_backend/github_client.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env -S uv run
+
+import logging
+import subprocess
+from typing import Any, Dict, List, Tuple
+
+import httpx
+
+logger = logging.getLogger("github_client")
+
+
+def run_gh(*args: str) -> str:
+    """Run a GitHub CLI command and return its output."""
+    try:
+        result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        from app_backend.git_client import GitError
+
+        raise GitError(f"GitHub CLI command failed ({e.returncode}): {e.stderr.strip()}") from e
+    except FileNotFoundError as e:
+        from app_backend.git_client import GitError
+
+        raise GitError("GitHub CLI (gh) is not installed!") from e
+
+
+class GitCommit:
+    """Represents a git commit with relevant information."""
+
+    def __init__(self, hash: str, message: str, author: str, date: str):
+        self.hash = hash
+        self.message = message
+        self.author = author
+        self.date = date
+
+    def __repr__(self) -> str:
+        return f"GitCommit(hash='{self.hash[:8]}', message='{self.message[:50]}...')"
+
+
+class GitHubClient:
+    """Client for GitHub operations using only HTTP requests."""
+
+    REPO_OWNER = "Metta-AI"
+    REPO_NAME = "metta"
+
+    def __init__(self, http_client: httpx.Client):
+        """
+        Initialize the GitHub client.
+
+        Args:
+            http_client: HTTP client implementation to use for requests
+        """
+        self.http_client = http_client
+        self._compare_cache: Dict[str, Dict] = {}  # Cache for compare API responses
+
+    def _get_compare_data(self, base: str, head: str) -> Dict:
+        """
+        Get compare data from GitHub API with caching.
+
+        Args:
+            base: Base branch or commit
+            head: Head commit
+
+        Returns:
+            GitHub API compare response data
+        """
+        cache_key = f"{base}...{head}"
+
+        if cache_key in self._compare_cache:
+            logger.debug(f"GitHub API: Using cached compare data for {cache_key}")
+            return self._compare_cache[cache_key]
+
+        logger.debug(f"GitHub API: Fetching compare data for {cache_key}")
+        url = f"https://api.github.com/repos/{self.REPO_OWNER}/{self.REPO_NAME}/compare/{cache_key}"
+        response = self.http_client.get(url)
+        response.raise_for_status()
+
+        data = response.json()
+        self._compare_cache[cache_key] = data
+        return data
+
+    def get_merge_base(self, commit_hash: str, base_branch: str = "main") -> str:
+        """
+        Get merge base between commit and base branch using GitHub API.
+
+        Args:
+            commit_hash: The commit hash
+            base_branch: The base branch (default: main)
+
+        Returns:
+            The merge base commit hash
+
+        Raises:
+            httpx.HTTPStatusError: If GitHub API request fails
+        """
+        logger.debug(f"GitHub API: Getting merge base for {commit_hash[:8]} from {base_branch}")
+        data = self._get_compare_data(base_branch, commit_hash)
+        merge_base = data["merge_base_commit"]["sha"]
+        logger.debug(f"GitHub API: Found merge base {merge_base[:8]}")
+        return merge_base
+
+    def get_commit_range(self, merge_base: str, commit_hash: str) -> List[GitCommit]:
+        """
+        Get commits between merge base and target commit using GitHub API.
+
+        Args:
+            merge_base: The merge base commit hash
+            commit_hash: The target commit hash
+
+        Returns:
+            List of GitCommit objects
+
+        Raises:
+            httpx.HTTPStatusError: If GitHub API request fails
+        """
+        logger.debug(f"GitHub API: Getting commit range {merge_base[:8]}...{commit_hash[:8]}")
+        data = self._get_compare_data(merge_base, commit_hash)
+        commits = []
+
+        for commit_data in data["commits"]:
+            commits.append(
+                GitCommit(
+                    hash=commit_data["sha"],
+                    message=commit_data["commit"]["message"],
+                    author=commit_data["commit"]["author"]["name"],
+                    date=commit_data["commit"]["author"]["date"][:10],  # Extract date only
+                )
+            )
+
+        logger.debug(f"GitHub API: Retrieved {len(commits)} commits")
+        return commits
+
+    def get_range_diff_stats(self, merge_base: str, commit_hash: str) -> str:
+        """
+        Get the diff stats for the range between merge base and commit using GitHub API.
+
+        Args:
+            merge_base: The merge base commit hash
+            commit_hash: The target commit hash
+
+        Returns:
+            Diff summary string with file stats
+
+        Raises:
+            httpx.HTTPStatusError: If GitHub API request fails
+        """
+        logger.debug(f"GitHub API: Getting range diff stats {merge_base[:8]}...{commit_hash[:8]}")
+        data = self._get_compare_data(merge_base, commit_hash)
+
+        # Extract file stats from the comparison
+        files_changed = len(data.get("files", []))
+        total_additions = sum(f.get("additions", 0) for f in data.get("files", []))
+        total_deletions = sum(f.get("deletions", 0) for f in data.get("files", []))
+
+        # Format diff stats similar to git diff --stat
+        diff_stats = [f" {files_changed} files changed"]
+        if total_additions > 0:
+            diff_stats.append(f"{total_additions} insertions(+)")
+        if total_deletions > 0:
+            diff_stats.append(f"{total_deletions} deletions(-)")
+
+        # Add file-by-file breakdown
+        file_stats = []
+        for file_info in data.get("files", []):
+            filename = file_info.get("filename", "")
+            additions = file_info.get("additions", 0)
+            deletions = file_info.get("deletions", 0)
+            changes = file_info.get("changes", 0)
+
+            # Format like git diff --stat
+            file_line = f" {filename}"
+            if changes > 0:
+                file_line += f" | {changes} "
+                if additions > 0:
+                    file_line += "+" * min(additions, 20)
+                if deletions > 0:
+                    file_line += "-" * min(deletions, 20)
+            file_stats.append(file_line)
+
+        result = "\n".join(file_stats)
+        if diff_stats:
+            result += "\n " + ", ".join(diff_stats)
+
+        logger.debug(f"GitHub API: Retrieved diff stats for {files_changed} files")
+        return result
+
+    def get_range_diff(self, merge_base: str, commit_hash: str) -> str:
+        """
+        Get the actual diff content for the range between merge base and commit using GitHub API.
+
+        Args:
+            merge_base: The merge base commit hash
+            commit_hash: The target commit hash
+
+        Returns:
+            Actual diff content with + and - lines
+
+        Raises:
+            httpx.HTTPStatusError: If GitHub API request fails
+        """
+        logger.debug(f"GitHub API: Getting range diff {merge_base[:8]}...{commit_hash[:8]}")
+        data = self._get_compare_data(merge_base, commit_hash)
+
+        # Build actual diff content from file patches
+        diff_content = []
+        for file_info in data.get("files", []):
+            filename = file_info.get("filename", "")
+            patch = file_info.get("patch", "")
+
+            if patch:
+                # Add file header
+                diff_content.append(f"diff --git a/{filename} b/{filename}")
+                diff_content.append(f"--- a/{filename}")
+                diff_content.append(f"+++ b/{filename}")
+                diff_content.append(patch)
+                diff_content.append("")  # Empty line between files
+
+        result = "\n".join(diff_content)
+        logger.debug(f"GitHub API: Retrieved actual diff content for {len(data.get('files', []))} files")
+        return result
+
+    def get_all_commit_data(self, commit_hash: str, base_branch: str = "main") -> Tuple[str, List[GitCommit], str, str]:
+        """
+        Get all commit data (merge base, commits, file stats, diff) in a single optimized call.
+
+        Args:
+            commit_hash: The target commit hash
+            base_branch: The base branch (default: main)
+
+        Returns:
+            Tuple of (merge_base, commits, file_stats, actual_diff)
+        """
+        logger.debug(f"GitHub API: Getting all commit data for {commit_hash[:8]} from {base_branch}")
+
+        # Get API data
+        merge_base_data = self._get_compare_data(base_branch, commit_hash)
+        merge_base = merge_base_data["merge_base_commit"]["sha"]
+        commit_data = self._get_compare_data(merge_base, commit_hash)
+
+        # Extract components
+        commits = self._extract_commits_from_response(commit_data)
+        file_stats_str = self._build_file_stats_summary(commit_data)
+        actual_diff = self._build_diff_content(commit_data)
+
+        num_files = len(commit_data.get("files", []))
+        logger.debug(f"GitHub API: Retrieved all data for {len(commits)} commits, {num_files} files")
+        return merge_base, commits, file_stats_str, actual_diff
+
+    def _extract_commits_from_response(self, commit_data: Dict[str, Any]) -> List[GitCommit]:
+        """Extract GitCommit objects from GitHub API response."""
+        commits = []
+        for commit_item in commit_data["commits"]:
+            commits.append(
+                GitCommit(
+                    hash=commit_item["sha"],
+                    message=commit_item["commit"]["message"],
+                    author=commit_item["commit"]["author"]["name"],
+                    date=commit_item["commit"]["author"]["date"][:10],
+                )
+            )
+        return commits
+
+    def _build_file_stats_summary(self, commit_data: Dict[str, Any]) -> str:
+        """Build file statistics summary from GitHub API response."""
+        files = commit_data.get("files", [])
+        files_changed = len(files)
+        total_additions = sum(f.get("additions", 0) for f in files)
+        total_deletions = sum(f.get("deletions", 0) for f in files)
+
+        # Build summary line
+        diff_stats = [f" {files_changed} files changed"]
+        if total_additions > 0:
+            diff_stats.append(f"{total_additions} insertions(+)")
+        if total_deletions > 0:
+            diff_stats.append(f"{total_deletions} deletions(-)")
+
+        # Build individual file stats
+        file_stats = []
+        for file_info in files:
+            filename = file_info.get("filename", "")
+            additions = file_info.get("additions", 0)
+            deletions = file_info.get("deletions", 0)
+            changes = file_info.get("changes", 0)
+
+            file_line = f" {filename}"
+            if changes > 0:
+                file_line += f" | {changes} "
+                # Use proportional scaling instead of arbitrary limits
+                file_line += self._build_change_indicator(additions, deletions)
+            file_stats.append(file_line)
+
+        # Combine file stats with summary
+        result = "\n".join(file_stats)
+        if diff_stats:
+            result += "\n " + ", ".join(diff_stats)
+        return result
+
+    def _build_diff_content(self, commit_data: Dict[str, Any]) -> str:
+        """Build unified diff content from GitHub API response."""
+        diff_parts = []
+
+        for file_info in commit_data.get("files", []):
+            filename = file_info.get("filename", "")
+            patch = file_info.get("patch", "")
+
+            if patch:
+                # Use more robust diff header construction
+                diff_header = self._build_diff_header(filename, file_info)
+                diff_parts.extend([diff_header, patch, ""])
+
+        return "\n".join(diff_parts)
+
+    def _build_diff_header(self, filename: str, file_info: Dict[str, Any]) -> str:
+        """
+        Build a proper git diff header for a file.
+
+        Args:
+            filename: The file name
+            file_info: File information from GitHub API
+
+        Returns:
+            Formatted diff header
+        """
+        # Handle different file statuses (added, deleted, renamed, etc.)
+        status = file_info.get("status", "modified")
+
+        sha = file_info.get("sha", "unknown")[:7]
+
+        if status == "added":
+            return (
+                f"diff --git a/{filename} b/{filename}\n"
+                f"new file mode 100644\n"
+                f"index 0000000..{sha}\n"
+                f"--- /dev/null\n"
+                f"+++ b/{filename}"
+            )
+        elif status == "deleted":
+            return (
+                f"diff --git a/{filename} b/{filename}\n"
+                f"deleted file mode 100644\n"
+                f"index {sha}..0000000\n"
+                f"--- a/{filename}\n"
+                f"+++ /dev/null"
+            )
+        elif status == "renamed":
+            previous_filename = file_info.get("previous_filename", filename)
+            changes = file_info.get("changes", 0)
+            return (
+                f"diff --git a/{previous_filename} b/{filename}\n"
+                f"similarity index {changes}%\n"
+                f"rename from {previous_filename}\n"
+                f"rename to {filename}\n"
+                f"index {sha}..{sha}\n"
+                f"--- a/{previous_filename}\n"
+                f"+++ b/{filename}"
+            )
+        else:
+            # Standard modification
+            return (
+                f"diff --git a/{filename} b/{filename}\nindex {sha}..{sha} 100644\n--- a/{filename}\n+++ b/{filename}"
+            )
+
+    def _build_change_indicator(self, additions: int, deletions: int, max_width: int = 40) -> str:
+        """
+        Build a proportional visual indicator for file changes.
+
+        Args:
+            additions: Number of lines added
+            deletions: Number of lines deleted
+            max_width: Maximum width for the indicator
+
+        Returns:
+            String with + and - characters representing changes proportionally
+        """
+        if additions == 0 and deletions == 0:
+            return ""
+
+        total_changes = additions + deletions
+        if total_changes <= max_width:
+            # Small changes - show exactly
+            return "+" * additions + "-" * deletions
+        else:
+            # Large changes - scale proportionally
+            add_chars = int((additions / total_changes) * max_width)
+            del_chars = max_width - add_chars  # Ensure we use the full width
+            return "+" * add_chars + "-" * del_chars

--- a/app_backend/llm_client.py
+++ b/app_backend/llm_client.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env -S uv run
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger("llm_client")
+
+
+@dataclass
+class ModelPricing:
+    """Pricing information for a single model."""
+
+    prompt_cost_per_1k: float
+    completion_cost_per_1k: float
+
+    def calculate_cost(self, prompt_tokens: int, completion_tokens: int) -> float:
+        """Calculate total cost based on token usage.
+
+        Args:
+            prompt_tokens: Number of prompt/input tokens
+            completion_tokens: Number of completion/output tokens
+
+        Returns:
+            Total cost in USD
+        """
+        prompt_cost = (prompt_tokens / 1000) * self.prompt_cost_per_1k
+        completion_cost = (completion_tokens / 1000) * self.completion_cost_per_1k
+        return prompt_cost + completion_cost
+
+
+class LLMProvider(ABC):
+    """Base class for LLM providers."""
+
+    def __init__(self, api_key: str, api_url: str, default_model: str):
+        self.api_key = api_key
+        self.api_url = api_url
+        self.default_model = default_model
+
+    @abstractmethod
+    def get_headers(self) -> Dict[str, str]:
+        """Get headers for API request."""
+        pass
+
+    @abstractmethod
+    def encode_request(self, model: str, messages: List[Dict[str, str]], opts: Dict[str, Any]) -> Dict[str, Any]:
+        """Encode request body for API."""
+        pass
+
+    @abstractmethod
+    def decode_response(self, response_data: Dict[str, Any]) -> str:
+        """Decode API response to get text."""
+        pass
+
+    @abstractmethod
+    def extract_usage_info(self, response_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract usage and cost information from API response."""
+        pass
+
+    @abstractmethod
+    def calculate_cost(self, model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+        """Calculate cost based on model and token usage.
+
+        Args:
+            model: Model name
+            prompt_tokens: Number of prompt tokens
+            completion_tokens: Number of completion tokens
+
+        Returns:
+            Cost in USD, or None if model pricing not available
+        """
+        pass
+
+
+class OpenAIProvider(LLMProvider):
+    """OpenAI API provider."""
+
+    # Pricing per 1K tokens (as of 2025)
+    # Note: OpenAI now prices per 1M tokens, converted here to per 1K for consistency
+    PRICING = {
+        # GPT-4.1 series (latest)
+        "gpt-4.1": ModelPricing(0.005, 0.02),  # Estimated based on performance improvements
+        "gpt-4.1-mini": ModelPricing(0.00015, 0.0006),  # 83% cheaper than GPT-4o
+        "gpt-4.1-nano": ModelPricing(0.0001, 0.0004),  # Estimated
+        # GPT-4o series
+        "gpt-4o": ModelPricing(0.005, 0.02),  # $5/1M input, $20/1M output
+        "gpt-4o-mini": ModelPricing(0.00015, 0.0006),  # $0.15/1M input, $0.60/1M output
+        "gpt-4o-audio": ModelPricing(0.1, 0.2),  # $100/1M input, $200/1M output
+        # GPT-4 series
+        "gpt-4-turbo": ModelPricing(0.01, 0.03),  # $10/1M input, $30/1M output
+        "gpt-4-turbo-128k": ModelPricing(0.01, 0.03),
+        "gpt-4": ModelPricing(0.03, 0.06),  # $30/1M input, $60/1M output
+        "gpt-4-32k": ModelPricing(0.06, 0.12),  # $60/1M input, $120/1M output
+        "gpt-4.5-preview": ModelPricing(0.075, 0.15),  # $75/1M input, $150/1M output (deprecated July 2025)
+        # GPT-3.5 series
+        "gpt-3.5-turbo": ModelPricing(0.0015, 0.002),
+        "gpt-3.5-turbo-0125": ModelPricing(0.0005, 0.0015),
+    }
+
+    def get_headers(self) -> Dict[str, str]:
+        return {"authorization": f"bearer {self.api_key}"}
+
+    def encode_request(self, model: str, messages: List[Dict[str, str]], opts: Dict[str, Any]) -> Dict[str, Any]:
+        return {"model": model, "messages": messages, **opts}
+
+    def decode_response(self, response_data: Dict[str, Any]) -> str:
+        return response_data["choices"][0]["message"]["content"]
+
+    def extract_usage_info(self, response_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract usage and cost information from OpenAI API response."""
+        usage_info = {}
+
+        # Extract token usage
+        usage = response_data.get("usage", {})
+        if usage:
+            usage_info.update(
+                {
+                    "prompt_tokens": usage.get("prompt_tokens", 0),
+                    "completion_tokens": usage.get("completion_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                }
+            )
+
+        # OpenAI now often includes cost directly in the response
+        if "cost" in response_data:
+            usage_info["cost_usd"] = response_data["cost"]
+        elif usage and "prompt_tokens_details" in usage:
+            # Some OpenAI responses include detailed cost breakdown
+            details = usage.get("prompt_tokens_details", {})
+            if "cost" in details:
+                usage_info["cost_usd"] = details["cost"]
+
+        return usage_info
+
+    def calculate_cost(self, model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+        """Calculate cost for OpenAI models."""
+        # Find matching model pricing
+        pricing = None
+        model_lower = model.lower()
+
+        # Direct match first
+        if model_lower in self.PRICING:
+            pricing = self.PRICING[model_lower]
+        else:
+            # Partial match for model variations
+            for known_model, model_pricing in self.PRICING.items():
+                if known_model in model_lower:
+                    pricing = model_pricing
+                    break
+
+        if not pricing:
+            logger.debug(f"No pricing found for OpenAI model: {model}")
+            return None
+
+        return pricing.calculate_cost(prompt_tokens, completion_tokens)
+
+
+class OpenRouterProvider(OpenAIProvider):
+    """OpenRouter API provider (uses OpenAI-compatible format but different pricing)."""
+
+    # OpenRouter has dynamic pricing based on the model
+    # These are example prices - OpenRouter pricing varies by model
+    PRICING = {
+        "openrouter/auto": ModelPricing(0.0, 0.0),  # Auto-routing, price varies
+        "gpt-4": ModelPricing(0.03, 0.06),
+        "gpt-3.5-turbo": ModelPricing(0.001, 0.002),
+        "claude-3-opus": ModelPricing(0.015, 0.075),
+        "claude-3-sonnet": ModelPricing(0.003, 0.015),
+        "claude-3-haiku": ModelPricing(0.00025, 0.00125),
+        "llama-3-70b": ModelPricing(0.0007, 0.0009),
+        "mixtral-8x7b": ModelPricing(0.0003, 0.0003),
+    }
+
+    def extract_usage_info(self, response_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract usage and cost information from OpenRouter API response."""
+        usage_info = super().extract_usage_info(response_data)
+
+        # OpenRouter often includes direct cost information
+        if "cost" in response_data:
+            usage_info["cost_usd"] = response_data["cost"]
+
+        # OpenRouter may include model info in response
+        if "model" in response_data:
+            usage_info["model"] = response_data["model"]
+
+        return usage_info
+
+
+class AnthropicProvider(LLMProvider):
+    """Anthropic API provider."""
+
+    # Pricing per 1K tokens (as of 2025)
+    PRICING = {
+        # Claude 4 series (latest)
+        "claude-opus-4": ModelPricing(0.015, 0.075),  # $15/1M input, $75/1M output
+        "claude-sonnet-4": ModelPricing(0.003, 0.015),  # $3/1M input, $15/1M output
+        # Claude 3.5 series
+        "claude-3-5-sonnet-20241022": ModelPricing(0.003, 0.015),
+        "claude-3-5-sonnet": ModelPricing(0.003, 0.015),
+        "claude-3-7-sonnet": ModelPricing(0.003, 0.015),
+        "claude-3-5-haiku": ModelPricing(0.00025, 0.00125),  # Pricing estimated
+        # Claude 3 series
+        "claude-3-opus-20240229": ModelPricing(0.015, 0.075),
+        "claude-3-opus": ModelPricing(0.015, 0.075),
+        "claude-3-sonnet-20240229": ModelPricing(0.003, 0.015),
+        "claude-3-haiku-20240307": ModelPricing(0.00025, 0.00125),
+        # Claude 2 series (legacy)
+        "claude-2.1": ModelPricing(0.008, 0.024),
+        "claude-2.0": ModelPricing(0.008, 0.024),
+        "claude-instant-1.2": ModelPricing(0.0008, 0.0024),
+    }
+
+    def get_headers(self) -> Dict[str, str]:
+        return {"x-api-key": self.api_key, "anthropic-version": "2023-06-01"}
+
+    def encode_request(self, model: str, messages: List[Dict[str, str]], opts: Dict[str, Any]) -> Dict[str, Any]:
+        # Anthropic requires max_tokens
+        if "max_tokens" not in opts:
+            opts["max_tokens"] = 1024
+
+        # Extract system messages - Anthropic expects system as a top-level parameter
+        system_content = None
+        filtered_messages = []
+
+        for message in messages:
+            if message["role"] == "system":
+                # Take the first system message content (combine multiple if needed)
+                if system_content is None:
+                    system_content = message["content"]
+                else:
+                    # If multiple system messages, combine them
+                    system_content += "\n\n" + message["content"]
+            else:
+                filtered_messages.append(message)
+
+        # Build request body
+        request_body = {"model": model, "messages": filtered_messages, **opts}
+
+        # Add system parameter if we found system messages
+        if system_content is not None:
+            request_body["system"] = system_content
+
+        return request_body
+
+    def decode_response(self, response_data: Dict[str, Any]) -> str:
+        return response_data["content"][0]["text"]
+
+    def extract_usage_info(self, response_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract usage and cost information from Anthropic API response."""
+        usage_info = {}
+
+        # Anthropic usage is in a different format
+        usage = response_data.get("usage", {})
+        if usage:
+            usage_info.update(
+                {
+                    "prompt_tokens": usage.get("input_tokens", 0),
+                    "completion_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+                }
+            )
+
+        return usage_info
+
+    def calculate_cost(self, model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+        """Calculate cost for Anthropic models."""
+        # Find matching model pricing
+        pricing = None
+        model_lower = model.lower()
+
+        # Direct match first
+        if model in self.PRICING:
+            pricing = self.PRICING[model]
+        else:
+            # Partial match for model variations
+            for known_model, model_pricing in self.PRICING.items():
+                if known_model in model_lower or model_lower in known_model:
+                    pricing = model_pricing
+                    break
+
+        if not pricing:
+            logger.debug(f"No pricing found for Anthropic model: {model}")
+            return None
+
+        return pricing.calculate_cost(prompt_tokens, completion_tokens)
+
+
+class LLMClient:
+    """
+    Client for LLM API operations with OpenAI, OpenRouter, and Anthropic support.
+    Follows the existing client pattern with dependency injection.
+    """
+
+    def __init__(
+        self,
+        http_client: httpx.Client,
+        openai_api_key: Optional[str] = None,
+        anthropic_api_key: Optional[str] = None,
+        openrouter_api_key: Optional[str] = None,
+        openai_api_base: Optional[str] = None,
+        openrouter_api_base: Optional[str] = None,
+        anthropic_api_url: Optional[str] = None,
+        openai_model: Optional[str] = None,
+        anthropic_model: Optional[str] = None,
+        openrouter_model: Optional[str] = None,
+    ):
+        """
+        Initialize the LLM client with configuration.
+
+        Args:
+            http_client: HTTP client for making API requests
+            openai_api_key: OpenAI API key
+            anthropic_api_key: Anthropic API key
+            openrouter_api_key: OpenRouter API key
+            openai_api_base: OpenAI API endpoint
+            openrouter_api_base: OpenRouter API endpoint
+            anthropic_api_url: Anthropic API endpoint
+            openai_model: Default model for OpenAI provider
+            anthropic_model: Default model for Anthropic provider
+            openrouter_model: Default model for OpenRouter provider
+        """
+        from app_backend import config
+
+        self.http_client = http_client
+
+        # Initialize providers with config defaults
+        self.providers: List[LLMProvider] = []
+
+        if openai_api_key:
+            api_base = openai_api_base or config.openai_api_base
+            model = openai_model or config.openai_model
+            self.providers.append(OpenAIProvider(openai_api_key, api_base, model))
+
+        if anthropic_api_key:
+            api_url = anthropic_api_url or config.anthropic_api_url
+            model = anthropic_model or config.anthropic_model
+            self.providers.append(AnthropicProvider(anthropic_api_key, api_url, model))
+
+        if openrouter_api_key:
+            # OpenRouter uses OpenAI-compatible API but different pricing
+            api_base = openrouter_api_base or config.openrouter_api_base
+            model = openrouter_model or config.openrouter_model
+            self.providers.append(OpenRouterProvider(openrouter_api_key, api_base, model))
+
+    def is_available(self) -> bool:
+        """
+        Check if LLM client has at least one API key available.
+
+        Returns:
+            True if at least one API key is available, False otherwise
+        """
+        return len(self.providers) > 0
+
+    def generate_text_with_messages(self, messages: List[Dict[str, str]], **opts) -> str:
+        """
+        Generate text using available LLM API with multi-message conversation support.
+
+        Args:
+            messages: List of messages in conversation format [{"role": "user/assistant/system", "content": "..."}]
+            **opts: Additional options (model, max_tokens, temperature, etc.)
+
+        Returns:
+            Generated text response
+
+        Raises:
+            RuntimeError: If no API keys are available
+            Exception: For API call failures
+        """
+        if not self.is_available():
+            raise RuntimeError("No LLM API keys available")
+
+        # Try providers in order until one succeeds
+        last_error = None
+        logger.debug(f"Attempting LLM generation with {len(self.providers)} available provider(s)")
+
+        for i, provider in enumerate(self.providers):
+            provider_name = provider.__class__.__name__
+            logger.debug(f"Trying provider {i + 1}/{len(self.providers)}: {provider_name} at {provider.api_url}")
+            try:
+                # Prepare request
+                model = opts.pop("model", provider.default_model)
+                body = provider.encode_request(model, messages, opts)
+                headers = provider.get_headers()
+
+                # Set timeout
+                timeout = opts.get("timeout", 60)
+
+                logger.debug(f"Making LLM API request to {provider.api_url} with model {model}")
+                logger.debug(f"=== LLM REQUEST ({len(messages)} messages) ===")
+                for i, msg in enumerate(messages):
+                    logger.debug(f"Message {i + 1} [{msg['role']}]:")
+                    logger.debug(msg["content"])
+                    logger.debug("---")
+
+                # Make API request
+                response = self.http_client.post(provider.api_url, headers=headers, json=body, timeout=timeout)
+                response.raise_for_status()
+
+                # Decode response
+                response_json = response.json()
+                result = provider.decode_response(response_json)
+
+                # Log usage and cost information if available
+                self._log_usage_info(provider, model, response_json)
+
+                logger.debug(f"=== LLM RESPONSE ({len(result)} chars) ===")
+                logger.debug(result)
+
+                return result
+
+            except httpx.HTTPStatusError as e:
+                logger.debug(f"Provider {provider_name} failed with HTTP error: {e.response.status_code}")
+                logger.error(f"LLM API HTTP error: {e.response.status_code} - {e.response.text}")
+                last_error = Exception(f"LLM API request failed: {e.response.status_code}")
+                continue
+            except httpx.TimeoutException as e:
+                logger.debug(f"Provider {provider_name} failed with timeout")
+                logger.error(f"LLM API timeout: {e}")
+                last_error = Exception("LLM API request timed out")
+                continue
+            except KeyError as e:
+                logger.debug(f"Provider {provider_name} failed with response parsing error")
+                logger.error(f"LLM API response parsing error: {e}")
+                last_error = Exception(f"Invalid LLM API response format: {e}")
+                continue
+            except Exception as e:
+                logger.debug(f"Provider {provider_name} failed with error: {e}")
+                logger.error(f"LLM API error: {e}")
+                last_error = Exception(f"LLM API request failed: {str(e)}")
+                continue
+
+        # If we get here, all providers failed
+        if last_error:
+            raise last_error
+        else:
+            raise Exception("All LLM providers failed")
+
+    def _log_usage_info(self, provider: LLMProvider, model: str, response_json: Dict[str, Any]) -> None:
+        """
+        Log usage and cost information from LLM API response.
+
+        Args:
+            provider: The provider instance used for the request
+            model: Model used for the request
+            response_json: Full API response JSON
+        """
+        try:
+            provider_name = provider.__class__.__name__
+            usage_info = provider.extract_usage_info(response_json)
+
+            if not usage_info:
+                return
+
+            prompt_tokens = usage_info.get("prompt_tokens", 0)
+            completion_tokens = usage_info.get("completion_tokens", 0)
+            total_tokens = usage_info.get("total_tokens", 0)
+
+            logger.info(
+                f"LLM API Usage - Provider: {provider_name}, Model: {model}, "
+                f"Tokens: {prompt_tokens} prompt + {completion_tokens} completion = {total_tokens} total"
+            )
+
+            # Use direct cost if available, otherwise calculate using provider pricing
+            if "cost_usd" in usage_info:
+                logger.info(f"LLM API Cost: ${usage_info['cost_usd']:.6f} USD")
+            else:
+                cost_estimate = provider.calculate_cost(model, prompt_tokens, completion_tokens)
+                if cost_estimate:
+                    logger.info(f"LLM API Cost Estimate: ~${cost_estimate:.6f} USD")
+
+        except Exception as e:
+            logger.debug(f"Could not extract usage info from response: {e}")

--- a/app_backend/routes/stats_routes.py
+++ b/app_backend/routes/stats_routes.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -16,7 +16,7 @@ class PolicyIdResponse(BaseModel):
 
 class TrainingRunCreate(BaseModel):
     name: str
-    attributes: Dict[str, str] = Field(default_factory=dict)
+    attributes: Dict[str, Union[str, bool]] = Field(default_factory=dict)
     url: Optional[str] = None
 
 
@@ -27,7 +27,7 @@ class TrainingRunResponse(BaseModel):
 class EpochCreate(BaseModel):
     start_training_epoch: int
     end_training_epoch: int
-    attributes: Dict[str, str] = Field(default_factory=dict)
+    attributes: Dict[str, Union[str, bool]] = Field(default_factory=dict)
 
 
 class EpochResponse(BaseModel):

--- a/app_backend/stats_client.py
+++ b/app_backend/stats_client.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from pydantic import BaseModel
@@ -82,7 +82,7 @@ class StatsClient:
         return ClientPolicyIdResponse(policy_ids=policy_ids_uuid)
 
     def create_training_run(
-        self, name: str, attributes: Optional[Dict[str, str]] = None, url: Optional[str] = None
+        self, name: str, attributes: Optional[Dict[str, Union[str, bool]]] = None, url: Optional[str] = None
     ) -> ClientTrainingRunResponse:
         """
         Create a new training run.
@@ -113,7 +113,7 @@ class StatsClient:
         run_id: uuid.UUID,
         start_training_epoch: int,
         end_training_epoch: int,
-        attributes: Optional[Dict[str, str]] = None,
+        attributes: Optional[Dict[str, Union[str, bool]]] = None,
     ) -> ClientEpochResponse:
         """
         Create a new policy epoch.

--- a/common/src/metta/common/util/git.py
+++ b/common/src/metta/common/util/git.py
@@ -1,6 +1,10 @@
 import json
 import subprocess
 
+# NOTE: This file duplicates functionality with app_backend/git_client.py
+# Both files implement similar git operations but with different interfaces.
+# TODO: Extract common git functionality into a shared library to avoid duplication.
+
 
 class GitError(Exception):
     """Custom exception for git-related errors."""

--- a/observatory/src/repo.ts
+++ b/observatory/src/repo.ts
@@ -63,6 +63,11 @@ export type SavedDashboardListResponse = {
   dashboards: SavedDashboard[]
 }
 
+export type TrainingRunAttributes = {
+  git_hash?: string
+  has_uncommitted_changes?: boolean
+}
+
 export type TrainingRun = {
   id: string
   name: string
@@ -72,6 +77,7 @@ export type TrainingRun = {
   status: string
   url: string | null
   description: string | null
+  attributes?: TrainingRunAttributes
 }
 
 export type TrainingRunListResponse = {
@@ -151,6 +157,7 @@ export interface Repo {
   getTrainingRuns(): Promise<TrainingRunListResponse>
   getTrainingRun(runId: string): Promise<TrainingRun>
   updateTrainingRunDescription(runId: string, description: string): Promise<TrainingRun>
+  generateTrainingRunDescription(runId: string): Promise<TrainingRun>
   getTrainingRunHeatmapData(
     runId: string,
     metric: string,
@@ -298,6 +305,13 @@ export class ServerRepo implements Repo {
     return this.apiCallWithBodyPut<TrainingRun>(
       `/dashboard/training-runs/${encodeURIComponent(runId)}/description`,
       { description }
+    )
+  }
+
+  async generateTrainingRunDescription(runId: string): Promise<TrainingRun> {
+    return this.apiCallWithBody<TrainingRun>(
+      `/dashboard/training-runs/${encodeURIComponent(runId)}/generate-description`,
+      {}
     )
   }
 

--- a/tests/app/test_description_generator.py
+++ b/tests/app/test_description_generator.py
@@ -1,0 +1,379 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app_backend.description_generator import GitDataProvider, TrainingRunDescriptionGenerator
+from app_backend.git_client import GitCommit
+from app_backend.llm_client import LLMClient
+
+
+class TestTrainingRunDescriptionGenerator:
+    """Tests for TrainingRunDescriptionGenerator."""
+
+    def test_generator_initialization_no_llm_client(self):
+        """Test generator initialization without LLM client."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            with patch("app_backend.description_generator.logger") as mock_logger:
+                TrainingRunDescriptionGenerator(git_data_provider, None)
+                mock_logger.warning.assert_called_once_with("No LLM client available - will fall back to git logs only")
+
+    def test_generator_initialization_with_available_llm_client(self):
+        """Test generator initialization with available LLM client."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            llm_client = LLMClient(http_client)
+
+            with patch.object(llm_client, "is_available", return_value=True):
+                generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+                assert generator.llm_client == llm_client
+
+    def test_generate_description_local_git_success_with_llm(self):
+        """Test successful description generation using local git and LLM."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            llm_client = LLMClient(http_client)
+
+            with patch.object(llm_client, "is_available", return_value=True):
+                generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+
+                with (
+                    patch.object(
+                        git_data_provider,
+                        "get_commit_data",
+                        return_value=(
+                            [
+                                GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01"),
+                                GitCommit("efgh5678", "Fix bug", "Author", "2024-01-02"),
+                            ],
+                            "2 files changed",
+                            "diff content",
+                        ),
+                    ),
+                    patch.object(llm_client, "generate_text_with_messages", return_value="Generated LLM description"),
+                ):
+                    result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                    assert result == "Generated LLM description"
+                    llm_client.generate_text_with_messages.assert_called_once()
+
+    def test_generate_description_local_git_success_fallback_to_git_logs(self):
+        """Test successful description generation falling back to git logs."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(
+                git_data_provider,
+                "get_commit_data",
+                return_value=(
+                    [
+                        GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01"),
+                        GitCommit("efgh5678", "Fix bug", "Author", "2024-01-02"),
+                    ],
+                    "2 files changed",
+                    "diff content",
+                ),
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert "Training run based on 2 commits:" in result
+                assert "abcd1234: Add new feature" in result
+                assert "efgh5678: Fix bug" in result
+
+    def test_generate_description_llm_failure_fallback_to_git_logs(self):
+        """Test LLM failure fallback to git logs."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            # Create LLM client with key so it's available
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+
+            # Mock HTTP client to prevent real API calls
+            with (
+                patch.object(
+                    git_data_provider,
+                    "get_commit_data",
+                    return_value=(
+                        [GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01")],
+                        "1 file changed",
+                        "diff content",
+                    ),
+                ),
+                patch.object(http_client, "post", side_effect=Exception("LLM API error")),
+                patch("app_backend.description_generator.logger") as mock_logger,
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert "Training run based on 1 commit:" in result
+                assert "abcd1234: Add new feature" in result
+                mock_logger.warning.assert_called_once()
+
+    def test_generate_description_github_fallback_success(self):
+        """Test successful description generation falling back to GitHub."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(
+                git_data_provider,
+                "get_commit_data",
+                return_value=(
+                    [
+                        GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01"),
+                        GitCommit("efgh5678", "Fix bug", "Author", "2024-01-02"),
+                    ],
+                    "2 files changed",
+                    "diff content",
+                ),
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert "Training run based on 2 commits:" in result
+                assert "abcd1234: Add new feature" in result
+                assert "efgh5678: Fix bug" in result
+
+    def test_generate_description_commit_not_found(self):
+        """Test description generation with commit not found anywhere."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(git_data_provider, "get_commit_data", side_effect=ValueError("Commit not found")):
+                with pytest.raises(ValueError) as exc_info:
+                    generator.generate_description("invalid-commit-hash")
+                assert "Commit not found" in str(exc_info.value)
+
+    def test_generate_description_no_commits(self):
+        """Test description generation when no commits are found."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(git_data_provider, "get_commit_data", return_value=([], "stats", "diff")):
+                with pytest.raises(ValueError) as exc_info:
+                    generator.generate_description("some-commit-hash")
+                assert "No commits found" in str(exc_info.value)
+
+    def test_build_llm_messages(self):
+        """Test LLM messages building."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            from app_backend.description_generator import TrainingRunInput
+
+            input_data = TrainingRunInput(
+                commits=[
+                    GitCommit("abcd1234", "Add feature X", "John Doe", "2024-01-01"),
+                    GitCommit("efgh5678", "Improve performance", "Jane Smith", "2024-01-02"),
+                ],
+                diff_stats="2 files changed, 10 insertions(+), 5 deletions(-)",
+                diff_content="diff --git a/file.py b/file.py\n+new code",
+            )
+
+            messages = generator._build_llm_messages(input_data)
+
+            # Check that we have system message and examples plus current request
+            assert len(messages) > 1
+            assert messages[0]["role"] == "system"
+            assert "Metta AI" in messages[0]["content"]
+            assert "multi-agent" in messages[0]["content"]
+            assert "cooperation" in messages[0]["content"]
+
+            # Check current request message contains our data (but not commit hashes)
+            current_message = messages[-1]
+            assert current_message["role"] == "user"
+            assert "Add feature X" in current_message["content"]
+            assert "Improve performance" in current_message["content"]
+            assert "John Doe" in current_message["content"]
+            assert "Jane Smith" in current_message["content"]
+
+    def test_build_git_summary(self):
+        """Test git summary building."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            commits = [
+                GitCommit("abcd1234", "Add feature X", "John Doe", "2024-01-01"),
+                GitCommit("efgh5678", "Improve performance", "Jane Smith", "2024-01-02"),
+            ]
+
+            summary = generator._build_git_summary(commits)
+
+            assert "Training run based on 2 commits:" in summary
+            assert "abcd1234: Add feature X (by John Doe on 2024-01-01)" in summary
+            assert "efgh5678: Improve performance (by Jane Smith on 2024-01-02)" in summary
+
+    def test_build_git_summary_empty(self):
+        """Test git summary with no commits."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with pytest.raises(ValueError) as exc_info:
+                generator._build_git_summary([])
+            assert "No commits found in this training run" in str(exc_info.value)
+
+    def test_add_uncommitted_changes_disclaimer(self):
+        """Test uncommitted changes disclaimer."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            # Test with uncommitted changes
+            result = generator._add_uncommitted_changes_disclaimer(
+                "Test description", "abcd1234567890abcd1234567890abcd12345678", True
+            )
+            assert result.startswith("WARNING: Training run abcd1234 included uncommitted changes\n\n")
+            assert "Test description" in result
+
+            # Test without uncommitted changes
+            result = generator._add_uncommitted_changes_disclaimer(
+                "Test description", "abcd1234567890abcd1234567890abcd12345678", False
+            )
+            assert result == "Test description"
+
+    def test_generate_description_with_uncommitted_changes(self):
+        """Test description generation with uncommitted changes disclaimer."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(
+                git_data_provider,
+                "get_commit_data",
+                return_value=(
+                    [GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01")],
+                    "1 file changed",
+                    "diff content",
+                ),
+            ):
+                result = generator.generate_description(
+                    "abcd1234567890abcd1234567890abcd12345678", has_uncommitted_changes=True
+                )
+
+                assert "WARNING: Training run abcd1234 included uncommitted changes" in result
+                assert "Training run based on 1 commit:" in result
+
+    def test_git_error_converted_to_value_error(self):
+        """Test that GitError from git client gets converted to ValueError."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(git_data_provider, "get_commit_data", side_effect=ValueError("Git error")):
+                with pytest.raises(ValueError) as exc_info:
+                    generator.generate_description("invalid-commit-hash")
+                assert "Git error" in str(exc_info.value)
+
+    def test_git_not_installed_github_also_fails(self):
+        """Test when git is not installed and GitHub API also fails."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, None)
+
+            with patch.object(git_data_provider, "get_commit_data", side_effect=Exception("All clients failed")):
+                with pytest.raises(Exception) as exc_info:
+                    generator.generate_description("some-commit-hash")
+                assert "All clients failed" in str(exc_info.value)
+
+    def test_working_llm_client_generates_description(self):
+        """Test successful description generation with working LLM client."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            # Create LLM client with key and mock HTTP to prevent real calls
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+
+            # Mock successful API response
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "LLM generated description"}}]}
+
+            with (
+                patch.object(
+                    git_data_provider,
+                    "get_commit_data",
+                    return_value=(
+                        [
+                            GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01"),
+                            GitCommit("efgh5678", "Fix bug", "Author", "2024-01-02"),
+                        ],
+                        "2 files changed",
+                        "diff content",
+                    ),
+                ),
+                patch.object(http_client, "post", return_value=mock_response),
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert result == "LLM generated description"
+
+    def test_non_working_llm_client_falls_back_to_git_logs(self):
+        """Test fallback to git logs when LLM client is not working."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            # Create LLM client without keys (won't be available)
+            llm_client = LLMClient(http_client)
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+
+            with patch.object(
+                git_data_provider,
+                "get_commit_data",
+                return_value=(
+                    [GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01")],
+                    "1 file changed",
+                    "diff content",
+                ),
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert "Training run based on 1 commit:" in result
+                assert "abcd1234: Add new feature" in result
+
+    def test_llm_client_available_but_generation_fails(self):
+        """Test LLM client is available but generation fails, fallback to git logs."""
+        with httpx.Client() as http_client:
+            git_data_provider = GitDataProvider(http_client)
+            # Create LLM client with key and mock HTTP failure
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            generator = TrainingRunDescriptionGenerator(git_data_provider, llm_client)
+
+            with (
+                patch.object(
+                    git_data_provider,
+                    "get_commit_data",
+                    return_value=(
+                        [GitCommit("abcd1234", "Add new feature", "Author", "2024-01-01")],
+                        "1 file changed",
+                        "diff content",
+                    ),
+                ),
+                patch.object(http_client, "post", side_effect=Exception("API rate limit exceeded")),
+            ):
+                result = generator.generate_description("abcd1234567890abcd1234567890abcd12345678")
+
+                assert "Training run based on 1 commit:" in result
+                assert "abcd1234: Add new feature" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/app/test_git_client.py
+++ b/tests/app/test_git_client.py
@@ -1,0 +1,153 @@
+import pytest
+
+from app_backend.git_client import GitClient, GitCommit, GitError, run_git
+
+
+class TestGitUtilities:
+    """Tests for git utility functions."""
+
+    def test_run_git_success(self):
+        """Test successful git command execution."""
+        result = run_git("rev-parse", "HEAD")
+        assert isinstance(result, str)
+        assert len(result) == 40  # SHA-1 hash
+
+    def test_run_git_failure(self):
+        """Test git command failure handling."""
+        with pytest.raises(GitError) as exc_info:
+            run_git("invalid-command", "invalid-args")
+        assert "Git command failed" in str(exc_info.value)
+
+
+class TestGitClient:
+    """Tests for GitClient."""
+
+    def test_commit_exists_valid(self):
+        """Test commit existence check with valid commit."""
+        git_client = GitClient()
+        current_commit = run_git("rev-parse", "HEAD")
+        assert git_client.commit_exists(current_commit)
+
+    def test_commit_exists_invalid(self):
+        """Test commit existence check with invalid commit."""
+        git_client = GitClient()
+        assert not git_client.commit_exists("invalid-commit-hash")
+
+    def test_get_current_commit(self):
+        """Test getting current commit."""
+        git_client = GitClient()
+        commit = git_client.get_current_commit()
+        assert isinstance(commit, str)
+        assert len(commit) == 40
+
+    def test_get_current_branch(self):
+        """Test getting current branch."""
+        git_client = GitClient()
+        branch = git_client.get_current_branch()
+        assert isinstance(branch, str)
+        assert len(branch) > 0
+
+    def test_get_merge_base_with_main(self):
+        """Test getting merge base with main branch."""
+        git_client = GitClient()
+        current_commit = run_git("rev-parse", "HEAD")
+        merge_base = git_client.get_merge_base(current_commit, "main")
+        assert isinstance(merge_base, str)
+        assert len(merge_base) == 40  # SHA-1 hash
+
+    def test_get_commit_range_single_commit(self):
+        """Test getting commit range for single commit."""
+        git_client = GitClient()
+        current_commit = run_git("rev-parse", "HEAD")
+
+        commits = git_client.get_commit_range(current_commit)
+        assert isinstance(commits, list)
+        if commits:  # Only check if we have commits
+            assert all(isinstance(c, GitCommit) for c in commits)
+            assert all(len(c.hash) == 40 for c in commits)
+
+    def test_get_commit_range_invalid_commit(self):
+        """Test getting commit range for invalid commit."""
+        git_client = GitClient()
+        with pytest.raises(ValueError) as exc_info:
+            git_client.get_commit_range("invalid-commit-hash")
+        assert "Could not retrieve commit history" in str(exc_info.value)
+
+    def test_get_commit_range_known_commit(self):
+        """Test getting commit range for known commit hash."""
+        git_client = GitClient()
+
+        # Use a known commit hash from the current repository
+        # This hash should exist in the metta project history
+        known_commit = "2308eaf792dc19726ba7056cda0a32f5b3cacf3a"
+        # Use a known base commit that should be in main (commit before the target)
+        known_base = "3af59ac4c5493815c141cd4db7435e8b57f67457"
+
+        # Only run test if both commits exist locally
+        if git_client.commit_exists(known_commit) and git_client.commit_exists(known_base):
+            commits = git_client.get_commit_range(known_commit, known_base)
+            assert isinstance(commits, list)
+            assert len(commits) > 0
+
+            # Check that the commit we're looking for is in the range
+            commit_hashes = [c.hash for c in commits]
+            assert known_commit in commit_hashes
+
+            # Verify the expected commit message exists
+            expected_commit = next(c for c in commits if c.hash == known_commit)
+            assert expected_commit.message == "Add training run description"
+            assert expected_commit.author == "Paul Tsier"
+
+    def test_get_commit_range_edge_case_same_commit(self):
+        """Test get_commit_range when commit_hash equals base_branch."""
+        git_client = GitClient()
+
+        # Use a known commit hash from the current repository
+        known_commit = "2308eaf792dc19726ba7056cda0a32f5b3cacf3a"
+
+        # Only run test if the commit exists locally
+        if git_client.commit_exists(known_commit):
+            # Test edge case: commit_hash equals base_branch
+            commits = git_client.get_commit_range(known_commit, known_commit)
+            assert isinstance(commits, list)
+            assert len(commits) == 1  # Should return the single commit
+            assert commits[0].hash == known_commit
+            assert commits[0].message == "Add training run description"
+            assert commits[0].author == "Paul Tsier"
+        else:
+            pytest.skip("Known commits not available locally")
+
+
+class TestGitCommit:
+    """Tests for GitCommit class."""
+
+    def test_git_commit_creation(self):
+        """Test GitCommit object creation."""
+        commit = GitCommit(
+            hash="abcd1234567890abcd1234567890abcd12345678",
+            message="Test commit message",
+            author="Test Author",
+            date="2024-01-01",
+        )
+
+        assert commit.hash == "abcd1234567890abcd1234567890abcd12345678"
+        assert commit.message == "Test commit message"
+        assert commit.author == "Test Author"
+        assert commit.date == "2024-01-01"
+
+    def test_git_commit_repr(self):
+        """Test GitCommit string representation."""
+        commit = GitCommit(
+            hash="abcd1234567890abcd1234567890abcd12345678",
+            message="This is a very long commit message that should be truncated in the repr",
+            author="Test Author",
+            date="2024-01-01",
+        )
+
+        repr_str = repr(commit)
+        assert "abcd1234" in repr_str  # Short hash
+        assert "This is a very long commit message that should be ..." in repr_str
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/app/test_github_client.py
+++ b/tests/app/test_github_client.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app_backend.git_client import GitCommit, GitError
+from app_backend.github_client import GitHubClient, run_gh
+
+
+class TestGithubUtilities:
+    def test_run_gh_not_installed(self):
+        """Test GitHub CLI not installed scenario."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            with pytest.raises(GitError) as exc_info:
+                run_gh("pr", "list")
+            assert "GitHub CLI (gh) is not installed" in str(exc_info.value)
+
+
+class TestGitHubClient:
+    """Tests for GitHubClient."""
+
+    def test_github_client_creation(self):
+        """Test GitHubClient creation with httpx dependency."""
+        with httpx.Client() as http_client:
+            github_client = GitHubClient(http_client)
+            assert github_client.http_client == http_client
+
+    def test_get_merge_base_success(self):
+        """Test successful merge base retrieval."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"merge_base_commit": {"sha": "abc123"}}
+
+        with httpx.Client() as http_client:
+            github_client = GitHubClient(http_client)
+
+            with patch.object(http_client, "get", return_value=mock_response):
+                result = github_client.get_merge_base("commit-hash")
+                assert result == "abc123"
+
+    def test_get_merge_base_failure(self):
+        """Test merge base retrieval failure."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not found", request=None, response=mock_response
+        )
+
+        with httpx.Client() as http_client:
+            github_client = GitHubClient(http_client)
+
+            with patch.object(http_client, "get", return_value=mock_response):
+                with pytest.raises(httpx.HTTPStatusError):
+                    github_client.get_merge_base("invalid-commit-hash")
+
+    def test_get_commit_range_success(self):
+        """Test successful commit range retrieval."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "commits": [
+                {
+                    "sha": "abc123",
+                    "commit": {
+                        "message": "Test commit",
+                        "author": {"name": "Test Author", "date": "2024-01-01T00:00:00Z"},
+                    },
+                }
+            ]
+        }
+
+        with httpx.Client() as http_client:
+            github_client = GitHubClient(http_client)
+
+            with patch.object(http_client, "get", return_value=mock_response):
+                commits = github_client.get_commit_range("merge-base", "commit-hash")
+                assert len(commits) == 1
+                assert isinstance(commits[0], GitCommit)
+                assert commits[0].hash == "abc123"
+                assert commits[0].message == "Test commit"
+                assert commits[0].author == "Test Author"
+                assert commits[0].date == "2024-01-01"
+
+    def test_get_commit_range_failure(self):
+        """Test commit range retrieval failure."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not found", request=None, response=mock_response
+        )
+
+        with httpx.Client() as http_client:
+            github_client = GitHubClient(http_client)
+
+            with patch.object(http_client, "get", return_value=mock_response):
+                with pytest.raises(httpx.HTTPStatusError):
+                    github_client.get_commit_range("merge-base", "invalid-commit-hash")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/app/test_llm_client.py
+++ b/tests/app/test_llm_client.py
@@ -1,0 +1,162 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app_backend.llm_client import LLMClient
+
+
+class TestLLMClient:
+    """Tests for LLMClient."""
+
+    def test_llm_client_creation(self):
+        """Test LLMClient creation with httpx dependency."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client)
+            assert llm_client.http_client == http_client
+
+    def test_is_available_no_keys(self):
+        """Test is_available returns False when no API keys are present."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client)
+            assert not llm_client.is_available()
+
+    def test_is_available_with_openai_key(self):
+        """Test is_available returns True when OpenAI key is present."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openai_api_key="test-openai-key")
+            assert llm_client.is_available()
+
+    def test_is_available_with_anthropic_key(self):
+        """Test is_available returns True when Anthropic key is present."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, anthropic_api_key="test-anthropic-key")
+            assert llm_client.is_available()
+
+    def test_is_available_with_openrouter_key(self):
+        """Test is_available returns True when OpenRouter key is present."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openrouter_api_key="test-openrouter-key")
+            assert llm_client.is_available()
+
+    def test_is_available_with_multiple_keys(self):
+        """Test is_available returns True when multiple keys are present."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(
+                http_client, openai_api_key="test-openai-key", anthropic_api_key="test-anthropic-key"
+            )
+            assert llm_client.is_available()
+
+    def test_generate_text_with_messages_no_keys(self):
+        """Test generate_text_with_messages raises error when no keys are available."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client)
+
+            with pytest.raises(RuntimeError) as exc_info:
+                llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+            assert "No LLM API keys available" in str(exc_info.value)
+
+    def test_generate_text_with_messages_openai_success(self):
+        """Test successful text generation with OpenAI."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            # Mock successful API response
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "Generated text response"}}]}
+
+            with patch.object(http_client, "post", return_value=mock_response):
+                result = llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert result == "Generated text response"
+
+    def test_generate_text_with_messages_anthropic_success(self):
+        """Test successful text generation with Anthropic."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, anthropic_api_key="test-key")
+
+            # Mock successful API response
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"content": [{"text": "Anthropic generated text"}]}
+
+            with patch.object(http_client, "post", return_value=mock_response):
+                result = llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert result == "Anthropic generated text"
+
+    def test_generate_text_with_messages_http_error(self):
+        """Test generate_text_with_messages handles HTTP errors properly."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            # Mock HTTP error
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_response.text = "Rate limit exceeded"
+
+            with patch.object(
+                http_client,
+                "post",
+                side_effect=httpx.HTTPStatusError("Rate limit", request=None, response=mock_response),
+            ):
+                with pytest.raises(Exception) as exc_info:
+                    llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert "LLM API request failed: 429" in str(exc_info.value)
+
+    def test_generate_text_with_messages_timeout_error(self):
+        """Test generate_text_with_messages handles timeout errors properly."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openai_api_key="test-key")
+
+            with patch.object(http_client, "post", side_effect=httpx.TimeoutException("Timeout")):
+                with pytest.raises(Exception) as exc_info:
+                    llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert "LLM API request timed out" in str(exc_info.value)
+
+    def test_generate_text_with_messages_openrouter_success(self):
+        """Test successful text generation with OpenRouter (uses OpenAI format)."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(http_client, openrouter_api_key="test-key")
+
+            # Mock successful API response (OpenAI format)
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"choices": [{"message": {"content": "OpenRouter generated text"}}]}
+
+            with patch.object(http_client, "post", return_value=mock_response):
+                result = llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert result == "OpenRouter generated text"
+
+                # Verify the API was called with the correct URL
+                http_client.post.assert_called_once()
+                call_args = http_client.post.call_args
+                assert "openrouter.ai" in call_args[0][0]
+
+    def test_provider_fallback(self):
+        """Test that providers are tried in order until one succeeds."""
+        with httpx.Client() as http_client:
+            llm_client = LLMClient(
+                http_client, openai_api_key="test-openai-key", anthropic_api_key="test-anthropic-key"
+            )
+
+            # Mock first provider fails, second succeeds
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"content": [{"text": "Anthropic fallback response"}]}
+
+            # First call raises error, second returns response
+            with patch.object(
+                http_client,
+                "post",
+                side_effect=[
+                    httpx.HTTPStatusError(
+                        "OpenAI failed", request=None, response=MagicMock(status_code=500, text="Error")
+                    ),
+                    mock_response,
+                ],
+            ):
+                result = llm_client.generate_text_with_messages([{"role": "user", "content": "test prompt"}])
+                assert result == "Anthropic fallback response"
+
+                # Verify both providers were tried
+                assert http_client.post.call_count == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/app/test_stats_server.py
+++ b/tests/app/test_stats_server.py
@@ -157,6 +157,19 @@ class TestStatsServerSimple:
         policy_ids = stats_client.get_policy_ids(["nonexistent_policy"])
         assert policy_ids.policy_ids == {}
 
+    def test_training_run_with_git_data(self, stats_client: StatsClient) -> None:
+        """Test training run creation with boolean attributes (for git hash functionality)."""
+        # Test git-like attributes with boolean values
+        git_attributes = {
+            "git_hash": "2308eaf792dc19726ba7056cda0a32f5b3cacf3a",
+            "has_uncommitted_changes": True,  # Native boolean
+        }
+
+        training_run = stats_client.create_training_run(
+            name="test_git_attributes_run", attributes=git_attributes, url="https://example.com/git-run"
+        )
+        assert training_run.id is not None
+
 
 if __name__ == "__main__":
     # Simple test runner for debugging


### PR DESCRIPTION
Video demo here: https://jam.dev/c/1447a335-7f06-409c-85a5-b8f35057b809

Automatically generate description for a training run based on git commit history.

# Key Features

  - 3 LLM providers: OpenAI, Anthropic, OpenRouter with automatic failover and cost tracking
  - Flexible git integration: Local git → GitHub API fallback for both dev and containerized environments
  - Environment configuration: All settings via env vars (OPENAI_API_KEY, GIT_CLIENT_MODE=auto|local_only|github_only, etc.)
  - Graceful degradation: Falls back to git logs when LLMs unavailable
  - Research-focused output: 80-word scientific descriptions for ML experiments

#  Implementation

  - description_generator.py: Core orchestration with dependency injection
  - llm_client.py: Multi-provider client with failover logic
  - git_client.py + github_client.py: Dual-mode git data providers
  - REST API: POST /dashboard/training-runs/{run_id}/generate-description
  - Frontend integration in training run detail view
  
# Configuration

## LLM Providers

If no API keys are set, git log is returned instead.

```bash
OPENAI_API_KEY=sk-...
ANTHROPIC_API_KEY=sk-ant-...
OPENROUTER_API_KEY=sk-or-...
```

## Default Models

```bash
OPENAI_MODEL=gpt-4o-mini
ANTHROPIC_MODEL=claude-3-5-haiku-20241022
OPENROUTER_MODEL=openrouter/auto
```

## Git Mode

```bash
GIT_CLIENT_MODE=auto        # auto|local_only|github_only
```

- `auto`: Try local git, fallback to GitHub API
- `local_only`: Only local git, for local dev/air-gapped environments
- `github_only`: Containers without git CLI