### PR TITLE
refactor(sweep): Replace bash sweep_rollout.sh with Python implementation

### DIFF
--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -6,7 +6,7 @@ protein:
   random_suggestions: 1024
   suggestions_per_pareto: 256
 
-metric: overview/reward
+metric: reward
 goal: maximize
 method: bayes
 

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -10,8 +10,8 @@ defaults:
 cmd: sweep
 sweep_name: ???  # Will be set via command line override
 
-# Override stats_server_uri from common.yaml to use localhost for sweep coordination
-sweep_server_uri: http://localhost:8000
+# Backend URL for centralized run assignment in Observatory
+sweep_server_uri: https://api.observatory.softmax-research.net
 
 trainer:
   total_timesteps: 5_000_000   # 5M timesteps for proper RL training (was 50k - too short!)

--- a/devops/sweep.sh
+++ b/devops/sweep.sh
@@ -40,7 +40,7 @@ MAX_CONSECUTIVE_FAILURES=3
 consecutive_failures=0
 
 while true; do
-  if ./devops/sweep_rollout.sh $args_for_rollout; then
+  if ./metta/sweep/sweep_rollout.py $args_for_rollout; then
     consecutive_failures=0
   else
     consecutive_failures=$((consecutive_failures + 1))

--- a/metta/sweep/sweep_rollout.py
+++ b/metta/sweep/sweep_rollout.py
@@ -18,35 +18,94 @@ from omegaconf import DictConfig
 
 from metta.common.util.lock import run_once
 from metta.common.util.logging_helpers import setup_mettagrid_logger
+from tools.sweep_eval import main as sweep_eval_main
 from tools.sweep_prepare_run import setup_next_run
 
 logger = setup_mettagrid_logger("sweep_rollout")
 
 
-def generate_dist_cfg_path(data_dir: str, sweep_name: str) -> str:
-    """Generate distributed config path with process-unique hash."""
-    dist_id = os.environ.get("DIST_ID", "localhost")
-    return f"{data_dir}/sweep/{sweep_name}/dist_{dist_id}.yaml"
-
-
-def prepare_sweep_run(cfg: DictConfig, dist_cfg_path: str, logger: Logger) -> str:
-    """
-    Prepare a sweep run by calling setup_next_run.
-    Returns the generated run ID.
-    """
-    # Set up config for sweep_prepare_run
-    prep_cfg = cfg.copy()
-    prep_cfg.dist_cfg_path = dist_cfg_path
+@hydra.main(config_path="../../configs", config_name="sweep_job", version_base=None)
+def main(cfg: DictConfig) -> int:
+    """Main entry point for sweep rollout."""
+    # Don't use @metta_script decorator since we need to generate run ID first
+    # Use module-level logger created at import time
 
     try:
