### PR TITLE
Disable unneeded actions from nav evals

### DIFF
--- a/configs/env/mettagrid/navigation/evals/defaults.yaml
+++ b/configs/env/mettagrid/navigation/evals/defaults.yaml
@@ -13,6 +13,16 @@ game:
     last_reward: true
     resource_rewards: false # This feature wasn't present when older policies were trained
 
+  # Disable unneeded actions from nav evals
+  actions:
+    put_items:
+      enabled: false
+    attack:
+      enabled: false
+    swap:
+      enabled: false
+    change_color:
+      enabled: false
   agent:
     rewards:
       inventory:
@@ -21,11 +31,6 @@ game:
   objects:
     altar:
       initial_resource_count: 1
-
-  # Disable attack action since laser is not in the inventory
-  actions:
-    attack:
-      enabled: false
 
   map_builder:
     _target_: metta.map.mapgen_ascii.MapGenAscii


### PR DESCRIPTION
Disables unnecessary actions in navigation evaluation configurations.

Navigation tasks only require movement actions to complete their objectives. Disabling unnecessary actions simplifies the action space for navigation-specific evaluations, making them more focused and potentially improving agent performance by removing irrelevant action choices.

Mostly: it seems like "navigate while dealing with a bunch of irrelevant actions" is a different skill from "navigate", and so it's reasonable for us to separate these.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210853082082452)