### PR TITLE
[Policy evaluator] 4: Update eval task management API + add client

### DIFF
--- a/app_backend/src/metta/app_backend/eval_task_client.py
+++ b/app_backend/src/metta/app_backend/eval_task_client.py
@@ -20,7 +20,7 @@ T = TypeVar("T", bound=BaseModel)
 class EvalTaskClient:
     def __init__(self, backend_url: str) -> None:
         self._http_client = httpx.AsyncClient(base_url=backend_url, timeout=30.0)
-        if not (token := get_machine_token()):
+        if not (token := get_machine_token(backend_url)):
             raise ValueError("Machine token is not set")
         self._machine_token = token
 

--- a/app_backend/src/metta/app_backend/eval_task_client.py
+++ b/app_backend/src/metta/app_backend/eval_task_client.py
@@ -33,11 +33,9 @@ class EvalTaskClient:
     async def close(self):
         await self._http_client.aclose()
 
-    async def _make_request(self, response_type: Type[T] | None, method: str, url: str, **kwargs) -> T:
+    async def _make_request(self, response_type: Type[T], method: str, url: str, **kwargs) -> T:
         response = await self._http_client.request(method, url, headers={"X-Auth-Token": self._machine_token}, **kwargs)
         response.raise_for_status()
-        if response_type is None:
-            return response.json()
         return response_type.model_validate(response.json())
 
     async def create_task(self, request: TaskCreateRequest) -> TaskResponse:

--- a/app_backend/src/metta/app_backend/eval_task_client.py
+++ b/app_backend/src/metta/app_backend/eval_task_client.py
@@ -47,8 +47,9 @@ class EvalTaskClient:
     async def claim_tasks(self, request: TaskClaimRequest) -> TaskClaimResponse:
         return await self._make_request(TaskClaimResponse, "POST", "/tasks/claim", json=request.model_dump(mode="json"))
 
-    async def get_claimed_tasks(self, assignee: str) -> TasksResponse:
-        return await self._make_request(TasksResponse, "GET", "/tasks/claimed", params={"assignee": assignee})
+    async def get_claimed_tasks(self, assignee: str | None = None) -> TasksResponse:
+        params = {"assignee": assignee} if assignee is not None else {}
+        return await self._make_request(TasksResponse, "GET", "/tasks/claimed", params=params)
 
     async def get_task_by_id(self, task_id: str) -> TaskResponse:
         return await self._make_request(TaskResponse, "GET", f"/tasks/{task_id}")

--- a/app_backend/src/metta/app_backend/eval_task_client.py
+++ b/app_backend/src/metta/app_backend/eval_task_client.py
@@ -1,0 +1,61 @@
+from typing import Any, Type, TypeVar
+
+import httpx
+from pydantic import BaseModel
+
+from metta.app_backend.routes.eval_task_routes import (
+    TaskClaimRequest,
+    TaskClaimResponse,
+    TaskCreateRequest,
+    TaskResponse,
+    TasksResponse,
+    TaskUpdateRequest,
+    TaskUpdateResponse,
+)
+from metta.common.util.stats_client_cfg import get_machine_token
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class EvalTaskClient:
+    def __init__(self, backend_url: str) -> None:
+        self._http_client = httpx.AsyncClient(base_url=backend_url, timeout=30.0)
+        if not (token := get_machine_token()):
+            raise ValueError("Machine token is not set")
+        self._machine_token = token
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any) -> None:
+        await self.close()
+
+    async def close(self):
+        await self._http_client.aclose()
+
+    async def _make_request(self, response_type: Type[T] | None, method: str, url: str, **kwargs) -> T:
+        response = await self._http_client.request(method, url, headers={"X-Auth-Token": self._machine_token}, **kwargs)
+        response.raise_for_status()
+        if response_type is None:
+            return response.json()
+        return response_type.model_validate(response.json())
+
+    async def create_task(self, request: TaskCreateRequest) -> TaskResponse:
+        return await self._make_request(TaskResponse, "POST", "/tasks", json=request.model_dump(mode="json"))
+
+    async def get_available_tasks(self, limit: int = 200) -> TasksResponse:
+        return await self._make_request(TasksResponse, "GET", "/tasks/available", params={"limit": limit})
+
+    async def claim_tasks(self, request: TaskClaimRequest) -> TaskClaimResponse:
+        return await self._make_request(TaskClaimResponse, "POST", "/tasks/claim", json=request.model_dump(mode="json"))
+
+    async def get_claimed_tasks(self, assignee: str) -> TasksResponse:
+        return await self._make_request(TasksResponse, "GET", "/tasks/claimed", params={"assignee": assignee})
+
+    async def get_task_by_id(self, task_id: str) -> TaskResponse:
+        return await self._make_request(TaskResponse, "GET", f"/tasks/{task_id}")
+
+    async def update_task_status(self, request: TaskUpdateRequest) -> TaskUpdateResponse:
+        return await self._make_request(
+            TaskUpdateResponse, "POST", "/tasks/claimed/update", json=request.model_dump(mode="json")
+        )

--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -284,6 +284,24 @@ class MettaRepo:
 
     # All methods are async - no sync versions
 
+    async def get_policy_by_id(self, policy_id: uuid.UUID) -> dict[str, Any] | None:
+        async with self.connect() as con:
+            res = await con.execute(
+                """
+                SELECT id, name
+                FROM policies
+                WHERE id = %s
+                """,
+                (policy_id,),
+            )
+            row = await res.fetchone()
+            if row is None:
+                return None
+            return {
+                "id": str(row[0]),
+                "name": row[1],
+            }
+
     async def get_policy_ids(self, policy_names: list[str]) -> dict[str, uuid.UUID]:
         if not policy_names:
             return {}

--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -5,7 +5,7 @@ import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from psycopg import Connection
 from psycopg.types.json import Jsonb
@@ -284,7 +284,7 @@ class MettaRepo:
 
     # All methods are async - no sync versions
 
