### PR TITLE
Add a sparse eval

### DIFF
--- a/configs/env/mettagrid/navigation/evals/emptyspace_sparse_medium.yaml
+++ b/configs/env/mettagrid/navigation/evals/emptyspace_sparse_medium.yaml
@@ -1,0 +1,44 @@
+defaults:
+  - /env/mettagrid/navigation/evals/defaults@
+  - _self_
+
+game:
+  max_steps: 1000
+
+  map_builder:
+    _target_: metta.map.mapgen.MapGen
+    width: 100
+    height: 100
+    border_width: 5
+
+    root:
+      type: metta.map.scenes.room_grid.RoomGrid
+      params:
+        border_width: 0
+        layout: [
+        ["border", "border", "border", "border", "border"],
+        ["border", "middle", "middle", "middle", "border"],
+        ["border", "middle", "middle", "middle", "border"],
+        ["border", "middle", "middle", "middle", "border"],
+        ["border", "border", "border", "border", "border"]
+        ]
+      children:
+        - where:
+            tags:
+              - middle
+          limit: 3
+          lock: lock
+          scene:
+            type: metta.map.scenes.random.Random
+            params:
+              objects:
+                altar: 1
+        - where:
+            tags:
+              - middle
+          limit: 1
+          lock: lock
+          scene:
+            type: metta.map.scenes.random.Random
+            params:
+              agents: 1

--- a/configs/env/mettagrid/navigation/training/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation/training/cylinder_world.yaml
@@ -3,17 +3,7 @@ defaults:
   - _self_
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/cylinder-world_large,varied_terrain/cylinder-world_medium,varied_terrain/cylinder-world_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1
+

--- a/configs/env/mettagrid/navigation/training/large.yaml
+++ b/configs/env/mettagrid/navigation/training/large.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_large,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/medium.yaml
+++ b/configs/env/mettagrid/navigation/training/medium.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_medium,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/small.yaml
+++ b/configs/env/mettagrid/navigation/training/small.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_small,varied_terrain/maze_small,varied_terrain/sparse_small,varied_terrain/dense_small,varied_terrain/cylinder-world_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
@@ -3,17 +3,6 @@ defaults:
   - _self_
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: terrain_maps_nohearts
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/balanced_large,varied_terrain/balanced_medium,varied_terrain/balanced_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/dense_large,varied_terrain/dense_medium,varied_terrain/dense_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
@@ -5,17 +5,6 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     room:
       dir: ${choose:varied_terrain/maze_large,varied_terrain/maze_medium,varied_terrain/maze_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
@@ -5,20 +5,9 @@ defaults:
 sampling: 1
 
 game:
-  num_agents: 4
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
     num_rooms: ${..num_agents}
     border_width: 6
     room:
       dir: ${choose:varied_terrain/sparse_large,varied_terrain/sparse_medium,varied_terrain/sparse_small}
-  objects:
-    altar:
-      cooldown: 1000
-      input_resources:
-        battery_red: 3
-      output_resources:
-        heart: 1
-      max_output: 5
-      conversion_ticks: 1
-      initial_resource_count: 1

--- a/configs/sim/all.yaml
+++ b/configs/sim/all.yaml
@@ -18,6 +18,8 @@ simulations:
     env: env/mettagrid/navigation/evals/emptyspace_outofsight
   navigation/emptyspace_sparse:
     env: env/mettagrid/navigation/evals/emptyspace_sparse
+  navigation/emptyspace_sparse_medium:
+    env: env/mettagrid/navigation/evals/emptyspace_sparse_medium
   navigation/walls_withinsight:
     env: env/mettagrid/navigation/evals/walls_withinsight
   navigation/walls_outofsight:

--- a/configs/sim/all_tokenized.yaml
+++ b/configs/sim/all_tokenized.yaml
@@ -11,6 +11,8 @@ simulations:
     env: env/mettagrid/navigation/evals/emptyspace_outofsight
   navigation/emptyspace_sparse:
     env: env/mettagrid/navigation/evals/emptyspace_sparse
+  navigation/emptyspace_sparse_medium:
+    env: env/mettagrid/navigation/evals/emptyspace_sparse_medium
   navigation/walls_withinsight:
     env: env/mettagrid/navigation/evals/walls_withinsight
   navigation/walls_outofsight:

--- a/configs/sim/navigation.yaml
+++ b/configs/sim/navigation.yaml
@@ -11,6 +11,8 @@ simulations:
     env: env/mettagrid/navigation/evals/emptyspace_outofsight
   navigation/emptyspace_sparse:
     env: env/mettagrid/navigation/evals/emptyspace_sparse
+  navigation/emptyspace_sparse_medium:
+    env: env/mettagrid/navigation/evals/emptyspace_sparse_medium
   navigation/walls_withinsight:
     env: env/mettagrid/navigation/evals/walls_withinsight
   navigation/walls_outofsight:


### PR DESCRIPTION
Adds a sparse eval for navigation training. This is larger than the previous sparse eval we had, and built in a somewhat different way.

Happy to discuss naming and implementation!

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210761075998485)