+        # Validate required arguments
+        if not cfg.get("sweep_name"):
+            raise ValueError("'sweep_name' argument is required (e.g., sweep_name=my_sweep_name)")
+
+        # Extract hardware argument from command line arguments (like bash script does)
+        hardware_arg = None
+        for arg in sys.argv[1:]:
+            if arg.startswith("+hardware="):
+                hardware_arg = arg
+                break
+
+        # Get data directory from environment (set by sweep.sh)
+        data_dir = os.environ.get("DATA_DIR", "./train_dir")
+
+        logger.info(f"[INFO] Starting sweep rollout: {cfg.sweep_name}")
+
+        # 1. Preparation phase (ONLY rank 0 - through run_once)
+        run_id, dist_cfg_path = run_once(lambda: prepare_sweep_run(cfg, logger))
+
+        # 2. Training phase (ALL ranks participate)
+        logger.info(f"[SWEEP:{cfg.sweep_name}] Starting training phase...")
+        run_training(
+            run_id=run_id,
+            dist_cfg_path=dist_cfg_path,
+            data_dir=data_dir,
+            sweep_name=cfg.sweep_name,
+            hardware_arg=hardware_arg,
+            logger=logger,
+        )
+
+        # 3. Evaluation phase (ONLY rank 0 - handled by sweep_eval internally)
+        logger.info(f"[SWEEP:{cfg.sweep_name}] Starting evaluation phase...")
+
+        # Create evaluation config
+        eval_cfg = cfg.copy()
+        eval_cfg.dist_cfg_path = dist_cfg_path
+        eval_cfg.data_dir = f"{data_dir}/sweep/{cfg.sweep_name}/runs"
+
+        # Log the command for consistency with bash script
+        logger.info(
+            f"[SWEEP:{cfg.sweep_name}] Running: ./tools/sweep_eval.py dist_cfg_path={dist_cfg_path} "
+            f"data_dir={data_dir}/sweep/{cfg.sweep_name}/runs"
+        )
+
+        # Direct function call to sweep_eval main
+        result = sweep_eval_main(eval_cfg)
+        if result != 0:
+            raise Exception(f"Evaluation failed for {cfg.sweep_name}")
+
+        logger.info(f"[SUCCESS] Sweep rollout completed: {cfg.sweep_name}")
+        return 0
+
+    except Exception as e:
+        logger.error(f"Rollout failed: {e}")
+        return 1
+
+
+def prepare_sweep_run(cfg: DictConfig, logger: Logger) -> tuple[str, str]:
+    """
+    Prepare a sweep run by calling setup_next_run.
+    Returns the generated run ID and the dist_cfg_path.
+    This function is called by run_once, so it is only executed by rank 0.
+    """
+    try:
         # Direct function call instead of subprocess
-        run_id = setup_next_run(prep_cfg, logger)
+        run_id, dist_cfg_path = setup_next_run(cfg, logger)
 
         if not run_id:
             raise ValueError("setup_next_run returned None/empty run_id")
 
+        # Construct final dist_cfg_path in run directory
         logger.info(f"Generated run ID: {run_id}")
-        return run_id
+        logger.info(f"Dist config written to: {dist_cfg_path}")
+
+        return run_id, dist_cfg_path
 
     except Exception as e:
         logger.error(f"[ERROR] Sweep run preparation failed: {cfg.sweep_name}")
