### PR TITLE
refactor(sweep): Improve sweep evaluation with distributed coordination and longer evaluation time

### DIFF
--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -12,7 +12,7 @@ sweep_name: ???  # Will be set via command line override
 
 trainer:
   total_timesteps: 5_000_000   # 5M timesteps for proper RL training (was 50k - too short!)
-  curriculum: /env/mettagrid/arena/basic_easy_shaped # This won't be used, but needed for Pydantic
+  curriculum: /env/mettagrid/arena/basic_easy_shaped
   simulation:
     evaluate_interval: 0  # No evaluation during training for speed
     replay_dir: "" # No replays for sweeps

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -12,15 +12,15 @@ sweep_name: ???  # Will be set via command line override
 
 trainer:
   total_timesteps: 5_000_000   # 5M timesteps for proper RL training (was 50k - too short!)
-  curriculum: /env/mettagrid/arena/basic_easy_shaped
+  curriculum: /env/mettagrid/arena/basic_easy_shaped # This won't be used, but needed for Pydantic
   simulation:
     evaluate_interval: 0  # No evaluation during training for speed
     replay_dir: "" # No replays for sweeps
 
 sim:
   name: sweep_eval  # Required field
-  num_episodes: 2
-  max_time_s: 10
+  num_episodes: 5
+  max_time_s: 240
   env_overrides: {}
   simulations:
     simple:
@@ -34,6 +34,7 @@ sweep_job:
   trainer: ${trainer}
   agent: ${agent}
   wandb: ${wandb}
+  run: ???
   runs_dir: "${sweep_dir}/runs"
   seed: null  # Will be randomly generated for each run if not specified
   stats_server_uri: null # No logging to observatory for sweeps

--- a/tools/sweep_eval.py
+++ b/tools/sweep_eval.py
@@ -15,6 +15,7 @@ import time
 from omegaconf import DictConfig, OmegaConf
 
 from metta.agent.policy_store import PolicyStore
+from metta.common.util.lock import run_once
 from metta.common.wandb.wandb_context import WandbContext
 from metta.eval.eval_stats_db import EvalStatsDB
 from metta.sim.simulation_config import SimulationSuiteConfig
@@ -45,121 +46,142 @@ def main(cfg: DictConfig) -> int:
     simulation_suite_cfg = SimulationSuiteConfig(**OmegaConf.to_container(cfg.sim, resolve=True))  # type: ignore[arg-type]
 
     results_path = os.path.join(cfg.run_dir, "sweep_eval_results.yaml")