-    async def get_policy_ids(self, policy_names: List[str]) -> Dict[str, uuid.UUID]:
+    async def get_policy_ids(self, policy_names: list[str]) -> dict[str, uuid.UUID]:
         if not policy_names:
             return {}
 
@@ -302,10 +302,10 @@ class MettaRepo:
         self,
         name: str,
         user_id: str,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
         url: str | None,
         description: str | None,
-        tags: List[str] | None,
+        tags: list[str] | None,
     ) -> uuid.UUID:
         status = "running"
         async with self.connect() as con:
@@ -338,7 +338,7 @@ class MettaRepo:
         run_id: uuid.UUID,
         start_training_epoch: int,
         end_training_epoch: int,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
     ) -> uuid.UUID:
         async with self.connect() as con:
             result = await con.execute(
@@ -376,14 +376,14 @@ class MettaRepo:
 
     async def record_episode(
         self,
-        agent_policies: Dict[int, uuid.UUID],
-        agent_metrics: Dict[int, Dict[str, float]],
+        agent_policies: dict[int, uuid.UUID],
+        agent_metrics: dict[int, dict[str, float]],
         primary_policy_id: uuid.UUID,
         stats_epoch: uuid.UUID | None,
         eval_name: str | None,
         simulation_suite: str | None,
         replay_url: str | None,
-        attributes: Dict[str, Any],
+        attributes: dict[str, Any],
         eval_task_id: uuid.UUID | None = None,
     ) -> uuid.UUID:
         async with self.connect() as con:
@@ -440,7 +440,7 @@ class MettaRepo:
                 )
 
             # Insert agent metrics in bulk
-            rows: List[Tuple[int, int, str, float]] = []
+            rows: list[tuple[int, int, str, float]] = []
             for agent_id, metrics in agent_metrics.items():
                 for metric_name, value in metrics.items():
                     rows.append((episode_internal_id, agent_id, metric_name, value))
@@ -456,7 +456,7 @@ class MettaRepo:
 
             return episode_id
 
-    async def get_suites(self) -> List[str]:
+    async def get_suites(self) -> list[str]:
         async with self.connect() as con:
             result = await con.execute("""
                 SELECT DISTINCT eval_category
@@ -467,7 +467,7 @@ class MettaRepo:
             rows = await result.fetchall()
             return [row[0] for row in rows]
 
-    async def get_metrics(self, suite: str) -> List[str]:
+    async def get_metrics(self, suite: str) -> list[str]:
         """Get all available metrics for a given suite."""
         async with self.connect() as con:
             result = await con.execute(
@@ -483,7 +483,7 @@ class MettaRepo:
             rows = await result.fetchall()
             return [row[0] for row in rows]
 
-    async def get_group_ids(self, suite: str) -> List[str]:
+    async def get_group_ids(self, suite: str) -> list[str]:
         """Get all available group IDs for a given suite."""
         async with self.connect() as con:
             result = await con.execute(
@@ -498,7 +498,7 @@ class MettaRepo:
             rows = await result.fetchall()
             return [row[0] for row in rows]
 
-    async def get_training_runs(self) -> List[Dict[str, Any]]:
+    async def get_training_runs(self) -> list[dict[str, Any]]:
         """Get all training runs."""
         async with self.connect() as con:
             result = await con.execute(
@@ -524,7 +524,7 @@ class MettaRepo:
                 for row in rows
             ]
 
-    async def get_training_run(self, run_id: str) -> Dict[str, Any] | None:
+    async def get_training_run(self, run_id: str) -> dict[str, Any] | None:
         """Get a specific training run by ID."""
         try:
             run_uuid = uuid.UUID(run_id)
@@ -577,7 +577,7 @@ class MettaRepo:
 
         return token
 
-    async def list_machine_tokens(self, user_id: str) -> List[Dict[str, Any]]:
+    async def list_machine_tokens(self, user_id: str) -> list[dict[str, Any]]:
         """List all machine tokens for a user."""
         async with self.connect() as con:
             result = await con.execute(
@@ -646,7 +646,7 @@ class MettaRepo:
         name: str,
         description: str | None,
         dashboard_type: str,
-        dashboard_state: Dict[str, Any],
+        dashboard_state: dict[str, Any],
     ) -> uuid.UUID:
         """Create a new saved dashboard (no upsert, always insert)."""
         async with self.connect() as con:
@@ -664,7 +664,7 @@ class MettaRepo:
                 raise RuntimeError("Failed to create saved dashboard")
             return row[0]
 
-    async def list_saved_dashboards(self) -> List[Dict[str, Any]]:
+    async def list_saved_dashboards(self) -> list[dict[str, Any]]:
         """List all saved dashboards."""
         async with self.connect() as con:
             result = await con.execute(
@@ -689,7 +689,7 @@ class MettaRepo:
                 for row in rows
             ]
 
-    async def get_saved_dashboard(self, dashboard_id: str) -> Dict[str, Any] | None:
+    async def get_saved_dashboard(self, dashboard_id: str) -> dict[str, Any] | None:
         """Get a specific saved dashboard by ID."""
         try:
             dashboard_uuid = uuid.UUID(dashboard_id)
@@ -745,7 +745,7 @@ class MettaRepo:
         name: str,
         description: str | None,
         dashboard_type: str,
-        dashboard_state: Dict[str, Any],
+        dashboard_state: dict[str, Any],
     ) -> bool:
         """Update an existing saved dashboard."""
         try:
@@ -782,7 +782,7 @@ class MettaRepo:
             )
             return result.rowcount > 0
 
-    async def update_training_run_tags(self, user_id: str, run_id: str, tags: List[str]) -> bool:
+    async def update_training_run_tags(self, user_id: str, run_id: str, tags: list[str]) -> bool:
         """Update the tags of a training run."""
         try:
             run_uuid = uuid.UUID(run_id)
@@ -804,23 +804,33 @@ class MettaRepo:
         self,
         policy_id: uuid.UUID,
         sim_suite: str,
-        attributes: Dict[str, Any],
-    ) -> uuid.UUID:
+        attributes: dict[str, Any],
+    ) -> dict[str, Any]:
         async with self.connect() as con:
             result = await con.execute(
                 """
                 INSERT INTO eval_tasks (policy_id, sim_suite, attributes)
                 VALUES (%s, %s, %s)
-                RETURNING id
+                RETURNING id, policy_id, sim_suite, status, assigned_at,
+                         assignee, created_at, attributes
                 """,
                 (policy_id, sim_suite, Jsonb(attributes)),
             )
             row = await result.fetchone()
             if row is None:
                 raise RuntimeError("Failed to create eval task")
-            return row[0]
+            return {
+                "id": row[0],
+                "policy_id": row[1],
+                "sim_suite": row[2],
+                "status": row[3],
+                "assigned_at": row[4],
+                "assignee": row[5],
+                "created_at": row[6],
+                "attributes": row[7],
+            }
 
-    async def get_available_tasks(self, limit: int = 200) -> List[Dict[str, Any]]:
+    async def get_available_tasks(self, limit: int = 200) -> list[dict[str, Any]]:
         async with self.connect() as con:
             result = await con.execute(
                 """
@@ -851,9 +861,9 @@ class MettaRepo:
 
     async def claim_tasks(
         self,
-        task_ids: List[uuid.UUID],
+        task_ids: list[uuid.UUID],
         assignee: str,
-    ) -> List[uuid.UUID]:
+    ) -> list[uuid.UUID]:
         if not task_ids:
             return []
 
