### PR TITLE
Bucket Based Curriculum

### DIFF
--- a/configs/env/mettagrid/curriculum/bbc/agent_1.altar.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.altar.yaml
@@ -1,0 +1,23 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.altar.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.altar.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.heart: { values: [1] }
+
+  # game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }
+
+  # game.agent.rewards.ore_red: { values: [0, 1] }
+  # game.agent.rewards.laser: { values: [0, 1] }
+  # game.agent.rewards.armor: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.armor.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.armor.yaml
@@ -1,0 +1,13 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.armor: { values: [0, 1] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.basic.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.basic.yaml
@@ -1,0 +1,29 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.agent.rewards.ore_red: { values: [0, 1] }
+
+  game.objects.generator_red.input_resources.ore_red: { values: [0, 1, 2] }
+  game.agent.rewards.battery_red: { values: [0, 1] }
+
+  # game.agent.rewards.battery_red: { values: [0, 1] }
+  # game.objects.altar.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.altar.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }
+
+  # game.agent.rewards.ore_red: { values: [0, 1] }
+  # game.agent.rewards.heart: { values: [0, 1] }
+  # game.agent.rewards.laser: { values: [0, 1] }
+  # game.agent.rewards.armor: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.combat.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.combat.yaml
@@ -1,0 +1,12 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+env_overrides:
+  game:
+    actions: { attack: { consumed_resources: { blueprint: 0 } } }
+    agent: { rewards: { heart: 1 } }
+
+buckets:
+  game.objects.altar.initial_resource_count: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.laser.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.laser.yaml
@@ -1,0 +1,13 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.laser: { values: [0, 1] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.tag.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.tag.yaml
@@ -1,0 +1,20 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+env_overrides:
+  game:
+    objects:
+      altar:
+        initial_resource_count: 1
+        # no new hearts
+        input_resources:
+          blueprint: 1
+
+    actions: { attack: { consumed_resources: { blueprint: 0 } } }
+    agent: { rewards: { heart: 1 } }
+
+buckets:
+  game.objects.lasery.initial_resource_count: { values: [0, 1] }
+  game.objects.armory.initial_resource_count: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/bbc.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/bbc.yaml
@@ -1,0 +1,29 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.learning_progress.LearningProgressCurriculum
+
+env_overrides:
+  game:
+    actions:
+      attack: { consumed_resources: { blueprint: 1 } }
+      change_color: { enabled: false }
+      swap: { enabled: false }
+
+    map_builder:
+      instances: 24
+      instance_border_width: 6
+      root:
+        params:
+          agents: 1
+          objects:
+            mine_red: 3
+            generator_red: 3
+            altar: 3
+
+tasks:
+  /env/mettagrid/curriculum/bbc/agent_1.basic: 1
+  /env/mettagrid/curriculum/bbc/agent_1.altar: 1
+  /env/mettagrid/curriculum/bbc/agent_1.laser: 1
+  /env/mettagrid/curriculum/bbc/agent_1.armor: 1
+  /env/mettagrid/curriculum/bbc/agent_1.combat: 1
+  /env/mettagrid/curriculum/bbc/agent_1.tag: 1

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -15,3 +15,11 @@ simulations:
     env: /env/mettagrid/arena/tag
   arena/advanced_poor:
     env: /env/mettagrid/arena/advanced_poor
+  # arena/combat_npc:
+  #   env: /env/mettagrid/arena/combat
+  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+  #   policy_agents_pct: 0.5
+  # arena/advanced_npc:
+  #   env: /env/mettagrid/arena/advanced
+  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+  #   policy_agents_pct: 0.5

--- a/configs/sim_job.yaml
+++ b/configs/sim_job.yaml
@@ -4,7 +4,7 @@ defaults:
   - sim: all
   - _self_
 
-run: null  # Auto-generated if not provided
+run: null # Auto-generated if not provided
 policy_uri: ???
 
 sim_job:

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -1,16 +1,15 @@
 # @package __global__
 
 defaults:
-  # - /sim/all@sim_job.simulation_suite
+  - /sim/arena@sim
   # - /env/mettagrid/game/agent/rewards/shaped@replay_job.sim.env_overrides.game.agent.rewards
   - _self_
 
 trainer:
   # env: /env/mettagrid/multienv_mettagrid
-  curriculum: /env/mettagrid/curriculum/resources
+  curriculum: /env/mettagrid/curriculum/bbc/bbc
 
   env_overrides:
-    sampling: 0.7
     game:
       max_steps: 13
 
@@ -37,7 +36,7 @@ trainer:
 # policy_uri: wandb://run/b.daveey.t.1.lra.dr.muon
 # policy_uri: pytorch:///tmp/puffer_metta.pt
 # policy_uri: pytorch:///tmp/puffer_metta.pt
-policy_uri: wandb://run/daveey.fixattack.cr.4x4.0
+policy_uri: wandb://run/daveey.lp.16x4.muon.lr3
 # policy_uri: pytorch://${data_dir}/puffer/puffer_metta.pt
 
 # policy_uri: ${trained_policy_uri}
@@ -56,9 +55,16 @@ analyzer:
 
 replay_job:
   sim:
-    env: /env/mettagrid/arena/advanced_poor
-    # env_overrides:
-    #   game:
+    env:
+      /env/mettagrid/arena/combat
+      # env_overrides:
+    # game:
+    #   max_steps: 5000
+    #   num_agents: 36
+    #   map_builder:
+    #     width: 35
+    #     height: 25
+
     #     objects:
     #       lasery:
     #         initial_resource_count: 20
@@ -84,3 +90,6 @@ trained_policy_uri: ${run_dir}/checkpoints
 sweep_params: "sweep/fast"
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"
 seed: null
+
+wandb:
+  enabled: false


### PR DESCRIPTION
# Add Bucketed Curriculum for BBC Learning Progress

Added a new Bucketed Curriculum implementation for BBC (Bucketed Based Curriculum) learning progress. This curriculum organizes training tasks into buckets with different parameter values to create a structured learning progression.

The implementation includes:
- Multiple curriculum configuration files for different agent training scenarios:
  - Basic resource collection
  - Altar interaction
  - Laser crafting
  - Armor crafting
  - Combat training
  - Tag gameplay

The BucketedCurriculum now extends LearningProgressCurriculum instead of PrioritizeRegressedCurriculum, simplifying the implementation while maintaining learning progress tracking.

Also updated the trainer to automatically include the current training task in evaluation simulations, providing better visibility into training progress.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210798057851918)