### PR TITLE
refactor: Update sweep configuration for faster evaluation

### DIFF
--- a/configs/sim/sweep_eval.yaml
+++ b/configs/sim/sweep_eval.yaml
@@ -5,8 +5,6 @@ defaults:
 name: sweep_eval
 
 simulations:
-  navigation/emptyspace_withinsight:
-    env: env/mettagrid/navigation/evals/emptyspace_withinsight
   simple:
-    env: env/mettagrid/arena/advanced
+    env: env/mettagrid/curriculum/basic_easy_shaped
 # selector_type: "latest"

--- a/configs/sweep/quick.yaml
+++ b/configs/sweep/quick.yaml
@@ -20,7 +20,6 @@ parameters:
         mean: 0.0005
         scale: 0.5
 
-    batch_size:      {distribution: uniform_pow2, min: 16,   max: 128,  mean: 64,  scale: auto}
+    batch_size:      {distribution: uniform_pow2, min: 256,   max: 1024,  mean: 512,  scale: auto}
     minibatch_size:  {distribution: uniform_pow2, min: 1,    max: 32,   mean: 8,   scale: auto}
     bptt_horizon:    {distribution: uniform_pow2, min: 1,    max: 32,   mean: 8,   scale: auto}
-    total_timesteps: {distribution: int_uniform,  min: 1000, max: 1000, mean: 1000, scale: auto}

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -4,7 +4,7 @@ defaults:
   - agent: fast
   - sim: sweep_eval
   - trainer: trainer
-  - sweep: full
+  - sweep: quick
   - _self_
 
 cmd: sweep
@@ -13,16 +13,18 @@ sweep_run: ???  # Will be set via command line override
 trainer:
   total_timesteps: 5_000_000   # 5M timesteps for proper RL training (was 50k - too short!)
   curriculum: /env/mettagrid/arena/basic_easy_shaped
-
+  simulation:
+    evaluate_interval: 0  # No evaluation during training for speed
+    replay_dir: "" # No replays for sweeps
 
 sim:
   name: sweep_eval  # Required field
-  num_episodes: 10  # Balance between statistical reliability and evaluation speed
-  max_time_s: 120  # Increased timeout for longer evaluation
+  num_episodes: 2
+  max_time_s: 60
   env_overrides: {}
   simulations:
     simple:
-      env: env/mettagrid/arena/basic
+      env: /env/mettagrid/arena/basic_easy_shaped
 
 wandb:
   group: ${sweep_run}
@@ -34,6 +36,7 @@ sweep_job:
   wandb: ${wandb}
   runs_dir: "${sweep_dir}/runs"
   seed: null  # Will be randomly generated for each run if not specified
+  stats_server_uri: null # No logging to observatory for sweeps
 
 # TODO: Remove and update references.
 sweep_dir: "${.data_dir}/sweep/${.sweep_run}"


### PR DESCRIPTION
config: disable in-training evaluation, observatory logging, and replay uploads

fix: fix latest policy selection for no runs with no in-training evaluation

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210807392720693)