### PR TITLE
Always evaluate policy at training end

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -378,10 +378,13 @@ class MettaTrainer:
             logger.info(f"  {name}: {self.timer.format_time(summary['total_elapsed'])}")
 
         # Force final saves
-        self._maybe_evaluate_policy(force=True)
         self._maybe_save_policy(force=True)
         self._maybe_save_training_state(force=True)
         self._maybe_upload_policy_record_to_wandb(force=True)
+
+        if self._stats_epoch_start < self.epoch:
+            # If we have not just evaluated the latest policy, evaluate it
+            self._maybe_evaluate_policy(force=True)
 
     def _on_train_step(self):
         pass

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -378,6 +378,7 @@ class MettaTrainer:
             logger.info(f"  {name}: {self.timer.format_time(summary['total_elapsed'])}")
 
         # Force final saves
+        self._maybe_evaluate_policy(force=True)
         self._maybe_save_policy(force=True)
         self._maybe_save_training_state(force=True)
         self._maybe_upload_policy_record_to_wandb(force=True)


### PR DESCRIPTION
To address confusion about the lack of generated eval metrics or replays, even though there are saved policy checkpoints, for runs with very few timesteps

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210794225364893)