### PR TITLE
Heavily reduce the amount of $sampling

### DIFF
--- a/configs/env/mettagrid/extended_sequence/backchain1.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain1.yaml
@@ -17,12 +17,12 @@ game:
       battery_green: 1
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1,0.01}
-        battery_red: ${sampling:0.01,0.3,0.1}
-        ore_blue: ${sampling:0.005,0.1,0.01}
-        battery_blue: ${sampling:0.01,0.3,0.1}
-        ore_green: ${sampling:0.005,0.1,0.01}
-        battery_green: ${sampling:0.01,0.3,0.1}
+        ore_red: 0.01
+        battery_red: 0.1
+        ore_blue: 0.01
+        battery_blue: 0.1
+        ore_green: 0.01
+        battery_green: 0.1
         heart: 1
 
   map_builder:
@@ -32,14 +32,14 @@ game:
 
     room:
       _target_: metta.mettagrid.room.navigation.varied_terrain.VariedTerrain
-      width: ${sampling:12,20,15}
-      height: ${sampling:12,20,15}
-      border_width: ${sampling:1,6,3}
+      width: 15
+      height: 15
+      border_width: 3
       agents: 1
       style: all-sparse
 
       objects:
-        altar: ${sampling:1,2,3}
+        altar: 2
         mine_red: 0
         generator_red: 0
         mine_blue: 0

--- a/configs/env/mettagrid/extended_sequence/backchain2.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain2.yaml
@@ -18,12 +18,12 @@ game:
       battery_green: 1
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1,0.01}
-        battery_red: ${sampling:0.01,0.3,0.1}
-        ore_blue: ${sampling:0.005,0.1,0.01}
-        battery_blue: ${sampling:0.01,0.3,0.1}
-        ore_green: ${sampling:0.005,0.1,0.01}
-        battery_green: ${sampling:0.01,0.3,0.1}
+        ore_red: 0.01
+        battery_red: 0.1
+        ore_blue: 0.01
+        battery_blue: 0.1
+        ore_green: 0.01
+        battery_green: 0.1
         heart: 1
 
   map_builder:
@@ -33,16 +33,16 @@ game:
 
     room:
       _target_: metta.mettagrid.room.navigation.varied_terrain.VariedTerrain
-      width: ${sampling:12,20,15}
-      height: ${sampling:12,20,15}
-      border_width: ${sampling:1,6,3}
+      width: 15
+      height: 15
+      border_width: 3
       agents: 1
       style: all-sparse
 
       objects:
-        altar: ${sampling:1,2,3}
+        altar: 2
         mine_red: 0
-        generator_red: ${sampling:1,2,3}
+        generator_red: 2
         mine_blue: 0
         generator_blue: 0
         mine_green: 0
@@ -58,7 +58,7 @@ game:
       conversion_ticks: 1
       initial_resource_count: 0
     generator_red:
-      cooldown: ${sampling:6,20,3}
+      cooldown: 3
       output_resources:
         battery_red: 1
       max_output: 1

--- a/configs/env/mettagrid/extended_sequence/backchain3.yaml
+++ b/configs/env/mettagrid/extended_sequence/backchain3.yaml
@@ -19,12 +19,12 @@ game:
       battery_green: 1
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1,0.01}
-        battery_red: ${sampling:0.01,0.3,0.1}
-        ore_blue: ${sampling:0.005,0.1,0.01}
-        battery_blue: ${sampling:0.01,0.3,0.1}
-        ore_green: ${sampling:0.005,0.1,0.01}
-        battery_green: ${sampling:0.01,0.3,0.1}
+        ore_red: 0.01
+        battery_red: 0.1
+        ore_blue: 0.01
+        battery_blue: 0.1
+        ore_green: 0.01
+        battery_green: 0.1
         heart: 1
 
   map_builder:
@@ -34,16 +34,16 @@ game:
 
     room:
       _target_: metta.mettagrid.room.navigation.varied_terrain.VariedTerrain
-      width: ${sampling:12,20,15}
-      height: ${sampling:12,20,15}
-      border_width: ${sampling:1,6,3}
+      width: 15
+      height: 15
+      border_width: 3
       agents: 1
       style: all-sparse
 
       objects:
-        altar: ${sampling:1,2,3}
-        mine_red: ${sampling:1,2,3}
-        generator_red: ${sampling:1,2,3}
+        altar: 2
+        mine_red: 2
+        generator_red: 2
         mine_blue: 0
         generator_blue: 0
         mine_green: 0

--- a/configs/env/mettagrid/game/map_builder/maze.yaml
+++ b/configs/env/mettagrid/game/map_builder/maze.yaml
@@ -1,8 +1,8 @@
 _target_: metta.map.mapgen.MapGen
 
 border_width: 1
