### PR TITLE
Disable stats metadata collection to reduce memory usage

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -859,14 +859,17 @@ class MettaTrainer:
 
         # Add hyperparameter values
 
+        system_stats = {}  # self._system_monitor.stats()
+        memory_stats = {}  # self._memory_monitor.stats()
+
         # Build complete stats dictionary for wandb
         all_stats = build_wandb_stats(
             processed_stats=processed_stats,
             timing_info=timing_info,
             weight_stats=weight_stats,
             grad_stats=self.grad_stats,
-            system_stats=self._system_monitor.stats() if hasattr(self, "_system_monitor") else {},
-            memory_stats=self._memory_monitor.stats() if hasattr(self, "_memory_monitor") else {},
+            system_stats=system_stats,
+            memory_stats=memory_stats,
             parameters=parameters,
             hyperparameters=self.hyperparameters,
             evals=self.evals,

--- a/mettagrid/src/metta/mettagrid/stats_tracker.hpp
+++ b/mettagrid/src/metta/mettagrid/stats_tracker.hpp
@@ -101,39 +101,39 @@ public:
       result[key] = value;
     }
 
-    // Add timing metadata and calculated stats
-    for (const auto& [key, step] : _first_seen_at) {
-      result[key + ".first_step"] = static_cast<float>(step);
-    }
+    // // Add timing metadata and calculated stats
+    // for (const auto& [key, step] : _first_seen_at) {
+    //   result[key + ".first_step"] = static_cast<float>(step);
+    // }
 
-    for (const auto& [key, step] : _last_seen_at) {
-      result[key + ".last_step"] = static_cast<float>(step);
-    }
+    // for (const auto& [key, step] : _last_seen_at) {
+    //   result[key + ".last_step"] = static_cast<float>(step);
+    // }
 
-    for (const auto& [key, count] : _update_count) {
-      result[key + ".updates"] = static_cast<float>(count);
-      result[key + ".rate"] = rate(key);
-      result[key + ".avg"] = result[key] / count;
+    // for (const auto& [key, count] : _update_count) {
+    //   result[key + ".updates"] = static_cast<float>(count);
+    //   result[key + ".rate"] = rate(key);
+    //   result[key + ".avg"] = result[key] / count;
 
-      // Also calculate activity rate if there's a time span
-      auto first_it = _first_seen_at.find(key);
-      auto last_it = _last_seen_at.find(key);
-      if (first_it != _first_seen_at.end() && last_it != _last_seen_at.end()) {
-        int duration = static_cast<int>(last_it->second) - static_cast<int>(first_it->second);
-        if (duration > 0 && count > 1) {
-          result[key + ".activity_rate"] = static_cast<float>(count - 1) / static_cast<float>(duration);
-        }
-      }
-    }
+    //   // Also calculate activity rate if there's a time span
+    //   auto first_it = _first_seen_at.find(key);
+    //   auto last_it = _last_seen_at.find(key);
+    //   if (first_it != _first_seen_at.end() && last_it != _last_seen_at.end()) {
+    //     int duration = static_cast<int>(last_it->second) - static_cast<int>(first_it->second);
+    //     if (duration > 0 && count > 1) {
+    //       result[key + ".activity_rate"] = static_cast<float>(count - 1) / static_cast<float>(duration);
+    //     }
+    //   }
+    // }
 
-    // Add min/max values
-    for (const auto& [key, min_val] : _min_value) {
-      result[key + ".min"] = min_val;
-    }
+    // // Add min/max values
+    // for (const auto& [key, min_val] : _min_value) {
+    //   result[key + ".min"] = min_val;
+    // }
 
-    for (const auto& [key, max_val] : _max_value) {
-      result[key + ".max"] = max_val;
-    }
+    // for (const auto& [key, max_val] : _max_value) {
+    //   result[key + ".max"] = max_val;
+    // }
 
     return result;
   }

--- a/mettagrid/tests/test_stats_tracker.cpp
+++ b/mettagrid/tests/test_stats_tracker.cpp
@@ -72,8 +72,8 @@ TEST_F(StatsTrackerTest, MinMaxTracking) {
 
   auto result = stats.to_dict();
   EXPECT_FLOAT_EQ(18.0f, result["temperature"]);      // Current value
-  EXPECT_FLOAT_EQ(15.0f, result["temperature.min"]);  // Minimum
-  EXPECT_FLOAT_EQ(25.0f, result["temperature.max"]);  // Maximum
+  // EXPECT_FLOAT_EQ(15.0f, result["temperature.min"]);  // Minimum
+  // EXPECT_FLOAT_EQ(25.0f, result["temperature.max"]);  // Maximum
 }
 
 // Test average calculation
@@ -88,8 +88,8 @@ TEST_F(StatsTrackerTest, AverageCalculation) {
   EXPECT_FLOAT_EQ(60.0f, result["points"]);  // Total
 
   // Without environment, we don't get timing metadata
-  EXPECT_EQ(0, result.count("points.updates"));
-  EXPECT_EQ(0, result.count("points.avg"));
+  // EXPECT_EQ(0, result.count("points.updates"));
+  // EXPECT_EQ(0, result.count("points.avg"));
 }
 
 // Test time tracking without environment =
