### PR TITLE
Change episode truncation to termination in MettaGrid

### DIFF
--- a/configs/env/mettagrid/curriculum/bbc/bbc.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/bbc.yaml
@@ -27,3 +27,4 @@ tasks:
   /env/mettagrid/curriculum/bbc/agent_1.armor: 1
   /env/mettagrid/curriculum/bbc/agent_1.combat: 1
   /env/mettagrid/curriculum/bbc/agent_1.tag: 1
+  /env/mettagrid/curriculum/arena/learning_progress: 1

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -416,10 +416,12 @@ void MettaGrid::_step(py::array_t<ActionType, py::array::c_style> actions) {
     episode_rewards_view(i) += rewards_view(i);
   }
 
-  // Check for truncation
+  // Check for termination. We could set truncations here instead,
+  // to make the agent think episodes never end. But currently
+  // we think it's more realistic to have episodes end.
   if (max_steps > 0 && current_step >= max_steps) {
-    std::fill(static_cast<bool*>(_truncations.request().ptr),
-              static_cast<bool*>(_truncations.request().ptr) + _truncations.size(),
+    std::fill(static_cast<bool*>(_terminals.request().ptr),
+              static_cast<bool*>(_terminals.request().ptr) + _terminals.size(),
               1);
   }
 }


### PR DESCRIPTION
### TL;DR

Changed episode ending behavior to use termination instead of truncation when max steps are reached.

### What changed?

Modified the `_step` method in `mettagrid_c.cpp` to set the `_terminals` flag instead of `_truncations` when the maximum number of steps is reached. This changes how episode endings are signaled to the agent.

### How to test?

1. Run an environment with a set `max_steps` value
2. Verify that episodes end with termination signals rather than truncation signals when reaching the maximum steps
3. Check that agent behavior is appropriate for terminated episodes

### Why make this change?

The code comments explain the rationale: setting termination instead of truncation is considered "more realistic" for the agent experience. This change makes the agent recognize that episodes genuinely end rather than being artificially cut short, which better aligns with the intended simulation behavior.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210798388172596)