-width: ${sampling:10,40,17}
-height: ${sampling:10,40,17}
+width: 17
+height: 17
 
 instances: 4
 instance_border_width: 5

--- a/configs/env/mettagrid/multiagent/experiments/boxshare.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/boxshare.yaml
@@ -6,9 +6,9 @@ game:
   map_builder:
     _target_: metta.mettagrid.room.multi_agent.boxshare.BoxShare
     border_width: 0
-    width: ${sampling:40,60,45}
-    height: ${sampling:40,60,45}
+    width: 45
+    height: 45
     objects:
-      altar: ${sampling:7,14,10}
-      mine_red: ${sampling:7,14,10}
-      generator_red: ${sampling:8,16,12}
+      altar: 10
+      mine_red: 10
+      generator_red: 12

--- a/configs/env/mettagrid/multiagent/experiments/boxy.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/boxy.yaml
@@ -6,6 +6,6 @@ game:
   map_builder:
     _target_: metta.mettagrid.room.multi_agent.boxy.Boxy
     objects:
-      altar: ${sampling:10,14,12}
-      mine_red: ${sampling:30,60,45}
-      generator_red: ${sampling:30,60,45}
+      altar: 12
+      mine_red: 45
+      generator_red: 45

--- a/configs/env/mettagrid/multiagent/experiments/cylinder_world.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/cylinder_world.yaml
@@ -8,6 +8,6 @@ game:
   map_builder:
     _target_: metta.mettagrid.room.navigation.cylinder_world_sequence.CylinderWorldSequence
     objects:
-      altar: ${sampling:15,25,20}
-      mine_red: ${sampling:15,25,20}
-      generator_red: ${sampling:15,25,20}
+      altar: 20
+      mine_red: 20
+      generator_red: 20

--- a/configs/env/mettagrid/multiagent/experiments/defaults.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/defaults.yaml
@@ -11,16 +11,16 @@ game:
   agent:
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
+        ore_red: 0.01
         ore_red_max: 3
-        battery_red: ${sampling:0.01,0.5, 0.1}
+        battery_red: 0.1
         battery_red_max: 5
         heart: 1
         heart_max: null
   map_builder:
     _target_: ???
-    width: ${sampling:50,100,90}
-    height: ${sampling:50,100,90}
+    width: 90
+    height: 90
     border_width: 2
     agents: 32
     objects: ???
@@ -29,9 +29,9 @@ game:
       input_resources:
         battery_red: 1
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     generator_red:
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 15

--- a/configs/env/mettagrid/multiagent/experiments/manhatten.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/manhatten.yaml
@@ -5,12 +5,12 @@ defaults:
 game:
   map_builder:
     _target_: metta.mettagrid.room.multi_agent.manhatten.Manhatten
-    width: ${sampling:60,120,90}
-    height: ${sampling:60,120,90}
-    corridor_spacing: ${sampling:15,40,25}
-    alcove_prob: ${sampling:0.05,0.3,0.15}
-    heart_prob: ${sampling:0.05,0.15,0.1}
+    width: 90
+    height: 90
+    corridor_spacing: 25
+    alcove_prob: 0.15
+    heart_prob: 0.1
     objects:
-      altar: ${sampling:5,15,10}
-      mine_red: ${sampling:5,15,10}
-      generator_red: ${sampling:5,15,10}
+      altar: 10
+      mine_red: 10
+      generator_red: 10

--- a/configs/env/mettagrid/multiagent/experiments/narrow_world.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/narrow_world.yaml
@@ -7,6 +7,6 @@ game:
     _target_: metta.mettagrid.room.multi_agent.narrow_world.NarrowWorld
     border_width: 0
     objects:
-      altar: ${sampling:20,60,40}
-      mine_red: ${sampling:20,60,40}
-      generator_red: ${sampling:20,60,40}
+      altar: 40
+      mine_red: 40
+      generator_red: 40

--- a/configs/env/mettagrid/multiagent/experiments/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/terrain_from_numpy.yaml
@@ -13,19 +13,19 @@ game:
   agent:
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
-        ore_blue: ${sampling:0.005,0.1, 0.01}
-        ore_green: ${sampling:0.005,0.1, 0.01}
+        ore_red: 0.01
+        ore_blue: 0.01
+        ore_green: 0.01
         ore_green_max: 3
         ore_blue_max: 3
         ore_red_max: 3
-        battery_red: ${sampling:0.01,0.5, 0.1}
+        battery_red: 0.1
         battery_red_max: 3
