### PR TITLE
Make BuckettedCurriculum use LearningProgress

### DIFF
--- a/configs/env/mettagrid/curriculum/bbc/agent_1.altar.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.altar.yaml
@@ -1,0 +1,23 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.altar.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.altar.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.heart: { values: [1] }
+
+  # game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }
+
+  # game.agent.rewards.ore_red: { values: [0, 1] }
+  # game.agent.rewards.laser: { values: [0, 1] }
+  # game.agent.rewards.armor: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.armor.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.armor.yaml
@@ -1,0 +1,13 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.armor: { values: [0, 1] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.basic.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.basic.yaml
@@ -1,0 +1,29 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.agent.rewards.ore_red: { values: [0, 1] }
+
+  game.objects.generator_red.input_resources.ore_red: { values: [0, 1, 2] }
+  game.agent.rewards.battery_red: { values: [0, 1] }
+
+  # game.agent.rewards.battery_red: { values: [0, 1] }
+  # game.objects.altar.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.altar.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.objects.armory.input_resources.ore_red: { values: [0, 1, 2] }
+  # game.objects.armory.input_resources.battery_red: { values: [0, 1, 2] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }
+
+  # game.agent.rewards.ore_red: { values: [0, 1] }
+  # game.agent.rewards.heart: { values: [0, 1] }
+  # game.agent.rewards.laser: { values: [0, 1] }
+  # game.agent.rewards.armor: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.combat.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.combat.yaml
@@ -1,0 +1,12 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+env_overrides:
+  game:
+    actions: { attack: { consumed_resources: { blueprint: 0 } } }
+    agent: { rewards: { heart: 1 } }
+
+buckets:
+  game.objects.altar.initial_resource_count: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.laser.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.laser.yaml
@@ -1,0 +1,13 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+
+buckets:
+  game.objects.lasery.input_resources.ore_red: { values: [0, 1, 2] }
+  game.objects.lasery.input_resources.battery_red: { values: [0, 1, 2] }
+  game.agent.rewards.laser: { values: [0, 1] }
+
+  # game.map_builder.width: { values: [5, 10, 25] }
+  # game.map_builder.height: { values: [5, 10, 25] }

--- a/configs/env/mettagrid/curriculum/bbc/agent_1.tag.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agent_1.tag.yaml
@@ -1,0 +1,20 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/arena/combat
+env_overrides:
+  game:
+    objects:
+      altar:
+        initial_resource_count: 1
+        # no new hearts
+        input_resources:
+          blueprint: 1
+
+    actions: { attack: { consumed_resources: { blueprint: 0 } } }
+    agent: { rewards: { heart: 1 } }
+
+buckets:
+  game.objects.lasery.initial_resource_count: { values: [0, 1] }
+  game.objects.armory.initial_resource_count: { values: [0, 1] }

--- a/configs/env/mettagrid/curriculum/bbc/bbc.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/bbc.yaml
@@ -1,0 +1,29 @@
+# BBC Learning Progress Curriculum
+
+_target_: metta.mettagrid.curriculum.learning_progress.LearningProgressCurriculum
+
+env_overrides:
+  game:
+    actions:
+      attack: { consumed_resources: { blueprint: 1 } }
+      change_color: { enabled: false }
+      swap: { enabled: false }
+
+    map_builder:
+      instances: 24
+      instance_border_width: 6
+      root:
+        params:
+          agents: 1
+          objects:
+            mine_red: 3
+            generator_red: 3
+            altar: 3
+
+tasks:
+  /env/mettagrid/curriculum/bbc/agent_1.basic: 1
+  /env/mettagrid/curriculum/bbc/agent_1.altar: 1
+  /env/mettagrid/curriculum/bbc/agent_1.laser: 1
+  /env/mettagrid/curriculum/bbc/agent_1.armor: 1
+  /env/mettagrid/curriculum/bbc/agent_1.combat: 1
+  /env/mettagrid/curriculum/bbc/agent_1.tag: 1

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -15,3 +15,11 @@ simulations:
     env: /env/mettagrid/arena/tag
   arena/advanced_poor:
     env: /env/mettagrid/arena/advanced_poor
+  # arena/combat_npc:
+  #   env: /env/mettagrid/arena/combat
+  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+  #   policy_agents_pct: 0.5
+  # arena/advanced_npc:
+  #   env: /env/mettagrid/arena/advanced
+  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+  #   policy_agents_pct: 0.5

--- a/configs/sim_job.yaml
+++ b/configs/sim_job.yaml
@@ -4,7 +4,7 @@ defaults:
   - sim: all
   - _self_
 
-run: null  # Auto-generated if not provided
+run: null # Auto-generated if not provided
 policy_uri: ???
 
 sim_job:

--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -1,16 +1,15 @@
 # @package __global__
 
 defaults:
-  # - /sim/all@sim_job.simulation_suite
+  - /sim/arena@sim
   # - /env/mettagrid/game/agent/rewards/shaped@replay_job.sim.env_overrides.game.agent.rewards
   - _self_
 
 trainer:
   # env: /env/mettagrid/multienv_mettagrid
-  curriculum: /env/mettagrid/curriculum/resources
+  curriculum: /env/mettagrid/curriculum/bbc/bbc
 
   env_overrides:
-    sampling: 0.7
     game:
       max_steps: 13
 
@@ -37,7 +36,7 @@ trainer:
 # policy_uri: wandb://run/b.daveey.t.1.lra.dr.muon
 # policy_uri: pytorch:///tmp/puffer_metta.pt
 # policy_uri: pytorch:///tmp/puffer_metta.pt
-policy_uri: wandb://run/daveey.fixattack.cr.4x4.0
+policy_uri: wandb://run/daveey.lp.16x4.muon.lr3
 # policy_uri: pytorch://${data_dir}/puffer/puffer_metta.pt
 
 # policy_uri: ${trained_policy_uri}
@@ -56,9 +55,16 @@ analyzer:
 
 replay_job:
   sim:
-    env: /env/mettagrid/arena/advanced_poor
-    # env_overrides:
-    #   game:
+    env:
+      /env/mettagrid/arena/combat
+      # env_overrides:
+    # game:
+    #   max_steps: 5000
+    #   num_agents: 36
+    #   map_builder:
+    #     width: 35
+    #     height: 25
+
     #     objects:
     #       lasery:
     #         initial_resource_count: 20
@@ -84,3 +90,6 @@ trained_policy_uri: ${run_dir}/checkpoints
 sweep_params: "sweep/fast"
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"
 seed: null
+
+wandb:
+  enabled: false

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -93,7 +93,7 @@ class MettaTrainer:
         if trainer_cfg.checkpoint.checkpoint_dir:
             os.makedirs(trainer_cfg.checkpoint.checkpoint_dir, exist_ok=True)
 
-        self.sim_suite_config = sim_suite_config
+        self._sim_suite_config = sim_suite_config
         self._stats_client = stats_client
 
         if torch.distributed.is_initialized():
@@ -135,6 +135,14 @@ class MettaTrainer:
         curriculum_config = trainer_cfg.curriculum_or_env
         env_overrides = DictConfig(trainer_cfg.env_overrides)
         self._curriculum = curriculum_from_config_path(curriculum_config, env_overrides)
+
+        # Add training task to the suite
+        self._sim_suite_config.simulations["eval/training_task"] = SingleEnvSimulationConfig(
+            env="/env/mettagrid/mettagrid",  # won't be used, dynamic `env_cfg()` should override all of it
+            num_episodes=1,
+            env_overrides=self._curriculum.get_task().env_cfg(),
+        )
+
         self._make_vecenv()
 
         metta_grid_env: MettaGridEnv = self.vecenv.driver_env  # type: ignore
@@ -708,26 +716,10 @@ class MettaTrainer:
                 attributes={},
             ).id
 
