### PR TITLE
Fix mixed meanings of SCRIPT_DIR

### DIFF
--- a/devops/tools/common.sh
+++ b/devops/tools/common.sh
@@ -14,8 +14,8 @@ check_cmd() {
 
 _find_project_root() {
   # When sourced from install.sh, SCRIPT_DIR is already the project root
-  if [ -n "${SCRIPT_DIR:-}" ]; then
-    echo "$SCRIPT_DIR"
+  if [ -n "${REPO_ROOT:-}" ]; then
+    echo "$REPO_ROOT"
   else
     # Fallback for other scripts - use the directory of the calling script
     echo "$(cd "$(dirname "$0")/../.." && pwd)"

--- a/install.sh
+++ b/install.sh
@@ -41,10 +41,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Assumes install.sh is in root of repo
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 # Source common functions
-. "$SCRIPT_DIR/devops/tools/common.sh"
+. "$REPO_ROOT/devops/tools/common.sh"
 
 echo "Welcome to Metta!"
 


### PR DESCRIPTION
Caused `pre-commit`'s usage of `common.sh` to give different behavior because of var collision

Avoids redetermining repo root if it is already defined, which it often is in our scripts

Ty to @sasmith for reporting here https://app.asana.com/1/1209016784099267/project/1210605789938112/task/1210864211357699?focus=true

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210873605124002)