### PR TITLE
Support building local docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,3 +40,6 @@ mettascope/dist
 /observatory/.vite/
 
 wandb
+
+# Ignore .metta directory at root (used temporarily during docker build)
+/.metta

--- a/devops/docker/Dockerfile.local
+++ b/devops/docker/Dockerfile.local
@@ -35,7 +35,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/home/linuxbrew/.local/bin:${PATH}"
 
 # Now run install.sh - it should find uv
-RUN bash install.sh || true
+RUN bash install.sh
 
 # Default command
 CMD ["/bin/bash"]

--- a/devops/docker/Dockerfile.local
+++ b/devops/docker/Dockerfile.local
@@ -3,23 +3,20 @@ FROM homebrew/brew:latest
 # Set non-interactive frontend
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install only the minimal system dependencies we need (cmake, ninja for building)
-# We stay as the default linuxbrew user - no user switching!
+# Minimal system deps
 RUN brew install cmake ninja
 
-# Set working directory
 WORKDIR /workspace
 
-# Copy the entire repository
+# Copy the entire repo
 COPY --chown=linuxbrew:linuxbrew . /workspace/metta
 
-# Copy .metta directory if it exists in the build context
+# Copy .metta directory
 RUN if [ -d /workspace/metta/.metta ]; then \
-        cp -r /workspace/metta/.metta /home/linuxbrew/ && \
-        chown -R linuxbrew:linuxbrew /home/linuxbrew/.metta; \
+    cp -r /workspace/metta/.metta /home/linuxbrew/ && \
+    chown -R linuxbrew:linuxbrew /home/linuxbrew/.metta; \
     fi
 
-# Set working directory
 WORKDIR /workspace/metta
 
 # Clean up git config for anonymous access
@@ -28,14 +25,10 @@ RUN git config --remove-section http."https://github.com/" || true && \
     git remote add origin https://github.com/Metta-AI/metta.git && \
     git fetch
 
-# Install uv directly
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Add uv to PATH
+# This is where uv is installed by default
+# TODO: update `install.sh` to accept a custom path we expect uv to be at.
 ENV PATH="/home/linuxbrew/.local/bin:${PATH}"
 
-# Now run install.sh - it should find uv
 RUN bash install.sh
 
-# Default command
 CMD ["/bin/bash"]

--- a/devops/docker/Dockerfile.local
+++ b/devops/docker/Dockerfile.local
@@ -1,0 +1,41 @@
+FROM homebrew/brew:latest
+
+# Set non-interactive frontend
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only the minimal system dependencies we need (cmake, ninja for building)
+# We stay as the default linuxbrew user - no user switching!
+RUN brew install cmake ninja
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy the entire repository
+COPY --chown=linuxbrew:linuxbrew . /workspace/metta
+
+# Copy .metta directory if it exists in the build context
+RUN if [ -d /workspace/metta/.metta ]; then \
+        cp -r /workspace/metta/.metta /home/linuxbrew/ && \
+        chown -R linuxbrew:linuxbrew /home/linuxbrew/.metta; \
+    fi
+
+# Set working directory
+WORKDIR /workspace/metta
+
+# Clean up git config for anonymous access
+RUN git config --remove-section http."https://github.com/" || true && \
+    git remote remove origin && \
+    git remote add origin https://github.com/Metta-AI/metta.git && \
+    git fetch
+
+# Install uv directly
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Add uv to PATH
+ENV PATH="/home/linuxbrew/.local/bin:${PATH}"
+
+# Now run install.sh - it should find uv
+RUN bash install.sh || true
+
+# Default command
+CMD ["/bin/bash"]

--- a/metta/setup/local_commands.py
+++ b/metta/setup/local_commands.py
@@ -1,0 +1,58 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from metta.setup.utils import error, info, success
+
+
+class LocalCommands:
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root
+
+    def build_docker_img(self, args) -> None:
+        """Build local development Docker image."""
+        docker_dir = self.repo_root / "devops" / "docker"
+        dockerfile_path = docker_dir / "Dockerfile.local"
+
+        if not dockerfile_path.exists():
+            error(f"Dockerfile not found at {dockerfile_path}")
+            sys.exit(1)
+
+        info("Building local development Docker image...")
+        info("Note: This will copy the entire repo and run install.sh during build.")
+        info("This may take several minutes...")
+        info("")
+
+        # Track if we copied .metta
+        copied_metta = False
+        metta_home_dir = Path.home() / ".metta"
+        metta_repo_dir = self.repo_root / ".metta"
+
+        try:
+            # Copy .metta directory if it exists
+            if metta_home_dir.exists():
+                info("Found ~/.metta directory - copying to build context")
+                shutil.copytree(metta_home_dir, metta_repo_dir, dirs_exist_ok=True)
+                copied_metta = True
+
+            tag = "metta-local:latest"
+            # Build the image with repo root as the build context
+            cmd = ["docker", "build", "-t", tag, "-f", str(dockerfile_path), str(self.repo_root)]
+
+            result = subprocess.run(cmd, cwd=self.repo_root)
+
+            if result.returncode == 0:
+                info("")
+                info("Note: The container has a full copy of the repo at build time.")
+                info("Local changes won't be reflected unless you rebuild or attach.")
+                success(f"Build complete! Image available as {tag}")
+            else:
+                error("Build failed!")
+                sys.exit(result.returncode)
+
+        finally:
+            # Clean up .metta directory if we copied it
+            if copied_metta and metta_repo_dir.exists():
+                info("Cleaning up .metta directory from build context")
+                shutil.rmtree(metta_repo_dir)


### PR DESCRIPTION
Right now, the docker image we build as a part of CI for skypilot isn't compatible with mac (arch issue). Coercing it to be without changing the base pufferlib image was hard

This builds a  docker image that avoids that, and as a bonus, uses `./install.sh` to install what it needs (other than brew) -- pretty exciting!

Also adds `metta local {x}` for us to put local development commands in. I would like to put all the commands for spinning up local observatory in there, for instance. For now it has `metta local build-docker-img`

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210816885719034)