### PR TITLE
[MettaScope] gamepad support

### DIFF
--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -1,6 +1,7 @@
 import { state } from './common.js'
 import { getAttr, sendAction } from './replay.js'
 import { find } from './htmlutils.js'
+import { requestFrame } from './main.js'
 
 /** Initializes the action buttons. */
 export function initActionButtons() {
@@ -139,4 +140,137 @@ export function processActions(event: KeyboardEvent) {
       sendAction('swap', 0)
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Gamepad support
+// ---------------------------------------------------------------------------
+
+// You can test your gamepad here: https://hardwaretester.com/gamepad
+
+// Remember the previous pressed state of each button so we can detect
+// rising edges (button just pressed) and avoid sending the same command
+// repeatedly every animation frame.
+
+const prevButtonPressed: boolean[] = []
+
+/**
+ * Processes the first connected gamepad (if any) and converts gamepad input
+ * into the same logical keyboard events that `processActions` already
+ * handles. This allows us to reuse the existing keyboard-driven action logic
+ * without duplicating it.
+ */
+export function processGamepad() {
+  const gamepads = navigator.getGamepads ? navigator.getGamepads() : []
+  if (!gamepads) {
+    return false
+  }
+
+  const gp = gamepads[0]
+  if (!gp) {
+    // gamepads do not show up until you press a button
+    return false
+  }
+
+  let inputDetected = false
+
+  // Helper to dispatch a synthetic keyboard event so that we can reuse the
+  // existing `processActions` logic.
+  const dispatchKey = (key: string) => {
+    // Construct a minimal KeyboardEvent carrying the `key` information.
+    // The event is not fired on the DOM; instead we pass it directly to
+    // `processActions`.
+    const evt = new KeyboardEvent('gamepad', { key })
+    processActions(evt)
+    inputDetected = true
+  }
+
+  // Map of gamepad button indices to associated keys.
+  const buttonKeyMap: Record<number, string> = {
+    0: 'q', // A – put items
+    1: 'e', // B – get items
+    2: '', // X – unmapped
+    3: '', // Y – unmapped
+    6: 'g', // LT – swap
+    7: 'c', // RT – change color
+  }
+
+  // Process face/shoulder buttons.
+  gp.buttons.forEach((btn, index) => {
+    const pressed = typeof btn === 'object' ? btn.pressed : btn === 1.0
+    const prev = prevButtonPressed[index] || false
+    // Log button state for debugging
+    if (pressed && !prev) {
+      const key = buttonKeyMap[index]
+      if (key) {
+        dispatchKey(key)
+      }
+    }
+    prevButtonPressed[index] = pressed
+  })
+
+  // Helper function to convert directional input into keys. We trigger the
+  // key event whenever the direction crosses a threshold from the neutral
+  // position. We treat both the left stick (axes 0 and 1) and the d-pad
+  // buttons (12-15).
+
+  const axisThreshold = 0.5
+
+  const directionActives: Record<string, boolean> = {
+    'w': false, // up
+    's': false, // down
+    'a': false, // left
+    'd': false  // right
+  }
+
+  // Set from D-pad buttons.
+  if (gp.buttons[12]?.pressed) directionActives['w'] = true
+  if (gp.buttons[13]?.pressed) directionActives['s'] = true
+  if (gp.buttons[14]?.pressed) directionActives['a'] = true
+  if (gp.buttons[15]?.pressed) directionActives['d'] = true
+
+  // Set from left stick axes.
+  if (gp.axes.length >= 2) {
+    const x = gp.axes[0]
+    const y = gp.axes[1]
+    if (y < -axisThreshold) directionActives['w'] = true
+    if (y > axisThreshold) directionActives['s'] = true
+    if (x < -axisThreshold) directionActives['a'] = true
+    if (x > axisThreshold) directionActives['d'] = true
+  }
+
+  // Trigger key events for newly active directions.
+  Object.entries(directionActives).forEach(([key, active]) => {
+    const idx = 100 + key.charCodeAt(0) // offset to avoid collision
+    const prev = prevButtonPressed[idx] || false
+    if (active && !prev) {
+      dispatchKey(key)
+    }
+    prevButtonPressed[idx] = active
+  })
+
+  return inputDetected
+}
+
+/**
+ * Starts the gamepad polling loop that runs independently of the main render loop.
+ * This ensures gamepad input is detected even when the game is idle.
+ */
+export function startGamepadPolling() {
+  const pollGamepad = () => {
+    try {
+      const inputDetected = processGamepad()
+      if (inputDetected) {
+        requestFrame()
+      }
+    } catch (e) {
+      console.error('Error processing gamepad input:', e)
+    }
+
+    // Continue polling
+    requestAnimationFrame(pollGamepad)
+  }
+
+  // Start the polling loop
+  requestAnimationFrame(pollGamepad)
 }

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -217,10 +217,10 @@ export function processGamepad() {
   const axisThreshold = 0.5
 
   const directionActives: Record<string, boolean> = {
-    'w': false, // up
-    's': false, // down
-    'a': false, // left
-    'd': false  // right
+    w: false, // up
+    s: false, // down
+    a: false, // left
+    d: false, // right
   }
 
   // Set from D-pad buttons.

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -187,8 +187,8 @@ export function processGamepad() {
 
   // Map of gamepad button indices to associated keys.
   const buttonKeyMap: Record<number, string> = {
-    0: 'q', // A – put items
-    1: 'e', // B – get items
+    0: 'q', // A – get items
+    1: 'e', // B – put items
     2: '', // X – unmapped
     3: '', // Y – unmapped
     6: 'g', // LT – swap

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -5,7 +5,7 @@ import { fetchReplay, getAttr, initWebSocket, readFile, sendAction } from './rep
 import { focusFullMap, drawMap } from './worldmap.js'
 import { drawTrace } from './traces.js'
 import { drawMiniMap } from './minimap.js'
-import { processActions, initActionButtons } from './actions.js'
+import { processActions, initActionButtons, startGamepadPolling } from './actions.js'
 import { initAgentTable, updateAgentTable } from './agentpanel.js'
 import {
   localStorageSetNumber,
@@ -529,6 +529,7 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
 
 /** Draws a frame. */
 export function onFrame() {
+
   if (state.replay === null || ctx === null || ctx.ready === false) {
     return
   }
@@ -953,6 +954,7 @@ initObjectMenu()
 initTimeline()
 initDemoMode()
 initializeTooltips()
+startGamepadPolling()
 
 window.addEventListener('load', async () => {
   // Use a local atlas texture.

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -529,7 +529,6 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
 
 /** Draws a frame. */
 export function onFrame() {
-
   if (state.replay === null || ctx === null || ctx.ready === false) {
     return
   }


### PR DESCRIPTION
- tested with a usb snes controller and a PS5 controller
- working for both d-pad and joyystick
- A (or O on ps5) button is to get items, B (or X on ps5) button is to deposit items.
- only one gamepad is supported by this PR

- you can first test your browser with your gamepad here to make sure things are working: https://hardwaretester.com/gamepad

- the gamepad doesn't show up to the browser until you do 1 button press.

- it's hard to play with one hand and record with the other: https://photos.app.goo.gl/wa7PrS22Eq7mE9YX7

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210873388577999)