@@ -872,7 +882,7 @@ class MettaRepo:
             rows = await result.fetchall()
             return [row[0] for row in rows]
 
-    async def get_claimed_tasks(self, assignee: str) -> List[Dict[str, Any]]:
+    async def get_claimed_tasks(self, assignee: str) -> list[dict[str, Any]]:
         async with self.connect() as con:
             result = await con.execute(
                 """
@@ -900,11 +910,36 @@ class MettaRepo:
                 for row in rows
             ]
 
+    async def get_task_by_id(self, task_id: uuid.UUID) -> dict[str, Any] | None:
+        async with self.connect() as con:
+            result = await con.execute(
+                """
+                SELECT id, policy_id, sim_suite, status, assigned_at,
+                       assignee, created_at, attributes
+                FROM eval_tasks
+                WHERE id = %s
+                """,
+                (task_id,),
+            )
+            row = await result.fetchone()
+            if row is None:
+                return None
+            return {
+                "id": row[0],
+                "policy_id": row[1],
+                "sim_suite": row[2],
+                "status": row[3],
+                "assigned_at": row[4],
+                "assignee": row[5],
+                "created_at": row[6],
+                "attributes": row[7],
+            }
+
     async def update_task_statuses(
         self,
         assignee: str,
-        task_updates: Dict[uuid.UUID, TaskStatusUpdate],
-    ) -> Dict[uuid.UUID, str]:
+        task_updates: dict[uuid.UUID, TaskStatusUpdate],
+    ) -> dict[uuid.UUID, str]:
         if not task_updates:
             return {}
 

--- a/app_backend/src/metta/app_backend/route_logger.py
+++ b/app_backend/src/metta/app_backend/route_logger.py
@@ -27,10 +27,9 @@ def timed_http_handler(func):
             return await timed_func(*args, **kwargs)
         except HTTPException:
             raise
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
         except Exception as e:
             operation = func.__name__.replace("_", " ")
+            route_logger.error(f"Failed to {operation}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to {operation}: {str(e)}") from e
 
     return wrapper

--- a/app_backend/src/metta/app_backend/route_logger.py
+++ b/app_backend/src/metta/app_backend/route_logger.py
@@ -5,7 +5,7 @@ import time
 from functools import wraps
 from typing import Any, Callable
 
-from fastapi import Request, Response
+from fastapi import HTTPException, Request, Response
 
 # Logger for route performance
 route_logger = logging.getLogger("route_performance")
@@ -13,6 +13,27 @@ route_logger.setLevel(logging.INFO)
 
 # Threshold for slow route warnings (2 seconds)
 SLOW_ROUTE_THRESHOLD_SECONDS = 2.0
+
+
+def timed_http_handler(func):
+    """
+    Exception handling wrapper for timed_route.
+    """
+    timed_func = timed_route(func.__name__)(func)
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await timed_func(*args, **kwargs)
+        except HTTPException:
+            raise
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        except Exception as e:
+            operation = func.__name__.replace("_", " ")
+            raise HTTPException(status_code=500, detail=f"Failed to {operation}: {str(e)}") from e
+
+    return wrapper
 
 
 def timed_route(route_name: str = ""):

--- a/app_backend/src/metta/app_backend/routes/eval_task_routes.py
+++ b/app_backend/src/metta/app_backend/routes/eval_task_routes.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -8,9 +8,10 @@ from pydantic import BaseModel, Field
 from metta.app_backend.auth import create_user_or_token_dependency
 from metta.app_backend.metta_repo import MettaRepo
 from metta.app_backend.metta_repo import TaskStatusUpdate as RepoTaskStatusUpdate
-from metta.app_backend.route_logger import timed_route
+from metta.app_backend.route_logger import timed_http_handler
 
-TaskIdStr = str
+T = TypeVar("T")
+
 TaskStatus = Literal["unprocessed", "canceled", "done", "error"]
 
 
@@ -22,8 +23,12 @@ class TaskCreateRequest(BaseModel):
 
 
 class TaskClaimRequest(BaseModel):
-    eval_task_ids: list[TaskIdStr]
+    tasks: list[uuid.UUID]
     assignee: str
+
+
+class TaskClaimResponse(BaseModel):
+    claimed: list[uuid.UUID]
 
 
 class TaskStatusUpdate(BaseModel):
@@ -33,12 +38,12 @@ class TaskStatusUpdate(BaseModel):
 
 class TaskUpdateRequest(BaseModel):
     assignee: str
-    statuses: dict[TaskIdStr, TaskStatusUpdate]
+    statuses: dict[uuid.UUID, TaskStatusUpdate]
 
 
 class TaskResponse(BaseModel):
-    id: TaskIdStr
-    policy_id: str
+    id: uuid.UUID
+    policy_id: uuid.UUID
     sim_suite: str
     status: TaskStatus
     assigned_at: datetime | None = None
@@ -46,8 +51,25 @@ class TaskResponse(BaseModel):
     created_at: datetime
     attributes: dict[str, Any]
 
+    @classmethod
+    def from_db(cls, task: dict[str, Any]) -> "TaskResponse":
+        return cls(
+            id=task["id"],
+            policy_id=task["policy_id"],
+            sim_suite=task["sim_suite"],
+            status=task["status"],
+            assigned_at=task["assigned_at"],
+            assignee=task["assignee"],
+            created_at=task["created_at"],
+            attributes=task["attributes"] or {},
+        )
 
-class AvailableTasksResponse(BaseModel):
+
+class TaskUpdateResponse(BaseModel):
+    statuses: dict[uuid.UUID, str]
+
+
+class TasksResponse(BaseModel):
     tasks: list[TaskResponse]
 
 
@@ -57,125 +79,70 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
     user_or_token = Depends(create_user_or_token_dependency(stats_repo))
 
     @router.post("", response_model=TaskResponse)
-    @timed_route("create_task")
+    @timed_http_handler
     async def create_task(request: TaskCreateRequest, user: str = user_or_token) -> TaskResponse:
-        try:
-            policy_uuid = uuid.UUID(request.policy_id)
+        policy_uuid = uuid.UUID(request.policy_id)
 
-            attributes = {
-                "env_overrides": request.env_overrides,
-                "git_hash": request.git_hash,
-            }
+        attributes = {
+            "env_overrides": request.env_overrides,
+            "git_hash": request.git_hash,
+        }
 
-            task_id = await stats_repo.create_eval_task(
-                policy_id=policy_uuid,
-                sim_suite=request.sim_suite,
-                attributes=attributes,
-            )
+        task = await stats_repo.create_eval_task(
+            policy_id=policy_uuid,
+            sim_suite=request.sim_suite,
+            attributes=attributes,
+        )
+        return TaskResponse.from_db(task)
 
-            return TaskResponse(
-                id=str(task_id),
-                policy_id=request.policy_id,
-                sim_suite=request.sim_suite,
-                status="unprocessed",
-                assigned_at=None,
-                assignee=None,
-                created_at=datetime.utcnow(),
-                attributes=attributes,
-            )
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail="Invalid UUID format") from e
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to create task: {str(e)}") from e
-
-    @router.get("/available", response_model=AvailableTasksResponse)
-    @timed_route("get_available_tasks")
+    @router.get("/available", response_model=TasksResponse)
+    @timed_http_handler
     async def get_available_tasks(
         limit: int = Query(default=200, ge=1, le=1000), user: str = user_or_token
-    ) -> AvailableTasksResponse:
-        try:
-            tasks = await stats_repo.get_available_tasks(limit=limit)
-
-            task_responses = [
-                TaskResponse(
-                    id=str(task["id"]),
-                    policy_id=str(task["policy_id"]),
-                    sim_suite=task["sim_suite"],
-                    status=task["status"],
-                    assigned_at=task["assigned_at"],
-                    assignee=task["assignee"],
-                    created_at=task["created_at"],
-                    attributes=task["attributes"] or {},
-                )
-                for task in tasks
-            ]
-
-            return AvailableTasksResponse(tasks=task_responses)
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to get available tasks: {str(e)}") from e
+    ) -> TasksResponse:
+        tasks = await stats_repo.get_available_tasks(limit=limit)
+        task_responses = [TaskResponse.from_db(task) for task in tasks]
+        return TasksResponse(tasks=task_responses)
 
     @router.post("/claim")
-    @timed_route("claim_tasks")
-    async def claim_tasks(request: TaskClaimRequest, user: str = user_or_token) -> list[TaskIdStr]:
-        try:
-            task_uuids = [uuid.UUID(task_id) for task_id in request.eval_task_ids]
-
-            claimed_ids = await stats_repo.claim_tasks(
-                task_ids=task_uuids,
-                assignee=request.assignee,
-            )
-
-            return [str(task_id) for task_id in claimed_ids]
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail="Invalid UUID format") from e
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to claim tasks: {str(e)}") from e
+    @timed_http_handler
+    async def claim_tasks(request: TaskClaimRequest, user: str = user_or_token) -> TaskClaimResponse:
+        claimed_ids = await stats_repo.claim_tasks(
+            task_ids=request.tasks,
+            assignee=request.assignee,
+        )
+        return TaskClaimResponse(claimed=claimed_ids)
 
     @router.get("/claimed")
-    @timed_route("get_claimed_tasks")
-    async def get_claimed_tasks(assignee: str = Query(...), user: str = user_or_token) -> AvailableTasksResponse:
-        try:
-            tasks = await stats_repo.get_claimed_tasks(assignee=assignee)
+    @timed_http_handler
+    async def get_claimed_tasks(assignee: str = Query(...), user: str = user_or_token) -> TasksResponse:
+        tasks = await stats_repo.get_claimed_tasks(assignee=assignee)
+        task_responses = [TaskResponse.from_db(task) for task in tasks]
+        return TasksResponse(tasks=task_responses)
 
-            task_responses = [
-                TaskResponse(
-                    id=str(task["id"]),
-                    policy_id=str(task["policy_id"]),
-                    sim_suite=task["sim_suite"],
-                    status=task["status"],
-                    assigned_at=task["assigned_at"],
-                    assignee=task["assignee"],
-                    created_at=task["created_at"],
-                    attributes=task["attributes"] or {},
-                )
-                for task in tasks
-            ]
+    @router.get("/{task_id}", response_model=TaskResponse)
+    @timed_http_handler
+    async def get_task_by_id(task_id: uuid.UUID, user: str = user_or_token) -> TaskResponse:
+        task = await stats_repo.get_task_by_id(task_id=task_id)
 
-            return AvailableTasksResponse(tasks=task_responses)
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to get claimed tasks: {str(e)}") from e
+        if not task:
+            raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+        return TaskResponse.from_db(task)
 
     @router.post("/claimed/update")
-    @timed_route("update_task_statuses")
-    async def update_task_statuses(request: TaskUpdateRequest, user: str = user_or_token) -> dict[TaskIdStr, str]:
-        try:
-            task_updates = {
-                uuid.UUID(task_id): RepoTaskStatusUpdate(status=status_update.status, details=status_update.details)
-                for task_id, status_update in request.statuses.items()
-            }
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail="Invalid format") from e
+    @timed_http_handler
+    async def update_task_statuses(request: TaskUpdateRequest, user: str = user_or_token) -> TaskUpdateResponse:
+        task_updates = {
+            task_id: RepoTaskStatusUpdate(status=status_update.status, details=status_update.details)
+            for task_id, status_update in request.statuses.items()
+        }
 
-        try:
-            updated = await stats_repo.update_task_statuses(
-                assignee=request.assignee,
-                task_updates=task_updates,
-            )
+        updated = await stats_repo.update_task_statuses(
+            assignee=request.assignee,
+            task_updates=task_updates,
+        )
 
-            return {str(task_id): status for task_id, status in updated.items()}
-        except HTTPException:
-            raise
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Failed to update task statuses: {str(e)}") from e
+        return TaskUpdateResponse(statuses=updated)
 
     return router

--- a/app_backend/src/metta/app_backend/routes/eval_task_routes.py
+++ b/app_backend/src/metta/app_backend/routes/eval_task_routes.py
@@ -98,7 +98,7 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
     @router.get("/available", response_model=TasksResponse)
     @timed_http_handler
     async def get_available_tasks(
-        limit: int = Query(default=200, ge=1, le=1000), user: str = user_or_token
+        limit: int = Query(default=200, ge=1, le=1000),
     ) -> TasksResponse:
         tasks = await stats_repo.get_available_tasks(limit=limit)
         task_responses = [TaskResponse.from_db(task) for task in tasks]
@@ -106,7 +106,7 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
 
     @router.post("/claim")
     @timed_http_handler
-    async def claim_tasks(request: TaskClaimRequest, user: str = user_or_token) -> TaskClaimResponse:
+    async def claim_tasks(request: TaskClaimRequest) -> TaskClaimResponse:
         claimed_ids = await stats_repo.claim_tasks(
             task_ids=request.tasks,
             assignee=request.assignee,
@@ -115,14 +115,14 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
 
     @router.get("/claimed")
     @timed_http_handler
-    async def get_claimed_tasks(assignee: str = Query(...), user: str = user_or_token) -> TasksResponse:
+    async def get_claimed_tasks(assignee: str = Query(...)) -> TasksResponse:
         tasks = await stats_repo.get_claimed_tasks(assignee=assignee)
         task_responses = [TaskResponse.from_db(task) for task in tasks]
         return TasksResponse(tasks=task_responses)
 
     @router.get("/{task_id}", response_model=TaskResponse)
     @timed_http_handler
-    async def get_task_by_id(task_id: uuid.UUID, user: str = user_or_token) -> TaskResponse:
+    async def get_task_by_id(task_id: uuid.UUID) -> TaskResponse:
         task = await stats_repo.get_task_by_id(task_id=task_id)
 
         if not task:
@@ -132,7 +132,7 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
 
     @router.post("/claimed/update")
     @timed_http_handler
-    async def update_task_statuses(request: TaskUpdateRequest, user: str = user_or_token) -> TaskUpdateResponse:
+    async def update_task_statuses(request: TaskUpdateRequest) -> TaskUpdateResponse:
         task_updates = {
             task_id: RepoTaskStatusUpdate(status=status_update.status, details=status_update.details)
             for task_id, status_update in request.statuses.items()

--- a/app_backend/src/metta/app_backend/routes/eval_task_routes.py
+++ b/app_backend/src/metta/app_backend/routes/eval_task_routes.py
@@ -115,7 +115,7 @@ def create_eval_task_router(stats_repo: MettaRepo) -> APIRouter:
 
     @router.get("/claimed")
     @timed_http_handler
-    async def get_claimed_tasks(assignee: str = Query(...)) -> TasksResponse:
+    async def get_claimed_tasks(assignee: str | None = Query(None)) -> TasksResponse:
         tasks = await stats_repo.get_claimed_tasks(assignee=assignee)
         task_responses = [TaskResponse.from_db(task) for task in tasks]
         return TasksResponse(tasks=task_responses)

--- a/app_backend/tests/test_eval_task_routes.py
+++ b/app_backend/tests/test_eval_task_routes.py
@@ -1,14 +1,39 @@
 import uuid
-from typing import Dict
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
+from metta.app_backend.eval_task_client import EvalTaskClient
 from metta.app_backend.metta_repo import MettaRepo
+from metta.app_backend.routes.eval_task_routes import (
+    TaskClaimRequest,
+    TaskCreateRequest,
+    TaskStatusUpdate,
+    TaskUpdateRequest,
+)
 from metta.app_backend.stats_client import StatsClient
 
 
 class TestEvalTaskRoutes:
     """End-to-end tests for eval task routes."""
+
+    @pytest.fixture
+    def eval_task_client(self, test_client: TestClient, test_app: FastAPI) -> EvalTaskClient:
+        """Create an eval task client for testing."""
+        token_response = test_client.post(
+            "/tokens",
+            json={"name": "eval_test_token", "permissions": ["read", "write"]},
+            headers={"X-Auth-Request-Email": "test_user@example.com"},
+        )
+        assert token_response.status_code == 200
+        token = token_response.json()["token"]
+        client = EvalTaskClient.__new__(EvalTaskClient)
+        client._http_client = AsyncClient(transport=ASGITransport(app=test_app), base_url=test_client.base_url)
+        client._machine_token = token
+
+        return client
 
     @pytest.fixture
     def test_policy_id(self, stats_client: StatsClient) -> str:
@@ -33,230 +58,170 @@ class TestEvalTaskRoutes:
 
         return str(policy.id)
 
-    def test_create_eval_task(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+    @pytest.mark.asyncio
+    async def test_create_eval_task(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test creating an eval task."""
-        response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "abc123def456",
-                "env_overrides": {"key": "value"},
-                "sim_suite": "navigation",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="abc123def456",
+            env_overrides={"key": "value"},
+            sim_suite="navigation",
         )
 
