### PR TITLE
Remove defaults from ConverterConfig

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -176,19 +176,9 @@ MettaGrid::MettaGrid(const GameConfig& cfg, const py::list map, unsigned int see
       const ConverterConfig* converter_config = dynamic_cast<const ConverterConfig*>(object_cfg);
       if (converter_config) {
         // Create a new ConverterConfig with the recipe offsets from the observation encoder
-        ConverterConfig config_with_offsets(
-            converter_config->type_id,
-            converter_config->type_name,
-            converter_config->input_resources,
-            converter_config->output_resources,
-            converter_config->max_output,
-            converter_config->conversion_ticks,
-            converter_config->cooldown,
-            converter_config->initial_resource_count,
-            converter_config->color,
-            converter_config->recipe_details_obs,
-            _obs_encoder->get_input_recipe_offset(),
-            _obs_encoder->get_output_recipe_offset());
+        ConverterConfig config_with_offsets(*converter_config);
+        config_with_offsets.input_recipe_offset = _obs_encoder->get_input_recipe_offset();
+        config_with_offsets.output_recipe_offset = _obs_encoder->get_output_recipe_offset();
 
         Converter* converter = new Converter(r, c, config_with_offsets);
         _grid->add_object(converter);
@@ -282,8 +272,6 @@ void MettaGrid::add_agent(Agent* agent) {
   agent->init(&_rewards.mutable_unchecked<1>()(_agents.size()));
   _agents.push_back(agent);
 }
-
-
 
 void MettaGrid::_compute_observation(GridCoord observer_row,
                                      GridCoord observer_col,

--- a/mettagrid/src/metta/mettagrid/objects/converter.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/converter.hpp
@@ -26,9 +26,7 @@ struct ConverterConfig : public GridObjectConfig {
                   unsigned short cooldown,
                   InventoryQuantity initial_resource_count,
                   ObservationType color,
-                  bool recipe_details_obs = false,
-                  ObservationType input_recipe_offset = 0,
-                  ObservationType output_recipe_offset = 0)
+                  bool recipe_details_obs)
       : GridObjectConfig(type_id, type_name),
         input_resources(input_resources),
         output_resources(output_resources),
@@ -38,8 +36,10 @@ struct ConverterConfig : public GridObjectConfig {
         initial_resource_count(initial_resource_count),
         color(color),
         recipe_details_obs(recipe_details_obs),
-        input_recipe_offset(input_recipe_offset),
-        output_recipe_offset(output_recipe_offset) {}
+        // These are always 0 when this is created, since we want a single constructor, and these
+        // shouldn't be provided by Python.
+        input_recipe_offset(0),
+        output_recipe_offset(0) {}
 
   std::map<InventoryItem, InventoryQuantity> input_resources;
   std::map<InventoryItem, InventoryQuantity> output_resources;
@@ -227,14 +227,16 @@ public:
       // Add recipe inputs (input:resource) - only non-zero values
       for (const auto& [item, amount] : this->input_resources) {
         if (amount > 0) {
-          features.push_back({static_cast<ObservationType>(input_recipe_offset + item), static_cast<ObservationType>(amount)});
+          features.push_back(
+              {static_cast<ObservationType>(input_recipe_offset + item), static_cast<ObservationType>(amount)});
         }
       }
 
       // Add recipe outputs (output:resource) - only non-zero values
       for (const auto& [item, amount] : this->output_resources) {
         if (amount > 0) {
-          features.push_back({static_cast<ObservationType>(output_recipe_offset + item), static_cast<ObservationType>(amount)});
+          features.push_back(
+              {static_cast<ObservationType>(output_recipe_offset + item), static_cast<ObservationType>(amount)});
         }
       }
     }

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -379,7 +379,8 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
                                 1,                        // conversion_ticks
                                 10,                       // cooldown
                                 0,                        // initial_resource_count
-                                0);                       // color
+                                0,                        // color
+                                false);                   // recipe_details_obs
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);
@@ -429,7 +430,8 @@ TEST_F(MettaGridCppTest, GetOutput) {
                                 1,                        // conversion_ticks
                                 10,                       // cooldown
                                 1,                        // initial_items
-                                0);                       // color
+                                0,                        // color
+                                false);                   // recipe_details_obs
   EventManager event_manager;
   Converter* generator = new Converter(0, 0, generator_cfg);
   grid.add_object(generator);


### PR DESCRIPTION
Simplifies the `ConverterConfig` constructor and improved recipe offset handling.

- Simplified the `ConverterConfig` constructor by removing optional parameters for `input_recipe_offset` and `output_recipe_offset`, setting them to 0 by default
- Added a copy constructor approach in `mettagrid_c.cpp` instead of passing all parameters individually
- Set recipe offsets after construction via direct property assignment

This should reduce the number of places people need to touch ConverterConfigs when adding features, and reduce the potential for confusing bugs.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210884742446512)