### PR TITLE
fix: satisfy uv venv warnings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -32,7 +32,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -50,7 +50,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -69,7 +69,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -87,7 +87,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -104,7 +104,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -122,7 +122,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -139,7 +139,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -156,7 +156,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -174,7 +174,7 @@
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
@@ -188,7 +188,7 @@
       "cwd": "${workspaceFolder}/mettagrid",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
-        "UV_PROJECT_ENVIRONMENT": "${workspaceFolder}/.venv"
+        "UV_PROJECT_ENVIRONMENT": "${env:VIRTUAL_ENV}"
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help:
 # Clean cmake build artifacts
 clean:
 	@echo "(Metta) Running clean command..."
-	uv run metta clean
+	uv run  --active metta clean
 
 # Dev all project dependencies and external components
 dev:
@@ -23,14 +23,14 @@ dev:
 
 test:
 	@echo "Running python tests with coverage"
-	uv run metta test --cov=metta --cov-report=term-missing
+	uv run  --active metta test --cov=metta --cov-report=term-missing
 
 install:
 	@echo "Installing package in editable mode..."
-	uv sync --inexact
+	uv sync --inexact --active
 
 pytest: install
 	@echo "Running Python tests..."
-	uv run metta test
+	uv run  --active metta test
 
 all: dev test

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -8,11 +8,11 @@ help:
 
 install:
 	@echo "Installing package in editable mode..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact
+	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact --active
 
 test:
 	@echo "Running tests with coverage..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv run pytest --cov=metta.agent --cov-report=term-missing
+	UV_PROJECT_ENVIRONMENT=../.venv uv run --active pytest --cov=metta.agent --cov-report=term-missing
 
 clean:
 	@echo "Cleaning extra venv..."

--- a/app_backend/Makefile
+++ b/app_backend/Makefile
@@ -8,11 +8,11 @@ help:
 
 install:
 	@echo "Installing package in editable mode..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact
+	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact --active
 
 test:
 	@echo "Running tests with coverage..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv run pytest --cov=metta.app_backend --cov-report=term-missing
+	UV_PROJECT_ENVIRONMENT=../.venv uv run --active pytest --cov=metta.app_backend --cov-report=term-missing
 
 clean:
 	@echo "Cleaning extra venv..."

--- a/common/Makefile
+++ b/common/Makefile
@@ -8,11 +8,11 @@ help:
 
 install:
 	@echo "Installing package in editable mode..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact
+	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact --active
 
 test:
 	@echo "Running tests with coverage..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv run pytest --cov=metta.common --cov-report=term-missing
+	UV_PROJECT_ENVIRONMENT=../.venv uv run --active pytest --cov=metta.common --cov-report=term-missing
 
 clean:
 	@echo "Cleaning extra venv..."

--- a/devops/tools/common.sh
+++ b/devops/tools/common.sh
@@ -25,7 +25,7 @@ get_project_root() {
 # Setup UV project environment
 setup_uv_project_env() {
   local project_root="$(get_project_root)"
-  export UV_PROJECT_ENVIRONMENT="${project_root}/.venv"
+  export UV_PROJECT_ENVIRONMENT="$(cd "${project_root}/.venv" && pwd)"
 }
 
 # Setup UV environment paths

--- a/mettagrid/Makefile
+++ b/mettagrid/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build lint test clean install pytest
+.PHONY: help build lint test clean install pytest tidy
 
 # Default target
 help:
@@ -6,6 +6,7 @@ help:
 	@echo "  build      - Build project for tests"
 	@echo "  build-prod - Build project for production"
 	@echo "  lint       - Run cpplint on all C++ source files"
+	@echo "  tidy       - Run clang-tidy static analysis"
 	@echo "  test       - Build and run all C++ tests"
 	@echo "  pytest     - Install package and run all Python tests"
 	@echo "  clean      - Clean all build artifacts"
@@ -40,8 +41,12 @@ clean:
 
 install:
 	@echo "Installing package in editable mode..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact
+	UV_PROJECT_ENVIRONMENT=../.venv uv sync --inexact --active
 
 pytest: install
 	@echo "Running Python tests..."
-	UV_PROJECT_ENVIRONMENT=../.venv uv run pytest
+	UV_PROJECT_ENVIRONMENT=../.venv uv run --active pytest
+
+tidy: build
+	@echo "Running clang-tidy..."
+	@bash clang-tidy.sh


### PR DESCRIPTION

This PR eliminates warnings from `uv` about mismatched virtual environment paths by:

* Replacing hardcoded `UV_PROJECT_ENVIRONMENT=${workspaceFolder}/.venv` with `UV_PROJECT_ENVIRONMENT=${env:VIRTUAL_ENV}` in `.vscode/launch.json`
* Updating Makefiles and shell scripts to use:

  * `uv sync --inexact --active`
  * `uv run --active`
  * Canonicalized virtualenv paths via `pwd` in `setup_uv_project_env`

### 🛠 Changes

* `.vscode/launch.json`: Use `${env:VIRTUAL_ENV}` instead of relative `.venv` path
* All Makefiles: Add `--active` to `uv sync` and `uv run` commands
* `devops/tools/common.sh`: Canonicalize `UV_PROJECT_ENVIRONMENT` using `cd ... && pwd`

### 🧹 Motivation

These changes resolve this common warning:

```
warning: VIRTUAL_ENV=/path/to/.venv does not match the project environment path ... and will be ignored
```

By ensuring consistent, canonical paths and explicitly activating the virtual environment, we eliminate noise in builds and avoid path confusion in CI/dev workflows.


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210815233406744)