### PR TITLE
Remove unused current_resource_reward field from Agent class

### DIFF
--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -69,7 +69,6 @@ public:
   ObservationType glyph;
   unsigned char agent_id;  // index into MettaGrid._agents (std::vector<Agent*>)
   StatsTracker stats;
-  RewardType current_resource_reward;
   RewardType current_stat_reward;
   RewardType* reward;
 
@@ -90,7 +89,6 @@ public:
         glyph(0),
         agent_id(0),
         stats(),  // default constructor
-        current_resource_reward(0),
         current_stat_reward(0),
         reward(nullptr) {
     GridObject::init(config.type_id, config.type_name, GridLocation(r, c, GridLayer::AgentLayer));
@@ -213,7 +211,6 @@ private:
 
     // Update both the current resource reward and the total reward
     float reward_delta = new_contribution - old_contribution;
-    this->current_resource_reward += reward_delta;
     *this->reward += reward_delta;
   }
 };

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -96,30 +96,34 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate) {
   AgentConfig agent_cfg = create_test_agent_config();
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
 
-  float dummy_reward = 0.0f;
-  agent->init(&dummy_reward);
+  float agent_reward = 0.0f;
+  agent->init(&agent_reward);
 
   // Test adding items
   int delta = agent->update_inventory(TestItems::ORE, 5);
   EXPECT_EQ(delta, 5);
   EXPECT_EQ(agent->inventory[TestItems::ORE], 5);
+  EXPECT_FLOAT_EQ(agent_reward, 0.625f);  // 5 * 0.125
 
   // Test removing items
   delta = agent->update_inventory(TestItems::ORE, -2);
   EXPECT_EQ(delta, -2);
   EXPECT_EQ(agent->inventory[TestItems::ORE], 3);
+  EXPECT_FLOAT_EQ(agent_reward, 0.375f);  // 3 * 0.125
 
   // Test hitting zero
   delta = agent->update_inventory(TestItems::ORE, -10);
   EXPECT_EQ(delta, -3);  // Should only remove what's available
   // check that the item is not in the inventory
   EXPECT_EQ(agent->inventory.find(TestItems::ORE), agent->inventory.end());
+  EXPECT_FLOAT_EQ(agent_reward, 0.0f);
 
   // Test hitting resource_limits limit
   agent->update_inventory(TestItems::ORE, 30);
   delta = agent->update_inventory(TestItems::ORE, 50);  // resource_limits is 50
   EXPECT_EQ(delta, 20);                                 // Should only add up to resource_limits
   EXPECT_EQ(agent->inventory[TestItems::ORE], 50);
+  EXPECT_FLOAT_EQ(agent_reward, 6.25f);  // 50 * 0.125
 }
 
 // Test for reward capping behavior with a lower cap to actually hit it
@@ -136,44 +140,50 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_RewardCappingBehavior) {
       0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
-  float dummy_reward = 0.0f;
-  agent->init(&dummy_reward);
+  float agent_reward = 0.0f;
+  agent->init(&agent_reward);
 
   // Test 1: Add items up to the cap
   // 16 ORE * 0.125 = 2.0 (exactly at cap)
   int delta = agent->update_inventory(TestItems::ORE, 16);
   EXPECT_EQ(delta, 16);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 16);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);
 
   // Test 2: Add more items beyond the cap
   // 32 ORE * 0.125 = 4.0, but capped at 2.0
   delta = agent->update_inventory(TestItems::ORE, 16);
   EXPECT_EQ(delta, 16);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);  // Still capped at 2.0
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 32);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);  // Still capped at 2.0
 
   // Test 3: Remove some items while still over cap
   // 24 ORE * 0.125 = 3.0, but still capped at 2.0
   delta = agent->update_inventory(TestItems::ORE, -8);
   EXPECT_EQ(delta, -8);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);  // Should remain at cap
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 24);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);  // Should remain at cap
 
   // Test 4: Remove enough items to go below cap
   // 12 ORE * 0.125 = 1.5 (now below cap)
   delta = agent->update_inventory(TestItems::ORE, -12);
   EXPECT_EQ(delta, -12);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 1.5f);  // Now tracking actual value
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 12);
+  EXPECT_FLOAT_EQ(agent_reward, 1.5f);  // Now tracking actual value
 
   // Test 5: Add items again, but not enough to hit cap
   // 14 ORE * 0.125 = 1.75 (still below cap)
   delta = agent->update_inventory(TestItems::ORE, 2);
   EXPECT_EQ(delta, 2);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 1.75f);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 14);
+  EXPECT_FLOAT_EQ(agent_reward, 1.75f);
 
   // Test 6: Add items to go over cap again
   // 20 ORE * 0.125 = 2.5, but capped at 2.0
   delta = agent->update_inventory(TestItems::ORE, 6);
   EXPECT_EQ(delta, 6);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 20);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);
 }
 
 // Test multiple item types with different caps
