### PR TITLE
Fix metta command to detect and use closest checkout

### DIFF
--- a/metta/setup/installer/bin/metta
+++ b/metta/setup/installer/bin/metta
@@ -2,10 +2,31 @@
 # Wrapper script for metta command
 # This allows users to run 'metta' directly without prefixing with 'uv run'
 
-# Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# Get the project root directory (three levels up from metta/setup/installer/bin)
-PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# Function to find the metta repository root
+find_metta_root() {
+    local dir="$PWD"
+    while [ "$dir" != "/" ]; do
+        # Check if this is a metta repository
+        if [ -f "$dir/metta/setup/metta_cli.py" ] && [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+# First, try to find if we're in a metta repository
+if metta_root=$(find_metta_root); then
+    # We're in a metta repository (could be main repo or worktree)
+    PROJECT_DIR="$metta_root"
+else
+    # Fall back to the original install location
+    # Get the real path of this script (following symlinks)
+    SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+    PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+fi
 
 # Run metta using uv with the project directory
 exec uv run --project "$PROJECT_DIR" python -m metta.setup.metta_cli "$@"

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from metta.common.util.fs import get_repo_root
 from metta.setup.config import CURRENT_CONFIG_VERSION, PROFILE_DEFINITIONS, SetupConfig, UserType
 from metta.setup.local_commands import LocalCommands
 from metta.setup.registry import get_all_modules, get_applicable_modules
@@ -17,7 +18,7 @@ import_all_modules_from_subpackage("metta.setup", "components")
 
 class MettaCLI:
     def __init__(self):
-        self.repo_root: Path = Path(__file__).parent.parent.parent
+        self.repo_root: Path = get_repo_root()
         self.config: SetupConfig = SetupConfig()
         self.path_setup: PathSetup = PathSetup(self.repo_root)
         self.local_commands: LocalCommands = LocalCommands(self.repo_root)

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -233,6 +233,10 @@ class MettaCLI:
     def cmd_shell(self) -> None:
         subprocess.run(["uv", "run", "metta/setup/shell.py"], cwd=self.repo_root, check=True)
 
+    def cmd_report_env_details(self) -> None:
+        info(f"UV Project Directory: {self.repo_root}")
+        info(f"Metta CLI Working Directory: {Path.cwd()}")
+
     def cmd_local(self, args, unknown_args=None) -> None:
         """Handle local development commands."""
         if hasattr(args, "local_command") and args.local_command:
@@ -568,6 +572,11 @@ Examples:
         # Shell command
         subparsers.add_parser("shell", help="Start an IPython shell with Metta imports")
 
+        # Report Environment Details command
+        subparsers.add_parser(
+            "report-env-details", help="Report environment details including which UV project directory is being used"
+        )
+
         # Local command
         local_parser = subparsers.add_parser("local", help="Local development commands")
         local_subparsers = local_parser.add_subparsers(dest="local_command", help="Available local commands")
@@ -625,8 +634,8 @@ Examples:
             return
 
         # Check if configuration is required for this command
-        # Allow configure, symlink-setup, and local to run without config
-        if args.command not in ["configure", "symlink-setup", "local"]:
+        # Allow configure, symlink-setup, report-env-details, and local to run without config
+        if args.command not in ["configure", "symlink-setup", "report-env-details", "local"]:
             if not self.config.config_path.exists():
                 error("No configuration found. Please run 'metta configure' first.")
                 sys.exit(1)
@@ -659,6 +668,8 @@ Examples:
             self.cmd_lint(args)
         elif args.command == "shell":
             self.cmd_shell()
+        elif args.command == "report-env-details":
+            self.cmd_report_env_details()
         elif args.command == "local":
             self.cmd_local(args, unknown_args)
         else:


### PR DESCRIPTION
When running metta from a git worktree (or another checkout), it now detects and uses the uv project from the current repository (instead of the uv project from which the metta cli was originally installed)

This allows the metta command to work correctly with multiple worktrees.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210873403437186)