### PR TITLE
metta cli wraps tools

### DIFF
--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -204,6 +204,19 @@ class MettaCLI:
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
 
+    def cmd_tool(self, tool_name: str, args: list[str]) -> None:
+        """Run a tool from the tools/ directory using uv run."""
+        tool_path = self.repo_root / "tools" / f"{tool_name}.py"
+        if not tool_path.exists():
+            error(f"Tool '{tool_name}' not found at {tool_path}")
+            sys.exit(1)
+
+        cmd = [str(tool_path)] + args
+        try:
+            subprocess.run(cmd, cwd=self.repo_root, check=True)
+        except subprocess.CalledProcessError as e:
+            sys.exit(e.returncode)
+
     def cmd_status(self, _args) -> None:
         """Show status of all components."""
         modules = get_all_modules(self.config)
@@ -342,8 +355,12 @@ Examples:
   metta status                         # Show component status
   metta clean                          # Clean build artifacts
   metta symlink-setup                  # Set up symlink to make metta command globally available
+
   metta test ...                       # Run python unit tests
   metta test-changed ...               # Run python unit tests affected by changes
+
+  metta tool train run=test            # Run train.py tool with arguments
+  metta tool sim policy_uri=...        # Run sim.py tool with arguments
             """,
         )
 
@@ -388,10 +405,14 @@ Examples:
         subparsers.add_parser("test", help="Run python unit tests")
         subparsers.add_parser("test-changed", help="Run python unit tests affected by changes")
 
+        # Tool command
+        tool_parser = subparsers.add_parser("tool", help="Run a tool from the tools/ directory")
+        tool_parser.add_argument("tool_name", help="Name of the tool to run (e.g., 'train', 'sim', 'analyze')")
+
         # Use parse_known_args to handle unknown arguments for test commands
         args, unknown_args = parser.parse_known_args()
 
-        if args.command not in ["test", "test-changed"]:
+        if args.command not in ["test", "test-changed", "tool"]:
             if unknown_args:
                 parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
 
@@ -428,6 +449,8 @@ Examples:
             self.cmd_pytest(unknown_args)
         elif args.command == "test-changed":
             self.cmd_pytest(unknown_args + ["--testmon"])
+        elif args.command == "tool":
+            self.cmd_tool(args.tool_name, unknown_args)
         else:
             parser.print_help()
 


### PR DESCRIPTION
Reading all the `uv run ./tools/{x}.py {args}` commands [here](https://github.com/Metta-AI/metta/pull/1434/files#diff-e0d9c3f046dccba6f00e7cdeb50bfc30603c1a808a5b5ba27fd623a330d3bab9R24) inspired this

`metta tool {x} {args}` seems a bit cleaner, and moves us towards having a single entrypoint for developer commands in the repo

this change doesn't do much substantively. in the future, maybe `metta_cli` could:
- be the home for managing user configs (what we currently have in `configs/user/{name}.yaml`) and could automatically pass those along to tool commands
- parse arguments (e.g. `wandb` enabled) to these commands, check them against what is installed and connected, and prompt installation/authentication where not