### PR TITLE
chore: fix cpp warnings

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/attack.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/attack.hpp
@@ -49,11 +49,11 @@ protected:
     //   A    (Agent position)
 
     // Column offsets to check: center, left, right
-    static constexpr int COL_OFFSETS[3] = {0, -1, 1};
+    static constexpr short COL_OFFSETS[3] = {0, -1, 1};
 
     // Scan the 9 squares in front of the agent (3x3 grid)
-    for (int distance = 1; distance <= 3; distance++) {
-      for (int offset : COL_OFFSETS) {
+    for (short distance = 1; distance <= 3; distance++) {
+      for (short offset : COL_OFFSETS) {
         GridLocation target_loc = _grid->relative_location(actor->location, actor->orientation, distance, offset);
         target_loc.layer = GridLayer::AgentLayer;
 

--- a/mettagrid/src/metta/mettagrid/actions/change_color.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/change_color.hpp
@@ -1,5 +1,6 @@
 #ifndef ACTIONS_CHANGE_COLOR_HPP_
 #define ACTIONS_CHANGE_COLOR_HPP_
+
 #include <string>
 
 #include "action_handler.hpp"
@@ -16,16 +17,22 @@ public:
 
 protected:
   bool _handle_action(Agent* actor, ActionArg arg) override {
-    // Note: 'color' is interpreted as HSV hue (0-255 range, wrapping)
+    // Note: 'color' is uint8_t which naturally wraps at 256.
+    // This could be interpreted as circular hue behavior (red -> orange -> ... -> violet -> red)
+
+    // Calculate step size once (integer division is intentional)
+    const uint8_t step_size = static_cast<uint8_t>(255 / (max_arg() + 1));
+
     if (arg == 0) {  // Increment
-      actor->color = (actor->color + 1) % 256;
-    } else if (arg == 1) {                        // Decrement
-      actor->color = (actor->color + 255) % 256;  // Equivalent to -1 with wrapping
-    } else if (arg == 2) {                        // Large increment
-      actor->color = (actor->color + 255 / (max_arg() + 1)) % 256;
+      actor->color = static_cast<uint8_t>(actor->color + 1);
+    } else if (arg == 1) {  // Decrement
+      actor->color = static_cast<uint8_t>(actor->color - 1);
+    } else if (arg == 2) {  // Large increment
+      actor->color = static_cast<uint8_t>(actor->color + step_size);
     } else if (arg == 3) {  // Large decrement
-      actor->color = (actor->color + 256 - (255 / (max_arg() + 1))) % 256;
+      actor->color = static_cast<uint8_t>(actor->color - step_size);
     }
+
     return true;
   }
 };

--- a/mettagrid/src/metta/mettagrid/actions/change_glyph.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/change_glyph.hpp
@@ -30,7 +30,7 @@ protected:
   const ObservationType _number_of_glyphs;
 
   bool _handle_action(Agent* actor, ActionArg arg) override {
-    actor->glyph = arg;
+    actor->glyph = static_cast<ObservationType>(arg);  // ActionArg is int32 for puffer compatibility
     return true;
   }
 };

--- a/mettagrid/src/metta/mettagrid/event.hpp
+++ b/mettagrid/src/metta/mettagrid/event.hpp
@@ -47,10 +47,10 @@ public:
   Grid* grid;
   map<EventType, unique_ptr<EventHandler>> event_handlers;
 
-  EventManager() : grid(nullptr), _current_timestep(0) {}
+  EventManager() : _event_queue(), _current_timestep(0), grid(nullptr), event_handlers() {}
 
-  void init(Grid* grid) {
-    this->grid = grid;
+  void init(Grid* grid_ptr) {
+    this->grid = grid_ptr;
   }
 
   void schedule_event(EventType event_type, unsigned int delay, GridObjectId object_id, EventArg arg) {

--- a/mettagrid/src/metta/mettagrid/hash.hpp
+++ b/mettagrid/src/metta/mettagrid/hash.hpp
@@ -33,20 +33,20 @@ inline void _wymum(uint64_t* A, uint64_t* B) {
   // Fast path for 64-bit platforms with 128-bit support
   __uint128_t r = *A;
   r *= *B;
-  *A = (uint64_t)r;
-  *B = (uint64_t)(r >> 64);
+  *A = static_cast<uint64_t>(r);
+  *B = static_cast<uint64_t>(r >> 64);
 #else
   // Portable fallback
   uint64_t ha = *A >> 32, hb = *B >> 32;
-  uint64_t la = (uint32_t)*A, lb = (uint32_t)*B;
+  uint64_t la = static_cast<uint32_t>(*A), lb = static_cast<uint32_t>(*B);
   uint64_t rh = ha * hb;
   uint64_t rm0 = ha * lb;
   uint64_t rm1 = hb * la;
   uint64_t rl = la * lb;
   uint64_t t = rl + (rm0 << 32);
-  auto c = (uint64_t)(t < rl);
+  auto c = static_cast<uint64_t>(t < rl);
   uint64_t lo = t + (rm1 << 32);
-  c += (uint64_t)(lo < t);
+  c += static_cast<uint64_t>(lo < t);
   uint64_t hi = rh + (rm0 >> 32) + (rm1 >> 32) + c;
   *A = lo;
   *B = hi;
@@ -73,12 +73,12 @@ inline uint64_t _wyr4(const uint8_t* p) {
 }
 
 inline uint64_t _wyr3(const uint8_t* p, size_t k) {
-  return (((uint64_t)p[0]) << 16) | (((uint64_t)p[k >> 1]) << 8) | p[k - 1];
+  return ((static_cast<uint64_t>(p[0])) << 16) | ((static_cast<uint64_t>(p[k >> 1])) << 8) | p[k - 1];
 }
 
 // Main hash function
 inline uint64_t hash(const void* key, size_t len, uint64_t seed = 0) {
-  const uint8_t* p = (const uint8_t*)key;
+  const uint8_t* p = static_cast<const uint8_t*>(key);
   seed ^= _wymix(seed ^ _wyp[0], _wyp[1]);
   uint64_t a, b;
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -44,7 +44,7 @@ struct ChangeGlyphActionConfig;
 namespace py = pybind11;
 
 struct GameConfig {
-  int num_agents;
+  unsigned int num_agents;
   unsigned int max_steps;
   ObservationCoord obs_width;
   ObservationCoord obs_height;
@@ -101,6 +101,8 @@ private:
   // Member variables
   std::map<unsigned int, float> _group_reward_pct;
   std::map<unsigned int, unsigned int> _group_sizes;
+  std::vector<RewardType> _group_rewards;
+
   std::unique_ptr<Grid> _grid;
   std::unique_ptr<EventManager> _event_manager;
 

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -44,7 +44,7 @@ struct AgentConfig : public GridObjectConfig {
 
 class Agent : public GridObject {
 public:
-  unsigned char group;
+  ObservationType group;
   short frozen;
   short freeze_duration;
   Orientation orientation;
@@ -60,15 +60,15 @@ public:
   ObservationType glyph;
   unsigned char agent_id;  // index into MettaGrid._agents (vector<Agent*>)
   StatsTracker stats;
-  float current_resource_reward;
-  float* reward;
+  RewardType current_resource_reward;
+  RewardType* reward;
 
   Agent(GridCoord r, GridCoord c, const AgentConfig& config)
       : group(config.group_id),
         frozen(0),
         freeze_duration(config.freeze_duration),
         orientation(Orientation::Up),
-        resource_limits(config.resource_limits),  // inventory
+        inventory(),  // default constructor
         resource_rewards(config.resource_rewards),
         resource_reward_max(config.resource_reward_max),
         action_failure_penalty(config.action_failure_penalty),
@@ -76,62 +76,49 @@ public:
         color(0),
         glyph(0),
         agent_id(0),
-        // stats - default constructed
+        stats(),  // default constructor
         current_resource_reward(0),
-        reward(nullptr) {
+        reward(nullptr),
+        resource_limits(config.resource_limits) {
     GridObject::init(config.type_id, config.type_name, GridLocation(r, c, GridLayer::AgentLayer));
   }
 
-  void init(float* reward_ptr) {
+  void init(RewardType* reward_ptr) {
     this->reward = reward_ptr;
   }
 
   InventoryDelta update_inventory(InventoryItem item, InventoryDelta attempted_delta) {
-    InventoryQuantity initial_amount = this->inventory[item];
+    // Get the initial amount (0 if item doesn't exist)
+    InventoryQuantity initial_amount = 0;
+    auto inv_it = this->inventory.find(item);
+    if (inv_it != this->inventory.end()) {
+      initial_amount = inv_it->second;
+    }
 
+    // Calculate the new amount with clamping
     InventoryQuantity new_amount = static_cast<InventoryQuantity>(std::clamp(
         static_cast<int>(initial_amount + attempted_delta), 0, static_cast<int>(this->resource_limits[item])));
 
     InventoryDelta delta = new_amount - initial_amount;
 
+    // Update inventory
     if (new_amount > 0) {
       this->inventory[item] = new_amount;
     } else {
       this->inventory.erase(item);
     }
 
+    // Update stats
     if (delta > 0) {
       this->stats.add(this->stats.inventory_item_name(item) + ".gained", delta);
     } else if (delta < 0) {
       this->stats.add(this->stats.inventory_item_name(item) + ".lost", -delta);
     }
 
-    this->compute_resource_reward(item);
+    // Update resource rewards incrementally
+    this->_update_resource_reward(item, initial_amount, new_amount);
 
     return delta;
-  }
-
-  // Recalculates resource rewards for the agent.
-  // item -- the item that was added or removed from the inventory, triggering the reward recalculation.
-  inline void compute_resource_reward(InventoryItem item) {
-    if (this->resource_rewards.count(item) == 0) {
-      // If the item is not in the resource_rewards map, we don't need to recalculate the reward.
-      return;
-    }
-
-    // Recalculate resource rewards. Note that we're recalculating our total reward, not just the reward for the
-    // item that was added or removed.
-    // TODO: consider doing this only once per step, and not every time the inventory changes.
-    float new_reward = 0;
-    for (const auto& [item, amount] : this->inventory) {
-      uint8_t max_val = amount;
-      if (this->resource_reward_max.count(item) > 0 && max_val > this->resource_reward_max[item]) {
-        max_val = this->resource_reward_max[item];
-      }
-      new_reward += this->resource_rewards[item] * max_val;
-    }
-    *this->reward += (new_reward - this->current_resource_reward);
-    this->current_resource_reward = new_reward;
   }
 
   bool swappable() const override {
@@ -139,7 +126,7 @@ public:
   }
 
   std::vector<PartialObservationToken> obs_features() const override {
-    const int num_tokens = this->inventory.size() + 5 + (glyph > 0 ? 1 : 0);
+    const size_t num_tokens = this->inventory.size() + 5 + (glyph > 0 ? 1 : 0);
 
     std::vector<PartialObservationToken> features;
     features.reserve(num_tokens);
@@ -154,7 +141,7 @@ public:
     for (const auto& [item, amount] : this->inventory) {
       // inventory should only contain non-zero amounts
       assert(amount > 0);
-      ObservationType item_observation_feature = InventoryFeatureOffset + item;
+      auto item_observation_feature = static_cast<ObservationType>(InventoryFeatureOffset + item);
       features.push_back({item_observation_feature, static_cast<ObservationType>(amount)});
     }
 
@@ -163,6 +150,31 @@ public:
 
 private:
   std::map<InventoryItem, InventoryQuantity> resource_limits;
+
+  inline void _update_resource_reward(InventoryItem item, InventoryQuantity old_amount, InventoryQuantity new_amount) {
+    // Early exit if this item doesn't contribute to rewards
+    auto reward_it = this->resource_rewards.find(item);
+    if (reward_it == this->resource_rewards.end()) {
+      return;
+    }
+
+    // Apply reward caps if they exist
+    InventoryQuantity old_capped = old_amount;
+    InventoryQuantity new_capped = new_amount;
+
+    auto max_it = this->resource_reward_max.find(item);
+    if (max_it != this->resource_reward_max.end()) {
+      old_capped = std::min(old_amount, max_it->second);
+      new_capped = std::min(new_amount, max_it->second);
+    }
+
+    // Calculate only the delta in reward
+    float reward_delta = reward_it->second * (new_capped - old_capped);
+
+    // Update both the current reward and the agent's total reward
+    this->current_resource_reward += reward_delta;
+    *this->reward += reward_delta;
+  }
 };
 
 #endif  // OBJECTS_AGENT_HPP_

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -130,8 +130,8 @@ public:
     }
   }
 
-  void set_event_manager(EventManager* event_manager) {
-    this->event_manager = event_manager;
+  void set_event_manager(EventManager* event_manager_ptr) {
+    this->event_manager = event_manager_ptr;
     this->maybe_start_converting();
   }
 

--- a/mettagrid/src/metta/mettagrid/observation_encoder.hpp
+++ b/mettagrid/src/metta/mettagrid/observation_encoder.hpp
@@ -19,9 +19,10 @@ public:
     _feature_names = FeatureNames;
     assert(_feature_names.size() == InventoryFeatureOffset);
     assert(_feature_names.size() == _feature_normalizations.size());
-    for (int i = 0; i < static_cast<int>(inventory_item_names.size()); i++) {
-      _feature_normalizations.insert({InventoryFeatureOffset + i, DEFAULT_INVENTORY_NORMALIZATION});
-      _feature_names.insert({InventoryFeatureOffset + i, "inv:" + inventory_item_names[i]});
+    for (size_t i = 0; i < inventory_item_names.size(); i++) {
+      auto observation_feature = InventoryFeatureOffset + static_cast<ObservationType>(i);
+      _feature_normalizations.insert({observation_feature, DEFAULT_INVENTORY_NORMALIZATION});
+      _feature_names.insert({observation_feature, "inv:" + inventory_item_names[i]});
     }
   }
 

--- a/mettagrid/src/metta/mettagrid/stats_tracker.hpp
+++ b/mettagrid/src/metta/mettagrid/stats_tracker.hpp
@@ -119,7 +119,7 @@ public:
       auto first_it = _first_seen_at.find(key);
       auto last_it = _last_seen_at.find(key);
       if (first_it != _first_seen_at.end() && last_it != _last_seen_at.end()) {
-        int duration = last_it->second - first_it->second;
+        int duration = static_cast<int>(last_it->second) - static_cast<int>(first_it->second);
         if (duration > 0 && count > 1) {
           result[key + ".activity_rate"] = static_cast<float>(count - 1) / static_cast<float>(duration);
         }


### PR DESCRIPTION
This is a code cleanup PR addressing compiler warnings in the MettagGrid C++ codebase.

- **Explicit type conversions**: Added `static_cast` for all implicit conversions to make intent clear
- **Sign consistency**: Fixed signed/unsigned comparisons and conversions throughout

- **Field initialization order**: Fixed constructor initialization to match declaration order in `Agent`, `EventManager`, and `MettaGrid`
- **Variable shadowing**: Renamed shadowed variables (e.g., `item` → `inv_item`, `grid` → `grid_ptr`)
- **Modern C++ casts**: Replaced C-style casts with `static_cast` and `reinterpret_cast`

- **Pre-allocated group rewards**: Moved `_group_rewards` vector to class member to avoid per-step allocation
- **Incremental reward updates**: Refactored `Agent::compute_resource_reward()` from O(n) full recalculation to O(1) incremental updates