@@ -91,146 +150,6 @@ def run_training(
         else:
             print(f"[ERROR] Training failed for sweep: {sweep_name}")
         raise Exception(f"Training failed for {sweep_name} with exit code {e.returncode}") from e
-
-
-def run_evaluation(cfg: DictConfig, dist_cfg_path: str, data_dir: str, sweep_name: str, logger: Logger) -> bool:
-    """Run evaluation using direct Python import."""
-    from tools.sweep_eval import main as sweep_eval_main
-
-    logger.info(f"[SWEEP:{cfg.sweep_name}] Starting evaluation phase...")
-
-    # Create evaluation config
-    eval_cfg = cfg.copy()
-    eval_cfg.dist_cfg_path = dist_cfg_path
-    eval_cfg.data_dir = f"{data_dir}/sweep/{sweep_name}/runs"
-
-    # Build command string for logging (matching bash script output)
-    args_str = f"dist_cfg_path={dist_cfg_path} data_dir={data_dir}/sweep/{sweep_name}/runs"
-    logger.info(f"[SWEEP:{sweep_name}] Running: ./tools/sweep_eval.py {args_str}")
-
-    try:
-        # Direct function call instead of subprocess
-        result = sweep_eval_main(eval_cfg)
-        success = result == 0
-
-        if not success:
-            logger.error(f"[ERROR] Evaluation failed for sweep: {sweep_name}")
-            raise Exception(f"Evaluation failed for {sweep_name}")
-
-        return success
-
-    except Exception as e:
-        logger.error(f"[ERROR] Evaluation failed for sweep: {sweep_name}")
-        logger.error(f"Evaluation error details: {e}")
-        raise Exception(f"Evaluation failed for {sweep_name}") from e
-
-
-def run_single_rollout(cfg: DictConfig, logger: Logger) -> dict:
-    """Complete rollout: prepare, train, evaluate."""
-
-    # Validate required arguments
-    if not cfg.get("sweep_name"):
-        raise ValueError("'sweep_name' argument is required (e.g., sweep_name=my_sweep_name)")
-
-    # Extract hardware argument from command line arguments (like bash script does)
-    hardware_arg = None
-    for arg in sys.argv[1:]:
-        if arg.startswith("+hardware="):
-            hardware_arg = arg
-            break
-
-    # Get data directory from environment (set by sweep.sh)
-    data_dir = os.environ.get("DATA_DIR", "./train_dir")
-
-    # Generate distributed config path
-    dist_cfg_path = generate_dist_cfg_path(data_dir, cfg.sweep_name)
-
-    logger.info(f"[INFO] Starting sweep rollout: {cfg.sweep_name}")
-    logger.info(f"Distributed config path: {dist_cfg_path}")
-
-    try:
-        # 1. Prepare run (Pure Python)
-        run_id = prepare_sweep_run(cfg, dist_cfg_path, logger)
-
-        # 2. Training phase (Subprocess only)
-        logger.info(f"[SWEEP:{cfg.sweep_name}] Starting training phase...")
-        train_result = run_training(
-            run_id=run_id,
-            dist_cfg_path=dist_cfg_path,
-            data_dir=data_dir,
-            sweep_name=cfg.sweep_name,
-            hardware_arg=hardware_arg,
-            logger=logger,
-        )
-
-        # 3. Evaluation phase (Pure Python)
-        eval_success = run_evaluation(cfg, dist_cfg_path, data_dir, cfg.sweep_name, logger)
-
-        logger.info(f"[SUCCESS] Sweep rollout completed: {cfg.sweep_name}")
-
-        return {
-            "run_id": run_id,
-            "train_returncode": train_result.returncode,
-            "eval_success": eval_success,
-            "dist_cfg_path": dist_cfg_path,
-        }
-
-    except Exception as e:
-        logger.error(f"Sweep rollout failed: {e}")
-        raise
-
-
-@hydra.main(config_path="../../configs", config_name="sweep_job", version_base=None)
-def main(cfg: DictConfig) -> int:
-    """Main entry point for sweep rollout."""
-    # Don't use @metta_script decorator since we need to generate run ID first
-    # Use module-level logger created at import time
-
-    try:
-        # Extract hardware argument from command line arguments (like bash script does)
-        import sys
-
-        hardware_arg = None
-        for arg in sys.argv[1:]:
-            if arg.startswith("+hardware="):
-                hardware_arg = arg
-                break
-
-        # Get data directory from environment (set by sweep.sh)
-        data_dir = os.environ.get("DATA_DIR", "./train_dir")
-
-        # Generate distributed config path
-        dist_cfg_path = generate_dist_cfg_path(data_dir, cfg.sweep_name)
-
-        # 1. Preparation phase (ONLY rank 0)
-        def prepare_run():
-            return prepare_sweep_run(cfg, dist_cfg_path, logger)
-
-        run_id = run_once(prepare_run)
-
-        # 2. Training phase (ALL ranks participate)
-        logger.info(f"[SWEEP:{cfg.sweep_name}] Starting training phase...")
-        _ = run_training(
-            run_id=run_id,
-            dist_cfg_path=dist_cfg_path,
-            data_dir=data_dir,
-            sweep_name=cfg.sweep_name,
-            hardware_arg=hardware_arg,
-            logger=logger,
-        )
-
-        # 3. Evaluation phase (ONLY rank 0, others wait for results)
-        def evaluate_run():
-            return run_evaluation(cfg, dist_cfg_path, data_dir, cfg.sweep_name, logger)
-
-        _ = run_once(evaluate_run)
-
-        logger.info(f"[SUCCESS] Sweep rollout completed: {cfg.sweep_name}")
-        return 0
-
-    except Exception as e:
-        logger.error(f"Rollout failed: {e}")
-        return 1
 
 
 if __name__ == "__main__":

--- a/metta/sweep/sweep_rollout.py
+++ b/metta/sweep/sweep_rollout.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env -S uv run
+"""
+sweep_rollout.py - Execute a single sweep rollout in Python
+
+This module replaces sweep_rollout.sh with a Python implementation that:
+- Uses direct function imports for preparation and evaluation phases
+- Only launches training as a subprocess via devops/train.sh
+- Maintains compatibility with existing sweep infrastructure
+"""
+
+import os
+import subprocess
+import sys
+import uuid
+from logging import Logger
+
+import hydra
+from omegaconf import DictConfig
+
+from metta.common.util.logging_helpers import setup_mettagrid_logger
+
+logger = setup_mettagrid_logger("sweep_rollout")
+
+
+class SweepRolloutError(Exception):
+    """Custom exception for sweep rollout failures."""
+
+    pass
+
+
+def generate_dist_cfg_path(data_dir: str, sweep_name: str) -> str:
+    """Generate distributed config path with process-unique hash."""
+    dist_id = os.environ.get("DIST_ID", "localhost")
+    process_hash = uuid.uuid4().hex[:8]
+    return f"{data_dir}/sweep/{sweep_name}/dist_{dist_id}_{process_hash}.yaml"
+
+
+def extract_run_id_from_config(dist_cfg_path: str) -> str:
+    """Extract run ID from the generated distributed config file."""
+    if not os.path.exists(dist_cfg_path):
+        raise FileNotFoundError(f"Distributed config file not found: {dist_cfg_path}")
+
+    with open(dist_cfg_path, "r") as f:
+        content = f.read()
+
+    # Parse line by line to match bash logic: grep '^run:' | awk '{print $2}'
+    for line in content.split("\n"):
+        line = line.strip()
+        if line.startswith("run:"):
+            parts = line.split(":", 1)
+            if len(parts) == 2:
+                return parts[1].strip()
+
+    raise ValueError(f"Failed to read run ID from {dist_cfg_path}")
+
+
+def prepare_sweep_run(cfg: DictConfig, dist_cfg_path: str, logger: Logger) -> str:
+    """Prepare sweep run using direct Python import."""
+    from tools.sweep_prepare_run import setup_next_run
+
+    logger.info(f"[SWEEP:{cfg.sweep_name}] Preparing next run...")
+
+    # Ensure the dist config file is clean (remove if exists)
+    if os.path.exists(dist_cfg_path):
+        os.remove(dist_cfg_path)
+
+    # Create a modified config for sweep_prepare_run
+    prep_cfg = cfg.copy()
+    prep_cfg.dist_cfg_path = dist_cfg_path
+
+    try:
+        # Direct function call instead of subprocess
+        run_id = setup_next_run(prep_cfg, logger)
+
+        # setup_next_run returns the run_id, but let's ensure it's not None
+        if not run_id:
+            # Fallback: extract from config file if setup_next_run somehow returns None
+            run_id = extract_run_id_from_config(dist_cfg_path)
+
+        logger.info(f"Generated run ID: {run_id}")
+        return run_id
+
+    except Exception as e:
+        logger.error(f"[ERROR] Sweep run preparation failed: {cfg.sweep_name}")
+        logger.error(f"Preparation error details: {e}")
+        raise SweepRolloutError(f"Preparation failed for {cfg.sweep_name}") from e
+
+
+def run_training(
+    run_id: str,
+    dist_cfg_path: str,
+    data_dir: str,
+    sweep_name: str,
+    hardware_arg: str | None = None,
+    logger: Logger | None = None,
+) -> subprocess.CompletedProcess:
+    """Launch training as a subprocess and wait for completion."""
+
+    # Build the command exactly like the bash script
+    cmd = [
+        "./devops/train.sh",
+        f"run={run_id}",
+        f"dist_cfg_path={dist_cfg_path}",
+        f"data_dir={data_dir}/sweep/{sweep_name}/runs",
+    ]
+
+    if hardware_arg:
+        cmd.append(hardware_arg)
+
+    if logger:
+        logger.info(f"[SWEEP:{sweep_name}] Running: {' '.join(cmd)}")
+    else:
+        print(f"[SWEEP:{sweep_name}] Running: {' '.join(cmd)}")
+
+    try:
+        # Launch and wait (no capture_output to maintain real-time logging)
+        result = subprocess.run(cmd, check=True)
+        return result
+
+    except subprocess.CalledProcessError as e:
+        if logger:
+            logger.error(f"[ERROR] Training failed for sweep: {sweep_name}")
+        else:
+            print(f"[ERROR] Training failed for sweep: {sweep_name}")
+        raise SweepRolloutError(f"Training failed for {sweep_name} with exit code {e.returncode}") from e
+
+
+def run_evaluation(cfg: DictConfig, dist_cfg_path: str, data_dir: str, sweep_name: str, logger: Logger) -> bool:
+    """Run evaluation using direct Python import."""
+    from tools.sweep_eval import main as sweep_eval_main
+
+    logger.info(f"[SWEEP:{cfg.sweep_name}] Starting evaluation phase...")
+
+    # Create evaluation config
+    eval_cfg = cfg.copy()
+    eval_cfg.dist_cfg_path = dist_cfg_path
+    eval_cfg.data_dir = f"{data_dir}/sweep/{sweep_name}/runs"
+
+    # Build command string for logging (matching bash script output)
+    args_str = f"dist_cfg_path={dist_cfg_path} data_dir={data_dir}/sweep/{sweep_name}/runs"
+    logger.info(f"[SWEEP:{sweep_name}] Running: ./tools/sweep_eval.py {args_str}")
+
+    try:
+        # Direct function call instead of subprocess
+        result = sweep_eval_main(eval_cfg)
+        success = result == 0
+
+        if not success:
+            logger.error(f"[ERROR] Evaluation failed for sweep: {sweep_name}")
+            raise SweepRolloutError(f"Evaluation failed for {sweep_name}")
+
+        return success
+
+    except Exception as e:
+        logger.error(f"[ERROR] Evaluation failed for sweep: {sweep_name}")
+        logger.error(f"Evaluation error details: {e}")
+        raise SweepRolloutError(f"Evaluation failed for {sweep_name}") from e
+
+
+def run_single_rollout(cfg: DictConfig, logger: Logger) -> dict:
+    """Complete rollout: prepare, train, evaluate."""
+
+    # Validate required arguments
+    if not cfg.get("sweep_name"):
+        raise ValueError("'sweep_name' argument is required (e.g., sweep_name=my_sweep_name)")
+
+    # Extract hardware argument from command line arguments (like bash script does)
+    import sys
+
+    hardware_arg = None
+    for arg in sys.argv[1:]:
+        if arg.startswith("+hardware="):
+            hardware_arg = arg
+            break
+
+    # Get data directory from environment (set by sweep.sh)
+    data_dir = os.environ.get("DATA_DIR", "./train_dir")
+
+    # Generate distributed config path
+    dist_cfg_path = generate_dist_cfg_path(data_dir, cfg.sweep_name)
+
+    logger.info(f"[INFO] Starting sweep rollout: {cfg.sweep_name}")
+    logger.info(f"Distributed config path: {dist_cfg_path}")
+
+    try:
+        # 1. Prepare run (Pure Python)
+        run_id = prepare_sweep_run(cfg, dist_cfg_path, logger)
+
+        # Extract run_id from generated config file (matching bash script logic)
+        run_id = extract_run_id_from_config(dist_cfg_path)
+
+        if not run_id:
+            raise ValueError(f"Failed to read run ID from {dist_cfg_path}")
+
+        # 2. Training phase (Subprocess only)
+        logger.info(f"[SWEEP:{cfg.sweep_name}] Starting training phase...")
+        train_result = run_training(
+            run_id=run_id,
+            dist_cfg_path=dist_cfg_path,
+            data_dir=data_dir,
+            sweep_name=cfg.sweep_name,
+            hardware_arg=hardware_arg,
+            logger=logger,
+        )
+
+        # 3. Evaluation phase (Pure Python)
+        eval_success = run_evaluation(cfg, dist_cfg_path, data_dir, cfg.sweep_name, logger)
+
+        logger.info(f"[SUCCESS] Sweep rollout completed: {cfg.sweep_name}")
+
+        return {
+            "run_id": run_id,
+            "train_returncode": train_result.returncode,
+            "eval_success": eval_success,
+            "dist_cfg_path": dist_cfg_path,
+        }
+
+    except Exception as e:
+        logger.error(f"Sweep rollout failed: {e}")
+        raise
+
+
+@hydra.main(config_path="../../configs", config_name="sweep_job", version_base=None)
+def main(cfg: DictConfig) -> int:
+    """Main entry point for sweep rollout."""
+    # Don't use @metta_script decorator since we need to generate run ID first
+    # Use module-level logger created at import time
+
+    try:
+        # Set a temporary run ID to satisfy config validation
+        # This will be overridden by the actual run ID from setup_next_run
+        if not cfg.get("run"):
+            cfg.run = "temp_run_id"
+
+        # Run complete rollout
+        result = run_single_rollout(cfg, logger)
+        logger.info(f"Rollout completed successfully: {result}")
+        return 0
+
+    except Exception as e:
+        logger.error(f"Rollout failed: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sweep_prepare_run.py
+++ b/tools/sweep_prepare_run.py
@@ -33,10 +33,10 @@ def main(cfg: DictConfig) -> int:
     return 0
 
 
-def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
+def setup_next_run(cfg: DictConfig, logger: Logger) -> tuple[str, str]:
     """
     Create a new run for an existing sweep.
-    Returns the run ID.
+    Returns the run ID and the dist_cfg_path.
     """
     # Load sweep metadata
     sweep_metadata = OmegaConf.load(os.path.join(cfg.sweep_dir, "metadata.yaml"))
@@ -53,6 +53,7 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
 
     cfg.run = run_id  # Top-level for training scripts
     cfg.run_dir = run_dir  # Top-level for training scripts
+    dist_cfg_path = os.path.join(run_dir, "dist_cfg.yaml")
 
     def init_run():
         with WandbContext(cfg.wandb, cfg) as wandb_run:
@@ -93,7 +94,7 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
             sweep_job_final = OmegaConf.to_container(sweep_job_copy, resolve=True)
             assert isinstance(sweep_job_final, dict), "sweep_job_final must be a dictionary"
 
-            #
+            # TODO: Use sweep_config_utils.py to save config into run_dir
             train_cfg_overrides = DictConfig(
                 {
                     **sweep_job_final,
@@ -109,13 +110,13 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
             )
             OmegaConf.save(train_cfg_overrides, save_path)
 
-            os.makedirs(os.path.dirname(cfg.dist_cfg_path), exist_ok=True)
+            # We are now saving into the run directory directly
             OmegaConf.save(
                 {
                     "run": run_id,
                     "wandb_run_id": wandb_run_id,
                 },
-                cfg.dist_cfg_path,
+                dist_cfg_path,
             )
 
     # TODO: Why are we doing this in wandb.agent? What is WandB agent?
@@ -128,7 +129,7 @@ def setup_next_run(cfg: DictConfig, logger: Logger) -> str:
     )
 
     logger.info(f"Run created: {run_id}")
-    return run_id
+    return run_id, dist_cfg_path
 
 
 def validate_protein_suggestion(config: DictConfig, suggestion: dict):


### PR DESCRIPTION
# Refactor sweep_rollout.sh to Python

- Create metta/sweep/sweep_rollout.py as Python replacement
- Implement hybrid approach: direct imports for prep/eval, subprocess for training
- Fix hardware argument extraction from CLI for proper vectorization config
- Update devops/sweep.sh to call Python script instead of bash
- Maintain full compatibility with existing sweep behavior

## Fix sweep_rollout to use run_once appropriately

- Only rank 0 performs run preparation (run_once for setup_next_run)
- All ranks participate in training (no run_once for training subprocess)
- Only rank 0 performs evaluation (run_once for evaluation)
- Matches distributed training pattern used in other sweep tools
- Fixes hardware argument extraction for proper vectorization config

refactor(sweep): replace sweep_rollout.sh by Python version + write dist_cfg in run_dir

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210850305710735)