-        assert response.status_code == 200
-        data = response.json()
-        assert data["policy_id"] == test_policy_id
-        assert data["sim_suite"] == "navigation"
-        assert data["status"] == "unprocessed"
-        assert data["assigned_at"] is None
-        assert data["assignee"] is None
-        assert data["attributes"]["git_hash"] == "abc123def456"
-        assert data["attributes"]["env_overrides"] == {"key": "value"}
+        response = await eval_task_client.create_task(request)
 
-    def test_get_available_tasks(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+        assert str(response.policy_id) == test_policy_id
+        assert response.sim_suite == "navigation"
+        assert response.status == "unprocessed"
+        assert response.assigned_at is None
+        assert response.assignee is None
+        assert response.attributes["git_hash"] == "abc123def456"
+        assert response.attributes["env_overrides"] == {"key": "value"}
+
+    @pytest.mark.asyncio
+    async def test_get_available_tasks(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test getting available tasks."""
         # Create some tasks
         task_ids = []
         for i in range(3):
-            response = test_client.post(
-                "/tasks",
-                json={
-                    "policy_id": test_policy_id,
-                    "git_hash": f"hash_{i}",
-                    "sim_suite": f"suite_{i}",
-                },
-                headers=test_user_headers,
+            request = TaskCreateRequest(
+                policy_id=test_policy_id,
+                git_hash=f"hash_{i}",
+                sim_suite=f"suite_{i}",
             )
-            assert response.status_code == 200
-            task_ids.append(response.json()["id"])
+            response = await eval_task_client.create_task(request)
+            task_ids.append(response.id)
 
         # Get available tasks
-        response = test_client.get("/tasks/available?limit=10", headers=test_user_headers)
-        assert response.status_code == 200
+        response = await eval_task_client.get_available_tasks(limit=10)
 
-        tasks = response.json()["tasks"]
         # Should include at least the 3 we just created
-        assert len(tasks) >= 3
+        assert len(response.tasks) >= 3
 
         # Check that our tasks are in the results
-        returned_ids = [task["id"] for task in tasks]
+        returned_ids = [task.id for task in response.tasks]
         for task_id in task_ids:
             assert task_id in returned_ids
 
-    def test_claim_and_update_tasks(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+    @pytest.mark.asyncio
+    async def test_claim_and_update_tasks(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test the complete workflow of claiming and updating tasks."""
         # Create tasks
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "workflow_test_hash",
-                "sim_suite": "all",
-            },
-            headers=test_user_headers,
+        create_request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="workflow_test_hash",
+            sim_suite="all",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(create_request)
+        task_id = task_response.id
 
         # Claim the task
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_1",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_1",
         )
