### PR TITLE
[MettaScope] hide actions for replays

### DIFF
--- a/mettascope/src/hoverpanels.ts
+++ b/mettascope/src/hoverpanels.ts
@@ -68,7 +68,12 @@ hoverPanel.addEventListener('mousedown', (e: MouseEvent) => {
   // and if the websocket is connected.
   let actions = findIn(panel.div, '.actions')
   if (state.ws != null && panel.object.hasOwnProperty('agent_id')) {
-    actions.classList.remove('hidden')
+    if (state.replay != null) {
+      // Replay doesn't support actions
+      actions.classList.add('hidden')
+    } else {
+      actions.classList.remove('hidden')
+    }
   } else {
     actions.classList.add('hidden')
   }


### PR DESCRIPTION
https://app.asana.com/1/1209016784099267/project/1209513563278644/task/1210538273694971?focus=true

- Replays do not support actions. showing the memory interface is confusing since it doesn't do anything.
- if we loaded a replay, keep the actions hidden.

<img width="1385" height="636" alt="Screenshot From 2025-07-16 16-49-55" src="https://github.com/user-attachments/assets/5bd75304-b352-4532-9cfb-8d19d019e073" />
