### PR TITLE
Fix keys in all_objects curriculum

### DIFF
--- a/configs/env/mettagrid/curriculum/objects/all_objects.yaml
+++ b/configs/env/mettagrid/curriculum/objects/all_objects.yaml
@@ -29,10 +29,10 @@ buckets:
     range: [1, 3]
   game.map_builder.root.params.objects.temple:
     range: [1, 3]
-  game.objects.altar.initial_items: [0, 1]
+  game.objects.altar.initial_resource_count: [0, 1]
   game.objects.altar.cooldown:
     range: [10, 60]
-  game.objects.generator_red.initial_items: [0, 1]
+  game.objects.generator_red.initial_resource_count: [0, 1]
   game.objects.generator_red.cooldown:
     range: [10, 60]
   game.objects.mine_red.cooldown:


### PR DESCRIPTION
I was exploring changing our bucketing to only allow overwriting existing keys. This ended up seeming too limited, since we have a lot of sort-of-implicit keys like "agent.reward.resources.red_ore". This seems like a fine key for folks to bucket, even if the key isn't in the explicit configuration -- the error checking happens a little downstream in the Pydantic GameConfig object.

But in this exploration, I ran into `all_objects.yaml`, which seemed to just have an invalid config, since it was overriding "initial_items", which has been switched to "initial_resource_count". So this fixes that.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210877044770751)