-        laser: ${sampling:0.005,0.1, 0.01}
+        laser: 0.01
         laser_max: 1
-        blueprint: ${sampling:0.005,0.1, 0.01}
+        blueprint: 0.01
         blueprint_max: 1
-        armor: ${sampling:0.005,0.1, 0.01}
+        armor: 0.01
         armor_max: 1
         heart: 1
   map_builder:
@@ -34,45 +34,45 @@ game:
     border_width: 6
     room:
       _target_: metta.mettagrid.room.terrain_from_numpy.TerrainFromNumpy
-      border_width: ${sampling:1,6,3}
+      border_width: 3
       agents: 8
       objects:
-        mine_red: ${sampling:1,20,10}
-        # mine_blue: ${sampling:0,5,10}
-        # mine_green: ${sampling:0,5,10}
-        generator_red: ${sampling:1,20,10}
-        # generator_blue: ${sampling:0,5,10}
-        # generator_green: ${sampling:0,5,10}
-        altar: ${sampling:0,5,10}
-        armory: ${sampling:0,5,10}
-        lasery: ${sampling:0,5,10}
-        lab: ${sampling:0,5,10}
-        factory: ${sampling:0,5,10}
-        temple: ${sampling:1,5,1}
-        block: ${sampling:5,50,20}
-        wall: ${sampling:5,50,20}
+        mine_red: 10
+        # mine_blue: 5
+        # mine_green: 5
+        generator_red: 10
+        # generator_blue: 5
+        # generator_green: 5
+        altar: 5
+        armory: 5
+        lasery: 5
+        lab: 5
+        factory: 5
+        temple: 1
+        block: 20
+        wall: 20
   objects:
     altar:
       # initial_resource_count: ${choose:0,1}
-      cooldown: ${sampling:5, 50, 10}
+      cooldown: 10
       input_resources:
         battery_red: 1
 
     generator_red:
       # initial_resource_count: ${choose:0,1}
-      cooldown: ${sampling:5, 50, 10}
+      cooldown: 10
 
     # generator_blue:
-    #   cooldown: ${sampling:3, 20, 10}
+    #   cooldown: 10
 
     # generator_green:
-    #   cooldown: ${sampling:3, 20, 10}
+    #   cooldown: 10
 
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 15
 
     # mine_blue:
-    #   cooldown: ${sampling:15, 50, 10}
+    #   cooldown: 15
 
     # mine_green:
-    #   cooldown: ${sampling:15, 50, 10}
+    #   cooldown: 15

--- a/configs/env/mettagrid/multiagent/experiments/varied_terrain.yaml
+++ b/configs/env/mettagrid/multiagent/experiments/varied_terrain.yaml
@@ -12,19 +12,19 @@ game:
   agent:
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
-        ore_blue: ${sampling:0.005,0.1, 0.01}
-        ore_green: ${sampling:0.005,0.1, 0.01}
+        ore_red: 0.01
+        ore_blue: 0.01
+        ore_green: 0.01
         ore_green_max: 3
         ore_blue_max: 3
         ore_red_max: 3
-        battery_red: ${sampling:0.01,0.5, 0.1}
+        battery_red: 0.1
         battery_red_max: 3
-        laser: ${sampling:0.005,0.1, 0.01}
+        laser: 0.01
         laser_max: 1
-        blueprint: ${sampling:0.005,0.1, 0.01}
+        blueprint: 0.01
         blueprint_max: 1
-        armor: ${sampling:0.005,0.1, 0.01}
+        armor: 0.01
         armor_max: 1
         heart: 1
   map_builder:
@@ -33,43 +33,43 @@ game:
     border_width: 6
     room:
       _target_: metta.mettagrid.room.navigation.varied_terrain.VariedTerrain
-      width: ${sampling:20,80,30}
-      height: ${sampling:20,80,30}
-      border_width: ${sampling:1,6,3}
+      width: 30
+      height: 30
+      border_width: 3
       agents: 8
       style: ???
       objects:
-        mine_red: ${sampling:1,10,10}
-        # mine_blue: ${sampling:0,5,10}
-        # mine_green: ${sampling:0,5,10}
-        generator_red: ${sampling:1,10,10}
-        # generator_blue: ${sampling:0,5,10}
-        # generator_green: ${sampling:0,5,10}
-        altar: ${sampling:1,5,10}
-        armory: ${sampling:1,5,10}
-        lasery: ${sampling:1,5,10}
-        lab: ${sampling:1,5,10}
-        factory: ${sampling:1,5,1}
-        temple: ${sampling:1,5,1}
-        block: ${sampling:5,50,20}
-        wall: ${sampling:5,50,20}
+        mine_red: 10
+        # mine_blue: 5
+        # mine_green: 5
+        generator_red: 10
+        # generator_blue: 5
+        # generator_green: 5
+        altar: 5
+        armory: 5
+        lasery: 5
+        lab: 5
+        factory: 1
+        temple: 1
+        block: 20
+        wall: 20
   objects:
     altar:
       # initial_resource_count: ${choose:0,1}
