### PR TITLE
[MettaScope] build frontend as part of vscode / cursor default tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,21 @@
       "type": "shell",
       "command": "uv sync --inexact",
       "label": "uv sync",
+      "group": "build"
+    },
+    {
+      "type": "shell",
+      "command": "bash ./mettascope/install.sh",
+      "label": "build frontend",
+      "group": "build"
+    },
+    {
+      "label": "build all",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "uv sync",
+        "build frontend"
+      ],
       "group": {
         "kind": "build",
         "isDefault": true


### PR DESCRIPTION
- Update atlas to only change output when input files are newer than output
- Update our default tasks to build the frontend after doing uv sync