### PR TITLE
chore: improve CI test parallelism

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -86,6 +86,7 @@
     "finfo",
     "fvisibility",
     "GBENCHMARK",
+    "gcovr",
     "genai",
     "generativeai",
     "gethostname",

--- a/.github/actions/asana/ensure-task/action.yml
+++ b/.github/actions/asana/ensure-task/action.yml
@@ -86,4 +86,3 @@ runs:
         INPUT_ASANA_EMAIL_FIELD_ID: ${{ inputs.asana_email_field_id }}
         INPUT_PR_AUTHOR_FIELD_ID: ${{ inputs.pr_author_field_id }}
         INPUT_ASANA_ATTACHMENT_SECRET: ${{ inputs.asana_attachment_secret }}
-

--- a/.github/actions/fetch-artifacts/action.yml
+++ b/.github/actions/fetch-artifacts/action.yml
@@ -1,8 +1,8 @@
-name: 'Fetch Artifacts'
-description: 'Downloads zipped artifacts from previous successful workflow runs'
+name: "Fetch Artifacts"
+description: "Downloads zipped artifacts from previous successful workflow runs"
 inputs:
   github-token:
-    description: 'GitHub token for API access'
+    description: "GitHub token for API access"
     required: false
     default: ${{ github.token }}
   workflow-name:
@@ -12,22 +12,22 @@ inputs:
     description: 'Pattern to match artifact names (supports wildcards like "build-*" or exact names)'
     required: true
   num-artifacts:
-    description: 'Number of artifacts to collect'
+    description: "Number of artifacts to collect"
     required: false
-    default: '5'
+    default: "5"
   output-directory:
-    description: 'Directory to save downloaded artifacts'
+    description: "Directory to save downloaded artifacts"
     required: false
-    default: 'downloaded-artifacts'
+    default: "downloaded-artifacts"
 outputs:
   artifacts-found:
-    description: 'Number of artifacts found and downloaded'
+    description: "Number of artifacts found and downloaded"
     value: ${{ steps.fetch-artifacts.outputs.artifacts-found }}
   success:
-    description: 'Whether the operation completed successfully'
+    description: "Whether the operation completed successfully"
     value: ${{ steps.fetch-artifacts.outputs.success }}
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -35,13 +35,8 @@ runs:
         case "${{ inputs.install-mode }}" in
 
           "testing")
-            uv pip install --no-deps -e .
-            uv pip install --no-deps -e ./common
-            uv pip install --no-deps -e ./agent
-            uv pip install --no-deps -e ./app_backend
-            uv pip install scikit-build-core
+            uv sync --no-default-groups
             uv pip install pytest pytest-cov pytest-xdist pytest-benchmark gcovr
-            uv pip install torch numpy pydantic typing-extensions
             ;;
 
           "linting")

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: "true"
   install-mode:
-    description: "Installation mode: 'full' (default), 'testing', or 'linting'"
+    description: "Installation mode: 'full' (default), or 'linting'"
     required: false
     default: "full"
 

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -35,24 +35,15 @@ runs:
         case "${{ inputs.install-mode }}" in
 
           "testing")
-            # Install specific workspace members excluding mettagrid
-            echo "Installing dependencies and workspace members (except mettagrid)..."
-            # First sync to get all external dependencies
             uv sync --no-install-workspace
-            # Then install specific workspace members (excluding mettagrid)
             uv pip install --no-deps -e .
             uv pip install --no-deps -e ./common
             uv pip install --no-deps -e ./agent
             uv pip install --no-deps -e ./app_backend
-            # Also install mettagrid's build dependencies
-            echo "Installing build dependencies..."
-            uv pip install scikit-build-core
-            echo "Installing test dependencies..."
-            uv pip install pytest pytest-cov gcovr
+            uv pip install scikit-build-core pytest pytest-cov gcovr
             ;;
 
           "linting")
-            # Just install linting tools
             uv pip install ruff cpplint
             ;;
 

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: "true"
   install-mode:
-    description: "Installation mode: 'full' (default), 'no-mettagrid', or 'linting'"
+    description: "Installation mode: 'full' (default), 'testing', or 'linting'"
     required: false
     default: "full"
 
@@ -35,7 +35,7 @@ runs:
             uv pip install ruff cpplint
             ;;
           "full"|*)
-            # Normal installation
+            uv pip install pytest pytest-cov pytest-xdist
             if [ "${{ inputs.include-dev }}" = "true" ]; then
               uv sync
             else

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: "true"
   install-mode:
-    description: "Installation mode: 'full' (default), or 'linting'"
+    description: "Installation mode: 'full' (default), 'testing', or 'linting'"
     required: false
     default: "full"
 
@@ -33,16 +33,35 @@ runs:
 
         # Handle different installation modes
         case "${{ inputs.install-mode }}" in
+
+          "testing")
+            # Install specific workspace members excluding mettagrid
+            echo "Installing dependencies and workspace members (except mettagrid)..."
+            # First sync to get all external dependencies
+            uv sync --no-install-workspace
+            # Then install specific workspace members (excluding mettagrid)
+            uv pip install --no-deps -e .
+            uv pip install --no-deps -e ./common
+            uv pip install --no-deps -e ./agent
+            uv pip install --no-deps -e ./app_backend
+            # Also install mettagrid's build dependencies
+            echo "Installing build dependencies..."
+            uv pip install scikit-build-core
+            echo "Installing test dependencies..."
+            uv pip install pytest pytest-cov gcovr
+            ;;
+
           "linting")
             # Just install linting tools
             uv pip install ruff cpplint
             ;;
+
           "full"|*)
-            uv pip install pytest pytest-cov pytest-xdist gcovr
             if [ "${{ inputs.include-dev }}" = "true" ]; then
               uv sync
             else
               uv sync --no-default-groups
             fi
             ;;
+
         esac

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -35,7 +35,7 @@ runs:
             uv pip install ruff cpplint
             ;;
           "full"|*)
-            uv pip install pytest pytest-cov pytest-xdist
+            uv pip install pytest pytest-cov pytest-xdist gcovr
             if [ "${{ inputs.include-dev }}" = "true" ]; then
               uv sync
             else

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -20,6 +20,7 @@ runs:
         enable-cache: true
         cache-local-path: "~/.cache/uv"
         prune-cache: false
+        cache-suffix: "${{ inputs.install-mode }}-${{ inputs.include-dev }}"
 
     - name: Create virtual environment with uv
       shell: bash

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -39,7 +39,9 @@ runs:
             uv pip install --no-deps -e ./common
             uv pip install --no-deps -e ./agent
             uv pip install --no-deps -e ./app_backend
-            uv pip install scikit-build-core pytest pytest-cov pytest-xdist pytest-benchmark gcovr
+            uv pip install scikit-build-core
+            uv pip install pytest pytest-cov pytest-xdist pytest-benchmark gcovr
+            uv pip install torch numpy pydantic typing-extensions
             ;;
 
           "linting")

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -18,6 +18,8 @@ runs:
       with:
         version: "0.7.3"
         enable-cache: true
+        cache-local-path: "~/.cache/uv"
+        prune-cache: false
 
     - name: Create virtual environment with uv
       shell: bash

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -30,22 +30,6 @@ runs:
 
         # Handle different installation modes
         case "${{ inputs.install-mode }}" in
