### PR TITLE
add max_reward

### DIFF
--- a/configs/env/mettagrid/navigation/training/defaults.yaml
+++ b/configs/env/mettagrid/navigation/training/defaults.yaml
@@ -4,7 +4,7 @@ defaults:
 
 sampling: 1
 game:
-  num_agents: 4
+  num_agents: 1
   max_steps: 1000
   actions:
     attack:

--- a/configs/env/mettagrid/navigation/training/defaults.yaml
+++ b/configs/env/mettagrid/navigation/training/defaults.yaml
@@ -5,6 +5,7 @@ defaults:
 sampling: 1
 game:
   num_agents: 1
+  max_reward: ${sampling:3, 50, 25}
   max_steps: 1000
   actions:
     attack:
@@ -24,7 +25,7 @@ game:
       border_width: 3
       agents: 1
       objects:
-        altar: ${sampling:3, 50, 25}
+        altar: ${game.max_reward}
   objects:
     altar:
       cooldown: 1000

--- a/configs/env/mettagrid/navigation/training/sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse.yaml
@@ -14,6 +14,15 @@ game:
     put_items:
       enabled: false
   max_reward: ${sampling:1, 10, 5}
+  actions:
+    attack:
+      enabled: false
+    swap:
+      enabled: false
+    change_color:
+      enabled: false
+    put_items:
+      enabled: false
   agent:
     default_resource_limit: 5
   map_builder:

--- a/configs/env/mettagrid/navigation/training/sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse.yaml
@@ -14,15 +14,6 @@ game:
     put_items:
       enabled: false
   max_reward: ${sampling:1, 10, 5}
-  actions:
-    attack:
-      enabled: false
-    swap:
-      enabled: false
-    change_color:
-      enabled: false
-    put_items:
-      enabled: false
   agent:
     default_resource_limit: 5
   map_builder:

--- a/configs/env/mettagrid/navigation/training/sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
 
 game:
-  num_agents: 4
+  num_agents: 1
   actions:
     attack:
       enabled: false
@@ -13,6 +13,7 @@ game:
       enabled: false
     put_items:
       enabled: false
+  max_reward: ${sampling:1, 10, 5}
   agent:
     default_resource_limit: 5
   map_builder:
@@ -25,7 +26,7 @@ game:
       params:
         agents: 1
         objects:
-          altar: ???
+          altar: ${game.max_reward}
   objects:
     altar:
       initial_resource_count: 1

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -6,6 +6,10 @@ defaults:
 trainer:
   curriculum: /env/mettagrid/curriculum/navigation/learning_progress
 
+replay_job:
+  sim:
+    env: /env/mettagrid/navigation/training/sparse
+
 seed: null
-run_id: 20250716.02
+run_id: 20250716.03
 run: ${oc.env:USER}.local.${run_id}

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -89,7 +89,7 @@ GameConfig CreateBenchmarkConfig(size_t num_agents) {
   global_obs_config.resource_rewards = true;
 
   return GameConfig(
-      num_agents, 10000, false, 11, 11, inventory_item_names, 100, global_obs_config, actions_cfg, objects_cfg);
+      num_agents, 10000, 0, false, 11, 11, inventory_item_names, 100, global_obs_config, actions_cfg, objects_cfg);
 }
 
 py::list CreateDefaultMap(size_t num_agents_per_team = 2) {
@@ -239,9 +239,7 @@ int main(int argc, char** argv) {
 
   // Register benchmarks after Python is initialized
   // Use Threads(1) to ensure single-threaded execution for Python GIL safety
-  ::benchmark::RegisterBenchmark("BM_MettaGridStep", BM_MettaGridStep)
-      ->Unit(benchmark::kMillisecond)
-      ->Threads(1);
+  ::benchmark::RegisterBenchmark("BM_MettaGridStep", BM_MettaGridStep)->Unit(benchmark::kMillisecond)->Threads(1);
 
   // Run benchmarks
   ::benchmark::RunSpecifiedBenchmarks();

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.hpp
@@ -53,6 +53,7 @@ struct GlobalObsConfig {
 struct GameConfig {
   size_t num_agents;
   unsigned int max_steps;
+  float max_reward;
   bool episode_truncates;
   ObservationCoord obs_width;
   ObservationCoord obs_height;
@@ -74,6 +75,7 @@ public:
 
   unsigned int current_step;
   unsigned int max_steps;
+  float max_reward;
   bool episode_truncates;
 
   std::vector<std::string> inventory_item_names;

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -182,7 +182,10 @@ class PyGameConfig(BaseModelWithForbidExtra):
     num_agents: int = Field(ge=1)
     # max_steps = zero means "no limit"
     max_steps: int = Field(ge=0)
-    # default is that we terminate / use "done" vs truncation
+    # If this is non-zero, terminate after the total reward reaches this value.
+    # This is intended as "all the reward on the map has been collected".
+    max_reward: float = Field(default=0, ge=0)
+    # If true, truncate when max_steps is reached. Otherwise, terminate.
     episode_truncates: bool = Field(default=False)
     obs_width: Literal[3, 5, 7, 9, 11, 13, 15]
     obs_height: Literal[3, 5, 7, 9, 11, 13, 15]


### PR DESCRIPTION
Adds max_reward to terminate episodes when total reward threshold is reached

This PR adds a new `max_reward` parameter to the MettaGrid environment that terminates episodes when the total accumulated reward reaches this threshold. This is intended to represent scenarios where "all the reward on the map has been collected."

Key changes:
- Added `max_reward` field to GameConfig structure
- Implemented logic to check for episode termination when total reward exceeds max_reward
- Refactored navigation configs to use a centralized max_reward parameter instead of duplicating values
- Changed default number of agents from 4 to 1 in navigation configs

I'm currently testing a training run on this, both to test the max_reward and also to test the simpler 4 -> 1 agent switch.

This would be better with a unit test, but I'm submitting now since that pushes the code remotely, so I can start my training jobs.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210816370675249)