@@ -191,32 +201,38 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_MultipleItemCaps) {
       0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
-  float dummy_reward = 0.0f;
-  agent->init(&dummy_reward);
+  float agent_reward = 0.0f;
+  agent->init(&agent_reward);
 
   // Add ORE beyond its cap
   agent->update_inventory(TestItems::ORE, 50);  // 50 * 0.125 = 6.25, capped at 2.0
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 50);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);
 
   // Add HEART up to its cap
-  agent->update_inventory(TestItems::HEART, 30);           // 30 * 1.0 = 30.0
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 32.0f);  // 2.0 + 30.0
+  agent->update_inventory(TestItems::HEART, 30);  // 30 * 1.0 = 30.0
+  EXPECT_EQ(agent->inventory[TestItems::HEART], 30);
+  EXPECT_FLOAT_EQ(agent_reward, 32.0f);  // 2.0 + 30.0
 
   // Add more HEART beyond its cap
-  agent->update_inventory(TestItems::HEART, 10);           // 40 * 1.0 = 40.0, capped at 30.0
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 32.0f);  // Still 2.0 + 30.0
+  agent->update_inventory(TestItems::HEART, 10);  // 40 * 1.0 = 40.0, capped at 30.0
+  EXPECT_EQ(agent->inventory[TestItems::HEART], 40);
+  EXPECT_FLOAT_EQ(agent_reward, 32.0f);  // Still 2.0 + 30.0
 
   // Remove some ORE (still over cap)
-  agent->update_inventory(TestItems::ORE, -10);            // 40 * 0.125 = 5.0, still capped at 2.0
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 32.0f);  // No change
+  agent->update_inventory(TestItems::ORE, -10);  // 40 * 0.125 = 5.0, still capped at 2.0
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 40);
+  EXPECT_FLOAT_EQ(agent_reward, 32.0f);  // No change
 
   // Remove ORE to go below cap
-  agent->update_inventory(TestItems::ORE, -35);              // 5 * 0.125 = 0.625
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 30.625f);  // 0.625 + 30.0
+  agent->update_inventory(TestItems::ORE, -35);  // 5 * 0.125 = 0.625
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 5);
+  EXPECT_FLOAT_EQ(agent_reward, 30.625f);  // 0.625 + 30.0
 
   // Remove HEART to go below its cap
-  agent->update_inventory(TestItems::HEART, -15);            // 25 * 1.0 = 25.0
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 25.625f);  // 0.625 + 25.0
+  agent->update_inventory(TestItems::HEART, -15);  // 25 * 1.0 = 25.0
+  EXPECT_EQ(agent->inventory[TestItems::HEART], 25);
+  EXPECT_FLOAT_EQ(agent_reward, 25.625f);  // 0.625 + 25.0
 }
 
 // Test edge case: going to zero
@@ -231,16 +247,19 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_RewardToZero) {
       0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
-  float dummy_reward = 0.0f;
-  agent->init(&dummy_reward);
+  float agent_reward = 0.0f;
+  agent->init(&agent_reward);
 
   // Add items beyond cap
   agent->update_inventory(TestItems::ORE, 50);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 2.0f);
+  EXPECT_EQ(agent->inventory[TestItems::ORE], 50);
+  EXPECT_FLOAT_EQ(agent_reward, 2.0f);
 
   // Remove all items
   agent->update_inventory(TestItems::ORE, -50);
-  EXPECT_FLOAT_EQ(agent->current_resource_reward, 0.0f);
+  // When inventory goes to zero, the item should be removed from the map
+  EXPECT_EQ(agent->inventory.find(TestItems::ORE), agent->inventory.end());
+  EXPECT_FLOAT_EQ(agent_reward, 0.0f);
 }
 
 // ==================== Grid Tests ====================


### PR DESCRIPTION
### TL;DR

Removed the redundant `current_resource_reward` field from the Agent class and updated tests to verify reward calculations directly.

### What changed?

- Removed the `current_resource_reward` member variable from the Agent class
- Modified the `update_inventory_contribution` method to only update the total reward
- Updated all tests to verify reward calculations by checking the agent's total reward directly
- Added explicit inventory size checks in tests to ensure inventory is being properly tracked

### How to test?

Run the existing tests which now verify that:
- Basic inventory updates correctly modify the agent's reward
- Reward capping behavior works properly when items are added/removed
- Multiple item types with different reward caps function correctly
- Inventory items are properly removed when quantity reaches zero

### Why make this change?

The `current_resource_reward` field was redundant since the agent's total reward already tracks resource contributions. This change simplifies the code by removing the duplicate state tracking while maintaining the same functionality. The updated tests now explicitly verify both inventory state and reward calculations, making the test coverage more comprehensive.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210864414420987)