-          "no-mettagrid")
-            # Install specific workspace members excluding mettagrid
-            echo "Installing dependencies and workspace members (except mettagrid)..."
-            # First sync to get all external dependencies
-            uv sync --no-install-workspace
-            # Then install specific workspace members (excluding mettagrid)
-            uv pip install --no-deps -e .
-            uv pip install --no-deps -e ./common
-            uv pip install --no-deps -e ./agent
-            uv pip install --no-deps -e ./app_backend
-            # Also install mettagrid's build dependencies
-            echo "Installing build dependencies..."
-            uv pip install scikit-build-core
-            echo "Installing test dependencies..."
-            uv pip install pytest pytest-cov gcovr
-            ;;
           "linting")
             # Just install linting tools
             uv pip install ruff cpplint

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -20,7 +20,7 @@ runs:
         enable-cache: true
         cache-local-path: "~/.cache/uv"
         prune-cache: false
-        cache-suffix: "${{ inputs.install-mode }}-${{ inputs.include-dev }}"
+        cache-suffix: "${{ inputs.install-mode }}-${{ inputs.include-dev }}-${{ hashFiles('.github/actions/setup-uv/action.yml') }}"
 
     - name: Create virtual environment with uv
       shell: bash
@@ -35,7 +35,6 @@ runs:
         case "${{ inputs.install-mode }}" in
 
           "testing")
-            uv sync --no-install-workspace
             uv pip install --no-deps -e .
             uv pip install --no-deps -e ./common
             uv pip install --no-deps -e ./agent

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -39,7 +39,7 @@ runs:
             uv pip install --no-deps -e ./common
             uv pip install --no-deps -e ./agent
             uv pip install --no-deps -e ./app_backend
-            uv pip install scikit-build-core pytest pytest-cov gcovr
+            uv pip install scikit-build-core pytest pytest-cov pytest-xdist pytest-benchmark gcovr
             ;;
 
           "linting")

--- a/.github/scripts/check_mettagrid_build.py
+++ b/.github/scripts/check_mettagrid_build.py
@@ -153,7 +153,7 @@ class BuildChecker:
         summary = self.get_summary()
 
         print("\n" + "=" * 80)
-        print("BUILD SUMMARY")
+        print("METTAGRID C++ BUILD SUMMARY")
         print("=" * 80)
 
         if summary["build_success"]:

--- a/.github/scripts/upload_codecov.py
+++ b/.github/scripts/upload_codecov.py
@@ -93,7 +93,7 @@ def main():
 
     subpackages = os.environ.get("SUBPACKAGES", " ".join(DEFAULT_SUBPACKAGES)).split()
     coverage_files = [
-        (Path(f"{pkg}/coverage.xml" if pkg != "core" else "coverage-core.xml"), pkg) for pkg in subpackages
+        (Path('coverage.xml' if pkg == 'core' else f"{pkg}/coverage.xml"), pkg) for pkg in subpackages
     ]
 
     print("🔍 Codecov Upload Plan:")

--- a/.github/scripts/upload_codecov.py
+++ b/.github/scripts/upload_codecov.py
@@ -92,7 +92,9 @@ def main():
         sys.exit(1)
 
     subpackages = os.environ.get("SUBPACKAGES", " ".join(DEFAULT_SUBPACKAGES)).split()
-    coverage_files = [(Path("coverage.xml"), "core")] + [(Path(f"{pkg}/coverage.xml"), pkg) for pkg in subpackages]
+    coverage_files = [
+        (Path(f"{pkg}/coverage.xml" if pkg != "core" else "coverage-core.xml"), pkg) for pkg in subpackages
+    ]
 
     print("🔍 Codecov Upload Plan:")
     for path, flag in coverage_files:

--- a/.github/scripts/upload_codecov.py
+++ b/.github/scripts/upload_codecov.py
@@ -92,9 +92,7 @@ def main():
         sys.exit(1)
 
     subpackages = os.environ.get("SUBPACKAGES", " ".join(DEFAULT_SUBPACKAGES)).split()
-    coverage_files = [
-        (Path('coverage.xml' if pkg == 'core' else f"{pkg}/coverage.xml"), pkg) for pkg in subpackages
-    ]
+    coverage_files = [(Path("coverage.xml" if pkg == "core" else f"{pkg}/coverage.xml"), pkg) for pkg in subpackages]
 
     print("🔍 Codecov Upload Plan:")
     for path, flag in coverage_files:

--- a/.github/workflows/asana-integration.yml
+++ b/.github/workflows/asana-integration.yml
@@ -3,7 +3,8 @@ name: Asana Integration
 on:
   pull_request:
     # TODO: also handle reviews and comments
-    types: [opened, closed, reopened, edited, assigned, unassigned, review_requested, ready_for_review]
+    types:
+      [opened, closed, reopened, edited, assigned, unassigned, review_requested, ready_for_review]
 
 jobs:
   check-context:
@@ -18,7 +19,6 @@ jobs:
       - name: Detect PR context
         id: detect-pr
         uses: ./.github/actions/detect-external-pr
-
 
   asana_integration:
     needs: check-context

--- a/.github/workflows/auto-tag-researcher-current.yml
+++ b/.github/workflows/auto-tag-researcher-current.yml
@@ -11,43 +11,43 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Check if locked
-      id: check_lock
-      run: |
-        # Check if the lock tag exists
-        if git ls-remote --tags origin | grep -q "refs/tags/researcher_current_lock"; then
-          echo "locked=true" >> $GITHUB_OUTPUT
-          echo "System is locked with researcher_current_lock tag - skipping auto-update"
+      - name: Check if locked
+        id: check_lock
+        run: |
+          # Check if the lock tag exists
+          if git ls-remote --tags origin | grep -q "refs/tags/researcher_current_lock"; then
+            echo "locked=true" >> $GITHUB_OUTPUT
+            echo "System is locked with researcher_current_lock tag - skipping auto-update"
 
-          # Get lock tag info
-          LOCK_COMMIT=$(git ls-remote --tags origin | grep "refs/tags/researcher_current_lock" | cut -f1)
-          echo "Lock tag points to commit: ${LOCK_COMMIT:0:8}"
-        else
-          echo "locked=false" >> $GITHUB_OUTPUT
-          echo "System is not locked - will update researcher_current"
-        fi
+            # Get lock tag info
+            LOCK_COMMIT=$(git ls-remote --tags origin | grep "refs/tags/researcher_current_lock" | cut -f1)
+            echo "Lock tag points to commit: ${LOCK_COMMIT:0:8}"
+          else
+            echo "locked=false" >> $GITHUB_OUTPUT
+            echo "System is not locked - will update researcher_current"
+          fi
 
-    - name: Update researcher_current tag
-      if: steps.check_lock.outputs.locked == 'false'
-      run: |
-        # Configure git
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Update researcher_current tag
+        if: steps.check_lock.outputs.locked == 'false'
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        # Delete existing tag locally and remotely if it exists
-        if git tag -l | grep -q "^researcher_current$"; then
-          git tag -d researcher_current
-          git push origin :refs/tags/researcher_current || true
-        fi
+          # Delete existing tag locally and remotely if it exists
+          if git tag -l | grep -q "^researcher_current$"; then
+            git tag -d researcher_current
+            git push origin :refs/tags/researcher_current || true
+          fi
 