-    start_time = time.time()
-    if os.environ.get("NODE_INDEX", "0") != "0":
+
+    # Function to run evaluation - only executed by rank 0
+    def evaluate_policy():
+        logger.info(f"Starting evaluation for run: {cfg.run}")
+
+        with WandbContext(cfg.wandb, cfg) as wandb_run:
+            policy_store = PolicyStore(cfg, wandb_run)
+            try:
+                # Fetch the latest policy record from the run
+                policy_pr = policy_store.policy_record("wandb://run/" + cfg.run, selector_type="latest")
+                if not policy_pr:
+                    raise ValueError(f"No policy record found for run {cfg.run}")
+                if not policy_pr.uri:
+                    raise ValueError(f"Policy record has no URI for run {cfg.run}")
+
+                # Load the policy record directly using its wandb URI
+                # This will download the artifact and give us a local path
+                policy_pr = policy_store.load_from_uri(policy_pr.uri)
+
+            except Exception as e:
+                logger.error(f"Error getting policy for run {cfg.run}: {e}")
+                # Record failure in WandB if available
+                if wandb_run:
+                    wandb_run.summary.update(
+                        {"protein.state": "failure", "protein.error": f"Policy loading failed: {e}"}
+                    )
+                # Save error results for other ranks
+                OmegaConf.save({"eval_metric": None, "total_time": 0, "error": str(e)}, results_path)
+                return 1
+
+            eval = SimulationSuite(
+                simulation_suite_cfg,
+                policy_pr,
+                policy_store,
+                device=cfg.device,
+                vectorization=cfg.vectorization,
+            )
+
+            # Start evaluation process
+            sweep_stats = {}
+
+            # Update sweep stats with initial information
+            sweep_stats.update(
+                {
+                    "score.metric": cfg.sweep.metric,
+                }
+            )
+            if wandb_run:
+                wandb_run.summary.update(sweep_stats)
+
+            # Start evaluation
+            eval_start_time = time.time()
+
+            logger.info(f"Evaluating policy {policy_pr.run_name}")
+
+            if wandb_run:
+                log_file(cfg.run_dir, "sweep_eval_config.yaml", cfg, wandb_run)
+
+            results = eval.simulate()
+            eval_time = time.time() - eval_start_time
+            eval_stats_db = EvalStatsDB.from_sim_stats_db(results.stats_db)
+            eval_metric = eval_stats_db.get_average_metric_by_filter(cfg.sweep.metric, policy_pr)
+
+            # Get training stats from metadata if available
+            train_time = policy_pr.metadata.get("train_time", 0)
+            agent_step = policy_pr.metadata.get("agent_step", 0)
+            epoch = policy_pr.metadata.get("epoch", 0)
+
+            # Update sweep stats with evaluation results
+            stats_update = {
+                "train.agent_step": agent_step,
+                "train.epoch": epoch,
+                "time.train": train_time,
+                "time.eval": eval_time,
+                "time.total": train_time + eval_time,
+                "uri": policy_pr.uri,
+                "score": eval_metric,
+            }
+
+            sweep_stats.update(stats_update)
+
+            # Update lineage stats
+            for stat in ["train.agent_step", "train.epoch", "time.train", "time.eval", "time.total"]:
+                sweep_stats["lineage." + stat] = sweep_stats[stat] + policy_pr.metadata.get("lineage." + stat, 0)
+
+            # Update wandb summary
+            if wandb_run:
+                wandb_run.summary.update(sweep_stats)
+            logger.info("Sweep Stats: \n" + json.dumps({k: str(v) for k, v in sweep_stats.items()}, indent=4))
+
+            # Update policy metadata
+            policy_pr.metadata.update(
+                {
+                    **sweep_stats,
+                    "training_run": cfg.run,
+                }
+            )
+
+            # Add policy to wandb sweep
+            policy_store.add_to_wandb_sweep(cfg.sweep_name, policy_pr)
+
+            # Record observation in Protein sweep
+            total_time = train_time + eval_time
+            protein_wandb = MettaProtein(cfg.sweep, wandb_run)
+
+            # Record the observation properly so the Protein learns
+            protein_wandb.record_observation(eval_metric, total_time)
+
+            # Save results for all ranks to read
+            OmegaConf.save({"eval_metric": eval_metric, "total_time": total_time}, results_path)
+
+            if wandb_run:
+                wandb_run.summary.update({"run_time": total_time})
+            logger.info(f"Evaluation complete for run: {cfg.run}, score: {eval_metric}")
+
+        return 0
+
+    # Use run_once to ensure only rank 0 performs evaluation
+    run_once(evaluate_policy)
+
+    # All ranks (including rank 0) wait for results file
+    if not os.path.exists(results_path):
+        start_time = time.time()
         while not os.path.exists(results_path):
             time.sleep(1)
             if time.time() - start_time > 500:
-                logger.error("Timeout waiting for master to evaluate policy")
+                logger.error("Timeout waiting for evaluation results")
                 return 1
-        return 0
 
-    logger.info(f"Starting evaluation for run: {cfg.run}")
+    # Check if evaluation had an error
+    results = OmegaConf.load(results_path)
+    if "error" in results:
+        logger.error(f"Evaluation failed: {results.error}")
+        return 1
 
