### PR TITLE
Switch navigation training to be bucketed curricula instead of using random resolvers

### DIFF
--- a/configs/env/mettagrid/curriculum/all.yaml
+++ b/configs/env/mettagrid/curriculum/all.yaml
@@ -2,7 +2,7 @@ _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 tasks:
   /env/mettagrid/curriculum/arena/learning_progress: 5
-  /env/mettagrid/curriculum/navigation/prioritize_regressed: 3
+  /env/mettagrid/curriculum/navigation/learning_progress: 3
   /env/mettagrid/curriculum/object_use: 2
 
 env_overrides:

--- a/configs/env/mettagrid/curriculum/navigation/bucketed.yaml
+++ b/configs/env/mettagrid/curriculum/navigation/bucketed.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
 
-env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
 buckets:
   game.map_builder.room.dir:
@@ -26,6 +26,3 @@ buckets:
   game.map_builder.room.objects.altar:
     range: [2, 18]
     bins: 4
-
-env_overrides:
-  sampling: 0

--- a/configs/env/mettagrid/curriculum/navigation/prioritize_regressed.yaml
+++ b/configs/env/mettagrid/curriculum/navigation/prioritize_regressed.yaml
@@ -1,9 +1,0 @@
-_target_: metta.mettagrid.curriculum.prioritize_regressed.PrioritizeRegressedCurriculum
-
-tasks:
-  /env/mettagrid/navigation/training/terrain_from_numpy: 1
-  /env/mettagrid/navigation/training/cylinder_world: 1
-  /env/mettagrid/navigation/training/varied_terrain_sparse: 1
-  /env/mettagrid/navigation/training/varied_terrain_balanced: 1
-  /env/mettagrid/navigation/training/varied_terrain_maze: 1
-  /env/mettagrid/navigation/training/varied_terrain_dense: 1

--- a/configs/env/mettagrid/curriculum/navsequence/nav_backchain.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_backchain.yaml
@@ -1,5 +1,5 @@
 _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 tasks:
-  /env/mettagrid/curriculum/navigation/prioritize_regressed: 1
+  /env/mettagrid/curriculum/navigation/learning_progress: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1

--- a/configs/env/mettagrid/curriculum/navsequence/nav_backchain_mem.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_backchain_mem.yaml
@@ -3,6 +3,6 @@ _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 #train this pretrained on our best navigation policy
 #dd_navigation_curriculum:v54
 tasks:
-  /env/mettagrid/curriculum/navigation/prioritize_regressed: 1
+  /env/mettagrid/curriculum/navigation/learning_progress: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1
   /env/mettagrid/curriculum/navsequence/mem_medium: 1

--- a/configs/env/mettagrid/curriculum/navsequence/nav_mem.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_mem.yaml
@@ -3,6 +3,6 @@ _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 #use this environment pretrained on a policy that is the best at navigation sequence already
 #gd_backchain_mem_pretained:v18
 tasks:
-  /env/mettagrid/curriculum/navigation/prioritize_regressed: 5
+  /env/mettagrid/curriculum/navigation/learning_progress: 5
   /env/mettagrid/curriculum/navsequence/mem_medium: 5
   # /env/mettagrid/curriculum/navsequence/mem_hard: 2

--- a/configs/env/mettagrid/curriculum/navsequence/nav_navsequence_backchain.yaml
+++ b/configs/env/mettagrid/curriculum/navsequence/nav_navsequence_backchain.yaml
@@ -1,6 +1,6 @@
 _target_: metta.mettagrid.curriculum.random.RandomCurriculum
 
 tasks:
-  /env/mettagrid/curriculum/navigation/prioritize_regressed: 1
+  /env/mettagrid/curriculum/navigation/learning_progress: 1
   /env/mettagrid/curriculum/navsequence/navsequence_all: 1
   /env/mettagrid/curriculum/navsequence/backchain_seq: 1

--- a/configs/env/mettagrid/navigation/training/cylinder_world.yaml
+++ b/configs/env/mettagrid/navigation/training/cylinder_world.yaml
@@ -1,9 +1,11 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/cylinder-world_large,varied_terrain/cylinder-world_medium,varied_terrain/cylinder-world_small}
-
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/cylinder-world_large
+      - varied_terrain/cylinder-world_medium
+      - varied_terrain/cylinder-world_small
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/large.yaml
+++ b/configs/env/mettagrid/navigation/training/large.yaml
@@ -1,10 +1,13 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/balanced_large,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/balanced_large
+      - varied_terrain/maze_large
+      - varied_terrain/sparse_large
+      - varied_terrain/dense_large
+      - varied_terrain/cylinder-world_large
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/medium.yaml
+++ b/configs/env/mettagrid/navigation/training/medium.yaml
@@ -1,10 +1,13 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/balanced_medium,varied_terrain/maze_medium,varied_terrain/sparse_medium,varied_terrain/dense_medium,varied_terrain/cylinder-world_medium}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/balanced_medium
+      - varied_terrain/maze_medium
+      - varied_terrain/sparse_medium
+      - varied_terrain/dense_medium
+      - varied_terrain/cylinder-world_medium
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/small.yaml
+++ b/configs/env/mettagrid/navigation/training/small.yaml
@@ -1,10 +1,13 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/balanced_small,varied_terrain/maze_small,varied_terrain/sparse_small,varied_terrain/dense_small,varied_terrain/cylinder-world_small}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/balanced_small
+      - varied_terrain/maze_small
+      - varied_terrain/sparse_small
+      - varied_terrain/dense_small
+      - varied_terrain/cylinder-world_small
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
+++ b/configs/env/mettagrid/navigation/training/terrain_from_numpy.yaml
@@ -1,8 +1,9 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-game:
-  map_builder:
-    room:
-      dir: terrain_maps_nohearts
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - terrain_maps_nohearts
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/terrain_from_numpy_defaults.yaml
+++ b/configs/env/mettagrid/navigation/training/terrain_from_numpy_defaults.yaml
@@ -24,7 +24,7 @@ game:
       border_width: 3
       agents: 1
       objects:
