### PR TITLE
Add recipe_details_obs to BBC agent defaults

### DIFF
--- a/configs/env/mettagrid/curriculum/bbc/agents/defaults.yaml
+++ b/configs/env/mettagrid/curriculum/bbc/agents/defaults.yaml
@@ -6,6 +6,7 @@ env_overrides:
   game:
     global_obs:
       resource_rewards: true
+    recipe_details_obs: true
 
     actions:
       attack: { consumed_resources: { laser: 100 } }


### PR DESCRIPTION
### TL;DR

Enable recipe details observation in BBC curriculum agents.

### What changed?

Added `recipe_details_obs: true` to the default configuration for BBC curriculum agents in MetaGrid. This enables agents to observe recipe details as part of their observation space.

### How to test?

1. Run a BBC curriculum agent in MetaGrid
2. Verify that the agent receives recipe details in its observation
3. Check that the agent can properly utilize this information during gameplay

### Why make this change?

Providing recipe details in the observation space gives agents more information about crafting requirements, which should help them make better decisions about resource gathering and item crafting. This is particularly important in the BBC curriculum where agents need to understand blueprint consumption mechanics.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210839847618330)