### PR TITLE
feat(sweep): Add API support for sweep run id synchronization across workers

### DIFF
--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -1087,7 +1087,6 @@ class MettaRepo:
 
         return updated
 
-<<<<<<< HEAD
     async def add_episode_tags(self, episode_ids: list[uuid.UUID], tag: str) -> int:
         """Add a tag to multiple episodes by UUID. Returns number of episodes tagged."""
         if not episode_ids:
@@ -1162,10 +1161,10 @@ class MettaRepo:
             )
             rows = await result.fetchall()
             return [row[0] for row in rows]
-=======
+
     # Sweep coordination methods
 
-    async def create_sweep(self, name: str, project: str, entity: str, wandb_sweep_id: str, user_id: str) -> str:
+    async def create_sweep(self, name: str, project: str, entity: str, wandb_sweep_id: str, user_id: str) -> uuid.UUID:
         """Create a new sweep."""
         async with self.connect() as con:
             result = await con.execute(
@@ -1179,7 +1178,7 @@ class MettaRepo:
             row = await result.fetchone()
             if row is None:
                 raise ValueError("Failed to create sweep")
-            return str(row[0])
+            return row[0]
 
     async def get_sweep_by_name(self, name: str) -> dict[str, Any] | None:
         """Get sweep by name."""
@@ -1209,7 +1208,7 @@ class MettaRepo:
                 "updated_at": row[9],
             }
 
-    async def get_next_sweep_run_counter(self, sweep_id: str) -> int:
+    async def get_next_sweep_run_counter(self, sweep_id: uuid.UUID) -> int:
         """Atomically increment and return the next run counter for a sweep."""
         async with self.connect() as con:
             result = await con.execute(
@@ -1220,10 +1219,9 @@ class MettaRepo:
                 WHERE id = %s
                 RETURNING run_counter
                 """,
-                (uuid.UUID(sweep_id),),
+                (sweep_id,),
             )
             row = await result.fetchone()
             if row is None:
                 raise ValueError(f"Sweep {sweep_id} not found")
             return row[0]
->>>>>>> 27a329c48 (feat(sweep): Add API support for sweep run id synchronization across workers)

--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -296,6 +296,25 @@ MIGRATIONS = [
             """,
         ],
     ),
+    SqlMigration(
+        version=15,
+        description="Add sweeps table for sweep coordination",
+        sql_statements=[
+            """CREATE TABLE sweeps (
+                id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                name TEXT NOT NULL UNIQUE,
+                project TEXT NOT NULL,
+                entity TEXT NOT NULL,
+                wandb_sweep_id TEXT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'running',
+                run_counter INTEGER NOT NULL DEFAULT 0,
+                user_id TEXT NOT NULL,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )""",
+            """CREATE INDEX idx_sweeps_name ON sweeps(name)""",
+        ],
+    ),
 ]
 
 
@@ -1068,6 +1087,7 @@ class MettaRepo:
 
         return updated
 
+<<<<<<< HEAD
     async def add_episode_tags(self, episode_ids: list[uuid.UUID], tag: str) -> int:
         """Add a tag to multiple episodes by UUID. Returns number of episodes tagged."""
         if not episode_ids:
@@ -1142,3 +1162,68 @@ class MettaRepo:
             )
             rows = await result.fetchall()
             return [row[0] for row in rows]