-        # Create new tag at current commit
-        git tag researcher_current
-        git push origin researcher_current
+          # Create new tag at current commit
+          git tag researcher_current
+          git push origin researcher_current
 
-        echo "Updated researcher_current tag to commit ${{ github.sha }}"
+          echo "Updated researcher_current tag to commit ${{ github.sha }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -161,13 +161,26 @@ jobs:
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
     outputs:
-      build_success: ${{ steps.mettagrid_build_check.outputs.build_success }}
+      venv_cache_key: ${{ steps.compute_venv_key.outputs.key }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup uv
+      - name: Compute venv cache key
+        id: compute_venv_key
+        run: |
+          echo "key=${{ runner.os }}-venv-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      # Build fresh env (authoritative)
+      - name: Setup uv (fresh build)
         uses: ./.github/actions/setup-uv
+
+      # Save newly built env to cache
+      - name: Save venv cache
+        uses: actions/cache/save@v4
+        with:
+          path: .venv
+          key: ${{ steps.compute_venv_key.outputs.key }}
 
   test-matrix:
     name: "Unit Tests - ${{ matrix.package }}"
@@ -186,8 +199,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
+      - name: Restore virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          path: .venv
+          key: ${{ needs.test-setup.outputs.venv_cache_key }}
+
+      - name: Activate cached venv
+        shell: bash
+        run: |
+          if [ ! -d ".venv" ]; then
+            echo "::error::Cached .venv missing!"
+            exit 1
+          fi
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run tests
         run: |
@@ -269,8 +295,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
+      - name: Restore virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          path: .venv
+          key: ${{ needs.test-setup.outputs.venv_cache_key }}
+
+      - name: Activate cached venv
+        shell: bash
+        run: |
+          if [ ! -d ".venv" ]; then
+            echo "::error::Cached .venv missing!"
+            exit 1
+          fi
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Training smoke test
         id: train
@@ -361,8 +400,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
+      - name: Restore virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          path: .venv
+          key: ${{ needs.test-setup.outputs.venv_cache_key }}
+
+      - name: Activate cached venv
+        shell: bash
+        run: |
+          if [ ! -d ".venv" ]; then
+            echo "::error::Cached .venv missing!"
+            exit 1
+          fi
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run Python benchmarks
         env:
@@ -396,8 +448,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
+      - name: Restore virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          path: .venv
+          key: ${{ needs.test-setup.outputs.venv_cache_key }}
+
+      - name: Activate cached venv
+        shell: bash
+        run: |
+          if [ ! -d ".venv" ]; then
+            echo "::error::Cached .venv missing!"
+            exit 1
+          fi
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Build and run C++ benchmarks
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -173,7 +173,7 @@ jobs:
         uses: ./.github/actions/setup-uv
 
       - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid'
+        if: matrix.package == 'mettagrid' || matrix.package == 'core'
         id: mettagrid_build_check
         run: |
           .github/scripts/check_mettagrid_build.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -173,7 +173,7 @@ jobs:
         uses: ./.github/actions/setup-uv
 
       - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid' || matrix.package == 'core'
+        if: matrix.package == 'mettagrid'
         id: mettagrid_build_check
         run: |
           .github/scripts/check_mettagrid_build.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -171,6 +171,8 @@ jobs:
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
+        with:
+          install-mode: "testing"
 
       - name: Run tests
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -124,7 +124,7 @@ jobs:
 
   lint:
     name: "Lint"
-    needs: [graphite-ci-optimizer, setup-checks]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_lint == 'true')
@@ -156,7 +156,7 @@ jobs:
   test-setup:
     name: Setup Test Environment
     runs-on: ubuntu-latest
-    needs: [setup-checks, graphite-ci-optimizer]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
@@ -180,9 +180,9 @@ jobs:
         run: |
           uv pip install --no-build-isolation --no-deps -e ./mettagrid
 
-  test:
-    name: "Tests - ${{ matrix.package }}"
-    needs: [test-setup, graphite-ci-optimizer, setup-checks]
+  test-matrix:
+    name: "Unit Tests - ${{ matrix.package }}"
+    needs: [test-setup]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
@@ -239,8 +239,8 @@ jobs:
           verbose: true
 
   tests-summary:
