### PR TITLE
fix variable interpolation

### DIFF
--- a/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
+++ b/configs/env/mettagrid/navigation/training/sparse_bucketed_cfg.yaml
@@ -36,5 +36,5 @@ game:
             type: metta.map.scenes.random.Random
             params:
               objects:
-                altar: ???
+                altar: ${num_altars}
               agents: 1


### PR DESCRIPTION
Fixed altar configuration in sparse bucketed navigation config to use the `num_altars` variable.

In a last minute change to a prior PR, I had swapped the {num_altars} for ???. This is wrong in this context, as the bucketing is done over {num_altars}, not `game.map_builder.root...`. Moreover, I don't think the bucketing can be done over the latter, since the we need to go through a list (vs a dict).

Regardless, this is the version that currently works, and that's better than not working.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210855214856568)