### PR TITLE
[MettaScope] esc should close panels and search menu

### DIFF
--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -385,23 +385,25 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
     // Close the currently visible panel, preferring the ones most likely to be on top.
     if (state.showAgentPanel) {
       state.showAgentPanel = false
+      localStorage.setItem('showAgentPanel', state.showAgentPanel.toString())
       toggleOpacity(html.agentPanelToggle, state.showAgentPanel)
     } else if (state.showInfo) {
       state.showInfo = false
+      localStorage.setItem('showInfo', state.showInfo.toString())
       toggleOpacity(html.infoToggle, state.showInfo)
     } else if (state.showTraces) {
       state.showTraces = false
+      localStorage.setItem('showTraces', state.showTraces.toString())
       toggleOpacity(html.tracesToggle, state.showTraces)
       onResize()
     } else if (state.showActionButtons) {
       state.showActionButtons = false
+      localStorage.setItem('showActionButtons', state.showActionButtons.toString())
       toggleOpacity(html.controlsToggle, state.showActionButtons)
     }
 
     updateSelection(null)
     setFollowSelection(false)
-    requestFrame()
-    return
   }
   // '[' and ']' scrub forward and backward.
   if (event.key == '[') {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -376,10 +376,14 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
 
     // Clear the search field and related state.
     const searchInput = document.getElementById('search-input') as HTMLInputElement | null
-    if (searchInput && searchInput.value.length > 0) {
-      searchInput.value = ''
-      // Trigger the input handler registered in search.ts so internal state updates.
-      searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+    if (searchInput) {
+      if (searchInput.value.length > 0) {
+        searchInput.value = ''
+        // Trigger the input handler registered in search.ts so internal state updates.
+        searchInput.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      // Remove focus from the search input
+      searchInput.blur()
     }
 
     // Close the currently visible panel, preferring the ones most likely to be on top.

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -374,20 +374,19 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
     hideMenu()
     hideDropdown()
 
-    // Clear the search field and related state.
     const searchInput = document.getElementById('search-input') as HTMLInputElement | null
-    if (searchInput) {
+    if (searchInput && (searchInput.value.length > 0 || document.activeElement === searchInput)) {
+      // Clear the search field and related state.
       if (searchInput.value.length > 0) {
         searchInput.value = ''
         // Trigger the input handler registered in search.ts so internal state updates.
         searchInput.dispatchEvent(new Event('input', { bubbles: true }))
       }
+
       // Remove focus from the search input
       searchInput.blur()
-    }
-
-    // Close the currently visible panel, preferring the ones most likely to be on top.
-    if (state.showAgentPanel) {
+      // Otherwise, close the currently visible panel, preferring the ones most likely to be on top.
+    } else if (state.showAgentPanel) {
       state.showAgentPanel = false
       localStorage.setItem('showAgentPanel', state.showAgentPanel.toString())
       toggleOpacity(html.agentPanelToggle, state.showAgentPanel)

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -363,8 +363,7 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
 
   // Prevent keyboard events if we are focused on a text field, except for the Escape key
   if (
-    (document.activeElement instanceof HTMLInputElement ||
-      document.activeElement instanceof HTMLTextAreaElement) &&
+    (document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement) &&
     event.key !== 'Escape'
   ) {
     return
@@ -390,9 +389,6 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
     } else if (state.showInfo) {
       state.showInfo = false
       toggleOpacity(html.infoToggle, state.showInfo)
-    } else if (state.showMiniMap) {
-      state.showMiniMap = false
-      toggleOpacity(html.minimapToggle, state.showMiniMap)
     } else if (state.showTraces) {
       state.showTraces = false
       toggleOpacity(html.tracesToggle, state.showTraces)


### PR DESCRIPTION
- https://app.asana.com/1/1209016784099267/project/1209513563278644/task/1210748130054789?focus=true

- hitting esc will now clear the search
- esc will now also close panels if any are open (except for the minimap, for me that one just didn't feel right)

[Screencast From 2025-07-16 15-58-42.webm](https://github.com/user-attachments/assets/67d52b08-c29a-47c8-8add-afca328a5c1b)


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210815545975990)