### PR TITLE
hotfix: gitignore coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 **/__pycache__/
 .coverage
 .coverage.*
+coverage.xml
+htmlcov/
 cython_debug/
 .venv/
 


### PR DESCRIPTION

coverage files added for codecov are breaking the git util unit test (where we assert there are no unstashed changes)