### PR TITLE
Fix heartbeat timeout by ensuring all ranks update local heartbeat files

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -553,10 +553,8 @@ class MettaTrainer:
         return self.epoch % interval == 0
 
     def _maybe_record_heartbeat(self, force=False):
-        if not self._should_run(10, force):
-            return
-
-        record_heartbeat()
+        if force or (self.epoch % 10 == 0):
+            record_heartbeat()
 
     def _maybe_save_training_state(self, force=False):
         """Save training state if on checkpoint interval"""


### PR DESCRIPTION
**Problem:**
#1199 wrapped `_record_heartbeat` to `_maybe_record_heartbeat` which doesn't record a heartbeat for non master nodes. This always leads to a heartbeat timeout when training on multiple nodes. 

**Fix:**
We no longer check for master status before recording a heartbeat.

**Testing:**
A simple run on 2 nodes timed out before and now works perfectly. 

**Further thoughts:**
I'm not sure if it is smart to only record heartbeats every 10 epochs. Recording heartbeats is cheap and so I see no reason to only to it every n epochs, but it is not strictly a problem for now. I just have a bad feeling that one day we will test something that causes us to have very long epochs and then this is going to come back to haunt us. 