-      cooldown: ${sampling:5, 50, 10}
+      cooldown: 10
       input_resources:
         battery_red: 1
 
     generator_red:
       # initial_resource_count: ${choose:0,1}
-      cooldown: ${sampling:5, 50, 10}
+      cooldown: 10
     # generator_blue:
-    #   cooldown: ${sampling:5, 20, 10}
+    #   cooldown: 10
     # generator_green:
-    #   cooldown: ${sampling:5, 20, 10}
+    #   cooldown: 10
     mine_red:
-      cooldown: ${sampling:15, 50, 20}
+      cooldown: 20
     # mine_blue:
-    #   cooldown: ${sampling:15, 50, 20}
+    #   cooldown: 20
     # mine_green:
-    #   cooldown: ${sampling:15, 50, 20}
+    #   cooldown: 20

--- a/configs/env/mettagrid/multiagent/multiagent/boxshare.yaml
+++ b/configs/env/mettagrid/multiagent/multiagent/boxshare.yaml
@@ -6,9 +6,9 @@ game:
   map_builder:
     _target_: metta.mettagrid.room.multi_agent.boxshare.BoxShare
     border_width: 0
-    width: ${sampling:40,60,45}
-    height: ${sampling:40,60,45}
+    width: 45
+    height: 45
     objects:
-      altar: ${sampling:7,14,10}
-      mine_red: ${sampling:7,14,10}
-      generator_red: ${sampling:8,16,12}
+      altar: 10
+      mine_red: 10
+      generator_red: 12

--- a/configs/env/mettagrid/navigation/evals/emptyspace_sparse.yaml
+++ b/configs/env/mettagrid/navigation/evals/emptyspace_sparse.yaml
@@ -14,6 +14,6 @@ game:
     root:
       type: metta.map.scenes.mean_distance.MeanDistance
       params:
-        mean_distance: ${sampling:20,30,30}
+        mean_distance: 30
         objects:
           altar: 3

--- a/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/cylinder_world.yaml
@@ -10,16 +10,16 @@ game:
   num_agents: 4
   agent:
     resource_limits:
-      ore_red: ${sampling:1,2,3}
-      ore_blue: ${sampling:1,2,3}
-      ore_green: ${sampling:1,2,3}
-      battery_red: ${sampling:1,2,3}
-      battery_blue: ${sampling:1,2,3}
-      battery_green: ${sampling:1,2,3}
+      ore_red: 3
+      ore_blue: 3
+      ore_green: 3
+      battery_red: 3
+      battery_blue: 3
+      battery_green: 3
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
-        battery_red: ${sampling:0.01,0.5, 0.1}
+        ore_red: 0.01
+        battery_red: 0.1
         battery_red_max: 5
         heart: 1
   map_builder:
@@ -28,21 +28,21 @@ game:
     border_width: 6
     room:
       _target_: metta.mettagrid.room.terrain_from_numpy.TerrainFromNumpy
-      border_width: ${sampling:1,6,3}
+      border_width: 3
       agents: 1
       dir: ${choose:varied_terrain/cylinder-world_small,varied_terrain/cylinder-world_medium,varied_terrain/cylinder-world_large}
       objects:
         altar: 5
-        mine_red: ${sampling:1,12,6}
-        generator_red: ${sampling:1,12,6}
+        mine_red: 6
+        generator_red: 6
   objects:
     altar:
       input_resources:
         battery_red: 1
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     generator_red:
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 10

--- a/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/hard_mem_defaults.yaml
@@ -17,12 +17,12 @@ game:
   max_steps: 2000
   agent:
     resource_limits:
-      ore_red: ${sampling:1,10,5}
-      battery_red: ${sampling:1,10,5}
+      ore_red: 5
+      battery_red: 5
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.05, 0.01}
-        battery_red: ${sampling:0.01,0.1, 0.1}
+        ore_red: 0.01
+        battery_red: 0.1
         heart: 1
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
@@ -34,8 +34,8 @@ game:
       agents: 1
       dir: ${choose:varied_terrain/sparse_small,varied_terrain/balanced_small,varied_terrain/dense_small,varied_terrain/maze_small}
       objects:
