### PR TITLE
Move last reference to private resource out of trainer config

### DIFF
--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -305,7 +305,7 @@ def create_trainer_config(
         config_dict["checkpoint"]["checkpoint_dir"] = f"{cfg.run_dir}/checkpoints"
 
     if "replay_dir" not in config_dict.setdefault("simulation", {}):
-        config_dict["simulation"]["replay_dir"] = f"s3://softmax-public/replays/{cfg.run}"
+        config_dict["simulation"]["replay_dir"] = f"{cfg.run_dir}/replays/"
 
     if "profile_dir" not in config_dict.setdefault("profiler", {}):
         config_dict["profiler"]["profile_dir"] = f"{cfg.run_dir}/torch_traces"

--- a/tests/rl/test_trainer_config.py
+++ b/tests/rl/test_trainer_config.py
@@ -142,7 +142,7 @@ class TestTypedConfigs:
 
         # Test that runtime paths are set correctly
         assert trainer_config.checkpoint.checkpoint_dir == "/tmp/test_run/checkpoints"
-        assert trainer_config.simulation.replay_dir == "s3://softmax-public/replays/test_run"
+        assert trainer_config.simulation.replay_dir == "/tmp/test_run/replays/"
 
     def test_config_field_validation(self):
         # invalid field


### PR DESCRIPTION
trainer.yaml already references the softmax bucket

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210863856292109)