### PR TITLE
Take advantage of defaults in mettagrid configuration more

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -22,39 +22,37 @@ def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> CppGameConfi
     objects_cpp_params = {}  # params for CppConverterConfig or CppWallConfig
 
     # These are the baseline settings for all agents
-    default_agent_config_dict = game_config.agent.model_dump(by_alias=True, exclude_unset=True)
-    default_resource_limit = default_agent_config_dict.get("default_resource_limit", 0)
+    default_agent_config_dict = game_config.agent.model_dump()
+    default_resource_limit = default_agent_config_dict["default_resource_limit"]
 
     # Group information is more specific than the defaults, so it should override
     for group_name, group_config in game_config.groups.items():
         agent_group_props = copy.deepcopy(default_agent_config_dict)
 
-        group_config_dict = group_config.model_dump(by_alias=True, exclude_unset=True)
-
         # Update, but in a nested way
-        for key, value in group_config_dict.get("props", {}).items():
+        for key, value in group_config.props.model_dump(exclude_unset=True).items():
             agent_group_props[key] = value
 
         agent_cpp_params = {
-            "freeze_duration": agent_group_props.get("freeze_duration", 0),
+            "freeze_duration": agent_group_props["freeze_duration"],
             "group_id": group_config.id,
             "group_name": group_name,
-            "action_failure_penalty": agent_group_props.get("action_failure_penalty", 0),
+            "action_failure_penalty": agent_group_props["action_failure_penalty"],
             "resource_limits": {
-                resource_id: agent_group_props.get("resource_limits", {}).get(resource_name, default_resource_limit)
+                resource_id: agent_group_props["resource_limits"].get(resource_name, default_resource_limit)
                 for resource_id, resource_name in enumerate(resource_names)
             },
             "resource_rewards": {
                 resource_name_to_id[k]: v
-                for k, v in agent_group_props.get("rewards", {}).items()
-                if not k.endswith("_max")
+                for k, v in agent_group_props["rewards"].items()
+                if v is not None and not k.endswith("_max")
             },
             "resource_reward_max": {
                 resource_name_to_id[k[:-4]]: v
-                for k, v in agent_group_props.get("rewards", {}).items()
+                for k, v in agent_group_props["rewards"].items()
                 if k.endswith("_max") and v is not None
             },
-            "group_reward_pct": group_config.group_reward_pct or 0,
+            "group_reward_pct": group_config.group_reward_pct,
             "type_id": 0,
             "type_name": "agent",
         }
@@ -88,7 +86,7 @@ def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> CppGameConfi
         else:
             raise ValueError(f"Unknown object type: {object_type}")
 
-    game_cpp_params = game_config.model_dump(by_alias=True, exclude_none=True)
+    game_cpp_params = game_config.model_dump(exclude_none=True)
     del game_cpp_params["agent"]
     del game_cpp_params["groups"]
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -1,6 +1,6 @@
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import Field, RootModel
+from pydantic import Field
 
 from metta.common.util.typed_config import BaseModelWithForbidExtra
 
@@ -35,17 +35,11 @@ class PyAgentRewards(BaseModelWithForbidExtra):
 class PyAgentConfig(BaseModelWithForbidExtra):
     """Python agent configuration."""
 
-    default_resource_limit: Optional[int] = Field(default=None, ge=0)
+    default_resource_limit: Optional[int] = Field(default=0, ge=0)
     resource_limits: Optional[dict[str, int]] = Field(default_factory=dict)
-    freeze_duration: Optional[int] = Field(default=None, ge=-1)
-    rewards: Optional[PyAgentRewards] = Field(default=None)
-    action_failure_penalty: Optional[float] = Field(default=None, ge=0)
-
-
-class PyGroupProps(RootModel[dict[str, Any]]):
-    """Python group properties configuration."""
-
-    pass
+    freeze_duration: Optional[int] = Field(default=0, ge=-1)
+    rewards: Optional[PyAgentRewards] = Field(default_factory=PyAgentRewards)
+    action_failure_penalty: Optional[float] = Field(default=0, ge=0)
 
 
 class PyGroupConfig(BaseModelWithForbidExtra):
@@ -55,8 +49,8 @@ class PyGroupConfig(BaseModelWithForbidExtra):
     sprite: Optional[int] = Field(default=None)
     # group_reward_pct values outside of [0.0,1.0] are probably mistakes, and are probably
     # unstable. If you want to use values outside this range, please update this comment!
-    group_reward_pct: Optional[float] = Field(default=None, ge=0, le=1)
-    props: Optional[PyGroupProps] = Field(default=None)
+    group_reward_pct: float = Field(default=0, ge=0, le=1)
+    props: PyAgentConfig = Field(default_factory=PyAgentConfig)
 
 
 class PyActionConfig(BaseModelWithForbidExtra):


### PR DESCRIPTION
Refactors the MettagridConfig classes and conversion to use default values more, instead of having default values in code.

- Made various optional parameters have default values other than None (mostly zeros).
- Replaced `PyGroupProps` dictionary with direct use of `PyAgentConfig` in `PyGroupConfig`, since the props should be overrides of the agent's configuration.
- Updated the `from_mettagrid_config` function to work with the new structure, using property access instead of turning everything into a dictionary. Also reducing `exclude_unset` flags, since in most circumstances we want to use the default values.


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210815317788811)