-        mine_red: ${sampling:1,3,2}
-        generator_red: ${sampling:1,3,2}
+        mine_red: 2
+        generator_red: 2
         altar: 5
 
   objects:
@@ -43,9 +43,9 @@ game:
       input_resources:
         battery_red: 1
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:1, 20, 10}
+      cooldown: 10
     generator_red:
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:30, 70, 40}
+      cooldown: 40
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 10

--- a/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/mem_defaults.yaml
@@ -17,12 +17,12 @@ game:
   max_steps: 2000
   agent:
     resource_limits:
-      ore_red: ${sampling:5,20,15}
-      battery_red: ${sampling:5,20,15}
+      ore_red: 15
+      battery_red: 15
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.05, 0.01}
-        battery_red: ${sampling:0.01,0.1, 0.1}
+        ore_red: 0.01
+        battery_red: 0.1
         heart: 1
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
@@ -34,17 +34,17 @@ game:
       agents: 1
       dir: ${choose:varied_terrain/sparse_small,varied_terrain/balanced_small,varied_terrain/dense_small,varied_terrain/maze_small}
       objects:
-        mine_red: ${sampling:2,10,5}
-        generator_red: ${sampling:2,10,5}
+        mine_red: 5
+        generator_red: 5
         altar: 5
   objects:
     altar:
       input_resources:
         battery_red: 1
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:1, 20, 10}
+      cooldown: 10
     generator_red:
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 10

--- a/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/sequence_defaults.yaml
@@ -19,12 +19,12 @@ game:
   max_steps: 2000
   agent:
     resource_limits:
-      ore_red: ${sampling:5,20,15}
-      battery_red: ${sampling:5,20,15}
+      ore_red: 15
+      battery_red: 15
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
-        battery_red: ${sampling:0.01,0.3, 0.1}
+        ore_red: 0.01
+        battery_red: 0.1
         heart: 1
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
@@ -36,8 +36,8 @@ game:
       agents: 1
       dir: ???
       objects:
-        mine_red: ${sampling:5,20,15}
-        generator_red: ${sampling:5,20,15}
+        mine_red: 15
+        generator_red: 15
         altar: 5
   objects:
     altar:
@@ -47,6 +47,6 @@ game:
       cooldown: 1
     generator_red:
       initial_resource_count: 0
-      cooldown: ${sampling:100,500,100}
+      cooldown: 100
     mine_red:
-      cooldown: ${sampling:100,500,100}
+      cooldown: 100

--- a/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation_sequence/experiments/terrain_from_numpy.yaml
@@ -13,12 +13,12 @@ game:
   max_steps: 2000
   agent:
     resource_limits:
-      ore_red: ${sampling:5,25,15}
-      battery_red: ${sampling:5,25,15}
+      ore_red: 15
+      battery_red: 15
     rewards:
       inventory:
-        ore_red: ${sampling:0.005,0.1, 0.01}
-        battery_red: ${sampling:0.01,0.3, 0.1}
+        ore_red: 0.01
+        battery_red: 0.1
         heart: 1
   map_builder:
     _target_: metta.mettagrid.room.multi_room.MultiRoom
@@ -26,20 +26,20 @@ game:
     border_width: 6
     room:
       _target_: metta.mettagrid.room.terrain_from_numpy.TerrainFromNumpy
-      border_width: ${sampling:1,6,3}
+      border_width: 3
       agents: 1
       objects:
-        mine_red: ${sampling:3,15,2}
-        generator_red: ${sampling:3,15,2}
+        mine_red: 2
+        generator_red: 2
         altar: 5
   objects:
     altar:
       input_resources:
         battery_red: 1
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     generator_red:
       initial_resource_count: ${choose:0,0,0,1}
-      cooldown: ${sampling:5, 20, 10}
+      cooldown: 10
     mine_red:
-      cooldown: ${sampling:15, 50, 10}
+      cooldown: 10


### PR DESCRIPTION
Remove $sampling from most environment configs by replacing it with the provided mid value (or an appropriate seeming value when the parameters were invalid).

The direction we want to move is to have randomness at fewer layers. It should be controlled above for things we want to be able to adjust in curricula, and below for things we don't care about. Aka, randomness in BucketCurricula is okay, and randomness in mapgen is okay, and randomness in OmegaConf is not.

This change does not preserve any randomness in the files is touches. I want feedback on that! This doesn't touch the nav curricula, since I want to preserve randomness there, and so I'll want to convert things to bucketed curricula; but that takes more work. My hope here is to spend an amount of effort proportional to how much we care.

So, if any of these are places where we think the randomness is important, please speak up, and I'll happily do a more random-preserving change instead.

After this, I'll also need to update $choice.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210853702533283)