-        assert claim_response.status_code == 200
-        claimed_ids = claim_response.json()
-        assert task_id in claimed_ids
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert task_id in claim_response.claimed
 
         # Get claimed tasks for the assignee
-        claimed_response = test_client.get(
-            "/tasks/claimed?assignee=worker_1",
-            headers=test_user_headers,
-        )
-        assert claimed_response.status_code == 200
-        claimed_tasks = claimed_response.json()["tasks"]
-        assert len(claimed_tasks) >= 1
-        assert any(task["id"] == task_id for task in claimed_tasks)
+        claimed_response = await eval_task_client.get_claimed_tasks(assignee="worker_1")
+        assert len(claimed_response.tasks) >= 1
+        assert any(task.id == task_id for task in claimed_response.tasks)
 
         # Update task status to done
-        update_response = test_client.post(
-            "/tasks/claimed/update",
-            json={
-                "assignee": "worker_1",
-                "statuses": {task_id: {"status": "done"}},
-            },
-            headers=test_user_headers,
+        update_request = TaskUpdateRequest(
+            assignee="worker_1",
+            statuses={task_id: TaskStatusUpdate(status="done")},
         )
-        assert update_response.status_code == 200
-        updated = update_response.json()
-        assert updated[task_id] == "done"
+        update_response = await eval_task_client.update_task_status(update_request)
+        assert update_response.statuses[task_id] == "done"
 
         # Verify the task is no longer available
-        available_response = test_client.get("/tasks/available", headers=test_user_headers)
-        assert available_response.status_code == 200
-        available_tasks = available_response.json()["tasks"]
-        available_ids = [task["id"] for task in available_tasks]
+        available_response = await eval_task_client.get_available_tasks()
+        available_ids = [task.id for task in available_response.tasks]
         assert task_id not in available_ids
 
-    def test_task_assignment_expiry(
-        self, test_client, test_user_headers: Dict[str, str], test_policy_id: str, stats_repo: MettaRepo
-    ):
+    @pytest.mark.asyncio
+    async def test_task_assignment_expiry(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test that assigned tasks become available again after expiry."""
         # Create a task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "expiry_test",
-                "sim_suite": "navigation",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="expiry_test",
+            sim_suite="navigation",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(request)
+        task_id = task_response.id
 
         # Claim it
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_timeout",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_timeout",
         )
-        assert claim_response.status_code == 200
-        assert task_id in claim_response.json()
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert task_id in claim_response.claimed
 
         # Verify it's not available immediately
-        available_response = test_client.get("/tasks/available", headers=test_user_headers)
-        available_ids = [task["id"] for task in available_response.json()["tasks"]]
+        available_response = await eval_task_client.get_available_tasks()
+        available_ids = [task.id for task in available_response.tasks]
         assert task_id not in available_ids
 
         # TODO: In a real test, we would need to mock time or update the database directly
         # to simulate assignment expiry. For now, we'll just verify the claimed task shows up
         # in the claimed tasks list
-        claimed_response = test_client.get(
-            "/tasks/claimed?assignee=worker_timeout",
-            headers=test_user_headers,
-        )
-        assert claimed_response.status_code == 200
-        claimed_tasks = claimed_response.json()["tasks"]
-        assert any(task["id"] == task_id for task in claimed_tasks)
+        claimed_response = await eval_task_client.get_claimed_tasks(assignee="worker_timeout")
+        assert any(task.id == task_id for task in claimed_response.tasks)
 
-    def test_multiple_workers_claiming_same_task(
-        self, test_client, test_user_headers: Dict[str, str], test_policy_id: str
-    ):
+    @pytest.mark.asyncio
+    async def test_multiple_workers_claiming_same_task(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test that only one worker can claim a task."""
         # Create a task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "concurrent_test",
-                "sim_suite": "memory",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="concurrent_test",
+            sim_suite="memory",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(request)
+        task_id = task_response.id
 
         # First worker claims it
-        claim1_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_a",
-            },
-            headers=test_user_headers,
+        claim1_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_a",
         )