-        # Create an extended simulation suite that includes the training task
-        extended_suite_config = SimulationSuiteConfig(
-            name=self.sim_suite_config.name,
-            simulations=dict(self.sim_suite_config.simulations),  # Copy existing simulations
-            env_overrides=self.sim_suite_config.env_overrides,
-            num_episodes=self.sim_suite_config.num_episodes,
-        )
-
-        # Add training task to the suite
-        training_task_config = SingleEnvSimulationConfig(
-            env="/env/mettagrid/mettagrid",  # won't be used, dynamic `env_cfg()` should override all of it
-            num_episodes=1,
-            env_overrides=self._curriculum.get_task().env_cfg(),
-        )
-        extended_suite_config.simulations["eval/training_task"] = training_task_config
-
         logger.info(f"Simulating policy: {self.latest_saved_policy_uri} with extended config including training task")
         evaluation_results = evaluate_policy(
             policy_record=self.latest_saved_policy_record,
-            simulation_suite=extended_suite_config,
+            simulation_suite=self._sim_suite_config,
             device=self.device,
             vectorization=self.cfg.vectorization,
             replay_dir=self.trainer_cfg.simulation.replay_dir,  # Pass replay_dir to enable replay generation

--- a/mettagrid/src/metta/mettagrid/curriculum/bucketed.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/bucketed.py
@@ -12,19 +12,18 @@ from metta.mettagrid.curriculum.core import Curriculum
 from metta.mettagrid.curriculum.sampling import SampledTaskCurriculum
 from metta.mettagrid.curriculum.util import config_from_path
 
-from .prioritize_regressed import PrioritizeRegressedCurriculum
+from .learning_progress import LearningProgressCurriculum
 
 logger = logging.getLogger(__name__)
 
 
-class BucketedCurriculum(PrioritizeRegressedCurriculum):
+class BucketedCurriculum(LearningProgressCurriculum):
     def __init__(
         self,
         env_cfg_template: str,
         buckets: Dict[str, Dict[str, Any]],
         env_overrides: Optional[DictConfig] = None,
         default_bins: int = 1,
-        moving_avg_decay_rate: float = 0.01,
     ):
         expanded_buckets = _expand_buckets(buckets, default_bins)
 
@@ -39,7 +38,7 @@ class BucketedCurriculum(PrioritizeRegressedCurriculum):
                 curriculum_id, env_cfg_template, expanded_buckets.keys(), parameter_values
             )
         tasks = {t: 1.0 for t in self._id_to_curriculum.keys()}
