### PR TITLE
`metta run [component]`, `metta configure [component]`, and updated pre-commit hooks

### DIFF
--- a/devops/git-hooks/pre-commit
+++ b/devops/git-hooks/pre-commit
@@ -10,12 +10,5 @@ source "$REPO_ROOT/devops/tools/common.sh"
 
 ensure_uv_setup
 
-# Run metta lint on staged files only
-if ! uv run metta lint --staged; then
-    echo "❌ Linting failed. Please fix the issues before committing."
-    echo "Consider running `metta lint --fix` to fix some issues automatically."
-    exit 1
-fi
-
-# No output on success - GitHub Desktop works better with silent success
-exit 0
+# Delegate to metta
+exec uv run metta run githooks pre-commit

--- a/metta/setup/README.md
+++ b/metta/setup/README.md
@@ -16,3 +16,74 @@ To add a new tool or service dependency:
 1. Create a new file `metta/setup/components/[tool_name].py` and subclass `SetupModule`
 
 2. (Optional) Add to profiles in `config.py`, specifying expected connected accounts if applicable
+
+## Per-Component Configuration
+
+Components can store and retrieve their own configuration settings. This allows components to remember user preferences and customize their behavior.
+
+### For Component Developers
+
+1. Define configuration options in your `SetupModule` subclass:
+
+```python
+class MyComponentSetup(SetupModule):
+    def get_configuration_options(self) -> dict[str, tuple[Any, str]]:
+        """Define available configuration options."""
+        return {
+            "install_mode": ("standard", "Installation mode"),
+            "verbose": (False, "Enable verbose output"),
+        }
+    
+    def configure(self) -> None:
+        """Interactive configuration for this component."""
+        # Implement interactive configuration logic
+        mode = prompt_choice(...)
+        self.set_setting("install_mode", mode)
+    
+    def install(self):
+        # Get settings with defaults - only non-default values are stored
+        mode = self.get_setting("install_mode", "standard")
+```
+
+Key principles:
+- All settings must have defaults defined in `get_configuration_options()`
+- Only non-default values are written to disk
+- Settings are automatically namespaced under `module_settings.<component_name>`
+- Installation (`metta install`) should never prompt for configuration
+
+### For Users
+
+Configure components using the `metta configure` command:
+
+```bash
+# Configure a specific component
+metta configure githooks
+
+# Run the general setup wizard
+metta configure
+
+# Set a profile directly
+metta configure --profile=softmax
+```
+
+Component settings are stored in `~/.metta/config.yaml` under the `module_settings` section. Only non-default values are saved:
+
+```yaml
+module_settings:
+  githooks:
+    commit_hook_mode: fix  # Only saved because it differs from default "check"
+```
+
+### Example: Git Hooks Configuration
+
+The git hooks component supports three commit hook modes:
+- `none`: No pre-commit linting
+- `check`: Check only, fail if issues found (default)
+- `fix`: Auto-fix issues before committing
+
+To configure:
+```bash
+metta configure githooks
+```
+
+Since `check` is the default, it won't appear in your config file unless you change it.

--- a/metta/setup/components/base.py
+++ b/metta/setup/components/base.py
@@ -1,8 +1,12 @@
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any, TypeVar
 
 from metta.setup.config import SetupConfig
+from metta.setup.utils import error
+
+T = TypeVar("T")
 
 
 class SetupModule(ABC):