@@ -107,10 +107,10 @@ TEST_F(StatsTrackerTest, TimingWithoutEnvironment) {
   EXPECT_FLOAT_EQ(3.0f, result["action.move"]);
 
   // Without environment, no timing data
-  EXPECT_EQ(0, result.count("action.move.first_step"));
-  EXPECT_EQ(0, result.count("action.move.last_step"));
-  EXPECT_EQ(0, result.count("action.move.updates"));
-  EXPECT_EQ(0, result.count("action.move.rate"));
+  // EXPECT_EQ(0, result.count("action.move.first_step"));
+  // EXPECT_EQ(0, result.count("action.move.last_step"));
+  // EXPECT_EQ(0, result.count("action.move.updates"));
+  // EXPECT_EQ(0, result.count("action.move.rate"));
 }
 
 // Test rate calculation
@@ -148,9 +148,9 @@ TEST_F(StatsTrackerTest, NoEnvironmentNoTiming) {
 
   auto result = stats.to_dict();
   EXPECT_FLOAT_EQ(2.0f, result["action"]);
-  EXPECT_EQ(0, result.count("action.first_step"));  // No timing data
-  EXPECT_EQ(0, result.count("action.last_step"));
-  EXPECT_EQ(0, result.count("action.rate"));
+  // EXPECT_EQ(0, result.count("action.first_step"));  // No timing data
+  // EXPECT_EQ(0, result.count("action.last_step"));
+  // EXPECT_EQ(0, result.count("action.rate"));
 }
 
 // Test complex stat keys
@@ -178,8 +178,8 @@ TEST_F(StatsTrackerTest, EdgeCases) {
   auto result = stats.to_dict();
   EXPECT_FLOAT_EQ(0.0f, result["zero"]);
   EXPECT_FLOAT_EQ(-5.0f, result["negative"]);
-  EXPECT_FLOAT_EQ(-10.0f, result["negative.min"]);
-  EXPECT_FLOAT_EQ(-5.0f, result["negative.max"]);
+  // EXPECT_FLOAT_EQ(-10.0f, result["negative.min"]);
+  // EXPECT_FLOAT_EQ(-5.0f, result["negative.max"]);
 }
 
 // Test large numbers
@@ -191,7 +191,7 @@ TEST_F(StatsTrackerTest, LargeNumbers) {
   EXPECT_FLOAT_EQ(3000000.0f, result["large"]);
 
   // Without environment, no average calculation
-  EXPECT_EQ(0, result.count("large.avg"));
+  // EXPECT_EQ(0, result.count("large.avg"));
   EXPECT_EQ(0, result.count("large.updates"));
 }
 
@@ -207,13 +207,13 @@ TEST_F(StatsTrackerTest, CompleteMetadata) {
 
   // Check basic values
   EXPECT_FLOAT_EQ(50.0f, result["resource"]);      // Total: 10+20+15+5
-  EXPECT_FLOAT_EQ(10.0f, result["resource.min"]);  // Min cumulative value
-  EXPECT_FLOAT_EQ(50.0f, result["resource.max"]);  // Max cumulative value
+  // EXPECT_FLOAT_EQ(10.0f, result["resource.min"]);  // Min cumulative value
+  // EXPECT_FLOAT_EQ(50.0f, result["resource.max"]);  // Max cumulative value
 
   // Timing-related metadata won't be present without environment
-  EXPECT_EQ(0, result.count("resource.avg"));
-  EXPECT_EQ(0, result.count("resource.first_step"));
-  EXPECT_EQ(0, result.count("resource.last_step"));
-  EXPECT_EQ(0, result.count("resource.updates"));
-  EXPECT_EQ(0, result.count("resource.rate"));
+  // EXPECT_EQ(0, result.count("resource.avg"));
+  // EXPECT_EQ(0, result.count("resource.first_step"));
+  // EXPECT_EQ(0, result.count("resource.last_step"));
+  // EXPECT_EQ(0, result.count("resource.updates"));
+  // EXPECT_EQ(0, result.count("resource.rate"));
 }


### PR DESCRIPTION
### TL;DR

Disabled detailed statistics tracking to reduce memory usage and improve performance.

- system and memory stats were sufficiently slow as to contribute to training time
- the .avg / .stdev stats were never used and just poluted wandb

### What changed?

- Commented out the system and memory monitoring stats collection in `metta/rl/trainer.py`, replacing them with empty dictionaries
- Disabled the calculation and tracking of metadata statistics in `StatsTracker.to_dict()` method, including:
  - First/last seen timestamps
  - Update counts and rates
  - Min/max values
  - Average calculations
  - Activity rate calculations
- Updated corresponding tests to reflect the disabled functionality

### How to test?

1. Run the trainer with a memory-intensive workload and verify reduced memory usage
2. Check that basic statistics are still being collected and reported correctly
3. Verify that the tests pass with the updated expectations

### Why make this change?

The detailed statistics tracking was consuming excessive memory and processing resources during training. This change reduces overhead by temporarily disabling non-essential statistics calculations while preserving core functionality. This should improve performance and reduce memory pressure for large-scale training runs.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210849040011815)