-        super().__init__(tasks=tasks, env_overrides=env_overrides, moving_avg_decay_rate=moving_avg_decay_rate)
+        super().__init__(tasks=tasks, env_overrides=env_overrides)
 
     def _curriculum_from_id(self, id: str) -> Curriculum:
         return self._id_to_curriculum[id]

--- a/mettascope/server.py
+++ b/mettascope/server.py
@@ -211,7 +211,7 @@ def make_app(cfg: DictConfig):
             else:
                 raise ValueError(f"Unknown type: {message['type']}")
 
-            if current_step < 1000:
+            if current_step < sim._vecenv.driver_env.max_steps:
                 await send_message(type="message", message="Step!")
 
                 actions = sim.generate_actions()


### PR DESCRIPTION
# Improved Curriculum Evaluation and Environment Configuration

### TL;DR

Make BuckettedCurriculum use LearningProgress.

Refactored simulation suite configuration to include training tasks earlier and improved environment step handling.

### What changed?

- Renamed `sim_suite_config` to `_sim_suite_config` to follow private member naming convention
- Added training task to simulation suite during initialization instead of creating an extended suite during evaluation
- Updated `BucketedCurriculum` to inherit from `LearningProgressCurriculum` instead of `PrioritizeRegressedCurriculum`
- Removed `moving_avg_decay_rate` parameter from `BucketedCurriculum`
- Fixed replay step limit in mettascope server to use the environment's `max_steps` instead of hardcoded 1000

### How to test?

1. Run a training session to verify the curriculum loads correctly
2. Test policy evaluation to ensure training tasks are properly included
3. Verify replays in mettascope respect the environment's max steps setting

### Why make this change?

- Simplifies policy evaluation by adding the training task to the simulation suite at initialization
- Improves code organization by following consistent naming conventions
- Updates curriculum inheritance to use the more appropriate base class
- Makes replay step limits dynamic based on environment configuration rather than using a hardcoded value

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210798116279590)