@@ -72,3 +76,95 @@ class SetupModule(ABC):
             Current account/profile/org or None if not connected
         """
         return None
+
+    def get_configuration_options(self) -> dict[str, tuple[Any, str]]:
+        """
+        Dict of {setting_name: (default_value, description)}
+        """
+        return {}
+
+    def configure(self) -> None:
+        """This method is called by 'metta configure <component>'.
+        Override this to provide custom configuration logic.
+        """
+        error(f"Component {self.name} does not support configure commands.")
+
+    def run(self, args: list[str]) -> None:
+        """Run a component-specific command.
+
+        This method is called by 'metta run <component> <args>'.
+        Override this to provide component-specific commands.
+
+        Args:
+            args: Command arguments passed after the component name
+        """
+        error(f"Component {self.name} does not support running commands.")
+
+    def get_setting(self, key: str, default: T) -> T:
+        """Get a module-specific setting from the configuration.
+
+        Args:
+            key: The setting key (will be prefixed with module name)
+            default: Default value if setting not found
+
+        Returns:
+            The setting value or default
+        """
+        full_key = f"module_settings.{self.name}.{key}"
+        value = self.config.get(full_key, None)
+        # Only return saved value if it differs from default
+        return value if value is not None else default
+
+    def set_setting(self, key: str, value: Any) -> None:
+        """Save a module-specific setting to the configuration.
+
+        Only saves if value differs from the default defined in get_configuration_options().
+
+        Args:
+            key: The setting key (will be prefixed with module name)
+            value: The value to save
+        """
+        # Check if this is the default value
+        options = self.get_configuration_options()
+        if key in options:
+            default_value, _ = options[key]
+            if value == default_value:
+                # Don't save default values, remove if exists
+                full_key = f"module_settings.{self.name}.{key}"
+                self._remove_setting(full_key)
+                return
+
+        full_key = f"module_settings.{self.name}.{key}"
+        self.config.set(full_key, value)
+
+    def _remove_setting(self, full_key: str) -> None:
+        """Remove a setting from the configuration."""
+        keys = full_key.split(".")
+        config = self.config._config
+        for k in keys[:-1]:
+            if k not in config:
+                return  # Key doesn't exist
+            config = config[k]
+
+        # Remove the key if it exists
+        if keys[-1] in config:
+            del config[keys[-1]]
+            self.config.save()
+            self._cleanup_empty_dicts(self.config._config, keys[:-1])
+
+    def _cleanup_empty_dicts(self, config: dict, keys: list[str]) -> None:
+        if not keys:
+            return
+
+        # Navigate to the parent
+        parent = config
+        for k in keys[:-1]:
+            if k not in parent:
+                return
+            parent = parent[k]
+
+        # Check if the target dict is empty
+        if keys[-1] in parent and isinstance(parent[keys[-1]], dict) and not parent[keys[-1]]:
+            del parent[keys[-1]]
+            # Recursively clean up parent
+            self._cleanup_empty_dicts(config, keys[:-1])

--- a/metta/setup/components/githooks.py
+++ b/metta/setup/components/githooks.py
@@ -1,5 +1,35 @@
+import subprocess
+import sys
+from enum import Enum
+
 from metta.setup.components.base import SetupModule
 from metta.setup.registry import register_module
+from metta.setup.utils import error, green, info, prompt_choice
+
+
+class CommitHookMode(Enum):
+    NONE = "none"
+    CHECK = "check"
+    FIX = "fix"
+
+    def get_description(self) -> str:
+        descriptions = {
+            CommitHookMode.NONE: "No pre-commit linting",
+            CommitHookMode.CHECK: "Check only (fail if issues found)",
+            CommitHookMode.FIX: "Auto-fix issues before committing",
+        }
+        return descriptions.get(self, self.value)
+
+    @classmethod
+    def get_default(cls) -> "CommitHookMode":
+        return CommitHookMode.CHECK
+
+    @classmethod
+    def parse(cls, value: str | None) -> "CommitHookMode":
+        try:
+            return CommitHookMode(value)
+        except ValueError:
+            return cls.get_default()
 
 
 @register_module
@@ -23,3 +53,71 @@ class GitHooksSetup(SetupModule):
             return False
         pre_commit = git_hooks_dir / "pre-commit"
         return pre_commit.exists() and pre_commit.is_file()
+
+    def get_configuration_options(self) -> dict[str, tuple[str, str]]:
+        return {
+            "commit_hook_mode": (CommitHookMode.CHECK.value, "Pre-commit hook behavior"),
+        }
+
+    def configure(self) -> None:
+        info("Configuring git commit hooks...")
+
+        current = CommitHookMode.parse(self.get_setting("commit_hook_mode", default=None))
+
+        # Prompt for new mode
+        mode = prompt_choice(
+            "Select pre-commit hook behavior:",
+            [(mode, mode.get_description()) for mode in CommitHookMode],
+            default=CommitHookMode.get_default(),
+            current=current,
+        )
+
+        # Save the setting (only if non-default)
+        self.set_setting("commit_hook_mode", mode.value)
+
+        if mode.value == CommitHookMode.CHECK.value:
+            info("Using default mode: check only")
+        else:
+            print(f"Commit hook mode set to: {green(mode.get_description())}")
+
+    def run(self, args: list[str]) -> None:
+        if not args or args[0] != "pre-commit":
+            error("Usage: metta run githooks pre-commit")
+            sys.exit(1)
+
+        hook_mode = CommitHookMode.parse(self.get_setting("commit_hook_mode", default=None))
+
+        if hook_mode == CommitHookMode.NONE:
+            sys.exit(0)
+
+        # Get staged Python files
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        files = [f for f in result.stdout.strip().split("\n") if f.endswith(".py") and f]
+
+        if not files:
+            # No Python files to lint
+            sys.exit(0)
+
+        # Run linting
+        lint_cmd = ["metta", "lint", "--staged"]
+
+        if hook_mode == CommitHookMode.FIX:
+            lint_cmd.append("--fix")
+
+        try:
+            subprocess.run(lint_cmd, cwd=self.repo_root, check=True)
+
+            # If in fix mode, stage the fixed files
+            if hook_mode == CommitHookMode.FIX.value:
+                subprocess.run(["git", "add"] + files, cwd=self.repo_root, check=True)
+        except subprocess.CalledProcessError as e:
+            if hook_mode == CommitHookMode.CHECK.value:
+                error("Linting failed. Please fix the issues before committing.")
+                error("Consider running `metta lint --fix` to fix some issues automatically.")
+            sys.exit(e.returncode)

--- a/metta/setup/config.py
+++ b/metta/setup/config.py
@@ -11,6 +11,7 @@ class UserType(Enum):
     CLOUD = "cloud"
     SOFTMAX = "softmax"
     SOFTMAX_DOCKER = "softmax-docker"
+    CUSTOM = "custom"
 
     @property
     def is_softmax(self) -> bool:
@@ -22,6 +23,7 @@ class UserType(Enum):
             UserType.CLOUD: "User with own cloud account",
             UserType.SOFTMAX: "Softmax employee",
             UserType.SOFTMAX_DOCKER: "Softmax (Docker)",
+            UserType.CUSTOM: "Custom configuration",
         }
         return descriptions.get(self, self.value)
 

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -5,11 +5,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from metta.setup.config import CURRENT_CONFIG_VERSION, SetupConfig, UserType
+from metta.setup.config import CURRENT_CONFIG_VERSION, PROFILE_DEFINITIONS, SetupConfig, UserType
 from metta.setup.local_commands import LocalCommands
 from metta.setup.registry import get_all_modules, get_applicable_modules
 from metta.setup.symlink_setup import PathSetup
-from metta.setup.utils import error, header, import_all_modules_from_subpackage, info, success, warning
+from metta.setup.utils import error, header, import_all_modules_from_subpackage, info, prompt_choice, success, warning
 
 # Import all component modules to register them with the registry
 import_all_modules_from_subpackage("metta.setup", "components")
@@ -24,6 +24,7 @@ class MettaCLI:
 
     def setup_wizard(self) -> None:
         header("Welcome to Metta!\n\n")
+        info("Note: You can run 'metta configure <component>' to change component-level settings later.\n")
 
         if self.config.config_path.exists():
             info("Current configuration:")
@@ -36,52 +37,34 @@ class MettaCLI:
                     success(f"  + {comp}")
             info("\n")
 
-        info("Select configuration:")
-        # Dynamically generate user type options
-        user_types = list(UserType)
-        for i, user_type in enumerate(user_types, 1):
-            info(f"{i}. {user_type.get_description()}")
-        info(f"{len(user_types) + 1}. Custom configuration")
+        # Add "Custom configuration" as an option
+        choices = [(ut, ut.get_description()) for ut in UserType]
 
-        choice = input(f"\nEnter choice (1-{len(user_types) + 1}, or press Enter to keep current): ").strip()
+        # Current configuration
+        current_config = self.config.user_type if self.config.config_path.exists() else None
 
-        if not choice and self.config.config_path.exists():
-            info("Keeping current configuration.")
-            return
+        result = prompt_choice(
+            "Select configuration:",
+            choices,
+            current=current_config,
+        )
 
-        if choice == str(len(user_types) + 1):
+        if result == UserType.CUSTOM:
             self._custom_setup()
         else:
-            try:
-                choice_idx = int(choice) - 1
-                if 0 <= choice_idx < len(user_types):
-                    user_type = user_types[choice_idx]
-                else:
-                    user_type = UserType.EXTERNAL
-            except (ValueError, IndexError):
-                user_type = UserType.EXTERNAL
-
-            self.config.apply_profile(user_type)
-            success(f"\nConfigured as {user_type.value} user.")
+            self.config.apply_profile(result)
+            success(f"\nConfigured as {result.value} user.")
         info("\nRun 'metta install' to set up your environment.")
 
         if not self.path_setup.check_installation():
             info("You may want to run 'metta symlink-setup' to make the metta command globally available.")
 
     def _custom_setup(self) -> None:
-        info("\nSelect base profile for custom configuration:")
-        # Dynamically generate user type options
-        user_types = list(UserType)
-        for i, user_type in enumerate(user_types, 1):
-            info(f"{i}. {user_type.get_description()}")
-
-        choice = input(f"\nEnter choice (1-{len(user_types)}): ").strip()
-
-        choice_idx = int(choice) - 1
-        if 0 <= choice_idx < len(user_types):
-            user_type = user_types[choice_idx]
-        else:
-            raise ValueError(f"Invalid choice: {choice}")
+        user_type = prompt_choice(
+            "Select base profile for custom configuration:",
+            [(ut, ut.get_description()) for ut in UserType if ut != UserType.CUSTOM],
+            default=UserType.EXTERNAL,
+        )
 
         self.config.setup_custom_profile(user_type)
 
@@ -92,30 +75,68 @@ class MettaCLI:
         all_modules.sort(key=lambda m: m.name)
 
         for module in all_modules:
-            current = self.config.is_component_enabled(module.name)
-            prompt = f"Enable {module.name}? (y/n, current: {'y' if current else 'n'}): "
-            choice = input(prompt).strip().lower()
-            if choice in ["y", "n"]:
-                self.config.set(f"components.{module.name}.enabled", choice == "y")
+            current_enabled = self.config.is_component_enabled(module.name)
+
+            # Use prompt_choice for yes/no
+            enabled = prompt_choice(
+                f"Enable {module.name} ({module.description})?",
+                [(True, "Yes"), (False, "No")],
+                default=current_enabled,
+                current=current_enabled,
+            )
+
+            # Only save if different from profile default
+            profile_default = (
+                PROFILE_DEFINITIONS.get(user_type, {}).get("components", {}).get(module.name, {}).get("enabled", False)
+            )
+            if enabled != profile_default:
+                self.config.set(f"components.{module.name}.enabled", enabled)
 
         success("\nCustom configuration saved.")
         info("\nRun 'metta install' to set up your environment.")
 
     def cmd_configure(self, args) -> None:
-        if args.profile:
-            # Dynamically build profile map from UserType enum
-            profile_map = {ut.value: ut for ut in UserType}
-            if args.profile in profile_map:
-                self.config.apply_profile(profile_map[args.profile])
-                success(f"Configured as {profile_map[args.profile].value} user.")
+        if args.component:
+            self.configure_component(args.component)
+        elif args.profile:
+            selected_user_type = UserType(args.profile)
+            if selected_user_type in PROFILE_DEFINITIONS:
+                self.config.apply_profile(selected_user_type)
+                success(f"Configured as {selected_user_type.value} user.")
                 info("\nRun 'metta install' to set up your environment.")
             else:
                 error(f"Unknown profile: {args.profile}")
-                available_profiles = [ut.value for ut in UserType if ut != UserType.SOFTMAX_DOCKER]
-                info(f"Available profiles: {', '.join(available_profiles)}")
                 sys.exit(1)
         else:
             self.setup_wizard()
+
+    def configure_component(self, component_name: str) -> None:
+        modules = get_all_modules(self.config)
+        module_map = {m.name: m for m in modules}
+
+        if not (module := module_map.get(component_name)):
+            error(f"Unknown component: {component_name}")
+            info(f"Available components: {', '.join(sorted(module_map.keys()))}")
+            sys.exit(1)
+
+        options = module.get_configuration_options()
+        if not options:
+            info(f"Component '{component_name}' has no configuration options.")
+            return
+        module.configure()
+
+    def cmd_run(self, args) -> None:
+        """Run component-specific commands."""
+        modules = get_all_modules(self.config)
+        module_map = {m.name: m for m in modules}
+
+        if not (module := module_map.get(args.component)):
+            error(f"Unknown component: {args.component}")
+            info(f"Available components: {', '.join(sorted(module_map.keys()))}")
+            sys.exit(1)
+
+        # Run the component's command
+        module.run(args.args)
 
     def cmd_install(self, args) -> None:
         if not self.config.config_path.exists():
@@ -240,7 +261,7 @@ class MettaCLI:
 
         check_cmd = ["uv", "run", "ruff", "check"]
         format_cmd = ["uv", "run", "ruff", "format"]
-        cmds = [check_cmd, format_cmd]
+        cmds = [format_cmd, check_cmd]
 
         # ruff check: warns
         # ruff format check: warns
@@ -408,12 +429,15 @@ class MettaCLI:
             epilog="""
 Examples:
   metta configure                      # Run interactive setup wizard
