### PR TITLE
Load skypilot aliases with env

### DIFF
--- a/devops/setup.env
+++ b/devops/setup.env
@@ -4,3 +4,7 @@ export PYTHONOPTIMIZE=1
 export HYDRA_FULL_ERROR=1
 export WANDB_DIR="./wandb"
 export DATA_DIR=${DATA_DIR:-./train_dir}
+# Automatically load SkyPilot aliases when the environment is activated
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/skypilot/setup_shell.sh" ]; then
+  source "$(dirname "${BASH_SOURCE[0]}")/skypilot/setup_shell.sh"
+fi


### PR DESCRIPTION
Having to manually source our SkyPilot `setup_shell.sh` every time I open a new terminal is annoying. This PR intends to change that by automatically loading the SkyPilot aliases with our venv.

------
https://chatgpt.com/codex/tasks/task_e_687eaf345a6483258a0cb863d5f974fa

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210851726222944)