-    with WandbContext(cfg.wandb, cfg) as wandb_run:
-        policy_store = PolicyStore(cfg, wandb_run)
-        try:
-            # Fetch the latest policy record from the run
-            policy_pr = policy_store.policy_record("wandb://run/" + cfg.run, selector_type="latest")
-            if not policy_pr:
-                raise ValueError(f"No policy record found for run {cfg.run}")
-
-            # Load the policy record directly using its wandb URI
-            # This will download the artifact and give us a local path
-            policy_pr = policy_store.load_from_uri(policy_pr.uri)
-
-        except Exception as e:
-            logger.error(f"Error getting policy for run {cfg.run}: {e}")
-            # Record failure in WandB directly since we don't have a Protein instance yet
-            wandb_run.summary.update({"protein.state": "failure", "protein.error": f"Policy loading failed: {e}"})
-            return 1
-
-        eval = SimulationSuite(
-            simulation_suite_cfg,
-            policy_pr,
-            policy_store,
-            device=cfg.device,
-            vectorization=cfg.vectorization,
-        )
-
-        # Start evaluation process
-        sweep_stats = {}
-        start_time = time.time()
-
-        # Update sweep stats with initial information
-        sweep_stats.update(
-            {
-                "score.metric": cfg.sweep.metric,
-            }
-        )
-        if wandb_run:
-            wandb_run.summary.update(sweep_stats)
-
-        # Start evaluation
-        eval_start_time = time.time()
-
-        logger.info(f"Evaluating policy {policy_pr.run_name}")
-
-        log_file(cfg.run_dir, "sweep_eval_config.yaml", cfg, wandb_run)
-
-        results = eval.simulate()
-        eval_time = time.time() - eval_start_time
-        eval_stats_db = EvalStatsDB.from_sim_stats_db(results.stats_db)
-        eval_metric = eval_stats_db.get_average_metric_by_filter(cfg.sweep.metric, policy_pr)
-
-        # Get training stats from metadata if available
-        train_time = policy_pr.metadata.get("train_time", 0)
-        agent_step = policy_pr.metadata.get("agent_step", 0)
-        epoch = policy_pr.metadata.get("epoch", 0)
-
-        # Update sweep stats with evaluation results
-        stats_update = {
-            "train.agent_step": agent_step,
-            "train.epoch": epoch,
-            "time.train": train_time,
-            "time.eval": eval_time,
-            "time.total": train_time + eval_time,
-            "uri": policy_pr.uri,
-            "score": eval_metric,
-        }
-
-        sweep_stats.update(stats_update)
-
-        # Update lineage stats
-        for stat in ["train.agent_step", "train.epoch", "time.train", "time.eval", "time.total"]:
-            sweep_stats["lineage." + stat] = sweep_stats[stat] + policy_pr.metadata.get("lineage." + stat, 0)
-
-        # Update wandb summary
-        if wandb_run:
-            wandb_run.summary.update(sweep_stats)
-        logger.info("Sweep Stats: \n" + json.dumps({k: str(v) for k, v in sweep_stats.items()}, indent=4))
-
-        # Update policy metadata
-        policy_pr.metadata.update(
-            {
-                **sweep_stats,
-                "training_run": cfg.run,
-            }
-        )
-
-        # Add policy to wandb sweep
-        policy_store.add_to_wandb_sweep(cfg.sweep_name, policy_pr)
-
-        # Record observation in Protein sweep
-        total_time = train_time + eval_time
-        protein_wandb = MettaProtein(cfg.sweep, wandb_run)
-
-        # Record the observation properly so the Protein learns
-        protein_wandb.record_observation(eval_metric, total_time)
-
-        # Save results for worker nodes
-        if os.environ.get("NODE_INDEX", "0") == "0":
-            OmegaConf.save({"eval_metric": eval_metric, "total_time": total_time}, results_path)
-
-        if wandb_run:
-            wandb_run.summary.update({"run_time": total_time})
-        logger.info(f"Evaluation complete for run: {cfg.run}, score: {eval_metric}")
-        return 0
+    return 0
 
 
 metta_script(main, "sweep_eval")

--- a/tools/sweep_prepare_run.py
+++ b/tools/sweep_prepare_run.py
@@ -12,11 +12,10 @@ if not hasattr(np, "byte"):
 
 import os
 import random
-import time
 from logging import Logger
 
 import wandb
-from omegaconf import DictConfig, ListConfig, OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from metta.common.util.lock import run_once
 from metta.common.util.numpy_helpers import clean_numpy_types
@@ -44,7 +43,6 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
 
     # Generate a new run ID for the sweep, e.g. "simple_sweep.r.0"
     # TODO: Use sweep_id instead of sweep_path, currently very confusing.
-    # TODO: Once again cfg.runs_dir pops up, done dirty.
     run_id = generate_run_id_for_sweep(sweep_metadata.wandb_path, cfg.runs_dir)
     logger.info(f"Creating new run: {run_id}")
 
