### PR TITLE
remove imagePullSecrets from observatory manifests

### DIFF
--- a/devops/charts/observatory-backend/templates/deployment.yaml
+++ b/devops/charts/observatory-backend/templates/deployment.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
-      imagePullSecrets:
-      - name: dockerconfig
       containers:
         - name: server
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ required "tag is required" .Values.image.tag }}"

--- a/devops/charts/observatory/templates/deployment.yaml
+++ b/devops/charts/observatory/templates/deployment.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
-      imagePullSecrets:
-      - name: dockerconfig
       containers:
         - name: server
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ required "tag is required" .Values.image.tag }}"


### PR DESCRIPTION
This should fix the deployments. No idea where `dockerconfig` has gone, but in my tests I can run new pods without the secrets.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210795467404260)