### PR TITLE
Add poor resource variants to mettagrid arena environments

### DIFF
--- a/configs/env/mettagrid/arena/advanced_poor.yaml
+++ b/configs/env/mettagrid/arena/advanced_poor.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - combat_poor
+  - /env/mettagrid/game/objects/advanced@game.objects
+  - _self_
+
+game:
+  map_builder:
+    root:
+      params:
+        objects:
+          lab: 1
+          factory: 1
+          temple: 1

--- a/configs/env/mettagrid/arena/basic_poor.yaml
+++ b/configs/env/mettagrid/arena/basic_poor.yaml
@@ -1,0 +1,14 @@
+# Simple map with mines / generators / altar
+# and default settings.
+
+defaults:
+  - basic
+  - _self_
+
+game:
+  map_builder:
+    root:
+      params:
+        objects:
+          mine_red: 3
+          generator_red: 2

--- a/configs/env/mettagrid/arena/combat_poor.yaml
+++ b/configs/env/mettagrid/arena/combat_poor.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - basic_poor
+  - /env/mettagrid/game/objects/combat@game.objects
+  - _self_
+
+game:
+  map_builder:
+    root:
+      params:
+        objects:
+          lasery: 1
+          armory: 1

--- a/configs/env/mettagrid/curriculum/arena/random.yaml
+++ b/configs/env/mettagrid/curriculum/arena/random.yaml
@@ -4,14 +4,17 @@ tasks:
   /env/mettagrid/arena/basic: 1
   /env/mettagrid/arena/basic_easy: 1
   /env/mettagrid/arena/basic_easy_shaped: 1
+  /env/mettagrid/arena/basic_poor: 1
 
   /env/mettagrid/arena/combat: 1
   /env/mettagrid/arena/combat_easy: 1
   /env/mettagrid/arena/combat_easy_shaped: 1
+  /env/mettagrid/arena/combat_poor: 1
 
   /env/mettagrid/arena/advanced: 1
   /env/mettagrid/arena/advanced_easy: 1
   /env/mettagrid/arena/advanced_easy_shaped: 1
+  /env/mettagrid/arena/advanced_poor: 1
 
   /env/mettagrid/arena/tag: 1
   /env/mettagrid/arena/tag_easy: 1

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -13,3 +13,5 @@ simulations:
     env: /env/mettagrid/arena/advanced
   arena/tag:
     env: /env/mettagrid/arena/tag
+  arena/advanced_poor:
+    env: /env/mettagrid/arena/advanced_poor

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -56,12 +56,12 @@ analyzer:
 
 replay_job:
   sim:
-    env: /env/mettagrid/arena/combat_easy
-    env_overrides:
-      game:
-        objects:
-          lasery:
-            initial_resource_count: 20
+    env: /env/mettagrid/arena/advanced_poor
+    # env_overrides:
+    #   game:
+    #     objects:
+    #       lasery:
+    #         initial_resource_count: 20
 
 # sim_job:
 # policy_agents_pct: 1

--- a/mettagrid/src/metta/mettagrid/mettagrid_env.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_env.py
@@ -146,7 +146,15 @@ class MettaGridEnv(PufferEnv, GymEnv):
         # Convert string array to list of strings for C++ compatibility
         # TODO: push the not-numpy-array higher up the stack, and consider pushing not-a-sparse-list lower.
         with self.timer("_initialize_c_env.make_c_env"):
-            self._c_env = MettaGrid(from_mettagrid_config(game_config_dict), level.grid.tolist(), self._current_seed)
+            c_cfg = None
+            try:
+                c_cfg = from_mettagrid_config(game_config_dict)
+            except Exception as e:
+                logger.error(f"Error initializing C++ environment: {e}")
+                logger.error(f"Game config: {game_config_dict}")
+                raise e
+
+            self._c_env = MettaGrid(c_cfg, level.grid.tolist(), self._current_seed)
 
         self._grid_env = self._c_env
 


### PR DESCRIPTION
### TL;DR

Added new "poor" arena variants with reduced resources and updated the curriculum to include them.

### What changed?

- Added three new arena configurations with reduced resources:
  - `basic_poor.yaml`: A variant of basic arena with fewer mines and generators
  - `combat_poor.yaml`: Extends basic_poor with combat objects
  - `advanced_poor.yaml`: Extends combat_poor with advanced objects (lab, factory, temple)
- Updated the random curriculum to include these new poor variants
- Added advanced_poor to the sim configurations
- Updated error handling in the C++ environment initialization to provide more detailed error messages
- Updated daveey's user config to use advanced_poor for replay jobs

### How to test?

1. Run a simulation with the new poor variants:
   ```
   python -m metta.cli.sim arena/advanced_poor
   ```
2. Verify the random curriculum includes the new poor variants
3. Check that the environments initialize correctly with reduced resources

### Why make this change?

These new "poor" variants provide environments with fewer resources, creating more challenging scenarios for agents to learn resource management. This helps test agent adaptability in resource-constrained environments and provides more diverse training scenarios in the curriculum.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210768744534170)