+  metta configure githooks             # Configure a specific component
   metta configure --profile=softmax    # Configure for Softmax employee
   metta install                        # Install all configured components
   metta install aws wandb              # Install specific components
   metta status                         # Show component status
   metta clean                          # Clean build artifacts
   metta symlink-setup                  # Set up symlink to make metta command globally available
+
+  metta run githooks pre-commit        # Run component-specific commands
 
   metta test ...                       # Run python unit tests
   metta test-changed ...               # Run python unit tests affected by changes
@@ -428,10 +452,21 @@ Examples:
         # Configure command
         configure_parser = subparsers.add_parser("configure", help="Configure Metta for your environment")
         configure_parser.add_argument(
-            "--profile",
-            choices=[ut.value for ut in UserType if ut != UserType.SOFTMAX_DOCKER],
-            help="Set user profile (external, cloud, or softmax)",
+            "component",
+            nargs="?",
+            help="Specific component to configure (e.g., githooks). If omitted, runs the setup wizard.",
         )
+        available_preset_profiles = [u.value for u in list(PROFILE_DEFINITIONS.keys())]
+        configure_parser.add_argument(
+            "--profile",
+            choices=available_preset_profiles,
+            help=f"Set user profile (available: {', '.join(available_preset_profiles)})",
+        )
+
+        # Run command
+        run_parser = subparsers.add_parser("run", help="Run component-specific commands")
+        run_parser.add_argument("component", help="Component to run command for (e.g., githooks)")
+        run_parser.add_argument("args", nargs="*", help="Arguments to pass to the component")
 
         # Install command
         install_parser = subparsers.add_parser("install", help="Install configured components")
