### PR TITLE
Optional limit on Converter operations

### DIFF
--- a/configs/env/mettagrid/game/objects/advanced.yaml
+++ b/configs/env/mettagrid/game/objects/advanced.yaml
@@ -6,6 +6,7 @@ lab:
   output_resources:
     blueprint: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 5
   initial_resource_count: 0
@@ -20,6 +21,7 @@ factory:
     armor: 5
     laser: 5
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 5
   initial_resource_count: 0
@@ -32,6 +34,7 @@ temple:
   output_resources:
     heart: 5
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 5
   initial_resource_count: 0

--- a/configs/env/mettagrid/game/objects/basic.yaml
+++ b/configs/env/mettagrid/game/objects/basic.yaml
@@ -5,6 +5,7 @@ altar:
   output_resources:
     heart: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 10
   initial_resource_count: 0

--- a/configs/env/mettagrid/game/objects/combat.yaml
+++ b/configs/env/mettagrid/game/objects/combat.yaml
@@ -5,6 +5,7 @@ armory:
   output_resources:
     armor: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 10
   initial_resource_count: 0
@@ -17,6 +18,7 @@ lasery:
   output_resources:
     laser: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 10
   initial_resource_count: 0

--- a/configs/env/mettagrid/game/objects/generators.yaml
+++ b/configs/env/mettagrid/game/objects/generators.yaml
@@ -6,6 +6,7 @@ generator_red:
     battery_red: 1
   color: 0
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 25
   initial_resource_count: 0
@@ -18,6 +19,7 @@ generator_blue:
     battery_blue: 1
   color: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 25
   initial_resource_count: 0
@@ -30,6 +32,7 @@ generator_green:
     battery_green: 1
   color: 2
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
   cooldown: 25
   initial_resource_count: 0

--- a/configs/env/mettagrid/game/objects/mines.yaml
+++ b/configs/env/mettagrid/game/objects/mines.yaml
@@ -4,8 +4,9 @@ mine_red:
     ore_red: 1
   color: 0
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
-  cooldown: 50
+  cooldown: 2
   initial_resource_count: 0
 
 mine_blue:
@@ -14,8 +15,9 @@ mine_blue:
   output_resources:
     ore_blue: 1
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
-  cooldown: 50
+  cooldown: 2
   initial_resource_count: 0
 
 mine_green:
@@ -24,6 +26,7 @@ mine_green:
     ore_green: 1
   color: 2
   max_output: 5
+  max_conversions: -1
   conversion_ticks: 1
-  cooldown: 50
+  cooldown: 2
   initial_resource_count: 0

--- a/configs/user/lsoros.yaml
+++ b/configs/user/lsoros.yaml
@@ -1,10 +1,10 @@
 # @package __global__
 
-# This file is private property of Lisa Soros.
-# DO NOT MODIFY.
+run: testing_2025_07_15_test0_frx
+trainer:
+  env: /env/mettagrid/arena/advanced
 
-#run: andre_local_2025_06_18_a
-policy_uri: null
+#policy_uri: null
 
 # replay_job:
 #   sim:

--- a/metta.code-workspace
+++ b/metta.code-workspace
@@ -134,6 +134,7 @@
 			"fstream": "cpp",
 			"future": "cpp",
 			"__config": "cpp"
-		}
+		},
+		"makefile.configureOnOpen": false
 	}
 }

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -863,15 +863,17 @@ PYBIND11_MODULE(mettagrid_c, m) {
                     const std::map<InventoryItem, InventoryQuantity>&,
                     const std::map<InventoryItem, InventoryQuantity>&,
                     short,
+                    short,  // max_conversions
                     unsigned short,
                     unsigned short,
-                    unsigned char,
+                    InventoryQuantity,
                     ObservationType>(),
            py::arg("type_id"),
            py::arg("type_name"),
            py::arg("input_resources"),
            py::arg("output_resources"),
            py::arg("max_output"),
+           py::arg("max_conversions"),
            py::arg("conversion_ticks"),
            py::arg("cooldown"),
            py::arg("initial_resource_count") = 0,
@@ -881,6 +883,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def_readwrite("input_resources", &ConverterConfig::input_resources)
       .def_readwrite("output_resources", &ConverterConfig::output_resources)
       .def_readwrite("max_output", &ConverterConfig::max_output)
+      .def_readwrite("max_conversions", &ConverterConfig::max_conversions)
       .def_readwrite("conversion_ticks", &ConverterConfig::conversion_ticks)
       .def_readwrite("cooldown", &ConverterConfig::cooldown)
       .def_readwrite("initial_resource_count", &ConverterConfig::initial_resource_count)

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.pyi
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.pyi
@@ -74,6 +74,7 @@ class ConverterConfig(GridObjectConfig):
         input_resources: dict[int, int],
         output_resources: dict[int, int],
         max_output: int,
+        max_conversions: int,
         conversion_ticks: int,
         cooldown: int,
         initial_resource_count: int = 0,
@@ -84,6 +85,7 @@ class ConverterConfig(GridObjectConfig):
     input_resources: dict[int, int]
     output_resources: dict[int, int]
     max_output: int
+    max_conversions: int
     conversion_ticks: int
     cooldown: int
     initial_resource_count: int

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -70,6 +70,7 @@ def from_mettagrid_config(mettagrid_config_dict: dict[str, Any]) -> CppGameConfi
                     resource_name_to_id[k]: v for k, v in object_config.output_resources.items() if v > 0
                 },
                 max_output=object_config.max_output,
+                max_conversions=object_config.max_conversions,
                 conversion_ticks=object_config.conversion_ticks,
                 cooldown=object_config.cooldown,
                 initial_resource_count=object_config.initial_resource_count,

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -106,6 +106,7 @@ class PyConverterConfig(BaseModelWithForbidExtra):
     output_resources: dict[str, int] = Field(default_factory=dict)
     type_id: int = Field(default=0, ge=0, le=255)
     max_output: int = Field(ge=-1)
+    max_conversions: int = Field(ge=-1)
     conversion_ticks: int = Field(ge=0)
     cooldown: int = Field(ge=0)
     initial_resource_count: int = Field(ge=0)


### PR DESCRIPTION
- **Adding support for limiting the number of conversion operations that can be done by a converter. max_conversions can now be specified in config, and the converter will be set to permanent stop once that limit has been reached.**
- **Added optional limit for Converter unit operations**

In the object config files, there is now a field for specifying a max number of conversion operations that can be performed. Default value of -1 means unlimited conversions. 

Tested with values -1, 0, 1, and 2 on red mines.