-    name: "Tests"
-    needs: [test]
+    name: "Check Tests"
+    needs: [test-matrix]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -261,7 +261,7 @@ jobs:
     name: "Smoke Tests"
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false')
-    needs: [graphite-ci-optimizer, setup-checks]
+    needs: [setup-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -352,7 +352,7 @@ jobs:
 
   python-benchmark:
     name: "Python Benchmarks"
-    needs: [graphite-ci-optimizer, setup-checks]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
@@ -387,7 +387,7 @@ jobs:
 
   cpp-benchmark:
     name: "C++ Benchmarks"
-    needs: [graphite-ci-optimizer, setup-checks]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
@@ -421,7 +421,7 @@ jobs:
 
   upload-benchmarks:
     name: "Upload Benchmarks"
-    needs: [python-benchmark, cpp-benchmark, setup-checks]
+    needs: [python-benchmark, cpp-benchmark]
     if: |
       (needs.setup-checks.outputs.run_benchmark == 'true') &&
       (always() && (needs.python-benchmark.result == 'success' || needs.cpp-benchmark.result == 'success'))

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -242,6 +242,25 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  tests-summary:
+    name: "Tests"
+    needs: [test-matrix]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          echo "Test job results: ${{ toJSON(needs) }}"
+          if [ "${{ contains(join(needs.*.result, ','), 'failure') }}" == "true" ]; then
+            echo "One or more test jobs failed"
+            exit 1
+          elif [ "${{ contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]; then
+            echo "One or more test jobs were cancelled"
+            exit 1
+          else
+            echo "All test jobs completed successfully"
+          fi
+
   smoke-test:
     name: "Smoke Tests"
     if: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -206,7 +206,7 @@ jobs:
           .github/scripts/check_mettagrid_build.py
 
       - name: Check MettaGrid build warnings
-        if: always()
+        if: matrix.package == 'mettagrid'
         run: |
           errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
           warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -171,8 +171,7 @@ jobs:
         run: |
           echo "key=${{ runner.os }}-venv-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
-      # Build fresh env (authoritative)
-      - name: Setup uv (fresh build)
+      - name: Setup uv
         uses: ./.github/actions/setup-uv
 
       # Save newly built env to cache
@@ -205,15 +204,8 @@ jobs:
           path: .venv
           key: ${{ needs.test-setup.outputs.venv_cache_key }}
 
-      - name: Activate cached venv
-        shell: bash
-        run: |
-          if [ ! -d ".venv" ]; then
-            echo "::error::Cached .venv missing!"
-            exit 1
-          fi
-          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
-          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Run tests
         run: |
@@ -310,6 +302,16 @@ jobs:
           fi
           echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
           echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Debug venv contents
+        run: |
+          ls -lah .venv
+          ls -lah .venv/bin
+          which python
+          python --version
+          which pytest
+          pytest --version || true
+
 
       - name: Training smoke test
         id: train

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -175,7 +175,7 @@ jobs:
           install-mode: 'testing'
 
       - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid' || matrix.package == 'core'
+        if: matrix.package == 'mettagrid'
         id: mettagrid_build_check
         run: |
           .github/scripts/check_mettagrid_build.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -172,7 +172,13 @@ jobs:
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
-          install-mode: "testing"
+          install-mode: 'testing'
+
+      - name: Build MettaGrid C++
+        if: matrix.package == 'mettagrid' || matrix.package == 'core'
+        id: mettagrid_build_check
+        run: |
+          .github/scripts/check_mettagrid_build.py
 
       - name: Run tests
         run: |
@@ -198,12 +204,6 @@ jobs:
         run: |
           chmod +x .github/scripts/upload_codecov.py
           SUBPACKAGES="${{ matrix.package }}" .github/scripts/upload_codecov.py
-
-      - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid'
-        id: mettagrid_build_check
-        run: |
-          .github/scripts/check_mettagrid_build.py
 
       - name: Run MettaGrid C++ coverage
         if: matrix.package == 'mettagrid'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -180,7 +180,6 @@ jobs:
         run: |
           uv pip install --no-build-isolation --no-deps -e ./mettagrid
 
-
   test:
     name: "Tests - ${{ matrix.package }}"
     needs: [test-setup, graphite-ci-optimizer, setup-checks]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ permissions:
 env:
   HYDRA_FULL_ERROR: 1
   VENV_PATH: .venv
-  PYTEST_WORKERS: auto
+  PYTEST_WORKERS: 4
 
 jobs:
   # check if CI should run based on Graphite's stack position
@@ -160,7 +160,7 @@ jobs:
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -174,12 +174,6 @@ jobs:
         with:
           install-mode: 'testing'
 
-      - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid'
-        id: mettagrid_build_check
-        run: |
-          .github/scripts/check_mettagrid_build.py
-
       - name: Run tests
         run: |
           PYTEST_ARGS="-n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v --cov-report=xml:coverage.xml"
@@ -197,13 +191,39 @@ jobs:
           fi
           pytest $PYTEST_ARGS
 
-      - name: Upload coverage to Codecov
+      - name: Upload python test coverage to Codecov
         if: needs.setup-checks.outputs.is_external != 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           chmod +x .github/scripts/upload_codecov.py
           SUBPACKAGES="${{ matrix.package }}" .github/scripts/upload_codecov.py
+
+      - name: Build MettaGrid C++
+        if: matrix.package == 'mettagrid'
+        id: mettagrid_build_check
+        run: |
+          .github/scripts/check_mettagrid_build.py
+
+      - name: Check MettaGrid build warnings
+        if: always()
+        run: |
+          errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
+          warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}
+          max_warnings=${{ vars.MAX_ALLOWED_METTAGRID_WARNINGS || 1000 }}
+
+          echo "Build Summary: $errors errors, $warnings warnings"
+          echo "Maximum allowed warnings: $max_warnings"
+
+          if [ "$errors" -gt 0 ]; then
+            echo "❌ MettaGrid has build errors!"
+            exit 1
+          elif [ "$warnings" -gt "$max_warnings" ]; then
+            echo "⚠️ Too many warnings in MettaGrid build ($warnings > $max_warnings)"
+            exit 1
+          else
+            echo "✅ MettaGrid build quality check passed"
+          fi
 
       - name: Run MettaGrid C++ coverage
         if: matrix.package == 'mettagrid'
@@ -221,25 +241,6 @@ jobs:
           name: mettagrid-cpp-coverage
           fail_ci_if_error: false
           verbose: true
-
-  tests-summary:
-    name: "Check Tests"
-    needs: [test-matrix]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check test results
-        run: |
-          echo "Test job results: ${{ toJSON(needs) }}"
-          if [ "${{ contains(join(needs.*.result, ','), 'failure') }}" == "true" ]; then
-            echo "❌ One or more test jobs failed"
-            exit 1
-          elif [ "${{ contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]; then
-            echo "⚠️ One or more test jobs were cancelled"
-            exit 1
-          else
-            echo "✅ All test jobs completed successfully"
-          fi
 
   smoke-test:
     name: "Smoke Tests"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -183,6 +183,12 @@ jobs:
         package: [core, app_backend, agent, mettagrid, common]
     steps:
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
+
       - name: Run tests
         run: |
           PYTEST_ARGS="-n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v --cov-report=xml:coverage.xml"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,22 +163,11 @@ jobs:
     outputs:
       build_success: ${{ steps.mettagrid_build_check.outputs.build_success }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
-        with:
-          install-mode: "no-mettagrid"
-
-      - name: Build MettaGrid C++
-        id: mettagrid_build_check
-        run: |
-          .github/scripts/check_mettagrid_build.py
-
-      - name: Install mettagrid
-        if: steps.mettagrid_build_check.outputs.build_success == 'true'
-        run: |
-          uv pip install --no-build-isolation --no-deps -e ./mettagrid
 
   test-matrix:
     name: "Unit Tests - ${{ matrix.package }}"
@@ -193,8 +182,6 @@ jobs:
       matrix:
         package: [core, app_backend, agent, mettagrid, common]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Run tests
         run: |
@@ -220,6 +207,12 @@ jobs:
         run: |
           chmod +x .github/scripts/upload_codecov.py
           SUBPACKAGES="${{ matrix.package }}" .github/scripts/upload_codecov.py
+
+      - name: Build MettaGrid C++
+        if: matrix.package == 'mettagrid'
+        id: mettagrid_build_check
+        run: |
+          .github/scripts/check_mettagrid_build.py
 
       - name: Run MettaGrid C++ coverage
         if: matrix.package == 'mettagrid'
@@ -261,17 +254,12 @@ jobs:
     name: "Smoke Tests"
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false')
-    needs: [setup-checks]
+    needs: [test-setup]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       CHECKPOINT_PATH: ./train_dir/github_test/checkpoints/
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
 
       - name: Training smoke test
         id: train
@@ -352,18 +340,13 @@ jobs:
 
   python-benchmark:
     name: "Python Benchmarks"
-    needs: [setup-checks]
+    needs: [test-setup]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
 
       - name: Run Python benchmarks
         env:
@@ -387,18 +370,13 @@ jobs:
 
   cpp-benchmark:
     name: "C++ Benchmarks"
-    needs: [setup-checks]
+    needs: [test-setup]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
 
       - name: Build and run C++ benchmarks
         run: |
@@ -428,8 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+
 
       - name: Download Python benchmark results
         uses: actions/download-artifact@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -492,6 +492,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Download Python benchmark results
         uses: actions/download-artifact@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -155,7 +155,7 @@ jobs:
         run: ./mettagrid/tests/cpplint.sh
 
   test:
-    name: "Tests - ${{ matrix.package || 'core' }}"
+    name: "Tests - ${{ matrix.package }}"
     needs: [graphite-ci-optimizer, setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
@@ -166,33 +166,27 @@ jobs:
       fail-fast: false
       matrix:
         package: ['core', app_backend, agent, mettagrid, common]
-    env:
-      SUBPACKAGES: "app_backend agent mettagrid common"  # keep this synced with the non-empty items in strategy.matrix.package
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
-        with:
-          install-mode: "no-mettagrid"
 
       - name: Build MettaGrid C++
-        if: matrix.package == 'core' || matrix.package == 'mettagrid'
+        if: matrix.package == 'mettagrid'
         id: mettagrid_build_check
         run: |
           .github/scripts/check_mettagrid_build.py
 
       - name: Check MettaGrid build warnings
-        if: matrix.package == 'core' && always()
+        if: matrix.package == 'mettagrid' && always()
         run: |
           errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
           warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}
           max_warnings=${{ vars.MAX_ALLOWED_METTAGRID_WARNINGS || 1000 }}
-
           echo "Build Summary: $errors errors, $warnings warnings"
           echo "Maximum allowed warnings: $max_warnings"
-
           if [ "$errors" -gt 0 ]; then
             echo "❌ MettaGrid has build errors!"
             exit 1
@@ -203,25 +197,22 @@ jobs:
             echo "✅ MettaGrid build quality check passed"
           fi
 
-      - name: Install metta-mettagrid package
-        if: (matrix.package == 'core' || matrix.package == 'mettagrid') && steps.mettagrid_build_check.outputs.build_success == 'true'
-        run: |
-          uv pip install --no-build-isolation --no-deps -e ./mettagrid
-
       - name: Run tests
         run: |
+          PYTEST_ARGS="-n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v --cov-report=xml:coverage.xml"
           if [ "${{ matrix.package }}" == "core" ]; then
-            # build ignore list from SUBPACKAGES
+            # Define packages to ignore (keep synced with non-core items in matrix)
+            SUBPACKAGES=(app_backend agent mettagrid common)
             IGNORE_ARGS=""
-            for pkg in $SUBPACKAGES; do
+            for pkg in "${SUBPACKAGES[@]}"; do
               IGNORE_ARGS="$IGNORE_ARGS --ignore=$pkg"
             done
-            pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml:coverage.xml --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v $IGNORE_ARGS
+            PYTEST_ARGS="$PYTEST_ARGS $IGNORE_ARGS"
           else
             # Subpackage tests
             cd ${{ matrix.package }}
-            pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml:coverage.xml --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v
           fi
+          pytest $PYTEST_ARGS
 
       - name: Upload coverage to Codecov
         if: needs.setup-checks.outputs.is_external != 'true'
@@ -232,13 +223,13 @@ jobs:
           SUBPACKAGES="${{ matrix.package }}" .github/scripts/upload_codecov.py
 
       - name: Run MettaGrid C++ coverage
-        if: matrix.package == 'mettagrid' && steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: matrix.package == 'mettagrid'
         run: |
           cd mettagrid
           make coverage
 
       - name: Upload MettaGrid C++ coverage to Codecov
-        if: matrix.package == 'mettagrid' && needs.setup-checks.outputs.is_external != 'true' && steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: matrix.package == 'mettagrid' && needs.setup-checks.outputs.is_external != 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,7 @@ permissions:
 env:
   HYDRA_FULL_ERROR: 1
   VENV_PATH: .venv
-  PYTEST_WORKERS: 4
+  PYTEST_WORKERS: auto
 
 jobs:
   # check if CI should run based on Graphite's stack position
@@ -153,9 +153,37 @@ jobs:
       - name: Run cpplint
         run: ./mettagrid/tests/cpplint.sh
 
+  test-setup:
+    name: Setup Test Environment
+    runs-on: ubuntu-latest
+    needs: [setup-checks, graphite-ci-optimizer]
+    if: |
+      (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
+      (needs.setup-checks.outputs.run_test == 'true')
+    outputs:
+      build_success: ${{ steps.mettagrid_build_check.outputs.build_success }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
+        with:
+          install-mode: "no-mettagrid"
+
+      - name: Build MettaGrid C++
+        id: mettagrid_build_check
+        run: |
+          .github/scripts/check_mettagrid_build.py
+
+      - name: Install mettagrid
+        if: steps.mettagrid_build_check.outputs.build_success == 'true'
+        run: |
+          uv pip install --no-build-isolation --no-deps -e ./mettagrid
+
+
   test:
     name: "Tests - ${{ matrix.package }}"
-    needs: [graphite-ci-optimizer, setup-checks]
+    needs: [test-setup, graphite-ci-optimizer, setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
@@ -164,37 +192,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['core', app_backend, agent, mettagrid, common]
+        package: [core, app_backend, agent, mettagrid, common]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
-
-      - name: Build MettaGrid C++
-        if: matrix.package == 'mettagrid'
-        id: mettagrid_build_check
-        run: |
-          .github/scripts/check_mettagrid_build.py
-
-      - name: Check MettaGrid build warnings
-        if: matrix.package == 'mettagrid' && always()
-        run: |
-          errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
-          warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}
-          max_warnings=${{ vars.MAX_ALLOWED_METTAGRID_WARNINGS || 1000 }}
-          echo "Build Summary: $errors errors, $warnings warnings"
-          echo "Maximum allowed warnings: $max_warnings"
-          if [ "$errors" -gt 0 ]; then
-            echo "❌ MettaGrid has build errors!"
-            exit 1
-          elif [ "$warnings" -gt "$max_warnings" ]; then
-            echo "⚠️ Too many warnings in MettaGrid build ($warnings > $max_warnings)"
-            exit 1
-          else
-            echo "✅ MettaGrid build quality check passed"
-          fi
 
       - name: Run tests
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,8 +33,7 @@ permissions:
 env:
   HYDRA_FULL_ERROR: 1
   VENV_PATH: .venv
-  # Use 4 workers for parallel test execution (GitHub Actions runners have 2 CPU cores)
-  PYTEST_WORKERS: 4
+  PYTEST_WORKERS: auto
 
 jobs:
   # check if CI should run based on Graphite's stack position

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -226,13 +226,13 @@ jobs:
           fi
 
       - name: Run MettaGrid C++ coverage
-        if: matrix.package == 'mettagrid'
+        if: matrix.package == 'mettagrid' && steps.mettagrid_build_check.outputs.build_success == 'true'
         run: |
           cd mettagrid
           make coverage
 
       - name: Upload MettaGrid C++ coverage to Codecov
-        if: matrix.package == 'mettagrid' && needs.setup-checks.outputs.is_external != 'true'
+        if: matrix.package == 'mettagrid' && needs.setup-checks.outputs.is_external != 'true' && steps.mettagrid_build_check.outputs.build_success == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -153,37 +153,10 @@ jobs:
       - name: Run cpplint
         run: ./mettagrid/tests/cpplint.sh
 
-  test-setup:
-    name: Setup Test Environment
-    runs-on: ubuntu-latest
-    needs: [setup-checks]
-    if: |
-      (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
-      (needs.setup-checks.outputs.run_test == 'true')
-    outputs:
-      venv_cache_key: ${{ steps.compute_venv_key.outputs.key }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Compute venv cache key
-        id: compute_venv_key
-        run: |
-          echo "key=${{ runner.os }}-venv-${{ github.sha }}" >> "$GITHUB_OUTPUT"
-
-      - name: Setup uv
-        uses: ./.github/actions/setup-uv
-
-      # Save newly built env to cache
-      - name: Save venv cache
-        uses: actions/cache/save@v4
-        with:
-          path: .venv
-          key: ${{ steps.compute_venv_key.outputs.key }}
 
   test-matrix:
     name: "Unit Tests - ${{ matrix.package }}"
-    needs: [test-setup]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
@@ -197,12 +170,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Restore virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: .venv
-          key: ${{ needs.test-setup.outputs.venv_cache_key }}
 
       - name: Setup uv
         uses: ./.github/actions/setup-uv
@@ -278,7 +245,7 @@ jobs:
     name: "Smoke Tests"
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false')
-    needs: [test-setup]
+    needs: [setup-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -287,31 +254,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: .venv
-          key: ${{ needs.test-setup.outputs.venv_cache_key }}
-
-      - name: Activate cached venv
-        shell: bash
-        run: |
-          if [ ! -d ".venv" ]; then
-            echo "::error::Cached .venv missing!"
-            exit 1
-          fi
-          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
-          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
-
-      - name: Debug venv contents
-        run: |
-          ls -lah .venv
-          ls -lah .venv/bin
-          which python
-          python --version
-          which pytest
-          pytest --version || true
-
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Training smoke test
         id: train
@@ -392,7 +336,7 @@ jobs:
 
   python-benchmark:
     name: "Python Benchmarks"
-    needs: [test-setup]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
@@ -402,21 +346,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: .venv
-          key: ${{ needs.test-setup.outputs.venv_cache_key }}
-
-      - name: Activate cached venv
-        shell: bash
-        run: |
-          if [ ! -d ".venv" ]; then
-            echo "::error::Cached .venv missing!"
-            exit 1
-          fi
-          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
-          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Run Python benchmarks
         env:
@@ -440,7 +371,7 @@ jobs:
 
   cpp-benchmark:
     name: "C++ Benchmarks"
-    needs: [test-setup]
+    needs: [setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_benchmark == 'true')
@@ -450,21 +381,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore virtualenv
-        uses: actions/cache/restore@v4
-        with:
-          path: .venv
-          key: ${{ needs.test-setup.outputs.venv_cache_key }}
-
-      - name: Activate cached venv
-        shell: bash
-        run: |
-          if [ ! -d ".venv" ]; then
-            echo "::error::Cached .venv missing!"
-            exit 1
-          fi
-          echo "VIRTUAL_ENV=$(pwd)/.venv" >> "$GITHUB_ENV"
-          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Build and run C++ benchmarks
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,8 @@ permissions:
 env:
   HYDRA_FULL_ERROR: 1
   VENV_PATH: .venv
-  PYTEST_WORKERS: auto
+  # Use 4 workers for parallel test execution (GitHub Actions runners have 2 CPU cores)
+  PYTEST_WORKERS: 4
 
 jobs:
   # check if CI should run based on Graphite's stack position
@@ -154,13 +155,19 @@ jobs:
         run: ./mettagrid/tests/cpplint.sh
 
   test:
-    name: "Tests"
+    name: "Tests - ${{ matrix.package || 'core' }}"
     needs: [graphite-ci-optimizer, setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
       (needs.setup-checks.outputs.run_test == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ['core', app_backend, agent, mettagrid, common]
+    env:
+      SUBPACKAGES: "app_backend agent mettagrid common"  # keep this synced with the non-empty items in strategy.matrix.package
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -171,12 +178,13 @@ jobs:
           install-mode: "no-mettagrid"
 
       - name: Build MettaGrid C++
+        if: matrix.package == 'core' || matrix.package == 'mettagrid'
         id: mettagrid_build_check
         run: |
           .github/scripts/check_mettagrid_build.py
 
       - name: Check MettaGrid build warnings
-        if: always()
+        if: matrix.package == 'core' && always()
         run: |
           errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
           warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}
@@ -196,40 +204,41 @@ jobs:
           fi
 
       - name: Install metta-mettagrid package
-        if: steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: (matrix.package == 'core' || matrix.package == 'mettagrid') && steps.mettagrid_build_check.outputs.build_success == 'true'
         run: |
           uv pip install --no-build-isolation --no-deps -e ./mettagrid
 
-      - name: Run Pytest on core tests
+      - name: Run tests
         run: |
-          pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml --benchmark-skip --maxfail=1 --disable-warnings  --durations=10 -v
-
-      - name: Run Pytest on subpackage tests
-        env:
-          SUBPACKAGES: "app_backend agent mettagrid common"
-        run: |
-          for package in $SUBPACKAGES; do
-            echo "Running tests for $package..."
-            (cd "$package" && pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml --benchmark-skip --maxfail=1 --disable-warnings  --durations=10 -v) || exit 1
-          done
+          if [ "${{ matrix.package }}" == "core" ]; then
+            # build ignore list from SUBPACKAGES
+            IGNORE_ARGS=""
+            for pkg in $SUBPACKAGES; do
+              IGNORE_ARGS="$IGNORE_ARGS --ignore=$pkg"
+            done
+            pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml:coverage.xml --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v $IGNORE_ARGS
+          else
+            # Subpackage tests
+            cd ${{ matrix.package }}
+            pytest -n ${{ env.PYTEST_WORKERS }} --cov --cov-branch --cov-report=xml:coverage.xml --benchmark-skip --maxfail=1 --disable-warnings --durations=10 -v
+          fi
 
       - name: Upload coverage to Codecov
         if: needs.setup-checks.outputs.is_external != 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          SUBPACKAGES: "app_backend agent mettagrid common"
         run: |
           chmod +x .github/scripts/upload_codecov.py
-          .github/scripts/upload_codecov.py
+          SUBPACKAGES="${{ matrix.package }}" .github/scripts/upload_codecov.py
 
       - name: Run MettaGrid C++ coverage
-        if: steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: matrix.package == 'mettagrid' && steps.mettagrid_build_check.outputs.build_success == 'true'
         run: |
           cd mettagrid
           make coverage
 
       - name: Upload MettaGrid C++ coverage to Codecov
-        if: needs.setup-checks.outputs.is_external != 'true' && steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: matrix.package == 'mettagrid' && needs.setup-checks.outputs.is_external != 'true' && steps.mettagrid_build_check.outputs.build_success == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -239,6 +239,25 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  tests-summary:
+    name: "Tests"
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          echo "Test job results: ${{ toJSON(needs) }}"
+          if [ "${{ contains(join(needs.*.result, ','), 'failure') }}" == "true" ]; then
+            echo "❌ One or more test jobs failed"
+            exit 1
+          elif [ "${{ contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]; then
+            echo "⚠️ One or more test jobs were cancelled"
+            exit 1
+          else
+            echo "✅ All test jobs completed successfully"
+          fi
+
   smoke-test:
     name: "Smoke Tests"
     if: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -206,7 +206,7 @@ jobs:
           .github/scripts/check_mettagrid_build.py
 
       - name: Check MettaGrid build warnings
-        if: matrix.package == 'mettagrid'
+        if: matrix.package == 'mettagrid' && always()
         run: |
           errors=${{ steps.mettagrid_build_check.outputs.total_errors }}
           warnings=${{ steps.mettagrid_build_check.outputs.total_warnings }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -153,7 +153,6 @@ jobs:
       - name: Run cpplint
         run: ./mettagrid/tests/cpplint.sh
 
-
   test-matrix:
     name: "Unit Tests - ${{ matrix.package }}"
     needs: [setup-checks]
@@ -167,7 +166,6 @@ jobs:
       matrix:
         package: [core, app_backend, agent, mettagrid, common]
     steps:
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -266,6 +266,11 @@ jobs:
     env:
       CHECKPOINT_PATH: ./train_dir/github_test/checkpoints/
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Training smoke test
         id: train
@@ -353,6 +358,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Run Python benchmarks
         env:
@@ -383,6 +393,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
       - name: Build and run C++ benchmarks
         run: |
@@ -412,7 +427,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-
 
       - name: Download Python benchmark results
         uses: actions/download-artifact@v4

--- a/.github/workflows/claude-review-base.yml
+++ b/.github/workflows/claude-review-base.yml
@@ -145,7 +145,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
       - name: Check File Changes
         id: check-files
         run: |

--- a/.github/workflows/claude-review-orchestrator.yml
+++ b/.github/workflows/claude-review-orchestrator.yml
@@ -140,4 +140,3 @@ jobs:
           if [ "${{ inputs.run_einops }}" = "true" ]; then
             echo "- Einops Suggestions: ${{ needs.review-einops.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/.github/workflows/generate-newsletter.yml
+++ b/.github/workflows/generate-newsletter.yml
@@ -144,10 +144,10 @@ jobs:
       - name: Fetch previous newsletters
         uses: ./.github/actions/fetch-artifacts
         with:
-          workflow-name: 'generate-newsletter.yml'
-          artifact-name-pattern: 'newsletter-*'
-          num-artifacts: '3'
-          output-directory: 'previous-newsletters'
+          workflow-name: "generate-newsletter.yml"
+          artifact-name-pattern: "newsletter-*"
+          num-artifacts: "3"
+          output-directory: "previous-newsletters"
         continue-on-error: true
 
       - name: Generate Newsletter

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           days-before-stale: ${{ vars.DAYS_BEFORE_PR_IS_STALE || 3 }}
           days-before-close: -1 # Negative value means don't close automatically
-          stale-pr-label: 'stale 🥖'
-          stale-pr-message: 'This PR has been marked as stale due to ${{ vars.DAYS_BEFORE_PR_IS_STALE || 3 }} days of inactivity.'
+          stale-pr-label: "stale 🥖"
+          stale-pr-message: "This PR has been marked as stale due to ${{ vars.DAYS_BEFORE_PR_IS_STALE || 3 }} days of inactivity."
           remove-stale-when-updated: true

--- a/.github/workflows/test-demo-environments.yml
+++ b/.github/workflows/test-demo-environments.yml
@@ -2,17 +2,17 @@ name: Test Demo Environments
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
-      - 'mettagrid/demos/**'
-      - 'mettagrid/src/**'
-      - 'mettagrid/pyproject.toml'
+      - "mettagrid/demos/**"
+      - "mettagrid/src/**"
+      - "mettagrid/pyproject.toml"
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
-      - 'mettagrid/demos/**'
-      - 'mettagrid/src/**'
-      - 'mettagrid/pyproject.toml'
+      - "mettagrid/demos/**"
+      - "mettagrid/src/**"
+      - "mettagrid/pyproject.toml"
   workflow_dispatch:
 
 jobs:
@@ -25,23 +25,23 @@ jobs:
         demo: [demo_train_pettingzoo, demo_train_puffer, demo_train_gym]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Setup uv
-      uses: ./.github/actions/setup-uv
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
 
-    - name: Test ${{ matrix.demo }}
-      run: |
-        echo "Testing ${{ matrix.demo }}..."
-        timeout 45 uv run python mettagrid/demos/${{ matrix.demo }}.py
-        exit_code=$?
-        if [ $exit_code -eq 124 ]; then
-          echo "TIMEOUT: ${{ matrix.demo }} ran for 45 seconds (expected completion ~5s)"
-          exit 1
-        elif [ $exit_code -eq 0 ]; then
-          echo "SUCCESS: ${{ matrix.demo }} completed successfully"
-        else
-          echo "FAILED: ${{ matrix.demo }} failed with exit code $exit_code"
-          exit 1
-        fi
+      - name: Test ${{ matrix.demo }}
+        run: |
+          echo "Testing ${{ matrix.demo }}..."
+          timeout 45 uv run python mettagrid/demos/${{ matrix.demo }}.py
+          exit_code=$?
+          if [ $exit_code -eq 124 ]; then
+            echo "TIMEOUT: ${{ matrix.demo }} ran for 45 seconds (expected completion ~5s)"
+            exit 1
+          elif [ $exit_code -eq 0 ]; then
+            echo "SUCCESS: ${{ matrix.demo }} completed successfully"
+          else
+            echo "FAILED: ${{ matrix.demo }} failed with exit code $exit_code"
+            exit 1
+          fi

--- a/.github/workflows/test-fetch-artifacts.yml
+++ b/.github/workflows/test-fetch-artifacts.yml
@@ -1,11 +1,11 @@
-name: 'Test Fetch Artifacts'
+name: "Test Fetch Artifacts"
 
 on:
   workflow_dispatch:
   push:
     paths:
-      - '.github/actions/fetch-artifacts/**'
-      - '.github/workflows/test-fetch-artifacts.yml'
+      - ".github/actions/fetch-artifacts/**"
+      - ".github/workflows/test-fetch-artifacts.yml"
 
 jobs:
   test-fetch-artifacts:
@@ -18,10 +18,10 @@ jobs:
       - name: Fetch newsletter artifacts
         uses: ./.github/actions/fetch-artifacts
         with:
-          workflow-name: 'generate-newsletter.yml'
-          artifact-name-pattern: 'newsletter-*'
-          num-artifacts: '2'
-          output-directory: 'newsletter-artifacts'
+          workflow-name: "generate-newsletter.yml"
+          artifact-name-pattern: "newsletter-*"
+          num-artifacts: "2"
+          output-directory: "newsletter-artifacts"
 
       - name: List downloaded artifacts
         run: |

--- a/app_backend/src/metta/app_backend/docker-compose.yml
+++ b/app_backend/src/metta/app_backend/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ../../../:/workspace/metta/app_backend
       - /var/run/docker.sock:/var/run/docker.sock
-    command: [ "uv", "run", "python", "-m", "metta.app_backend.eval_task_orchestrator" ]
+    command: ["uv", "run", "python", "-m", "metta.app_backend.eval_task_orchestrator"]
     restart: unless-stopped
     # Run as root to access Docker socket - in production, use a proper docker group
     user: root

--- a/app_backend/tests/test_saved_dashboards.py
+++ b/app_backend/tests/test_saved_dashboards.py
@@ -46,32 +46,56 @@ class TestSavedDashboards(BaseAsyncTest):
     @pytest.mark.asyncio
     async def test_list_saved_dashboards(self, stats_repo: MettaRepo, user_id: str) -> None:
         """Test listing saved dashboards."""
-        dashboard_state = {
+        # Create multiple dashboards to ensure we have at least 2
+        dashboard_state_1 = {
+            "suite": "navigation",
+            "metric": "reward",
+            "group_metric": "",
+            "num_policies_to_show": 20,
+        }
+
+        dashboard_state_2 = {
             "suite": "object_use",
             "metric": "success_rate",
             "group_metric": "group1",
             "num_policies_to_show": 15,
         }
 
-        # Create a test dashboard
+        # Create first dashboard
+        await stats_repo.create_saved_dashboard(
+            user_id=user_id,
+            name="Test Dashboard 1",
+            description="First test dashboard",
+            dashboard_type="heatmap",
+            dashboard_state=dashboard_state_1,
+        )
+
+        # Create second dashboard
         await stats_repo.create_saved_dashboard(
             user_id=user_id,
             name="Test Dashboard 2",
             description="Another test dashboard",
             dashboard_type="heatmap",
-            dashboard_state=dashboard_state,
+            dashboard_state=dashboard_state_2,
         )
 
         # List dashboards
         dashboards = await stats_repo.list_saved_dashboards()
         assert len(dashboards) >= 2
 
-        # Find our test dashboard
-        test_dashboard = next((d for d in dashboards if d["name"] == "Test Dashboard 2"), None)
-        assert test_dashboard is not None
-        assert test_dashboard["description"] == "Another test dashboard"
-        assert test_dashboard["type"] == "heatmap"
-        assert test_dashboard["dashboard_state"] == dashboard_state
+        # Find our test dashboards
+        test_dashboard_1 = next((d for d in dashboards if d["name"] == "Test Dashboard 1"), None)
+        test_dashboard_2 = next((d for d in dashboards if d["name"] == "Test Dashboard 2"), None)
+
+        assert test_dashboard_1 is not None
+        assert test_dashboard_1["description"] == "First test dashboard"
+        assert test_dashboard_1["type"] == "heatmap"
+        assert test_dashboard_1["dashboard_state"] == dashboard_state_1
+
+        assert test_dashboard_2 is not None
+        assert test_dashboard_2["description"] == "Another test dashboard"
+        assert test_dashboard_2["type"] == "heatmap"
+        assert test_dashboard_2["dashboard_state"] == dashboard_state_2
 
     @pytest.mark.asyncio
     async def test_delete_saved_dashboard(self, stats_repo: MettaRepo, user_id: str) -> None:

--- a/tests/tools/map/maze.yaml
+++ b/tests/tools/map/maze.yaml
@@ -20,7 +20,7 @@ root:
             scene:
               type: metta.map.scenes.inline_ascii.InlineAscii
               params:
-                data: '@'
+                data: "@"
           - where:
               tags:
                 - bottom-right

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -155,7 +155,7 @@ class TestRendererJob:
             print(f"DEBUG_MAP_URI: {env.get('DEBUG_MAP_URI')}")
 
             try:
-                timeout = 120
+                timeout = 180
                 print(f'Running cmd "{cmd}" with timeout {timeout} sec')
                 result = subprocess.run(
                     cmd,

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -159,7 +159,7 @@ class TestRendererJob:
             print(f"DEBUG_MAP_URI: {env.get('DEBUG_MAP_URI')}")
 
             try:
-                timeout = 240
+                timeout = 300
                 print(f'Running cmd "{cmd}" with timeout {timeout} sec')
                 result = subprocess.run(
                     cmd,

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -132,6 +132,7 @@ class TestRendererJob:
                 f"run={run_name}",
                 "+hardware=macbook",
                 f"data_dir={temp_dir}",
+                "trainer.simulation.replay_dir=${run_dir}/replays/",
                 "trainer.curriculum=/env/mettagrid/debug",
                 "trainer.total_timesteps=50",  # Minimal training
                 "trainer.num_workers=1",
@@ -160,7 +161,7 @@ class TestRendererJob:
                     env=env,
                     capture_output=True,
                     text=True,
-                    timeout=60,  # Shorter timeout for CI
+                    timeout=120,
                     cwd=Path.cwd(),
                 )
             except subprocess.TimeoutExpired as e:

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -125,12 +125,16 @@ class TestRendererJob:
             print(f"Full map path: {full_map_path}")
             print(f"Map file exists: {full_map_path.exists()}")
 
+            # Detect if running in CI
+            is_ci = os.environ.get("CI", "").lower() == "true"
+            hardware_config = "+hardware=github" if is_ci else "+hardware=macbook"
+
             cmd = [
                 "python",
                 "-m",
                 "tools.train",
                 f"run={run_name}",
-                "+hardware=macbook",
+                hardware_config,
                 f"data_dir={temp_dir}",
                 "trainer.simulation.replay_dir=${run_dir}/replays/",
                 "trainer.curriculum=/env/mettagrid/debug",

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -61,7 +61,7 @@ class TestRendererJob:
                     cmd,
                     capture_output=True,
                     text=True,
-                    timeout=30,  # Short timeout
+                    timeout=60,  # Short timeout
                     cwd=Path.cwd(),
                 )
 
@@ -161,7 +161,7 @@ class TestRendererJob:
                     env=env,
                     capture_output=True,
                     text=True,
-                    timeout=120,
+                    timeout=120,  # Shorter timeout for CI
                     cwd=Path.cwd(),
                 )
             except subprocess.TimeoutExpired as e:

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -155,7 +155,7 @@ class TestRendererJob:
             print(f"DEBUG_MAP_URI: {env.get('DEBUG_MAP_URI')}")
 
             try:
-                timeout = 180
+                timeout = 240
                 print(f'Running cmd "{cmd}" with timeout {timeout} sec')
                 result = subprocess.run(
                     cmd,

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -155,17 +155,18 @@ class TestRendererJob:
             print(f"DEBUG_MAP_URI: {env.get('DEBUG_MAP_URI')}")
 
             try:
-                # Run with shorter timeout and better error handling
+                timeout = 120
+                print(f'Running cmd "{cmd}" with timeout {timeout} sec')
                 result = subprocess.run(
                     cmd,
                     env=env,
                     capture_output=True,
                     text=True,
-                    timeout=120,  # Shorter timeout for CI
+                    timeout=timeout,
                     cwd=Path.cwd(),
                 )
             except subprocess.TimeoutExpired as e:
-                print("\n=== Command timed out after 60 seconds ===")
+                print(f"\n=== Command timed out after {timeout} seconds ===")
 
                 # Decode bytes to string, defaulting to empty string if None
                 stdout_text = e.stdout.decode("utf-8") if e.stdout else "None"

--- a/tests/tools/test_renderer_job.py
+++ b/tests/tools/test_renderer_job.py
@@ -166,8 +166,13 @@ class TestRendererJob:
                 )
             except subprocess.TimeoutExpired as e:
                 print("\n=== Command timed out after 60 seconds ===")
-                print(f"Partial STDOUT: {e.stdout if e.stdout else 'None'}")
-                print(f"Partial STDERR: {e.stderr if e.stderr else 'None'}")
+
+                # Decode bytes to string, defaulting to empty string if None
+                stdout_text = e.stdout.decode("utf-8") if e.stdout else "None"
+                stderr_text = e.stderr.decode("utf-8") if e.stderr else "None"
+
+                print(f"Partial STDOUT: {stdout_text}")
+                print(f"Partial STDERR: {stderr_text}")
                 pytest.fail(f"Training validation timed out for {env_name}")
             except Exception as e:
                 print("\n=== Unexpected error running subprocess ===")


### PR DESCRIPTION

This switches unit tests to a matrix strategy which helps speed things up a bit.
We also adjusted some timeouts and improved the uv setup cache strategy -- although that did not make a bit difference.

We should revisit this after we finish up #1385 since the core unit tests are a clear bottleneck.


Edited: I've had CI fail because it exceeds 15 minutes several times. This attempts to speed it up

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210853241319543)