-        assert claim1_response.status_code == 200
-        assert task_id in claim1_response.json()
+        claim1_response = await eval_task_client.claim_tasks(claim1_request)
+        assert task_id in claim1_response.claimed
 
         # Second worker tries to claim it
-        claim2_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_b",
-            },
-            headers=test_user_headers,
+        claim2_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_b",
         )
-        assert claim2_response.status_code == 200
+        claim2_response = await eval_task_client.claim_tasks(claim2_request)
         # Should return empty list since task is already claimed
-        assert task_id not in claim2_response.json()
+        assert task_id not in claim2_response.claimed
 
     @pytest.mark.asyncio
     async def test_record_episode_with_eval_task(
         self,
         stats_client: StatsClient,
         test_policy_id: str,
-        test_client,
-        test_user_headers: Dict[str, str],
+        eval_task_client: EvalTaskClient,
         stats_repo: MettaRepo,
     ):
         """Test recording an episode linked to an eval task."""
         # Create an eval task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "episode_test",
-                "sim_suite": "all",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="episode_test",
+            sim_suite="all",
         )
-        assert create_response.status_code == 200
-        eval_task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(request)
+        eval_task_id = task_response.id
 
         # Record an episode with the eval_task_id
         policy_uuid = uuid.UUID(test_policy_id)
