### PR TITLE
feat: add gdb debug launcher for mettagrid

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -192,6 +192,117 @@
       },
       "python": "${workspaceFolder}/.venv/bin/python",
       "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "C++ Debug: Train Metta",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/.venv/bin/python",
+      "args": [
+        "-m", "tools.train",
+        "+hardware=macbook",
+        "+user=${env:USER}"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [
+        {
+          "name": "PYTHONPATH",
+          "value": "${workspaceFolder}"
+        },
+        {
+          "name": "UV_PROJECT_ENVIRONMENT",
+          "value": "${env:VIRTUAL_ENV}"
+        }
+      ],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set breakpoint pending",
+          "text": "set breakpoint pending on"
+        }
+      ],
+      "preLaunchTask": "install-debug"
+    },
+    {
+      "name": "C++ Debug: Test",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/.venv/bin/python",
+      "args": [
+        "-m", "pytest",
+        "-v", "-s",
+        "./tests"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [
+        {
+          "name": "PYTHONPATH",
+          "value": "${workspaceFolder}"
+        },
+        {
+          "name": "UV_PROJECT_ENVIRONMENT",
+          "value": "${env:VIRTUAL_ENV}"
+        }
+      ],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set breakpoint pending",
+          "text": "set breakpoint pending on"
+        }
+      ],
+      "preLaunchTask": "install-debug"
+    },
+    {
+      "name": "C++ Debug: Play Metta",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/.venv/bin/python",
+      "args": [
+        "-m", "tools.play",
+        "+user=${env:USER}",
+        "+hardware=macbook"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [
+        {
+          "name": "PYTHONPATH",
+          "value": "${workspaceFolder}"
+        },
+        {
+          "name": "UV_PROJECT_ENVIRONMENT",
+          "value": "${env:VIRTUAL_ENV}"
+        }
+      ],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set breakpoint pending",
+          "text": "set breakpoint pending on"
+        }
+      ],
+      "preLaunchTask": "install-debug"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,19 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "type": "shell",
+      "command": "./mettagrid//install-debug.sh",
+      "label": "install-debug",
+      "group": "build",
+      "problemMatcher": ["$gcc"],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      }
     }
   ]
 }

--- a/mettagrid/GDB_DEBUG.md
+++ b/mettagrid/GDB_DEBUG.md
@@ -1,0 +1,86 @@
+# C++ Debugging Guide for MettaGrid
+
+## One-Time Setup
+
+1. Make the debug script executable:
+```bash
+chmod +x mettagrid/install-debug.sh
+```
+
+2. Install debugger:
+```bash
+# Ubuntu/Debian
+sudo apt-get install gdb
+
+# macOS
+# LLDB comes with Xcode Command Line Tools:
+xcode-select --install
+# Note: You'll need to modify launch.json (see below)
+```
+
+### macOS Configuration
+If on macOS, modify the launch configurations in `.vscode/launch.json`:
+- Change `"MIMode": "gdb"` to `"MIMode": "lldb"`
+- Remove the `"miDebuggerPath"` line
+- Remove GDB-specific `setupCommands`
+
+## How to Debug C++ Code
+
+### Step 1: Build with Debug Symbols
+```bash
+./mettagrid/install-debug.sh
+```
+This builds the C++ extension with debug symbols and no optimization.
+
+### Step 2: Set Breakpoints
+- Open any `.hpp` file (e.g., `src/metta/mettagrid/agent.hpp`)
+- Click to the left of line numbers to set breakpoints
+- Breakpoints appear as red dots
+
+### Step 3: Start Debugging
+- Open VS Code/Cursor
+- Select `C++ Debug: Train Metta` from the debug dropdown (or `C++ Debug: Test` for tests)
+- Press F5 or click the green play button
+
+### Step 4: Debug
+- Execution will stop at your breakpoints
+- Hover over variables to see values
+- Use debug controls:
+  - F10: Step over
+  - F11: Step into
+  - Shift+F11: Step out
+  - F5: Continue
+
+## Example
+
+1. Open `agent.hpp`
+2. Find the `attack()` method
+3. Set a breakpoint inside the method
+4. Run `C++ Debug: Train Metta`
+5. When an agent attacks, execution stops at your breakpoint
+
+## Troubleshooting
+
+### Breakpoints not working?
+- Ensure you ran `./mettagrid/install-debug.sh` (not just `uv sync`)
+- Check that the breakpoint is on an executable line (not a comment or declaration)
+- Try rebuilding: `rm -rf _skbuild && ./mettagrid/install-debug.sh`
+
+### Can't see variable values?
+- Make sure you're in a debug build (`./mettagrid/install-debug.sh`)
+- Try adding a temporary variable: `int debug_energy = this->energy;`
+
+### Build errors?
+- Clean and rebuild: `rm -rf _skbuild build dist && ./mettagrid/install-debug.sh`
+
+## Tips
+
+- **Debug builds are slower** - use regular `uv sync` for normal development
+- **Printf debugging still works**: `std::cerr << "Debug: " << variable << std::endl;`
+- **Check if debug build**: Look for `-O0` in the build output
+
+## For the Team
+
+- **Normal development**: Use `uv sync` (fast, optimized)
+- **Debugging C++**: Use `./mettagrid/install-debug.sh` then VS Code's debug interface
+- **Back to normal**: Just run `uv sync` again