@@ -518,6 +553,8 @@ Examples:
         # Dispatch to command handler
         if args.command == "configure":
             self.cmd_configure(args)
+        elif args.command == "run":
+            self.cmd_run(args)
         elif args.command == "install":
             self.cmd_install(args)
         elif args.command == "status":

--- a/metta/setup/utils.py
+++ b/metta/setup/utils.py
@@ -1,8 +1,11 @@
 import importlib
 import textwrap
 from pathlib import Path
+from typing import TypeVar
 
 from metta.common.util.colorama import Fore, blue, bold, colorize, cyan, green, red, yellow
+
+T = TypeVar("T")
 
 
 def _format_message(message: str) -> str:
@@ -32,6 +35,46 @@ def header(message: str) -> None:
 
 def step(message: str) -> None:
     print(colorize(_format_message(message), Fore.WHITE))
+
+
+def prompt_choice(prompt: str, choices: list[tuple[T, str]], default: T | None = None, current: T | None = None) -> T:
+    """Prompt user to select from a list of choices.
+
+    Args:
+        prompt: The prompt message
+        choices: List of (value, description) tuples
+        default: Default choice if user presses Enter
+        current: Current value to highlight
+
+    Returns:
+        The selected value
+    """
+    print(f"\n{prompt}")
+    for i, (value, desc) in enumerate(choices):
+        markers = []
+        if current is not None and value == current:
+            markers.append("current")
+        if default is not None and value == default:
+            markers.append("default")
+
+        marker = f" ({', '.join(markers)})" if markers else ""
+        if current is not None and value == current:
+            print(cyan(f"  {i + 1}. {desc}{marker}"))
+        else:
+            print(f"  {i + 1}. {desc}{marker}")
+
+    while True:
+        try:
+            choice = input("\nEnter your choice (1-{}): ".format(len(choices))).strip()
+            if not choice and default is not None:
+                return default
+            idx = int(choice) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx][0]
+            else:
+                warning(f"Please enter a number between 1 and {len(choices)}")
+        except ValueError:
+            warning("Please enter a valid number")
 
 
 def import_all_modules_from_subpackage(package_name: str, subpackage: str) -> None:


### PR DESCRIPTION
Support run commands for components

Support configure commands for components (gets stored in the metta config file in ~/.metta)

Refactored other parts of the cli

pre-commit hooks now run `metta run githooks precommit`, which refer to a setting for how we want to lint. If you've selected to auto-fix, we also auto-re-add your staged files, so you shouldn't need to run the command twice.

`metta lint --fix` now flips the order of `format` and `check` so we format first, meaning you don't have to run it twice if there are fixable errors