@@ -53,9 +51,6 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
 
     cfg.run = run_id  # Top-level for training scripts
     cfg.run_dir = run_dir  # Top-level for training scripts
-
-    # Set Wandb config values explicitly so they contain concrete strings
-    # rather than unresolved interpolations when validated by Pydantic.
 
     def init_run():
         with WandbContext(cfg.wandb, cfg) as wandb_run:
@@ -80,16 +75,11 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
                 logger.warning("Failed to generate protein suggestion after 10 attempts. Giving up.")
                 raise e
 
-            # Apply Protein suggestions on top of sweep_job overrides
-            # Make a deepcopy of the sweep_job config to avoid modifying the original. We need
-            # to add the newly generated run-id into the subtree so that ${run} interpolations
-            # can resolve, but `cfg.sweep_job` is in struct mode, which forbids adding keys.
-            # Temporarily relax struct, insert the value, then restore the original safety.
-            OmegaConf.set_struct(cfg.sweep_job, False)
+            # Set the run ID in the sweep_job config
             cfg.sweep_job.run = cfg.run
-            OmegaConf.set_struct(cfg.sweep_job, True)
 
-            # TODO: I think we are close to getting rid of the need to pre-set a dist config file.
+            # Apply Protein suggestions on top of sweep_job overrides
+            # Make a deepcopy of the sweep_job config to avoid modifying the original.
             sweep_job_container = OmegaConf.to_container(cfg.sweep_job, resolve=True)
             assert isinstance(sweep_job_container, dict), "sweep_job must be a dictionary structure"
             sweep_job_copy = DictConfig(sweep_job_container)
@@ -138,20 +128,6 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
 
     logger.info(f"Run created: {run_id}")
     return run_id
-
-
-def wait_for_run(cfg: DictConfig | ListConfig, path: str, logger: Logger) -> None:
-    """
-    Wait for a run to exist.
-    """
-    # TODO: I am fairly certain this is not the right way to make workers wait.
-    for _ in range(10):
-        if os.path.exists(path):
-            break
-        time.sleep(5)
-
-    run_id = OmegaConf.load(path).run
-    logger.info(f"Run read: {run_id}")
 
 
 def validate_protein_suggestion(config: DictConfig, suggestion: dict):

--- a/tools/sweep_prepare_run.py
+++ b/tools/sweep_prepare_run.py
@@ -28,6 +28,7 @@ from metta.sweep.wandb_utils import generate_run_id_for_sweep
 logger = logging.getLogger(__name__)
 
 
+@hydra.main(config_path="../configs", config_name="sweep_job", version_base=None)
 def main(cfg: DictConfig) -> int:
     run_once(lambda: setup_next_run(cfg, logger))
     return 0
@@ -55,11 +56,6 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
 
     # Set Wandb config values explicitly so they contain concrete strings
     # rather than unresolved interpolations when validated by Pydantic.
-    # TODO: Check if this is actually necessary.
-    # TODO: Why isn't setting group name here sufficient?
-    cfg.wandb.group = cfg.sweep_name
-    cfg.wandb.name = run_id
-    cfg.wandb.run_id = run_id  # Required by WandbConfigOn schema
 
     def init_run():
         with WandbContext(cfg.wandb, cfg) as wandb_run:
@@ -114,7 +110,6 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
                     "run_dir": run_dir,
                     "seed": run_seed,
                     "sweep_name": cfg.sweep_name,  # Needed by sweep_eval.py