-        eval_task_uuid = uuid.UUID(eval_task_id)
+        eval_task_uuid = eval_task_id
         episode = stats_client.record_episode(
             agent_policies={0: policy_uuid},
             agent_metrics={0: {"score": 100.0, "steps": 50}},
@@ -280,181 +245,144 @@ class TestEvalTaskRoutes:
             assert episode_row is not None
             assert episode_row[0] == eval_task_uuid
 
-    def test_invalid_status_update(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+    @pytest.mark.asyncio
+    async def test_invalid_status_update(
+        self, eval_task_client: EvalTaskClient, test_policy_id: str, test_client, test_user_headers: dict[str, str]
+    ):
         """Test that invalid status updates are rejected."""
         # Create and claim a task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "invalid_status_test",
-                "sim_suite": "arena",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="invalid_status_test",
+            sim_suite="arena",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(request)
+        task_id = task_response.id
 
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_invalid",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_invalid",
         )
-        assert claim_response.status_code == 200
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert task_id in claim_response.claimed
 
-        # Try to update with invalid status
+        # Try to update with invalid status - this needs test_client to check the validation error
         update_response = test_client.post(
             "/tasks/claimed/update",
             json={
                 "assignee": "worker_invalid",
-                "statuses": {task_id: {"status": "invalid_status"}},
+                "statuses": {str(task_id): {"status": "invalid_status"}},
             },
             headers=test_user_headers,
         )
-        assert update_response.status_code == 422  # Pydantic validation error
-        # The error detail is in the validation errors format
+        assert update_response.status_code == 422
 
-    def test_update_task_with_error_reason(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+    @pytest.mark.asyncio
+    async def test_update_task_with_error_reason(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test updating task status to error with an error reason."""
         # Create and claim a task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "error_reason_test",
-                "sim_suite": "navigation",
-            },
-            headers=test_user_headers,
+        create_request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="error_reason_test",
+            sim_suite="navigation",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(create_request)
+        task_id = task_response.id
 
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_error",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_error",
         )
-        assert claim_response.status_code == 200
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert task_id in claim_response.claimed
 
         # Update task to error status with error reason
         error_reason = "Failed to checkout git hash: fatal: reference is not a tree"
-        update_response = test_client.post(
-            "/tasks/claimed/update",
-            json={
-                "assignee": "worker_error",
-                "statuses": {task_id: {"status": "error", "details": {"error_reason": error_reason}}},
-            },
-            headers=test_user_headers,
+        update_request = TaskUpdateRequest(
+            assignee="worker_error",
+            statuses={task_id: TaskStatusUpdate(status="error", details={"error_reason": error_reason})},
         )
-        assert update_response.status_code == 200
-        assert update_response.json()[task_id] == "error"
+        update_response = await eval_task_client.update_task_status(update_request)
+        assert update_response.statuses[task_id] == "error"
 
         # Verify task is no longer available (error tasks are not re-queued)
-        available_response = test_client.get("/tasks/available", headers=test_user_headers)
-        available_ids = [task["id"] for task in available_response.json()["tasks"]]
+        available_response = await eval_task_client.get_available_tasks()
+        available_ids = [task.id for task in available_response.tasks]
         assert task_id not in available_ids
 
-    def test_update_task_mixed_formats(self, test_client, test_user_headers: Dict[str, str], test_policy_id: str):
+    @pytest.mark.asyncio
+    async def test_update_task_mixed_formats(self, eval_task_client: EvalTaskClient, test_policy_id: str):
         """Test updating multiple tasks with mixed string and object formats."""
         # Create and claim multiple tasks
         task_ids = []
         for i in range(3):
-            create_response = test_client.post(
-                "/tasks",
-                json={
-                    "policy_id": test_policy_id,
-                    "git_hash": f"mixed_test_{i}",
-                    "sim_suite": "all",
-                },
-                headers=test_user_headers,
+            request = TaskCreateRequest(
+                policy_id=test_policy_id,
+                git_hash=f"mixed_test_{i}",
+                sim_suite="all",
             )
-            assert create_response.status_code == 200
-            task_ids.append(create_response.json()["id"])
+            task_response = await eval_task_client.create_task(request)
+            task_ids.append(task_response.id)
 
         # Claim all tasks
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": task_ids,
-                "assignee": "worker_mixed",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=task_ids,
+            assignee="worker_mixed",
         )
-        assert claim_response.status_code == 200
-        assert len(claim_response.json()) == 3
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert len(claim_response.claimed) == 3
 
         # Update with mixed formats
-        update_response = test_client.post(
-            "/tasks/claimed/update",
-            json={
-                "assignee": "worker_mixed",
-                "statuses": {
-                    task_ids[0]: {"status": "done"},  # Object format
-                    task_ids[1]: {  # Object format with error details
-                        "status": "error",
-                        "details": {"error_reason": "Simulation failed: OOM"},
-                    },
-                    task_ids[2]: {  # Object format without details
-                        "status": "canceled",
-                    },
-                },
+        update_request = TaskUpdateRequest(
+            assignee="worker_mixed",
+            statuses={
+                task_ids[0]: TaskStatusUpdate(status="done"),  # Object format
+                task_ids[1]: TaskStatusUpdate(  # Object format with error details
+                    status="error",
+                    details={"error_reason": "Simulation failed: OOM"},
+                ),
+                task_ids[2]: TaskStatusUpdate(  # Object format without details
+                    status="canceled",
+                ),
             },
-            headers=test_user_headers,
         )
-        assert update_response.status_code == 200
-        result = update_response.json()
-        assert result[task_ids[0]] == "done"
-        assert result[task_ids[1]] == "error"
-        assert result[task_ids[2]] == "canceled"
+        update_response = await eval_task_client.update_task_status(update_request)
+        assert update_response.statuses[task_ids[0]] == "done"
+        assert update_response.statuses[task_ids[1]] == "error"
+        assert update_response.statuses[task_ids[2]] == "canceled"
 
     @pytest.mark.asyncio
     async def test_error_reason_stored_in_db(
-        self, test_client, test_user_headers: Dict[str, str], test_policy_id: str, stats_repo: MettaRepo
+        self, eval_task_client: EvalTaskClient, test_policy_id: str, stats_repo: MettaRepo
     ):
         """Test that error_reason is properly stored in the database attributes."""
         # Create and claim a task
-        create_response = test_client.post(
-            "/tasks",
-            json={
-                "policy_id": test_policy_id,
-                "git_hash": "db_error_test",
-                "sim_suite": "navigation",
-            },
-            headers=test_user_headers,
+        request = TaskCreateRequest(
+            policy_id=test_policy_id,
+            git_hash="db_error_test",
+            sim_suite="navigation",
         )
-        assert create_response.status_code == 200
-        task_id = create_response.json()["id"]
+        task_response = await eval_task_client.create_task(request)
+        task_id = task_response.id
 
-        claim_response = test_client.post(
-            "/tasks/claim",
-            json={
-                "eval_task_ids": [task_id],
-                "assignee": "worker_db_test",
-            },
-            headers=test_user_headers,
+        claim_request = TaskClaimRequest(
+            tasks=[task_id],
+            assignee="worker_db_test",
         )
-        assert claim_response.status_code == 200
+        claim_response = await eval_task_client.claim_tasks(claim_request)
+        assert task_id in claim_response.claimed
 
         # Update with error and reason
         error_reason = "Database connection timeout after 30 seconds"
-        update_response = test_client.post(
-            "/tasks/claimed/update",
-            json={
-                "assignee": "worker_db_test",
-                "statuses": {task_id: {"status": "error", "details": {"error_reason": error_reason}}},
-            },
-            headers=test_user_headers,
+        update_request = TaskUpdateRequest(
+            assignee="worker_db_test",
+            statuses={task_id: TaskStatusUpdate(status="error", details={"error_reason": error_reason})},
         )
-        assert update_response.status_code == 200
+        update_response = await eval_task_client.update_task_status(update_request)
+        assert update_response.statuses[task_id] == "error"
 
         async with stats_repo.connect() as con:
-            result = await con.execute("SELECT status, attributes FROM eval_tasks WHERE id = %s", (uuid.UUID(task_id),))
+            result = await con.execute("SELECT status, attributes FROM eval_tasks WHERE id = %s", (task_id,))
             row = await result.fetchone()
             assert row is not None
             assert row[0] == "error"  # status


### PR DESCRIPTION
- Add a client for our task endpoints: EvalTaskClient
- Refactor some parsing of db objects -> pydantic objects
- Add timed_http_handler decorator combining timing and error handling
- Update tests to use EvalTaskClient instead of raw HTTP; effectively tests the EvalTaskClient too
- Return full task data from create_eval_task in MettaRepo
- Make use of fastapi's pydantic uuid and datetime default parsing
- Support querying for tasks assigned to anyone, not just a given assignee
- Only put the create_task task endpoint behind auth

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210805870544682)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210805665344837)