### PR TITLE
Is there a popup open, don't show another one.

### DIFF
--- a/mettascope/src/hoverpanels.ts
+++ b/mettascope/src/hoverpanels.ts
@@ -92,6 +92,14 @@ hoverPanel.addEventListener('mousedown', (e: MouseEvent) => {
 /** Updates the hover panel's visibility, position, and DOM tree. */
 export function updateHoverPanel(object: any) {
   if (object !== null && object !== undefined) {
+    // Is there a popup open for this object?
+    // Then don't show a new one.
+    for (let panel of ui.hoverPanels) {
+      if (panel.object === object) {
+        return
+      }
+    }
+
     let typeName = state.replay.object_types[getAttr(object, 'type')]
     if (typeName == 'wall') {
       // Don't show hover panel for walls.


### PR DESCRIPTION
Hovering over agents that have a popup open will not open a new one:

<img width="1335" height="671" alt="image" src="https://github.com/user-attachments/assets/110cdade-2149-44be-bb3e-a0a30ebeb4ca" />