-                    "device": cfg.device,  # Ensure device is at top level <-- probably messing with the cuda config?
                     "wandb": {
                         "group": cfg.sweep_name,  # Group all runs under the sweep name
                         "name": run_id,  # Individual run name

--- a/tools/sweep_prepare_run.py
+++ b/tools/sweep_prepare_run.py
@@ -2,10 +2,10 @@
 
 # NumPy 2.0 compatibility for WandB - must be imported before wandb
 import logging
+import sys
 
+import hydra
 import numpy as np
-
-from metta.util.metta_script import metta_script  # noqa: E402
 
 if not hasattr(np, "byte"):
     np.byte = np.int8
@@ -199,4 +199,5 @@ def apply_protein_suggestion(config: DictConfig, suggestion: dict):
             config[key] = cleaned_value
 
 
-metta_script(main, "sweep_job")
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sweep_setup.py
+++ b/tools/sweep_setup.py
@@ -2,7 +2,9 @@
 
 # NumPy 2.0 compatibility for WandB - must be imported before wandb
 import logging
+import sys
 
+import hydra
 import numpy as np  # noqa: E402
 
 if not hasattr(np, "byte"):
@@ -15,7 +17,6 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from metta.common.util.lock import run_once
 from metta.sweep.wandb_utils import create_wandb_sweep, sweep_id_from_name
-from metta.util.metta_script import metta_script
 
 logger = logging.getLogger(__name__)
 
@@ -62,4 +63,5 @@ def create_sweep(cfg: DictConfig | ListConfig, logger: Logger) -> None:
     )
 
 
-metta_script(main, "sweep_job")
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sweep_setup.py
+++ b/tools/sweep_setup.py
@@ -20,13 +20,10 @@ from metta.util.metta_script import metta_script
 logger = logging.getLogger(__name__)
 
 
+@hydra.main(config_path="../configs", config_name="sweep_job", version_base=None)
 def main(cfg: DictConfig) -> int:
     # Extract sweep base name from CLI sweep_name parameter (e.g., "simple_sweep")
     # Individual training runs will be "simple_sweep.r.0", etc.
-
-    # TODO: Config should handle this
-    # Looking ahead, I don't even think we really need it.
-    cfg.wandb.name = cfg.sweep_name
 
     # TODO: Check run_once -- I think it's messing with the CUDA context.
     run_once(lambda: create_sweep(cfg, logger))
@@ -39,7 +36,6 @@ def create_sweep(cfg: DictConfig | ListConfig, logger: Logger) -> None:
     Create a new sweep with the given name. If the sweep already exists, skip creation.
     Save the sweep configuration to sweep_dir/config.yaml.
     """
-
     # Check if sweep already exists
     wandb_sweep_id = sweep_id_from_name(cfg.wandb.project, cfg.wandb.entity, cfg.sweep_name)
 
@@ -47,9 +43,9 @@ def create_sweep(cfg: DictConfig | ListConfig, logger: Logger) -> None:
         logger.info(f"Sweep already exists in WandB, skipping creation for: {cfg.sweep_name}")
 
     else:
-        # TODO: Check that sweep_dir is passed as a CLI arg and not into the config.
         logger.info(f"Creating new WandB sweep: {cfg.sweep_name}: {cfg.sweep_dir}")
-        # Create dummy sweep using static methods from protein_wandb (Protein will control all parameters)
+
+        # Create sweep using static methods from protein_wandb (Protein will control all parameters)
         wandb_sweep_id = create_wandb_sweep(cfg.sweep_name, cfg.wandb.entity, cfg.wandb.project)
 
     # Save sweep metadata locally


### PR DESCRIPTION
### TL;DR

Improved sweep evaluation reliability and performance with distributed execution support.

### What changed?

- Enhanced the sweep evaluation process to properly support distributed execution
- Implemented the `run_once` pattern to ensure evaluation only runs on rank 0 while other ranks wait for results
- Increased evaluation parameters in `sweep_job.yaml` from 2 to 5 episodes and max time from 10s to 240s
- Simplified the sweep setup process by removing unnecessary distributed configuration files
- Added proper error handling and result sharing between ranks
- Replaced `run=` parameter with `sweep_name=` in the sweep script for consistency
- Added the `run` field to the `sweep_job` configuration

### How to test?

1. Run a sweep with the updated configuration:
   ```
   ./devops/sweep.sh run=my_test_sweep
   ```

2. Verify that evaluation runs correctly on distributed systems by checking logs for proper coordination between ranks

3. Confirm that evaluation results are properly saved and shared between processes

### Why make this change?

The previous implementation had issues with distributed execution during sweep evaluation. This change ensures that only one process (rank 0) performs the actual evaluation while other ranks wait for the results, preventing duplicate work and race conditions. The increased evaluation parameters provide more accurate assessment of agent performance. The simplified configuration approach reduces complexity and potential points of failure in the sweep setup process.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210836334213129)