### PR TITLE
Optimize policy distribution

### DIFF
--- a/agent/src/metta/agent/policy_store.py
+++ b/agent/src/metta/agent/policy_store.py
@@ -27,6 +27,7 @@ from metta.agent.metta_agent import make_policy
 from metta.agent.policy_cache import PolicyCache
 from metta.agent.policy_metadata import PolicyMetadata
 from metta.agent.policy_record import PolicyRecord
+from metta.common.util.distributed import distributed_torch_load
 from metta.common.wandb.wandb_context import WandbRun
 from metta.rl.policy import load_pytorch_policy
 from metta.rl.trainer_config import TrainerConfig, create_trainer_config
@@ -406,7 +407,7 @@ class PolicyStore:
         self._make_codebase_backwards_compatible()
 
         # Load checkpoint - could be PolicyRecord or legacy format
-        checkpoint = torch.load(path, map_location=self._device, weights_only=False)
+        checkpoint = distributed_torch_load(path, map_location=self._device, weights_only=False)
 
         if isinstance(checkpoint, PolicyRecord):
             # New format - PolicyRecord object

--- a/common/src/metta/common/util/distributed.py
+++ b/common/src/metta/common/util/distributed.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+
+def broadcast_bytes(data: bytes | None, device: torch.device | str) -> bytes:
+    """Broadcast bytes from rank 0 to all processes using NCCL.
+
+    Parameters
+    ----------
+    data: bytes | None
+        Data to broadcast on rank 0. Ignored on other ranks.
+    device: torch.device | str
+        Device for temporary tensors used in the broadcast.
+
+    Returns
+    -------
+    bytes
+        The broadcasted data on all ranks.
+    """
+    if not dist.is_initialized():
+        assert data is not None
+        return data
+
+    device = torch.device(device)
+    rank = dist.get_rank()
+
+    if rank == 0:
+        assert data is not None
+        buffer = torch.as_tensor(np.frombuffer(data, dtype=np.uint8), device=device)
+        size = torch.tensor([buffer.numel()], dtype=torch.long, device=device)
+    else:
+        buffer = torch.tensor([], dtype=torch.uint8, device=device)
+        size = torch.tensor([0], dtype=torch.long, device=device)
+
+    dist.broadcast(size, src=0)
+    if rank != 0:
+        buffer = torch.empty(size.item(), dtype=torch.uint8, device=device)
+    dist.broadcast(buffer, src=0)
+
+    if rank != 0:
+        data = buffer.cpu().numpy().tobytes()
+    return data
+
+
+def distributed_torch_load(
+    path: str, map_location: torch.device | str = "cpu", *, weights_only: bool | None = None
+) -> Any:
+    """Load a checkpoint on rank 0 and broadcast to other ranks."""
+    if dist.is_initialized():
+        broadcast_device = (
+            torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+        )
+        if dist.get_rank() == 0:
+            with open(path, "rb") as f:
+                data = f.read()
+        else:
+            data = None
+        data = broadcast_bytes(data, broadcast_device)
+        buffer = io.BytesIO(data)
+        return torch.load(buffer, map_location=map_location, weights_only=weights_only)
+
+    return torch.load(path, map_location=map_location, weights_only=weights_only)

--- a/metta/rl/policy.py
+++ b/metta/rl/policy.py
@@ -7,6 +7,7 @@ from pufferlib.pytorch import sample_logits
 from torch import nn
 
 from metta.agent.policy_state import PolicyState
+from metta.common.util.distributed import distributed_torch_load
 from metta.common.util.instantiate import instantiate
 
 logger = logging.getLogger("policy")
@@ -23,7 +24,7 @@ def load_pytorch_policy(path: str, device: str = "cpu", pytorch_cfg: DictConfig 
     Returns:
         PytorchAgent wrapping the loaded policy
     """
-    weights = torch.load(path, map_location=device, weights_only=True)
+    weights = distributed_torch_load(path, map_location=device, weights_only=True)
 
     try:
         num_actions, hidden_size = weights["policy.actor.0.weight"].shape


### PR DESCRIPTION
## Summary
- add distributed utilities for broadcasting bytes and loading checkpoints
- load checkpoints via `distributed_torch_load`
- share policy weights across ranks with NCCL broadcast

## Testing
- `ruff format --quiet`
- `ruff check --quiet`
- `mypy agent/src/metta/agent/policy_store.py metta/rl/policy.py common/src/metta/common/util/distributed.py` *(failed)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'hydra')*
- `python -m tools.train run=my_experiment +hardware=macbook wandb=off train_job.map_preview_uri=null` *(failed: ModuleNotFoundError: No module named 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_687eabc45bac8325b274b5b0c32ffa79