### PR TITLE
fix: troubleshoot CI timeout

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,7 +154,7 @@ jobs:
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
         run: |
           for package in $SUBPACKAGES; do
             echo "Running tests for $package..."
-            (cd "$package" && pytest -n ${{ env.PYTEST_WORKERS }} --benchmark-skip --maxfail=1 --disable-warnings -q) || exit 1
+            (cd "$package" && pytest -n ${{ env.PYTEST_WORKERS }} --benchmark-skip --maxfail=1 --disable-warnings -v) || exit 1
           done
 
       - name: Run MettaGrid C++ tests


### PR DESCRIPTION
The app_backend tests are timing out at 10 min.

```
Running tests for app_backend...
Cannot read termcap database;
using dumb terminal settings.
Cannot read termcap database;
using dumb terminal settings.
Cannot read termcap database;
using dumb terminal settings.
bringing up nodes...
bringing up nodes...

Error: The operation was canceled.
```

This PR increases the allowed time to 15 minutes and switches the test from quiet (-q) to verbose (-v) so that we can troubleshoot what is going on.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210778535720822)