### PR TITLE
fix: try to reduce newsletter fluff

### DIFF
--- a/.github/scripts/gemini_analyze_pr_digest.py
+++ b/.github/scripts/gemini_analyze_pr_digest.py
@@ -329,7 +329,8 @@ class CollectionAnalyzer:
 
         selected_bonus_prompt = random.choice(bonus_prompts)
 
-        prompt = f"""You are creating an executive summary of development activity for {repository} from {date_range}.
+        prompt = f"""
+You are creating an executive summary of development activity for {repository} from {date_range}.
 
 {previous_context}
 
@@ -372,7 +373,7 @@ OUTPUT FORMAT:
 
 ## Summary of changes from {date_range}
 
-**Development Focus:** [What were the main development themes and priorities this period?]
+**Development Focus:** [In 2-3 concise sentences, describe what the team actually built or fixed this period. Be specific and direct - avoid abstract themes or philosophical descriptions. Lead with concrete work: "We shipped X, refactored Y, and fixed Z" rather than "This period was characterized by..." Vary your language across summaries.]
 
 **Key Achievements:** [What significant features, improvements, or fixes were delivered?]
 


### PR DESCRIPTION

Our development newsletter summaries are verbose and repetitive, particularly in the "Development Focus" sections. 

The updated prompt attempts to avoid:
- Repetitive phrases like "this period was characterized by..." and "the primary theme was..."
- Focusing on abstract philosophical descriptions rather than concrete achievements
- Unnecessary wordiness when describing what was actually built or fixed
- Sounding similar from week to week, making it hard to distinguish between different development periods

**Before:** "This period was characterized by a dual-pronged strategy: expanding the frontier of our research capabilities while simultaneously professionalizing our development infrastructure..."

**Target:** "We shipped GPU-accelerated training pipelines, added real-time monitoring dashboards, and migrated CI/CD to GitHub Actions. The new agent interaction APIs enable researchers to run 3x more experiments per day."