### PR TITLE
add sparse nav training

### DIFF
--- a/configs/env/mettagrid/curriculum/navigation/learning_progress.yaml
+++ b/configs/env/mettagrid/curriculum/navigation/learning_progress.yaml
@@ -8,3 +8,4 @@ tasks:
   /env/mettagrid/navigation/training/varied_terrain_maze: 1
   /env/mettagrid/navigation/training/varied_terrain_dense: 1
   /env/mettagrid/curriculum/navigation/subcurricula/sparse: 1
+  /env/mettagrid/navigation/training/sparse_bucketed: 1

--- a/configs/env/mettagrid/navigation/training/sparse_bucketed.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse_bucketed.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
 
-env_cfg_template: /env/mettagrid/navigation/training/sparse_bucketed_cfg
+env_cfg_template_path: /env/mettagrid/navigation/training/sparse_bucketed_cfg
 
 buckets:
   game.max_steps:

--- a/configs/env/mettagrid/navigation/training/sparse_bucketed.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse_bucketed.yaml
@@ -1,0 +1,14 @@
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+
+env_cfg_template: /env/mettagrid/navigation/training/sparse_bucketed_cfg
+
+buckets:
+  game.max_steps:
+    range: [100, 2000]
+    bins: 5
+  game.map_builder.width:
+    range: [60, 300]
+    bins: 4
+  num_altars:
+    range: [3, 20]
+    bins: 2

--- a/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
@@ -1,0 +1,40 @@
+defaults:
+  - /env/mettagrid/mettagrid@
+  - _self_
+
+sampling: 1
+
+game:
+  max_steps: ???
+  num_agents: 4
+  actions:
+    put_items:
+      enabled: false
+    attack:
+      enabled: false
+    swap:
+      enabled: false
+    change_color:
+      enabled: false
+  objects:
+    altar:
+      cooldown: 1000
+      initial_resource_count: 1
+  map_builder:
+    _target_: metta.map.mapgen.MapGen
+    width: ???
+    height: ${game.map_builder.width}
+    border_width: 6
+
+    root:
+      type: metta.map.scenes.room_grid.RoomGrid
+      params:
+        rows: 2
+        columns: 2
+      children:
+        - scene:
+            type: metta.map.scenes.random.Random
+            params:
+              objects:
+                altar: ${num_altars}
+              agents: 1

--- a/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
@@ -36,5 +36,5 @@ game:
             type: metta.map.scenes.random.Random
             params:
               objects:
-                altar: ${num_altars}
+                altar: ???
               agents: 1

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -7,5 +7,5 @@ trainer:
   curriculum: /env/mettagrid/curriculum/navigation/learning_progress
 
 seed: null
-run_id: 20250716.02
+run_id: 20250720.01
 run: ${oc.env:USER}.local.${run_id}

--- a/tests/test_validate_all_envs.py
+++ b/tests/test_validate_all_envs.py
@@ -35,7 +35,7 @@ def map_or_env_configs() -> list[MettagridCfgFileMetadata]:
         "game/map_builder/load_random.yaml",
         "navigation/training/sparse.yaml",
         # Is a curriculum, not an env
-        "navigation/training/sparse_bucketed.yaml",
+        "navigation/training/sparse_bucketed",
     ]
 
     # exclude some configs that won't work

--- a/tests/test_validate_all_envs.py
+++ b/tests/test_validate_all_envs.py
@@ -34,6 +34,8 @@ def map_or_env_configs() -> list[MettagridCfgFileMetadata]:
         "game/map_builder/load.yaml",
         "game/map_builder/load_random.yaml",
         "navigation/training/sparse.yaml",
+        # Is a curriculum, not an env
+        "navigation/training/sparse_bucketed.yaml",
     ]
 
     # exclude some configs that won't work


### PR DESCRIPTION
Add a bucketed sparse navigation task.

The bucketed version adds on to the sparse navigation training we're doing. It varies map dimensions and available time to complete, as well as altars. This should allow it to find the best learning regime for big sparse maps.

I've trained on this a few times with inconsistent results (sometimes it seems to learn to sweep well; sometimes not). Merging since I think this is good to build off of.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210828076847588)