### PR TITLE
fix mapgen instances

### DIFF
--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -28,10 +28,17 @@ class MapGenParams(Config):
     # This value usually shouldn't be changed.
     border_width: int = 5
 
-    # Number of root scene instances to generate.
-    # If set, the map will be generated as a grid of instances, with the given border width.
-    # This is useful for additional parallelization.
-    # By default, the map will be generated as a single root scene instance, with the given width and height.
+    # Number of root scene instances to generate. If set, the map will be
+    # generated as a grid of instances, separated by the given
+    # `instance_border_width`.
+    #
+    # MapGen will try to make the grid as square as possible, and if that
+    # square-ish grid will have more areas than the number of instances, it will
+    # leave some areas empty.
+    #
+    # This is useful for additional parallelization. By default, the map will be
+    # generated as a single root scene instance, with the given width and
+    # height.
     instances: int = 1
     instance_border_width: int = 5
 

--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -79,6 +79,8 @@ class MapGen(LevelBuilder):
                     ChildrenAction(
                         scene=self.root,
                         where=AreaWhere(tags=["room"]),
+                        limit=self.instances,
+                        order_by="first",
                     )
                 ],
             )

--- a/tests/map/test_mapgen.py
+++ b/tests/map/test_mapgen.py
@@ -34,11 +34,18 @@ def test_mapgen_basic_dimensions(width, height, border_width):
 
 
 # 2. instances and instance_border_width ---------------------------------------
-@pytest.mark.parametrize("instances,instance_bw", [(4, 1), (9, 2)])
+@pytest.mark.parametrize(
+    "instances,instance_bw",
+    [
+        (4, 1),
+        (9, 2),
+        (24, 1),  # make sure it's 24 rooms, not 25 (5x5 grid but last room is empty)
+    ],
+)
 def test_mapgen_instances(instances, instance_bw):
     width, height, border_width = 5, 3, 2
     mg = MapGen(
-        root={"type": "metta.map.scenes.nop.Nop"},
+        root={"type": "metta.map.scenes.inline_ascii.InlineAscii", "params": {"data": "@"}},
         width=width,
         height=height,
         border_width=border_width,
@@ -54,6 +61,7 @@ def test_mapgen_instances(instances, instance_bw):
     expected_shape = (inner_h + 2 * border_width, inner_w + 2 * border_width)
     assert level.grid.shape == expected_shape
     assert isinstance(mg.root_scene, RoomGrid)
+    assert np.count_nonzero(np.char.startswith(level.grid, "agent")) == instances
 
 
 # 3. intrinsic_size interplay ---------------------------------------------------


### PR DESCRIPTION
Set `limit` so that we fill only `instances` sub-scenes instead of whatever grid was created.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210782204869203)