### PR TITLE
Rename action handlers from get_output/put_recipe_items to get_items/put_items

### DIFF
--- a/configs/user/daveey.yaml
+++ b/configs/user/daveey.yaml
@@ -36,8 +36,9 @@ trainer:
 # policy_uri: wandb://run/b.daveey.dr9.muon.latest
 # policy_uri: wandb://run/b.daveey.t.1.lra.dr.muon
 # policy_uri: pytorch:///tmp/puffer_metta.pt
-policy_uri: wandb://run/george.deane.navigation.baseline.06-19.2
+# policy_uri: pytorch:///tmp/puffer_metta.pt
 # policy_uri: wandb://run/daveey.lp.16x4.muon.lr3
+policy_uri: null
 # policy_uri: pytorch://${data_dir}/puffer/puffer_metta.pt
 
 # policy_uri: ${trained_policy_uri}

--- a/mettagrid/src/metta/mettagrid/actions/get_output.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/get_output.hpp
@@ -12,7 +12,7 @@
 
 class GetOutput : public ActionHandler {
 public:
-  explicit GetOutput(const ActionConfig& cfg) : ActionHandler(cfg, "get_output") {}
+  explicit GetOutput(const ActionConfig& cfg) : ActionHandler(cfg, "get_items") {}
 
   unsigned char max_arg() const override {
     return 0;

--- a/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/put_recipe_items.hpp
@@ -12,7 +12,7 @@
 
 class PutRecipeItems : public ActionHandler {
 public:
-  explicit PutRecipeItems(const ActionConfig& cfg) : ActionHandler(cfg, "put_recipe_items") {}
+  explicit PutRecipeItems(const ActionConfig& cfg) : ActionHandler(cfg, "put_items") {}
 
   unsigned char max_arg() const override {
     return 0;

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -370,7 +370,7 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   agent->update_inventory(TestItems::ORE, 1);
   agent->update_inventory(TestItems::HEART, 1);
 
-  // Create put_recipe_items action handler
+  // Create put_items action handler
   ActionConfig put_cfg({}, {});
   PutRecipeItems put(put_cfg);
   put.init(&grid);

--- a/mettagrid/tests/test_rewards.py
+++ b/mettagrid/tests/test_rewards.py
@@ -115,7 +115,7 @@ def collect_heart_from_altar(env):
         return False, 0.0
 
     # Collect heart
-    obs, reward, success = perform_action(env, "get_output", 0)
+    obs, reward, success = perform_action(env, "get_items", 0)
     return success, reward
 
 

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -29,7 +29,7 @@ export function initActionButtons() {
   })
 
   find('#action-buttons .put-recipe-items').addEventListener('click', () => {
-    sendAction('put_recipe_items', 0)
+    sendAction('put_items', 0)
   })
 
   find('#action-buttons .get-output').addEventListener('click', () => {
@@ -112,7 +112,7 @@ export function processActions(event: KeyboardEvent) {
     }
     if (event.key == 'q') {
       // Put recipe items.
-      sendAction('put_recipe_items', 0)
+      sendAction('put_items', 0)
     }
     if (event.key == 'e') {
       // Get the output.

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -288,7 +288,7 @@ function drawActions() {
             1,
             rotation
           )
-        } else if (action_name == 'put_recipe_items') {
+        } else if (action_name == 'put_items') {
           ctx.drawSprite(
             'actions/put_recipe_items.png',
             x * Common.TILE_SIZE,


### PR DESCRIPTION
# Rename action handlers for consistency

### TL;DR

Renamed action handlers from `get_output` to `get_items` and `put_recipe_items` to `put_items` for better naming consistency.

### What changed?

- Renamed the `get_output` action handler to `get_items` in the C++ implementation
- Renamed the `put_recipe_items` action handler to `put_items` in the C++ implementation
- Updated all references to these actions in tests and frontend code
- Set `policy_uri` to null in the user configuration file

### How to test?

1. Verify that all actions work correctly with the new names
2. Check that keyboard shortcuts (e for get_items, q for put_items) still function properly
3. Confirm that UI buttons trigger the correct actions with the updated names

### Why make this change?

This change improves naming consistency across the action system, making the API more intuitive by using the more generic `get_items` and `put_items` names that better reflect their functionality.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210871958837696)