+=======
+    # Sweep coordination methods
+
+    async def create_sweep(self, name: str, project: str, entity: str, wandb_sweep_id: str, user_id: str) -> str:
+        """Create a new sweep."""
+        async with self.connect() as con:
+            result = await con.execute(
+                """
+                INSERT INTO sweeps (name, project, entity, wandb_sweep_id, user_id)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (name, project, entity, wandb_sweep_id, user_id),
+            )
+            row = await result.fetchone()
+            if row is None:
+                raise ValueError("Failed to create sweep")
+            return str(row[0])
+
+    async def get_sweep_by_name(self, name: str) -> dict[str, Any] | None:
+        """Get sweep by name."""
+        async with self.connect() as con:
+            result = await con.execute(
+                """
+                SELECT id, name, project, entity, wandb_sweep_id, state, run_counter,
+                       user_id, created_at, updated_at
+                FROM sweeps
+                WHERE name = %s
+                """,
+                (name,),
+            )
+            row = await result.fetchone()
+            if row is None:
+                return None
+            return {
+                "id": str(row[0]),
+                "name": row[1],
+                "project": row[2],
+                "entity": row[3],
+                "wandb_sweep_id": row[4],
+                "state": row[5],
+                "run_counter": row[6],
+                "user_id": row[7],
+                "created_at": row[8],
+                "updated_at": row[9],
+            }
+
+    async def get_next_sweep_run_counter(self, sweep_id: str) -> int:
+        """Atomically increment and return the next run counter for a sweep."""
+        async with self.connect() as con:
+            result = await con.execute(
+                """
+                UPDATE sweeps
+                SET run_counter = run_counter + 1,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = %s
+                RETURNING run_counter
+                """,
+                (uuid.UUID(sweep_id),),
+            )
+            row = await result.fetchone()
+            if row is None:
+                raise ValueError(f"Sweep {sweep_id} not found")
+            return row[0]
+>>>>>>> 27a329c48 (feat(sweep): Add API support for sweep run id synchronization across workers)

--- a/app_backend/src/metta/app_backend/routes/sweep_routes.py
+++ b/app_backend/src/metta/app_backend/routes/sweep_routes.py
@@ -1,0 +1,90 @@
+"""Sweep coordination routes for managing distributed training sweeps."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from metta.app_backend.auth import create_user_or_token_dependency
+from metta.app_backend.metta_repo import MettaRepo
+from metta.app_backend.route_logger import timed_http_handler
+
+
+# Request/Response Models
+class SweepCreateRequest(BaseModel):
+    project: str
+    entity: str
+    wandb_sweep_id: str
+
+
+class SweepCreateResponse(BaseModel):
+    created: bool
+    sweep_id: str
+
+
+class SweepInfo(BaseModel):
+    exists: bool
+    wandb_sweep_id: str
+
+
+class RunIdResponse(BaseModel):
+    run_id: str
+
+
+def create_sweep_router(metta_repo: MettaRepo) -> APIRouter:
+    """Create a sweep coordination router with the given MettaRepo instance."""
+    router = APIRouter(prefix="/sweeps", tags=["sweeps"])
+
+    # Create the user-or-token authentication dependency
+    user_or_token = Depends(create_user_or_token_dependency(metta_repo))
+
+    @router.post("/{sweep_name}/create_sweep", response_model=SweepCreateResponse)
+    @timed_http_handler
+    async def create_sweep(
+        sweep_name: str, request: SweepCreateRequest, user: str = user_or_token
+    ) -> SweepCreateResponse:
+        """Initialize a new sweep or return existing sweep info (idempotent)."""
+        # Check if sweep already exists
+        existing_sweep = await metta_repo.get_sweep_by_name(sweep_name)
+
+        if existing_sweep:
+            return SweepCreateResponse(created=False, sweep_id=existing_sweep["id"])
+
+        # Create new sweep
+        sweep_id = await metta_repo.create_sweep(
+            name=sweep_name,
+            project=request.project,
+            entity=request.entity,
+            wandb_sweep_id=request.wandb_sweep_id,
+            user_id=user,
+        )
+
+        return SweepCreateResponse(created=True, sweep_id=sweep_id)
+
+    @router.get("/{sweep_name}", response_model=SweepInfo)
+    @timed_http_handler
+    async def get_sweep(sweep_name: str, user: str = user_or_token) -> SweepInfo:
+        """Get sweep information by name."""
+        sweep = await metta_repo.get_sweep_by_name(sweep_name)
+
+        if not sweep:
+            return SweepInfo(exists=False, wandb_sweep_id="")
+
+        return SweepInfo(exists=True, wandb_sweep_id=sweep["wandb_sweep_id"])
+
+    @router.post("/{sweep_name}/runs/next", response_model=RunIdResponse)
+    @timed_http_handler
+    async def get_next_run_id(sweep_name: str, user: str = user_or_token) -> RunIdResponse:
+        """Get the next run ID for a sweep (atomic operation)."""
+        sweep = await metta_repo.get_sweep_by_name(sweep_name)
+
+        if not sweep:
+            raise HTTPException(status_code=404, detail=f"Sweep '{sweep_name}' not found")
+
+        # Atomically increment and get next run counter
+        next_counter = await metta_repo.get_next_sweep_run_counter(sweep["id"])
+
+        # Format run ID as "sweep_name.r.counter"
+        run_id = f"{sweep_name}.r.{next_counter}"
+
+        return RunIdResponse(run_id=run_id)
+
+    return router

--- a/app_backend/src/metta/app_backend/server.py
+++ b/app_backend/src/metta/app_backend/server.py
@@ -16,6 +16,7 @@ from metta.app_backend.routes import (
     heatmap_routes,
     sql_routes,
     stats_routes,
+    sweep_routes,
     token_routes,
 )
 
@@ -101,6 +102,7 @@ def create_app(stats_repo: MettaRepo) -> fastapi.FastAPI:
     stats_router = stats_routes.create_stats_router(stats_repo)
     token_router = token_routes.create_token_router(stats_repo)
     heatmap_router = heatmap_routes.create_heatmap_router(stats_repo)
+    sweep_router = sweep_routes.create_sweep_router(stats_repo)
 
     app.include_router(dashboard_router)
     app.include_router(episode_router)
@@ -109,6 +111,7 @@ def create_app(stats_repo: MettaRepo) -> fastapi.FastAPI:
     app.include_router(stats_router)
     app.include_router(token_router)
     app.include_router(heatmap_router)
+    app.include_router(sweep_router)
 
     @app.get("/whoami")
     async def whoami(request: fastapi.Request):  # type: ignore

--- a/app_backend/src/metta/app_backend/sweep_client.py
+++ b/app_backend/src/metta/app_backend/sweep_client.py
@@ -1,0 +1,89 @@
+"""Client for sweep coordination API."""
+
+from typing import Optional
+
+import httpx
+
+from metta.app_backend.routes.sweep_routes import (
+    RunIdResponse,
+    SweepCreateResponse,
+    SweepInfo,
+)
+
+
+class SweepClient:
+    """Client for interacting with the sweep coordination API."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", auth_token: Optional[str] = None):
+        """
+        Initialize the sweep client.
+
+        Args:
+            base_url: Base URL of the API server
+            auth_token: Authentication token (machine token or user session)
+        """
+        self.base_url = base_url.rstrip("/")
+        self.headers = {}
+        if auth_token:
+            self.headers["X-Auth-Token"] = auth_token
+
+    def create_sweep(self, sweep_name: str, project: str, entity: str, wandb_sweep_id: str) -> SweepCreateResponse:
+        """Initialize a sweep (idempotent)."""
+        response = httpx.post(
+            f"{self.base_url}/sweeps/{sweep_name}/create_sweep",
+            json={
+                "project": project,
+                "entity": entity,
+                "wandb_sweep_id": wandb_sweep_id,
+            },
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        return SweepCreateResponse(**response.json())
+
+    def get_sweep(self, sweep_name: str) -> SweepInfo:
+        """Get sweep information."""
+        response = httpx.get(
+            f"{self.base_url}/sweeps/{sweep_name}",
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        return SweepInfo(**response.json())
+
+    def get_next_run_id(self, sweep_name: str) -> str:
+        """Get the next run ID for a sweep (atomic operation)."""
+        response = httpx.post(
+            f"{self.base_url}/sweeps/{sweep_name}/runs/next",
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        data = RunIdResponse(**response.json())
+        return data.run_id
+
+
+# Example usage for generate_run_id_for_sweep():
+def generate_run_id_for_sweep(
+    sweep_name: str, api_url: str = "http://localhost:8000", auth_token: Optional[str] = None
+) -> str:
+    """Generate a unique run ID for a sweep using the coordination API."""
+    client = SweepClient(api_url, auth_token)
+    return client.get_next_run_id(sweep_name)
+
+
+if __name__ == "__main__":
+    # Example usage
+    client = SweepClient()
+
+    # Initialize a sweep
+    result = client.create_sweep(
+        sweep_name="protein_opt", project="my_project", entity="my_entity", wandb_sweep_id="wandb_12345"
+    )
+    print(f"Sweep initialized: created={result.created}, sweep_id={result.sweep_id}")
+
+    # Get next run ID
+    run_id = client.get_next_run_id("protein_opt")
+    print(f"Next run ID: {run_id}")
+
+    # Get sweep info
+    info = client.get_sweep("protein_opt")
+    print(f"Sweep info: exists={info.exists}")

--- a/app_backend/tests/test_sweep_routes.py
+++ b/app_backend/tests/test_sweep_routes.py
@@ -1,0 +1,186 @@
+"""Tests for sweep coordination routes."""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from metta.app_backend.metta_repo import MettaRepo
+from metta.app_backend.server import create_app
+
+
+@pytest.fixture
+def mock_metta_repo():
+    """Create a mock MettaRepo for testing."""
+    return MagicMock(spec=MettaRepo)
+
+
+@pytest.fixture
+def test_client(mock_metta_repo):
+    """Create a test client with mocked dependencies."""
+    app = create_app(mock_metta_repo)
+    return TestClient(app)
+
+
+def test_create_sweep_creates_new(test_client, mock_metta_repo, auth_headers):
+    """Test creating a new sweep."""
+    mock_metta_repo.get_sweep_by_name.return_value = None
+    mock_metta_repo.create_sweep.return_value = "sweep_123"
+
+    response = test_client.post(
+        "/sweeps/test_sweep/create_sweep",
+        json={
+            "project": "test_project",
+            "entity": "test_entity",
+            "wandb_sweep_id": "wandb_123",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] is True
+    assert data["sweep_id"] == "sweep_123"
+
+    # Verify the repo was called correctly
+    mock_metta_repo.get_sweep_by_name.assert_called_once_with("test_sweep")
+    mock_metta_repo.create_sweep.assert_called_once_with(
+        name="test_sweep",
+        project="test_project",
+        entity="test_entity",
+        wandb_sweep_id="wandb_123",
+        user_id="test@example.com",
+    )
+
+
+def test_create_sweep_returns_existing(test_client, mock_metta_repo, auth_headers):
+    """Test returning existing sweep info (idempotent)."""
+    existing_sweep = {
+        "id": "existing_sweep_123",
+        "name": "test_sweep",
+        "project": "test_project",
+        "entity": "test_entity",
+        "wandb_sweep_id": "wandb_123",
+    }
+    mock_metta_repo.get_sweep_by_name.return_value = existing_sweep
+
+    response = test_client.post(
+        "/sweeps/test_sweep/create_sweep",
+        json={
+            "project": "test_project",
+            "entity": "test_entity",
+            "wandb_sweep_id": "wandb_123",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] is False
+    assert data["sweep_id"] == "existing_sweep_123"
+
+    # Verify only get was called, not create
+    mock_metta_repo.get_sweep_by_name.assert_called_once_with("test_sweep")
+    mock_metta_repo.create_sweep.assert_not_called()
+
+
+def test_create_sweep_with_machine_token(test_client, mock_metta_repo):
+    """Test creating a sweep with machine token authentication."""
+    mock_metta_repo.get_sweep_by_name.return_value = None
+    mock_metta_repo.create_sweep.return_value = "sweep_123"
+
+    response = test_client.post(
+        "/sweeps/test_sweep/create_sweep",
+        json={
+            "project": "test_project",
+            "entity": "test_entity",
+            "wandb_sweep_id": "wandb_123",
+        },
+        headers={"X-Auth-Token": "machine_token_123"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] is True
+    assert data["sweep_id"] == "sweep_123"
+
+
+def test_get_sweep_exists(test_client, mock_metta_repo, auth_headers):
+    """Test getting an existing sweep."""
+    mock_metta_repo.get_sweep_by_name.return_value = {
+        "id": str(uuid.uuid4()),
+        "name": "test_sweep",
+        "wandb_sweep_id": "wandb_123",
+    }
+
+    response = test_client.get("/sweeps/test_sweep", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exists"] is True
+    assert data["wandb_sweep_id"] == "wandb_123"
+
+
+def test_get_sweep_not_exists(test_client, mock_metta_repo, auth_headers):
+    """Test getting a non-existent sweep."""
+    mock_metta_repo.get_sweep_by_name.return_value = None
+
+    response = test_client.get("/sweeps/nonexistent", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exists"] is False
+    assert data["wandb_sweep_id"] == ""
+
+
+def test_get_next_run_id(test_client, mock_metta_repo, auth_headers):
+    """Test getting the next run ID (atomic counter)."""
+    sweep_id = str(uuid.uuid4())
+    mock_metta_repo.get_sweep_by_name.return_value = {
+        "id": sweep_id,
+        "name": "test_sweep",
+    }
+    mock_metta_repo.get_next_sweep_run_counter.return_value = 42
+
+    response = test_client.post("/sweeps/test_sweep/runs/next", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["run_id"] == "test_sweep.r.42"
+
+    # Verify the repo was called correctly
+    mock_metta_repo.get_sweep_by_name.assert_called_once_with("test_sweep")
+    mock_metta_repo.get_next_sweep_run_counter.assert_called_once_with(sweep_id)
+
+
+def test_get_next_run_id_sweep_not_found(test_client, mock_metta_repo, auth_headers):
+    """Test getting next run ID for non-existent sweep."""
+    mock_metta_repo.get_sweep_by_name.return_value = None
+
+    response = test_client.post("/sweeps/nonexistent/runs/next", headers=auth_headers)
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
+def test_auth_required_for_all_operations(test_client, mock_metta_repo):
+    """Test that all operations require authentication."""
+    # Test create_sweep without auth
+    response = test_client.post(
+        "/sweeps/test_sweep/create_sweep",
+        json={
+            "project": "test_project",
+            "entity": "test_entity",
+            "wandb_sweep_id": "wandb_123",
+        },
+    )
+    assert response.status_code == 401
+
+    # Test get_sweep without auth
+    response = test_client.get("/sweeps/test_sweep")
+    assert response.status_code == 401
+
+    # Test get_next_run_id without auth
+    response = test_client.post("/sweeps/test_sweep/runs/next")
+    assert response.status_code == 401


### PR DESCRIPTION
### TL;DR

Added sweep coordination API for managing distributed training sweeps.

### What changed?

- Created a new SQL migration (version 13) to add a `sweeps` table for tracking sweep metadata
- Added new methods to `MettaRepo` for sweep management:
  - `create_sweep`
  - `get_sweep_by_name`
  - `get_next_sweep_run_counter`
- Implemented new API routes in `sweep_routes.py` with endpoints for:
  - Creating/initializing sweeps
  - Getting sweep information
  - Generating unique run IDs with atomic counters
- Added a `SweepClient` class for easy interaction with the sweep API
- Included comprehensive tests for all new functionality

### How to test?

1. Run the database migrations to create the new `sweeps` table
2. Use the `SweepClient` to create a new sweep:
   ```python
   client = SweepClient()
   result = client.create_sweep(
       sweep_name="test_sweep", 
       project="my_project", 
       entity="my_entity", 
       wandb_sweep_id="wandb_12345"
   )
   ```
3. Generate unique run IDs for the sweep:
   ```python
   run_id = client.get_next_run_id("test_sweep")
   print(f"Next run ID: {run_id}")  # Should output "test_sweep.r.1"
   ```
4. Verify that subsequent calls increment the counter atomically

### Why make this change?

This API provides a coordination mechanism for distributed training sweeps, ensuring:
- Unique run IDs across multiple machines/processes
- Centralized tracking of sweep metadata
- Atomic counter operations to prevent race conditions
- Integration with W&B sweeps for hyperparameter optimization

The implementation allows multiple training jobs to coordinate through a central service, making distributed hyperparameter optimization more reliable and easier to manage.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210827591779839)