--- a/mettagrid/install-debug.sh
+++ b/mettagrid/install-debug.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Debug build script for MettaGrid
+# Location: mettagrid/install-debug.sh
+
+set -e
+
+echo "Building MettaGrid with debug symbols..."
+
+# Check for debugger availability
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    if ! command -v lldb &> /dev/null; then
+        echo "Error: LLDB not found. Please install Xcode Command Line Tools:"
+        echo "  xcode-select --install"
+        exit 1
+    fi
+    echo "Note: On macOS, you'll need to use LLDB instead of GDB."
+    echo "Make sure to change 'MIMode' from 'gdb' to 'lldb' in your launch.json"
+else
+    # Linux
+    if ! command -v gdb &> /dev/null; then
+        echo "Error: GDB not found. Please install it:"
+        echo "  Ubuntu/Debian: sudo apt-get install gdb"
+        echo "  Fedora: sudo dnf install gdb"
+        echo "  Arch: sudo pacman -S gdb"
+        exit 1
+    fi
+fi
+
+# Change to mettagrid directory
+cd "$(dirname "$0")"
+
+# Clean previous builds
+rm -rf build build-debug _skbuild dist
+
+# Set debug environment
+export SKBUILD_CMAKE_ARGS="--preset debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG='-g3 -ggdb -O0 -fno-omit-frame-pointer -fno-inline'"
+
+# Build with debug configuration
+pip install -e . -v --config-settings=cmake.build-type="Debug" \
+                    --config-settings=install.strip=false
+
+# Create symlink for compile_commands.json
+if [ -d "_skbuild" ]; then
+    COMPILE_COMMANDS=$(find _skbuild -name "compile_commands.json" | head -1)
+    if [ -n "$COMPILE_COMMANDS" ]; then
+        ln -sf "$COMPILE_COMMANDS" compile_commands.json
+    fi
+fi
+
+echo "Debug build complete!"
+echo "To debug: Use 'C++ Debug: Train Metta' (or similar) in VS Code"


### PR DESCRIPTION

This PR adds the ability to debug MettaGrid's C++ code using VS Code's integrated debugger. It addresses the team's need to set breakpoints in `.hpp` files and inspect variable values during runtime debugging.

### Problem
- Team members were unable to debug C++ code effectively
- Breakpoints in `.hpp` files weren't working
- No way to inspect C++ variable values at runtime
- Existing printf-style debugging was slowing down development

### Solution
Adds a debug build configuration that:
- Builds the C++ extension with full debug symbols (`-g3 -ggdb -O0`)
- Integrates with VS Code's C++ debugger (GDB/LLDB)
- Maintains the existing `uv sync` workflow for normal development
- Provides clear platform-specific setup instructions

### Changes
- **`.vscode/launch.json`**: Added three C++ debug configurations for common workflows (train, test, play)
- **`.vscode/tasks.json`**: Added `install-debug` task to build with debug symbols
- **`mettagrid/install-debug.sh`**: New script that builds the extension with debug symbols
- **`mettagrid/GDB_DEBUG.md`**: Documentation for the debugging workflow

### Usage
```bash
# One-time setup
chmod +x mettagrid/install-debug.sh

# Build with debug symbols
./mettagrid/install-debug.sh

# Then in VS Code:
# 1. Set breakpoints in any .hpp file
# 2. Select "C++ Debug: Train Metta" from debug dropdown
# 3. Press F5 to start debugging
```

### Platform Support
- **Linux**: Uses GDB (requires `apt-get install gdb`)
- **macOS**: Uses LLDB (comes with Xcode Command Line Tools)
- Script automatically detects platform and validates debugger installation

### Performance Note
Debug builds are intentionally unoptimized (-O0) for accurate debugging. Use regular `uv sync` for normal development to maintain performance.
