### PR TITLE
Upload fully-specified env configs per bucket to wandb

### DIFF
--- a/metta/api.py
+++ b/metta/api.py
@@ -323,6 +323,9 @@ class PreBuiltConfigCurriculum(Curriculum):
         task_name = f"prebuilt({self._env_name})"
         return {task_name: 1.0}
 
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        return {self._env_name: self._cfg_template}
+
 
 def _get_default_env_config(num_agents: int = 4, width: int = 32, height: int = 32) -> Dict[str, Any]:
     """Get default environment configuration for navigation training."""
@@ -526,6 +529,9 @@ class NavigationBucketedCurriculum(Curriculum):
         self.terrain_dirs = terrain_dirs
         self.altar_range = altar_range
         self.current_idx = 0
+
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        return {self._env_name: self._cfg_template}
 
     def get_task(self) -> "Task":
         import random

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import traceback
@@ -12,6 +13,7 @@ import torch.distributed
 import wandb
 from heavyball import ForeachMuon
 from omegaconf import DictConfig
+from omegaconf.omegaconf import OmegaConf
 
 from metta.agent.metta_agent import DistributedMettaAgent, make_policy
 from metta.agent.policy_metadata import PolicyMetadata
@@ -28,6 +30,7 @@ from metta.eval.eval_request_config import EvalRewardSummary
 from metta.eval.eval_service import evaluate_policy
 from metta.mettagrid.curriculum.util import curriculum_from_config_path
 from metta.mettagrid.mettagrid_env import MettaGridEnv, dtype_actions
+from metta.mettagrid.util.file import upload_data_as_wandb_file
 from metta.rl.experience import Experience
 from metta.rl.functions import (
     accumulate_rollout_stats,
@@ -236,7 +239,6 @@ class MettaTrainer:
                     torch.distributed.barrier()
 
         logging.info(f"Rank {self._rank}: USING {self.initial_policy_record.uri}")
-
         if self._master:
             logger.info(f"MettaTrainer loaded: {self.policy}")
 
@@ -257,6 +259,7 @@ class MettaTrainer:
             # Ensure all ranks have initialized DDP before proceeding
             torch.distributed.barrier()
 
+        self._maybe_upload_env_configs()
         self._make_experience_buffer()
 
         self._stats_epoch_start = self.epoch
@@ -791,6 +794,17 @@ class MettaTrainer:
                 "replays/link": wandb.Html(f'<a href="{player_url}">MetaScope Replay (Epoch {self.epoch})</a>')
             }
             self.wandb_run.log(link_summary, step=self.agent_step)
+
+    def _maybe_upload_env_configs(self):
+        if not self._master or not self.wandb_run:
+            return
+        try:
+            env_configs = {
+                k: OmegaConf.to_container(v, resolve=True) for k, v in self._curriculum.get_env_cfg_by_bucket().items()
+            }
+            upload_data_as_wandb_file(json.dumps(env_configs, indent=2), "env_configs.json", self.wandb_run)
+        except Exception as e:
+            logger.warning(f"Failed to upload env configs to wandb: {e}")
 
     @with_instance_timer("_process_stats")
     def _process_stats(self):

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -7,6 +7,11 @@ logger = logging.getLogger(__name__)
 
 
 class Curriculum:
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        # Gives a dictionary of bucket names to their fully specified configs
+        # If there is no bucket, then task name is the bucket name
+        raise NotImplementedError("Subclasses must implement this method")
+
     def get_task(self) -> "Task":
         raise NotImplementedError("Subclasses must implement this method")
 
@@ -76,3 +81,6 @@ class SingleTaskCurriculum(Curriculum):
 
     def get_task(self) -> Task:
         return Task(self._task_id, self, self._task_cfg)
+
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        return {self._task_id: self._task_cfg}

--- a/mettagrid/src/metta/mettagrid/curriculum/progressive.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/progressive.py
@@ -25,13 +25,16 @@ class ProgressiveCurriculum(SamplingCurriculum):
         cfg.game.map.width = self._width
         cfg.game.map.height = self._height
         OmegaConf.resolve(cfg)
-        return Task(f"sample({self._cfg_template.sampling})", self, cfg)
+        return Task(self._name, self, cfg)
 
     def complete_task(self, id: str, score: float):
         if score > 0.5:
             self._width = min(self._width * 2, 100)
             self._height = min(self._height * 2, 100)
         super().complete_task(id, score)
+
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        return {self._name: self._cfg_template}
 
 
 class ProgressiveMultiTaskCurriculum(RandomCurriculum):

--- a/mettagrid/src/metta/mettagrid/curriculum/random.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/random.py
@@ -31,3 +31,17 @@ class RandomCurriculum(MultiTaskCurriculum):
 
     def _curriculum_from_id(self, cfg_path: str) -> Curriculum:
         return curriculum_from_config_path(cfg_path, self.env_overrides)
+
+    def get_env_cfg_by_bucket(self) -> dict[str, DictConfig]:
+        configs = {}
+        for task_id, curriculum in self._curricula.items():
+            # Get configs from child curriculums without creating tasks
+            child_configs = curriculum.get_env_cfg_by_bucket()
+            # Use task_id as key if child returns a single config
+            if len(child_configs) == 1:
+                configs[task_id] = list(child_configs.values())[0]
+            else:
+                # Prefix multiple configs with task_id
+                for sub_id, cfg in child_configs.items():
+                    configs[f"{task_id}/{sub_id}"] = cfg
+        return configs


### PR DESCRIPTION
Jack wants an easy way to be able to give a run id, an epoch num, and get the set of tasks that were at play (and their probabilities, which can be inferred through completion rates already in wandb)

Right now, we upload bucket names, but not the full bucket specs to wandb

This means that in order to find out what the exact specs of a bucket was in a training run you have to also switch to the branch on which that run was run

This uploads the full env cfg for each bucket in the trainer's curriciulum. Can later be fetched using `metta.mettagrid.util.file`'s `read`

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210815074826584)