-        altar: ${sampling:3, 50, 25}
+        altar: 10
   objects:
     altar:
       cooldown: 1000

--- a/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_balanced.yaml
@@ -1,10 +1,11 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/balanced_large,varied_terrain/balanced_medium,varied_terrain/balanced_small}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/balanced_large
+      - varied_terrain/balanced_medium
+      - varied_terrain/balanced_small
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_dense.yaml
@@ -1,10 +1,11 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/dense_large,varied_terrain/dense_medium,varied_terrain/dense_small}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/dense_large
+      - varied_terrain/dense_medium
+      - varied_terrain/dense_small
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_maze.yaml
@@ -1,10 +1,11 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    room:
-      dir: ${choose:varied_terrain/maze_large,varied_terrain/maze_medium,varied_terrain/maze_small}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/maze_large
+      - varied_terrain/maze_medium
+      - varied_terrain/maze_small
+  game.map_builder.room.objects.altar:
+    range: [3, 50]

--- a/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
+++ b/configs/env/mettagrid/navigation/training/varied_terrain_sparse.yaml
@@ -1,15 +1,11 @@
-defaults:
-  - /env/mettagrid/navigation/training/defaults@
-  - _self_
+_target_: metta.mettagrid.curriculum.bucketed.BucketedCurriculum
+env_cfg_template_path: /env/mettagrid/navigation/training/terrain_from_numpy_defaults
 
-sampling: 1
-
-game:
-  map_builder:
-    _target_: metta.mettagrid.room.multi_room.MultiRoom
-    num_rooms: ${..num_agents}
-    border_width: 6
-    room:
-      dir: ${choose:varied_terrain/sparse_large,varied_terrain/sparse_medium,varied_terrain/sparse_small}
-      objects:
-        altar: ${sampling:1, 5, 3}
+buckets:
+  game.map_builder.room.dir:
+    values:
+      - varied_terrain/sparse_large
+      - varied_terrain/sparse_medium
+      - varied_terrain/sparse_small
+  game.map_builder.room.objects.altar:
+    range: [1, 5]

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,11 +4,11 @@ defaults:
   - _self_
 
 trainer:
-  curriculum: /env/mettagrid/curriculum/overcooked
+  curriculum: /env/mettagrid/curriculum/navigation/learning_progress
 
 replay_job:
   sim:
-    env: /env/mettagrid/cooperation/experimental/confined_room_coord_env
+    env: /env/mettagrid/curriculum/navigation/learning_progress
 
 seed: null
 run_id: 20250720.03

--- a/metta/interface/evaluation.py
+++ b/metta/interface/evaluation.py
@@ -31,7 +31,7 @@ def create_evaluation_config_suite() -> SimulationSuiteConfig:
 
     # Small terrain evaluation
     simulations["navigation/terrain_small"] = {
-        "env": "/env/mettagrid/navigation/training/terrain_from_numpy",
+        "env": "/env/mettagrid/navigation/training/terrain_from_numpy_defaults",
         "num_episodes": 5,
         "max_time_s": 30,
         "env_overrides": {
@@ -42,7 +42,7 @@ def create_evaluation_config_suite() -> SimulationSuiteConfig:
 
     # Medium terrain evaluation
     simulations["navigation/terrain_medium"] = {
-        "env": "/env/mettagrid/navigation/training/terrain_from_numpy",
+        "env": "/env/mettagrid/navigation/training/terrain_from_numpy_defaults",
         "num_episodes": 5,
         "max_time_s": 30,
         "env_overrides": {
@@ -53,7 +53,7 @@ def create_evaluation_config_suite() -> SimulationSuiteConfig:
 
     # Large terrain evaluation
     simulations["navigation/terrain_large"] = {
-        "env": "/env/mettagrid/navigation/training/terrain_from_numpy",
+        "env": "/env/mettagrid/navigation/training/terrain_from_numpy_defaults",
         "num_episodes": 5,
         "max_time_s": 30,
         "env_overrides": {

--- a/recipes/navigation.sh
+++ b/recipes/navigation.sh
@@ -6,7 +6,7 @@
 
 ./devops/skypilot/launch.py train \
 run=$USER.navigation.low_reward.baseline.$(date +%m-%d) \
-trainer.curriculum=env/mettagrid/curriculum/navigation/prioritize_regressed \
+trainer.curriculum=env/mettagrid/curriculum/navigation/learning_progress \
 --gpus=1 \
 +trainer.env_overrides.game.num_agents=4 \
 sim=navigation \

--- a/tests/test_validate_all_envs.py
+++ b/tests/test_validate_all_envs.py
@@ -35,8 +35,8 @@ def map_or_env_configs() -> list[MettagridCfgFileMetadata]:
         "game/map_builder/load_random.yaml",
         "navigation/training/sparse.yaml",
         "object_use/training/easy_all_objects.yaml",
-        # Is a curriculum, not an env
-        "navigation/training/sparse_bucketed",
+        # These are curricula, not envs
+        "navigation/training/",
         # These are broken into different files to work around curriculum needs. They don't load right in this test.
         "cooperation/experimental/",
     ]


### PR DESCRIPTION
The main thing this does is to switch all of the navigation training environments to be bucketed curricula; so their randomness can exist there instead of in $sampling resolver.

This also renames `defaults` to be `terrain_from_numpy_defaults`, since I've gotten confused about this for some time.

Smoke tested by training and playing localled.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210883516905365)