### PR TITLE
intall mettascope playwright properly in tests

### DIFF
--- a/.github/workflows/test-mettascope.yml
+++ b/.github/workflows/test-mettascope.yml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Install Playwright (Chromium only)
         run: |
-          npm install --no-save playwright
+          cd mettascope
+          npm install
           npx playwright install --with-deps chromium
 
       - name: Install uv


### PR DESCRIPTION
- fixes flake: https://github.com/Metta-AI/metta/runs/45758907730
- I was installing playwright with chrome in the wrong folder. I believe this caused issues when the cached playwright was a different version than the gone in node modules.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210768646656485)