### PR TITLE
feat: add codecov tool

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -43,6 +43,8 @@ runs:
             # Also install mettagrid's build dependencies
             echo "Installing build dependencies..."
             uv pip install scikit-build-core
+            echo "Installing test dependencies..."
+            uv pip install pytest pytest-cov
             ;;
           "linting")
             # Just install linting tools

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Run Pytest on core tests
         run: |
-          pytest -n ${{ env.PYTEST_WORKERS }} --benchmark-skip --maxfail=1 --disable-warnings -q
+          pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml --benchmark-skip --maxfail=1 --disable-warnings -q
 
       - name: Run Pytest on subpackage tests
         env:
@@ -204,8 +204,14 @@ jobs:
         run: |
           for package in $SUBPACKAGES; do
             echo "Running tests for $package..."
-            (cd "$package" && pytest -n ${{ env.PYTEST_WORKERS }} --benchmark-skip --maxfail=1 --disable-warnings -v) || exit 1
+            (cd "$package" && pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml --benchmark-skip --maxfail=1 --disable-warnings -v) || exit 1
           done
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Metta-AI/metta
 
       - name: Run MettaGrid C++ tests
         if: steps.mettagrid_build_check.outputs.build_success == 'true'


### PR DESCRIPTION

This PR integrates Codecov into our CI/CD pipeline to track and visualize test coverage across the Metta project. This will help us maintain and improve code quality by providing insights into which parts of our codebase are well-tested and which areas need more attention.

### Changes
- **Added pytest-cov dependency**: Updated the setup-uv action to install `pytest` and `pytest-cov` for coverage measurement
- **Modified test commands**: Updated all pytest invocations to generate coverage reports with the following flags:
  - `--cov`: Enable coverage collection
  - `--cov-branch`: Track branch coverage in addition to line coverage
  - `--cov-report=xml`: Generate XML reports compatible with Codecov
- **Added Codecov upload step**: Integrated the official Codecov GitHub Action to upload coverage reports after test execution

### Implementation Details
The coverage tracking has been implemented for:
- Core tests
- All subpackage tests (app_backend, agent, mettagrid, common)

Each test suite generates its own coverage report in XML format, which is then uploaded to Codecov for aggregation and visualization.

After merging this PR:
1. The Codecov bot will start commenting on PRs with coverage reports
2. Coverage badges can be added to the README
3. Coverage requirements can be configured in `codecov.yml` if desired
