### PR TITLE
Add codeflow tool for LLM-friendly code collection

### DIFF
--- a/experiments/notebooks/mettabook-template.ipynb
+++ b/experiments/notebooks/mettabook-template.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "import os\n",
+    "\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
@@ -44,9 +44,6 @@
     "from experiments.notebooks.utils.metrics import fetch_metrics\n",
     "from experiments.notebooks.utils.monitoring import monitor_training_statuses\n",
     "from experiments.notebooks.utils.replays import show_replay\n",
-    "from experiments.notebooks.utils.training import launch_training\n",
-    "from datetime import datetime\n",
-    "from experiments.notebooks.utils.metrics import find_training_jobs\n",
     "\n",
     "%matplotlib inline\n",
     "plt.style.use(\"default\")\n",

--- a/experiments/notebooks/mettabook-template.ipynb
+++ b/experiments/notebooks/mettabook-template.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
-    "\n",
+    "import os\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
@@ -44,6 +44,9 @@
     "from experiments.notebooks.utils.metrics import fetch_metrics\n",
     "from experiments.notebooks.utils.monitoring import monitor_training_statuses\n",
     "from experiments.notebooks.utils.replays import show_replay\n",
+    "from experiments.notebooks.utils.training import launch_training\n",
+    "from datetime import datetime\n",
+    "from experiments.notebooks.utils.metrics import find_training_jobs\n",
     "\n",
     "%matplotlib inline\n",
     "plt.style.use(\"default\")\n",

--- a/experiments/notebooks/research/example.ipynb
+++ b/experiments/notebooks/research/example.ipynb
@@ -1,194 +1,199 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Mettabook"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Optional: confirm you're set up to connect to the services used in this notebook\n",
-    "#    If the command does not run, run `./install.sh` from your terminal\n",
-    "\n",
-    "# !metta status --components=core,system,aws,wandb --non-interactive"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import pandas as pd\n",
-    "import plotly.graph_objects as go\n",
-    "from plotly.subplots import make_subplots\n",
-    "\n",
-    "from experiments.notebooks.utils.metrics import fetch_metrics\n",
-    "\n",
-    "%matplotlib inline\n",
-    "plt.style.use(\"default\")\n",
-    "\n",
-    "print(\"Setup complete! Auto-reload enabled.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Fetch Metrics"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_names = [\"b.jacke.basic_frost_125\", \"b.jacke.basic_frost_125\", \"b.jacke.basic_permafrost_update_branch\"]\n",
-    "metrics_dfs = fetch_metrics(run_names, samples=500)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## View how freeze_duration effects how often agents attack\n",
-    "\n",
-    "freeze_duration is [10, 125, 255] for [basic_simple, basic_frost, basic_permafrost] respectively. They are all based on the standard mettagrid environment, with a modified permafrost length."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Plot overview metrics for all fetched runs\n",
-    "if not metrics_dfs:\n",
-    "    print(\"No metrics data available. Please fetch metrics first.\")\n",
-    "else:\n",
-    "    print(f\"Plotting metrics for {len(metrics_dfs)} runs\")\n",
-    "\n",
-    "    # Find common metrics across all runs\n",
-    "    all_columns = set()\n",
-    "    for _, df in metrics_dfs.items():\n",
-    "        all_columns.update(df.columns)\n",
-    "\n",
-    "    columns = [\"env_agent/action.attack.agent\"]\n",
-    "    plot_cols = []\n",
-    "\n",
-    "    for col in all_columns:\n",
-    "        if col not in columns:\n",
-    "            continue\n",
-    "        # Check if this column exists in at least one run with numeric data\n",
-    "        has_numeric_data = False\n",
-    "        for df in metrics_dfs.values():\n",
-    "            if col in df.columns and pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() > 1:\n",
-    "                has_numeric_data = True\n",
-    "                break\n",
-    "        if has_numeric_data:\n",
-    "            plot_cols.append(col)\n",
-    "\n",
-    "    if not plot_cols:\n",
-    "        print(\"No plottable metrics found\")\n",
-    "    else:\n",
-    "        # Calculate grid dimensions\n",
-    "        n_metrics = len(plot_cols)\n",
-    "        n_cols = min(3, n_metrics)  # Max 3 columns\n",
-    "        n_rows = (n_metrics + n_cols - 1) // n_cols\n",
-    "\n",
-    "        # Create subplots\n",
-    "        fig = make_subplots(\n",
-    "            rows=n_rows,\n",
-    "            cols=n_cols,\n",
-    "            subplot_titles=[col.replace(\"overview/\", \"\").replace(\"_\", \" \") for col in plot_cols],\n",
-    "            vertical_spacing=0.08,\n",
-    "            horizontal_spacing=0.1,\n",
-    "        )\n",
-    "\n",
-    "        # Color palette for different runs\n",
-    "        colors = [\"blue\", \"red\", \"green\", \"orange\", \"purple\", \"brown\", \"pink\", \"gray\", \"olive\", \"cyan\"]\n",
-    "\n",
-    "        # Add traces for each metric and each run\n",
-    "        for idx, col in enumerate(plot_cols):\n",
-    "            row = (idx // n_cols) + 1\n",
-    "            col_idx = (idx % n_cols) + 1\n",
-    "\n",
-    "            # Plot each run for this metric\n",
-    "            for run_idx, (run_name, df) in enumerate(metrics_dfs.items()):\n",
-    "                if col in df.columns and \"_step\" in df.columns:\n",
-    "                    color = colors[run_idx % len(colors)]\n",
-    "\n",
-    "                    # Only show legend on first subplot to avoid clutter\n",
-    "                    show_legend = idx == 0\n",
-    "\n",
-    "                    fig.add_trace(\n",
-    "                        go.Scatter(\n",
-    "                            x=df[\"_step\"],\n",
-    "                            y=df[col],\n",
-    "                            mode=\"lines\",\n",
-    "                            name=run_name,\n",
-    "                            line=dict(color=color, width=2),\n",
-    "                            showlegend=show_legend,\n",
-    "                            legendgroup=run_name,  # Group all traces from same run\n",
-    "                        ),\n",
-    "                        row=row,\n",
-    "                        col=col_idx,\n",
-    "                    )\n",
-    "\n",
-    "        # Update layout\n",
-    "        runs_text = \"run\" if len(metrics_dfs) == 1 else \"runs\"\n",
-    "        fig.update_layout(\n",
-    "            height=250 * n_rows,\n",
-    "            showlegend=True,\n",
-    "            legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"right\", x=1),\n",
-    "        )\n",
-    "\n",
-    "        # Update x-axes labels for bottom row\n",
-    "        for col_idx in range(1, min(n_cols, n_metrics) + 1):\n",
-    "            fig.update_xaxes(title_text=\"Steps\", row=n_rows, col=col_idx)\n",
-    "\n",
-    "        fig.show()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Mettabook"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Setup"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Optional: confirm you're set up to connect to the services used in this notebook\n",
+                "#    If the command does not run, run `./install.sh` from your terminal\n",
+                "\n",
+                "# !metta status --components=core,system,aws,wandb --non-interactive"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "%load_ext autoreload\n",
+                "%autoreload 2\n",
+                "import os\n",
+                "\n",
+                "import matplotlib.pyplot as plt\n",
+                "import pandas as pd\n",
+                "import plotly.graph_objects as go\n",
+                "from plotly.subplots import make_subplots\n",
+                "\n",
+                "from experiments.notebooks.utils.metrics import fetch_metrics\n",
+                "from experiments.notebooks.utils.monitoring import monitor_training_statuses\n",
+                "from experiments.notebooks.utils.replays import show_replay\n",
+                "from experiments.notebooks.utils.training import launch_training\n",
+                "from datetime import datetime\n",
+                "from experiments.notebooks.utils.metrics import find_training_jobs\n",
+                "\n",
+                "%matplotlib inline\n",
+                "plt.style.use(\"default\")\n",
+                "\n",
+                "print(\"Setup complete! Auto-reload enabled.\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## Fetch Metrics"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "run_names = [\"b.jacke.basic_frost_125\", \"b.jacke.basic_frost_125\", \"b.jacke.basic_permafrost_update_branch\"]\n",
+                "metrics_dfs = fetch_metrics(run_names, samples=500)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## View how freeze_duration effects how often agents attack\n",
+                "\n",
+                "freeze_duration is [10, 125, 255] for [basic_simple, basic_frost, basic_permafrost] respectively. They are all based on the standard mettagrid environment, with a modified permafrost length."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Plot overview metrics for all fetched runs\n",
+                "if not metrics_dfs:\n",
+                "    print(\"No metrics data available. Please fetch metrics first.\")\n",
+                "else:\n",
+                "    print(f\"Plotting metrics for {len(metrics_dfs)} runs\")\n",
+                "\n",
+                "    # Find common metrics across all runs\n",
+                "    all_columns = set()\n",
+                "    for _, df in metrics_dfs.items():\n",
+                "        all_columns.update(df.columns)\n",
+                "\n",
+                "    columns = [\"env_agent/action.attack.agent\"]\n",
+                "    plot_cols = []\n",
+                "\n",
+                "    for col in all_columns:\n",
+                "        if col not in columns:\n",
+                "            continue\n",
+                "        # Check if this column exists in at least one run with numeric data\n",
+                "        has_numeric_data = False\n",
+                "        for df in metrics_dfs.values():\n",
+                "            if col in df.columns and pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() > 1:\n",
+                "                has_numeric_data = True\n",
+                "                break\n",
+                "        if has_numeric_data:\n",
+                "            plot_cols.append(col)\n",
+                "\n",
+                "    if not plot_cols:\n",
+                "        print(\"No plottable metrics found\")\n",
+                "    else:\n",
+                "        # Calculate grid dimensions\n",
+                "        n_metrics = len(plot_cols)\n",
+                "        n_cols = min(3, n_metrics)  # Max 3 columns\n",
+                "        n_rows = (n_metrics + n_cols - 1) // n_cols\n",
+                "\n",
+                "        # Create subplots\n",
+                "        fig = make_subplots(\n",
+                "            rows=n_rows,\n",
+                "            cols=n_cols,\n",
+                "            subplot_titles=[col.replace(\"overview/\", \"\").replace(\"_\", \" \") for col in plot_cols],\n",
+                "            vertical_spacing=0.08,\n",
+                "            horizontal_spacing=0.1,\n",
+                "        )\n",
+                "\n",
+                "        # Color palette for different runs\n",
+                "        colors = [\"blue\", \"red\", \"green\", \"orange\", \"purple\", \"brown\", \"pink\", \"gray\", \"olive\", \"cyan\"]\n",
+                "\n",
+                "        # Add traces for each metric and each run\n",
+                "        for idx, col in enumerate(plot_cols):\n",
+                "            row = (idx // n_cols) + 1\n",
+                "            col_idx = (idx % n_cols) + 1\n",
+                "\n",
+                "            # Plot each run for this metric\n",
+                "            for run_idx, (run_name, df) in enumerate(metrics_dfs.items()):\n",
+                "                if col in df.columns and \"_step\" in df.columns:\n",
+                "                    color = colors[run_idx % len(colors)]\n",
+                "\n",
+                "                    # Only show legend on first subplot to avoid clutter\n",
+                "                    show_legend = idx == 0\n",
+                "\n",
+                "                    fig.add_trace(\n",
+                "                        go.Scatter(\n",
+                "                            x=df[\"_step\"],\n",
+                "                            y=df[col],\n",
+                "                            mode=\"lines\",\n",
+                "                            name=run_name,\n",
+                "                            line=dict(color=color, width=2),\n",
+                "                            showlegend=show_legend,\n",
+                "                            legendgroup=run_name,  # Group all traces from same run\n",
+                "                        ),\n",
+                "                        row=row,\n",
+                "                        col=col_idx,\n",
+                "                    )\n",
+                "\n",
+                "        # Update layout\n",
+                "        runs_text = \"run\" if len(metrics_dfs) == 1 else \"runs\"\n",
+                "        fig.update_layout(\n",
+                "            height=250 * n_rows,\n",
+                "            showlegend=True,\n",
+                "            legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"right\", x=1),\n",
+                "        )\n",
+                "\n",
+                "        # Update x-axes labels for bottom row\n",
+                "        for col_idx in range(1, min(n_cols, n_metrics) + 1):\n",
+                "            fig.update_xaxes(title_text=\"Steps\", row=n_rows, col=col_idx)\n",
+                "\n",
+                "        fig.show()"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": ".venv",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.7"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
 }

--- a/experiments/notebooks/research/example.ipynb
+++ b/experiments/notebooks/research/example.ipynb
@@ -1,199 +1,194 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Mettabook"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Setup"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Optional: confirm you're set up to connect to the services used in this notebook\n",
-                "#    If the command does not run, run `./install.sh` from your terminal\n",
-                "\n",
-                "# !metta status --components=core,system,aws,wandb --non-interactive"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%load_ext autoreload\n",
-                "%autoreload 2\n",
-                "import os\n",
-                "\n",
-                "import matplotlib.pyplot as plt\n",
-                "import pandas as pd\n",
-                "import plotly.graph_objects as go\n",
-                "from plotly.subplots import make_subplots\n",
-                "\n",
-                "from experiments.notebooks.utils.metrics import fetch_metrics\n",
-                "from experiments.notebooks.utils.monitoring import monitor_training_statuses\n",
-                "from experiments.notebooks.utils.replays import show_replay\n",
-                "from experiments.notebooks.utils.training import launch_training\n",
-                "from datetime import datetime\n",
-                "from experiments.notebooks.utils.metrics import find_training_jobs\n",
-                "\n",
-                "%matplotlib inline\n",
-                "plt.style.use(\"default\")\n",
-                "\n",
-                "print(\"Setup complete! Auto-reload enabled.\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Fetch Metrics"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "run_names = [\"b.jacke.basic_frost_125\", \"b.jacke.basic_frost_125\", \"b.jacke.basic_permafrost_update_branch\"]\n",
-                "metrics_dfs = fetch_metrics(run_names, samples=500)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## View how freeze_duration effects how often agents attack\n",
-                "\n",
-                "freeze_duration is [10, 125, 255] for [basic_simple, basic_frost, basic_permafrost] respectively. They are all based on the standard mettagrid environment, with a modified permafrost length."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Plot overview metrics for all fetched runs\n",
-                "if not metrics_dfs:\n",
-                "    print(\"No metrics data available. Please fetch metrics first.\")\n",
-                "else:\n",
-                "    print(f\"Plotting metrics for {len(metrics_dfs)} runs\")\n",
-                "\n",
-                "    # Find common metrics across all runs\n",
-                "    all_columns = set()\n",
-                "    for _, df in metrics_dfs.items():\n",
-                "        all_columns.update(df.columns)\n",
-                "\n",
-                "    columns = [\"env_agent/action.attack.agent\"]\n",
-                "    plot_cols = []\n",
-                "\n",
-                "    for col in all_columns:\n",
-                "        if col not in columns:\n",
-                "            continue\n",
-                "        # Check if this column exists in at least one run with numeric data\n",
-                "        has_numeric_data = False\n",
-                "        for df in metrics_dfs.values():\n",
-                "            if col in df.columns and pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() > 1:\n",
-                "                has_numeric_data = True\n",
-                "                break\n",
-                "        if has_numeric_data:\n",
-                "            plot_cols.append(col)\n",
-                "\n",
-                "    if not plot_cols:\n",
-                "        print(\"No plottable metrics found\")\n",
-                "    else:\n",
-                "        # Calculate grid dimensions\n",
-                "        n_metrics = len(plot_cols)\n",
-                "        n_cols = min(3, n_metrics)  # Max 3 columns\n",
-                "        n_rows = (n_metrics + n_cols - 1) // n_cols\n",
-                "\n",
-                "        # Create subplots\n",
-                "        fig = make_subplots(\n",
-                "            rows=n_rows,\n",
-                "            cols=n_cols,\n",
-                "            subplot_titles=[col.replace(\"overview/\", \"\").replace(\"_\", \" \") for col in plot_cols],\n",
-                "            vertical_spacing=0.08,\n",
-                "            horizontal_spacing=0.1,\n",
-                "        )\n",
-                "\n",
-                "        # Color palette for different runs\n",
-                "        colors = [\"blue\", \"red\", \"green\", \"orange\", \"purple\", \"brown\", \"pink\", \"gray\", \"olive\", \"cyan\"]\n",
-                "\n",
-                "        # Add traces for each metric and each run\n",
-                "        for idx, col in enumerate(plot_cols):\n",
-                "            row = (idx // n_cols) + 1\n",
-                "            col_idx = (idx % n_cols) + 1\n",
-                "\n",
-                "            # Plot each run for this metric\n",
-                "            for run_idx, (run_name, df) in enumerate(metrics_dfs.items()):\n",
-                "                if col in df.columns and \"_step\" in df.columns:\n",
-                "                    color = colors[run_idx % len(colors)]\n",
-                "\n",
-                "                    # Only show legend on first subplot to avoid clutter\n",
-                "                    show_legend = idx == 0\n",
-                "\n",
-                "                    fig.add_trace(\n",
-                "                        go.Scatter(\n",
-                "                            x=df[\"_step\"],\n",
-                "                            y=df[col],\n",
-                "                            mode=\"lines\",\n",
-                "                            name=run_name,\n",
-                "                            line=dict(color=color, width=2),\n",
-                "                            showlegend=show_legend,\n",
-                "                            legendgroup=run_name,  # Group all traces from same run\n",
-                "                        ),\n",
-                "                        row=row,\n",
-                "                        col=col_idx,\n",
-                "                    )\n",
-                "\n",
-                "        # Update layout\n",
-                "        runs_text = \"run\" if len(metrics_dfs) == 1 else \"runs\"\n",
-                "        fig.update_layout(\n",
-                "            height=250 * n_rows,\n",
-                "            showlegend=True,\n",
-                "            legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"right\", x=1),\n",
-                "        )\n",
-                "\n",
-                "        # Update x-axes labels for bottom row\n",
-                "        for col_idx in range(1, min(n_cols, n_metrics) + 1):\n",
-                "            fig.update_xaxes(title_text=\"Steps\", row=n_rows, col=col_idx)\n",
-                "\n",
-                "        fig.show()"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": ".venv",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.7"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mettabook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: confirm you're set up to connect to the services used in this notebook\n",
+    "#    If the command does not run, run `./install.sh` from your terminal\n",
+    "\n",
+    "# !metta status --components=core,system,aws,wandb --non-interactive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import plotly.graph_objects as go\n",
+    "from plotly.subplots import make_subplots\n",
+    "\n",
+    "from experiments.notebooks.utils.metrics import fetch_metrics\n",
+    "\n",
+    "%matplotlib inline\n",
+    "plt.style.use(\"default\")\n",
+    "\n",
+    "print(\"Setup complete! Auto-reload enabled.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_names = [\"b.jacke.basic_frost_125\", \"b.jacke.basic_frost_125\", \"b.jacke.basic_permafrost_update_branch\"]\n",
+    "metrics_dfs = fetch_metrics(run_names, samples=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## View how freeze_duration effects how often agents attack\n",
+    "\n",
+    "freeze_duration is [10, 125, 255] for [basic_simple, basic_frost, basic_permafrost] respectively. They are all based on the standard mettagrid environment, with a modified permafrost length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot overview metrics for all fetched runs\n",
+    "if not metrics_dfs:\n",
+    "    print(\"No metrics data available. Please fetch metrics first.\")\n",
+    "else:\n",
+    "    print(f\"Plotting metrics for {len(metrics_dfs)} runs\")\n",
+    "\n",
+    "    # Find common metrics across all runs\n",
+    "    all_columns = set()\n",
+    "    for _, df in metrics_dfs.items():\n",
+    "        all_columns.update(df.columns)\n",
+    "\n",
+    "    columns = [\"env_agent/action.attack.agent\"]\n",
+    "    plot_cols = []\n",
+    "\n",
+    "    for col in all_columns:\n",
+    "        if col not in columns:\n",
+    "            continue\n",
+    "        # Check if this column exists in at least one run with numeric data\n",
+    "        has_numeric_data = False\n",
+    "        for df in metrics_dfs.values():\n",
+    "            if col in df.columns and pd.api.types.is_numeric_dtype(df[col]) and df[col].nunique() > 1:\n",
+    "                has_numeric_data = True\n",
+    "                break\n",
+    "        if has_numeric_data:\n",
+    "            plot_cols.append(col)\n",
+    "\n",
+    "    if not plot_cols:\n",
+    "        print(\"No plottable metrics found\")\n",
+    "    else:\n",
+    "        # Calculate grid dimensions\n",
+    "        n_metrics = len(plot_cols)\n",
+    "        n_cols = min(3, n_metrics)  # Max 3 columns\n",
+    "        n_rows = (n_metrics + n_cols - 1) // n_cols\n",
+    "\n",
+    "        # Create subplots\n",
+    "        fig = make_subplots(\n",
+    "            rows=n_rows,\n",
+    "            cols=n_cols,\n",
+    "            subplot_titles=[col.replace(\"overview/\", \"\").replace(\"_\", \" \") for col in plot_cols],\n",
+    "            vertical_spacing=0.08,\n",
+    "            horizontal_spacing=0.1,\n",
+    "        )\n",
+    "\n",
+    "        # Color palette for different runs\n",
+    "        colors = [\"blue\", \"red\", \"green\", \"orange\", \"purple\", \"brown\", \"pink\", \"gray\", \"olive\", \"cyan\"]\n",
+    "\n",
+    "        # Add traces for each metric and each run\n",
+    "        for idx, col in enumerate(plot_cols):\n",
+    "            row = (idx // n_cols) + 1\n",
+    "            col_idx = (idx % n_cols) + 1\n",
+    "\n",
+    "            # Plot each run for this metric\n",
+    "            for run_idx, (run_name, df) in enumerate(metrics_dfs.items()):\n",
+    "                if col in df.columns and \"_step\" in df.columns:\n",
+    "                    color = colors[run_idx % len(colors)]\n",
+    "\n",
+    "                    # Only show legend on first subplot to avoid clutter\n",
+    "                    show_legend = idx == 0\n",
+    "\n",
+    "                    fig.add_trace(\n",
+    "                        go.Scatter(\n",
+    "                            x=df[\"_step\"],\n",
+    "                            y=df[col],\n",
+    "                            mode=\"lines\",\n",
+    "                            name=run_name,\n",
+    "                            line=dict(color=color, width=2),\n",
+    "                            showlegend=show_legend,\n",
+    "                            legendgroup=run_name,  # Group all traces from same run\n",
+    "                        ),\n",
+    "                        row=row,\n",
+    "                        col=col_idx,\n",
+    "                    )\n",
+    "\n",
+    "        # Update layout\n",
+    "        runs_text = \"run\" if len(metrics_dfs) == 1 else \"runs\"\n",
+    "        fig.update_layout(\n",
+    "            height=250 * n_rows,\n",
+    "            showlegend=True,\n",
+    "            legend=dict(orientation=\"h\", yanchor=\"bottom\", y=1.02, xanchor=\"right\", x=1),\n",
+    "        )\n",
+    "\n",
+    "        # Update x-axes labels for bottom row\n",
+    "        for col_idx in range(1, min(n_cols, n_metrics) + 1):\n",
+    "            fig.update_xaxes(title_text=\"Steps\", row=n_rows, col=col_idx)\n",
+    "\n",
+    "        fig.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/metta/setup/components/codeflow.py
+++ b/metta/setup/components/codeflow.py
@@ -1,0 +1,48 @@
+import subprocess
+
+from metta.setup.components.base import SetupModule
+from metta.setup.config import UserType
+from metta.setup.registry import register_module
+from metta.setup.utils import info, success, warning
+
+
+@register_module
+class CodeflowSetup(SetupModule):
+    install_once = True  # Only install once, not every time
+
+    @property
+    def description(self) -> str:
+        return "Developer tools copying code for LLM contexts"
+
+    def is_applicable(self) -> bool:
+        # Only applicable for developer profiles, not docker profiles
+        return self.config.user_type in [UserType.SOFTMAX, UserType.EXTERNAL, UserType.CLOUD]
+
+    def check_installed(self) -> bool:
+        """Check if codeflow is installed."""
+        try:
+            result = subprocess.run(["uv", "tool", "list"], capture_output=True, text=True, check=True)
+            return "codeflow" in result.stdout
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+
+    def install(self) -> None:
+        """Install codeflow as an editable uv tool."""
+        codeflow_dir = self.repo_root / "metta" / "setup" / "tools" / "codeflow"
+
+        if not codeflow_dir.exists():
+            warning(f"Codeflow directory not found at {codeflow_dir}")
+            return
+
+        info("Installing codeflow tool...")
+
+        # Install as editable package using uv
+        try:
+            # Use --force to update if already installed
+            self.run_command(["uv", "tool", "install", "--force", "-e", str(codeflow_dir)])
+            success("Codeflow tool installed successfully!")
+            info("You can now use 'metta code' or 'codeflow' commands")
+        except subprocess.CalledProcessError as e:
+            warning(f"Failed to install codeflow: {e}")
+            warning("You can manually install it with:")
+            warning(f"  cd {codeflow_dir} && uv tool install --force -e .")

--- a/metta/setup/config.py
+++ b/metta/setup/config.py
@@ -90,6 +90,7 @@ PROFILE_DEFINITIONS: dict[UserType, ProfileConfig] = {
         "components": {
             "system": {"enabled": True},
             "core": {"enabled": True},
+            "codeflow": {"enabled": True},
             "githooks": {"enabled": True},
             "mettascope": {"enabled": True},
             "observatory-fe": {"enabled": True},

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -215,6 +215,17 @@ class MettaCLI:
             except subprocess.CalledProcessError as e:
                 warning(f"  Cleanup script failed: {e}")
 
+    def cmd_code(self, args) -> None:
+        """Run the codeflow tool with provided arguments."""
+        try:
+            # Simply pass through to codeflow
+            cmd = ["codeflow"] + (args.args if args.args else ["--help"])
+            subprocess.run(cmd, check=False)
+        except FileNotFoundError:
+            error("Codeflow is not installed.")
+            error("Run: metta install codeflow")
+            sys.exit(1)
+
     def _truncate(self, text: str, max_len: int) -> str:
         """Truncate text to max length with ellipsis."""
         if len(text) <= max_len:
@@ -610,6 +621,10 @@ Examples:
         enter_parser = kind_subparsers.add_parser("enter", help="Enter a pod with an interactive shell")
         enter_parser.add_argument("pod_name", help="Name of the pod to enter")
 
+        # Add code command
+        code_parser = subparsers.add_parser("code", help="copy subsets of code for LLM contexts", add_help=False)
+        code_parser.add_argument("args", nargs=argparse.REMAINDER, help="arguments to pass to the code tool")
+
         # Store local_parser for help display
         local_parser.set_defaults(local_parser=local_parser)
 
@@ -624,7 +639,7 @@ Examples:
         ):
             # These commands handle their own args
             pass
-        elif args.command not in ["test", "test-changed", "tool"]:
+        elif args.command not in ["code", "test", "test-changed", "tool"]:
             if unknown_args:
                 parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
 
@@ -671,6 +686,8 @@ Examples:
             self.cmd_shell()
         elif args.command == "report-env-details":
             self.cmd_report_env_details()
+        elif args.command == "code":
+            self.cmd_code(args)
         elif args.command == "local":
             self.cmd_local(args, unknown_args)
         else:

--- a/metta/setup/tools/codeflow/README.md
+++ b/metta/setup/tools/codeflow/README.md
@@ -1,0 +1,36 @@
+# codeflow
+
+**codeflow** is a tool for copying a codebase (or parts of it) for use with LLM prompts.
+
+## How it works
+
+codeflow is a spiritual descendant of [files-to-prompt](https://github.com/simonw/files-to-prompt),
+a tool for specifying and formatting a subset of a codebase to submit as context to an LLM.
+
+codeflow builds on files-to-prompt with additional features:
+
+- Automatic detection and prioritization of parent READMEs
+- Token profiling to understand context window usage
+- Flame graph visualization of token distribution
+
+## Usage
+
+```bash
+# Copy current directory to clipboard (macOS):
+metta code -p
+
+# Copy specific paths (space-separated, relative to current directory):
+metta code src tests
+
+# Filter to specific file types:
+metta code -e .py -e .js src
+
+# Generate raw output instead of XML-wrapped:
+metta code -r src tests
+
+# Profile token usage:
+metta code --profile src
+
+# Generate interactive flame graph of token distribution:
+metta code --flamegraph src
+```

--- a/metta/setup/tools/codeflow/codeflow/cli.py
+++ b/metta/setup/tools/codeflow/codeflow/cli.py
@@ -47,8 +47,14 @@ def cli(
 ) -> None:
     """
     Provide codebase context to LLMs with smart defaults.
-    - PATHS can be space-separated. Example: manabot managym/tests
+    - PATHS can be space-separated. Example: metta/rl tests/rl
     """
+    # If no paths provided and no flags, show help
+    if not paths and not any([profile, flamegraph, extension]):
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        ctx.exit()
+
     # Use provided paths or default to current directory
     path_list = list(paths) if paths else ["."]
     logger.debug(f"Paths: {path_list}")

--- a/metta/setup/tools/codeflow/codeflow/cli.py
+++ b/metta/setup/tools/codeflow/codeflow/cli.py
@@ -1,0 +1,108 @@
+"""
+Command-line interface for code context retrieval.
+
+Provides a flexible way to extract context from codebases for LLM interactions.
+"""
+
+import logging
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from typing import Tuple
+
+import click
+
+from .file import get_context
+from .token_profiler import generate_flamegraph, profile_code_context
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO if os.getenv("LOGLEVEL", "info").lower() == "info" else logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("codeflow.cli")
+
+
+def copy_to_clipboard(content: str) -> None:
+    """Copy content to clipboard on macOS."""
+    try:
+        process = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+        process.communicate(content.encode("utf-8"))
+    except FileNotFoundError:
+        click.echo("pbcopy not found - clipboard integration skipped", err=True)
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("paths", nargs=-1, type=str)
+@click.option("-p", "--pbcopy", is_flag=True, help="Copy to clipboard (macOS only)")
+@click.option("-r", "--raw", is_flag=True, help="Output in raw format instead of XML")
+@click.option("-e", "--extension", multiple=True, help="File extensions to include (e.g. -e .py -e .js)")
+@click.option("--profile", is_flag=True, help="Profile token distribution instead of outputting content")
+@click.option("--flamegraph", is_flag=True, help="Generate a flame graph HTML visualization of token distribution")
+def cli(
+    paths: Tuple[str, ...], pbcopy: bool, raw: bool, extension: Tuple[str, ...], profile: bool, flamegraph: bool
+) -> None:
+    """
+    Provide codebase context to LLMs with smart defaults.
+    - PATHS can be space-separated. Example: manabot managym/tests
+    """
+    # Use provided paths or default to current directory
+    path_list = list(paths) if paths else ["."]
+    logger.debug(f"Paths: {path_list}")
+
+    # Load context documents from current directory
+    try:
+        if profile or flamegraph:
+            logger.debug(f"Profiling code context for {path_list}")
+            output_content, profile_data = profile_code_context(path_list, raw, extension)
+            logger.debug("Profile complete")
+
+            if flamegraph:
+                # Create temp file in /tmp directory
+                project_name = path_list[0].split("/")[-1] if path_list else "code"
+                temp_file = tempfile.NamedTemporaryFile(
+                    prefix=f"flamegraph_{project_name}_", suffix=".html", dir="/tmp", delete=False
+                )
+                flamegraph_path = temp_file.name
+                temp_file.close()
+
+                # Generate the flame graph
+                logger.debug(f"Generating flame graph at: {flamegraph_path}")
+                generate_flamegraph(profile_data, flamegraph_path)
+                logger.debug(f"Flame graph generated at: {flamegraph_path}")
+                click.echo(f"Flame graph generated at: {flamegraph_path}")
+
+                # Open the file in Chrome
+                try:
+                    system = platform.system()
+                    if system == "Darwin":  # macOS
+                        subprocess.run(["open", "-a", "Google Chrome", flamegraph_path])
+                    elif system == "Linux":
+                        subprocess.run(["google-chrome", flamegraph_path])
+                    elif system == "Windows":
+                        subprocess.run(["chrome", flamegraph_path], shell=True)
+                    else:
+                        click.echo(f"Flame graph saved but couldn't auto-open browser on {system}.")
+                except Exception as e:
+                    click.echo(f"Flame graph saved but couldn't launch Chrome: {e}")
+
+                # Return early when flamegraph is generated - don't output content
+                return
+        else:
+            # Regular content output
+            output_content = get_context(paths=path_list, raw=raw, extensions=extension)
+    except Exception as e:
+        click.echo(f"Error loading context: {e}", err=True)
+        return
+
+    if pbcopy:
+        copy_to_clipboard(output_content)
+    else:
+        click.echo(output_content)
+
+
+if __name__ == "__main__":
+    cli()

--- a/metta/setup/tools/codeflow/codeflow/file.py
+++ b/metta/setup/tools/codeflow/codeflow/file.py
@@ -106,6 +106,61 @@ def _should_ignore(
     rel_path = os.path.relpath(str(path), root_dir)
     basename = path.name
 
+    # Common dependency/build directories to always ignore
+    ignored_dirs = {
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "env",
+        ".env",
+        "virtualenv",
+        ".tox",
+        "dist",
+        "build",
+        "target",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "htmlcov",
+        ".coverage",
+        "site-packages",
+        "vendor",
+        "vendors",
+        "bower_components",
+        ".bundle",
+        "deps",
+        "dependencies",
+        ".cargo",
+        ".gradle",
+        ".idea",
+        ".vscode",
+        ".vs",
+        "obj",
+        "bin",
+        "out",
+        ".next",
+        ".nuxt",
+        ".cache",
+        ".parcel-cache",
+        ".turbo",
+        ".vercel",
+        ".netlify",
+        ".serverless",
+        "tmp",
+        "temp",
+        "logs",
+        ".git",
+        ".svn",
+        ".hg",
+    }
+
+    # Check if any part of the path contains ignored directories
+    path_parts = Path(rel_path).parts
+    for part in path_parts:
+        if part in ignored_dirs:
+            return True
+
     # Always skip binary or data files
     if _should_ignore_file_type(path):
         return True
@@ -165,6 +220,7 @@ def _should_ignore_file_type(path: Path) -> bool:
         ".so",
         ".dll",
         ".dylib",
+        ".node",
         # Executables
         ".exe",
         ".bin",
@@ -176,6 +232,7 @@ def _should_ignore_file_type(path: Path) -> bool:
         ".xz",
         ".7z",
         ".rar",
+        ".z",
         # Images
         ".jpg",
         ".jpeg",
@@ -186,6 +243,12 @@ def _should_ignore_file_type(path: Path) -> bool:
         ".ico",
         ".webp",
         ".tiff",
+        # Fonts
+        ".ttf",
+        ".otf",
+        ".woff",
+        ".woff2",
+        ".eot",
         # ML model files
         ".pt",
         ".pth",
@@ -198,12 +261,14 @@ def _should_ignore_file_type(path: Path) -> bool:
         ".db",
         ".sqlite",
         ".sqlite3",
+        ".duckdb",
         # Data formats
         ".parquet",
         ".feather",
         ".arrow",
         ".hdf5",
         ".h5",
+        ".pbf",
         # Package files
         ".whl",
         ".egg",
@@ -222,6 +287,7 @@ def _should_ignore_file_type(path: Path) -> bool:
         ".swp",
         ".swo",
         ".swn",
+        ".wal",
     }
 
     # Specific filenames to ignore
@@ -428,7 +494,7 @@ def get_context(
     if not paths:
         return "" if raw else "<documents></documents>"
 
-    processed_files: Set[str] = set()
+    processed_files: Set[Path] = set()
     documents = []
     next_index = 1
 

--- a/metta/setup/tools/codeflow/codeflow/file.py
+++ b/metta/setup/tools/codeflow/codeflow/file.py
@@ -1,0 +1,480 @@
+"""
+File loading and context extraction utilities.
+
+Provides methods for collecting and formatting files from different project structures,
+with special handling for READMEs and support for both XML and raw output formats.
+"""
+
+import fnmatch
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Set, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Document:
+    """Represents a file's content and metadata for context output."""
+
+    index: int
+    source: str
+    content: str
+    is_readme: bool = False
+
+
+def resolve_codebase_path(path_str: Union[str, Path]) -> Path:
+    """
+    Convert path string to an absolute path relative to current working directory.
+
+    Args:
+        path_str: Path to resolve
+
+    Returns:
+        Resolved absolute path
+    """
+    path_obj = Path(str(path_str))
+
+    # If path is absolute, just return it
+    if path_obj.is_absolute():
+        return path_obj.resolve()
+
+    # All relative paths are resolved against current working directory
+    return (Path.cwd() / path_obj).resolve()
+
+
+def _find_git_root(start_path: Path) -> Optional[Path]:
+    """
+    Find the root of the git repository containing the given path.
+
+    Args:
+        start_path: Path to start searching from
+
+    Returns:
+        Path to git root directory, or None if not in a git repo
+    """
+    current = start_path if start_path.is_dir() else start_path.parent
+
+    # Search up the directory tree for .git directory
+    while current != current.parent:
+        if (current / ".git").is_dir():
+            return current
+        current = current.parent
+
+    return None
+
+
+def _find_parent_readmes(path: Path) -> List[Path]:
+    """
+    Find all README.md files from given path up to git root (or filesystem root).
+
+    Args:
+        path: Path to start from
+
+    Returns:
+        List of README paths from deepest to shallowest
+    """
+    readmes = []
+    current = path if path.is_dir() else path.parent
+
+    # Find the git root to use as our boundary
+    git_root = _find_git_root(current)
+    stop_at = git_root if git_root else Path("/")
+
+    # Collect READMEs up to the boundary
+    while True:
+        readme_path = current / "README.md"
+        if readme_path.exists() and readme_path not in readmes:
+            readmes.append(readme_path)
+
+        # Stop if we've reached our boundary or can't go higher
+        if current == stop_at or current == current.parent:
+            break
+
+        current = current.parent
+
+    # Sort by depth and path
+    readmes.sort(key=lambda p: (len(p.parts), str(p)))
+    return readmes
+
+
+def _should_ignore(
+    path: Path, gitignore_rules: List[str], root_dir: Path, extensions: Optional[Tuple[str, ...]] = None
+) -> bool:
+    rel_path = os.path.relpath(str(path), root_dir)
+    basename = path.name
+
+    # Always skip binary or data files
+    if _should_ignore_file_type(path):
+        return True
+
+    # Always include README.md
+    if basename == "README.md":
+        return False
+
+    # If filtering by extension for files, and this file doesn’t match, ignore it.
+    if extensions and path.is_file() and not any(path.name.endswith(ext) for ext in extensions):
+        return True
+
+    for rule in gitignore_rules:
+        rule = rule.strip()
+        if not rule or rule.startswith("#"):
+            continue
+
+        # If the rule contains a slash, treat it as relative to the project_dir.
+        if "/" in rule:
+            # For rules starting with a slash, strip it and check if rel_path starts with the pattern.
+            if rule.startswith("/"):
+                pattern = rule.lstrip("/")
+                # If rule ends with a slash, match directory prefixes.
+                if rule.endswith("/"):
+                    if rel_path.startswith(pattern):
+                        return True
+                else:
+                    # Use fnmatch to allow wildcards.
+                    if fnmatch.fnmatch(rel_path, pattern):
+                        return True
+            else:
+                # Rule with a slash but not anchored; apply fnmatch against the entire relative path.
+                if fnmatch.fnmatch(rel_path, rule):
+                    return True
+        else:
+            # For rules without a slash:
+            # If the rule appears as a glob pattern, match against basename and anywhere in rel_path.
+            if any(ch in rule for ch in "*?[]"):
+                if fnmatch.fnmatch(basename, rule) or fnmatch.fnmatch(rel_path, f"*{rule}*"):
+                    return True
+            else:
+                # Plain string: if the rule appears anywhere in basename or rel_path, ignore.
+                if rule in basename or rule in rel_path:
+                    return True
+    return False
+
+
+def _should_ignore_file_type(path: Path) -> bool:
+    """Check if a file should be ignored based on its type (extension, name, or pattern)."""
+    # Binary and compiled extensions
+    binary_extensions = {
+        # Python compiled
+        ".pyc",
+        ".pyo",
+        ".pyd",
+        # Native libraries
+        ".so",
+        ".dll",
+        ".dylib",
+        # Executables
+        ".exe",
+        ".bin",
+        # Archives
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".xz",
+        ".7z",
+        ".rar",
+        # Images
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".gif",
+        ".bmp",
+        ".svg",
+        ".ico",
+        ".webp",
+        ".tiff",
+        # ML model files
+        ".pt",
+        ".pth",
+        ".ckpt",
+        ".safetensors",
+        ".pkl",
+        ".pickle",
+        ".joblib",
+        # Database files
+        ".db",
+        ".sqlite",
+        ".sqlite3",
+        # Data formats
+        ".parquet",
+        ".feather",
+        ".arrow",
+        ".hdf5",
+        ".h5",
+        # Package files
+        ".whl",
+        ".egg",
+        # Misc binary
+        ".wandb",
+    }
+
+    # Non-source text extensions
+    data_extensions = {
+        ".log",
+        ".cache",
+        ".tmp",
+        ".temp",
+        ".bak",
+        ".backup",
+        ".swp",
+        ".swo",
+        ".swn",
+    }
+
+    # Specific filenames to ignore
+    ignored_filenames = {
+        # Lock files
+        "uv.lock",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "poetry.lock",
+        "Pipfile.lock",
+        "Cargo.lock",
+        "composer.lock",
+        # Cache files
+        ".DS_Store",
+        "Thumbs.db",
+        "desktop.ini",
+        # Build artifacts
+        ".coverage",
+        "coverage.xml",
+    }
+
+    # Check extensions
+    ext = path.suffix.lower()
+    if ext in binary_extensions or ext in data_extensions:
+        return True
+
+    # Check exact filenames
+    if path.name in ignored_filenames:
+        return True
+
+    # Check patterns
+    ignored_patterns = [
+        "*_cache.json",
+        "*.cache",
+        "*.egg-info",
+        "*~",  # Editor temp files
+        ".#*",  # Emacs lock files
+    ]
+
+    for pattern in ignored_patterns:
+        if fnmatch.fnmatch(path.name, pattern):
+            return True
+
+    return False
+
+
+def _load_file(
+    path: Path,
+    index: int,
+    processed_files: Set[Path],
+) -> Optional[Document]:
+    """Load a single file into a Document if it meets criteria."""
+    if path in processed_files:
+        return None
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return Document(index=index, source=str(path), content=f.read(), is_readme=path.name.endswith("README.md"))
+    except UnicodeDecodeError:
+        logger.warning(f"Skipping file {path} due to UnicodeDecodeError")
+        return None
+    except Exception as e:
+        logger.error(f"Error reading {path}: {e}")
+        return None
+
+
+def _matches_extensions(path: Path, extensions: Optional[Tuple[str, ...]] = None) -> bool:
+    """Check if a file path matches any of the given extensions."""
+    if extensions is None or len(extensions) == 0:
+        return True
+    logger.info(f"Checking if {path} matches extensions {extensions}")
+    logger.debug(f"Any extensions match? {any(path.name.endswith(ext) for ext in extensions)}")
+    return path.name.endswith("README.md") or any(path.name.endswith(ext) for ext in extensions)
+
+
+def _collect_files(
+    path: Path,
+    gitignore_rules: List[str],
+    gitignore_root: Optional[Path],
+    processed_files: Set[Path],
+    next_index: int,
+    extensions: Optional[Tuple[str, ...]] = None,
+) -> List[Document]:
+    """Recursively collect files into Document objects."""
+    documents = []
+    current_index = next_index
+    path_obj = Path(path)
+    # Use the gitignore root if provided, otherwise use the path's parent
+    root_dir = gitignore_root if gitignore_root else (path_obj if path_obj.is_dir() else path_obj.parent)
+
+    def process_file(file_path: Path) -> None:
+        nonlocal current_index
+        if doc := _load_file(file_path, current_index, processed_files):
+            documents.append(doc)
+            processed_files.add(file_path)
+            current_index += 1
+
+    if path_obj.is_file():
+        if not _should_ignore(path_obj, gitignore_rules, root_dir, extensions):
+            process_file(path_obj)
+
+    elif path_obj.is_dir():
+        for root, dirs, files in os.walk(path_obj):
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+            files = [f for f in files if not f.startswith(".")]
+
+            dirs[:] = [
+                d
+                for d in dirs
+                if not _should_ignore(Path(os.path.join(root, d)), gitignore_rules, root_dir, extensions)
+            ]
+            files = [
+                f
+                for f in files
+                if not _should_ignore(Path(os.path.join(root, f)), gitignore_rules, root_dir, extensions)
+            ]
+
+            for file_name in sorted(files):
+                process_file(Path(os.path.join(root, file_name)))
+
+    return documents
+
+
+def _read_gitignore(path: str) -> List[str]:
+    """Return lines from .gitignore for ignoring certain files/directories."""
+    if os.path.isfile(path):
+        try:
+            with open(path, "r") as f:
+                return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+        except Exception:
+            return []
+    return []
+
+
+def _find_gitignore(start_path: Path) -> Optional[Path]:
+    """
+    Find the nearest .gitignore file by searching up the directory tree.
+
+    Args:
+        start_path: Path to start searching from
+
+    Returns:
+        Path to .gitignore file, or None if not found
+    """
+    current = start_path if start_path.is_dir() else start_path.parent
+
+    # Find the git root to use as our boundary
+    git_root = _find_git_root(current)
+    stop_at = git_root if git_root else Path("/")
+
+    # Search up the directory tree for .gitignore
+    while True:
+        gitignore_path = current / ".gitignore"
+        if gitignore_path.exists():
+            return gitignore_path
+
+        # Stop if we've reached our boundary or can't go higher
+        if current == stop_at or current == current.parent:
+            break
+
+        current = current.parent
+
+    return None
+
+
+def _format_document(doc: Document, raw: bool) -> str:
+    """Format a document according to output format."""
+    if raw:
+        lines = [doc.source, "---"]
+        if doc.is_readme:
+            lines.append("### README START ###")
+        lines.append(doc.content)
+        if doc.is_readme:
+            lines.append("### README END ###")
+        lines.append("---")
+    else:
+        lines = [f'<document index="{doc.index}">', f"<source>{doc.source}</source>"]
+        if doc.is_readme:
+            lines.extend(["<type>readme</type>", "<instructions>", doc.content, "</instructions>"])
+        else:
+            lines.extend(["<document_content>", doc.content, "</document_content>"])
+        lines.append("</document>")
+
+    return "\n".join(lines)
+
+
+def get_context(
+    paths: Optional[List[Union[str, Path]]], raw: bool = False, extensions: Optional[Tuple[str, ...]] = None
+) -> str:
+    """
+    Load and format context from specified paths.
+
+    Args:
+        paths: List of paths to load context from, or None for no context
+        raw: Whether to use raw format instead of XML
+        extensions: Optional tuple of file extensions to filter
+
+    Returns:
+        Formatted context string
+    """
+
+    # Handle empty paths
+    if not paths:
+        return "" if raw else "<documents></documents>"
+
+    processed_files: Set[str] = set()
+    documents = []
+    next_index = 1
+
+    for path_str in paths:
+        try:
+            # Resolve path relative to current directory
+            path = resolve_codebase_path(path_str)
+
+            if not path.exists():
+                logger.warning(f"Path does not exist: {path}")
+                continue
+
+            # Process parent READMEs first
+            for readme_path in _find_parent_readmes(path):
+                if doc := _load_file(readme_path, next_index, processed_files):
+                    documents.append(doc)
+                    processed_files.add(readme_path)
+                    next_index += 1
+
+            # Process requested path
+            gitignore_path = _find_gitignore(path)
+            gitignore_rules = _read_gitignore(str(gitignore_path)) if gitignore_path else []
+            gitignore_root = gitignore_path.parent if gitignore_path else None
+            new_docs = _collect_files(path, gitignore_rules, gitignore_root, processed_files, next_index, extensions)
+            next_index += len(new_docs)
+            documents.extend(new_docs)
+
+        except Exception as e:
+            print(f"Error processing path {path_str}: {e}")
+
+    # Sort documents (READMEs first, then by path)
+    documents.sort(key=lambda d: (not d.is_readme, d.source))
+
+    # Re-index documents
+    for i, doc in enumerate(documents, 1):
+        doc.index = i
+
+    # Generate output
+    output_lines = []
+    if not raw:
+        output_lines.append("<documents>")
+
+    for doc in documents:
+        output_lines.append(_format_document(doc, raw))
+
+    if not raw:
+        output_lines.append("</documents>")
+
+    return "\n".join(output_lines)

--- a/metta/setup/tools/codeflow/codeflow/token_profiler.py
+++ b/metta/setup/tools/codeflow/codeflow/token_profiler.py
@@ -1,0 +1,499 @@
+"""
+Token profiling functionality with integrated flame graph generation and proper common prefix handling
+"""
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import tiktoken
+
+from .file import get_context
+
+
+@dataclass
+class TokenNode:
+    """Node for tracking token counts in a hierarchy."""
+
+    label: str
+    parent: Optional["TokenNode"]
+    total_tokens: int = 0
+
+    @property
+    def pct_of_parent(self) -> float:
+        if not self.parent:
+            return 100.0
+        return (self.total_tokens / self.parent.total_tokens * 100) if self.parent.total_tokens else 0.0
+
+    @property
+    def pct_of_total(self) -> float:
+        root = self
+        while root.parent:
+            root = root.parent
+        return (self.total_tokens / root.total_tokens * 100) if root.total_tokens else 0.0
+
+
+class TokenProfiler:
+    """Profiles token distribution across files and directories."""
+
+    def __init__(self):
+        self.encoding = tiktoken.get_encoding("cl100k_base")
+        # Cache nodes by full path
+        self.node_cache: Dict[str, TokenNode] = {}
+        # Track file types
+        self.type_counts: Dict[str, int] = {}
+        self.total_tokens = 0
+        # Store paths for common prefix calculation
+        self.file_paths: List[str] = []
+
+    def count_tokens(self, content: str) -> int:
+        """Count tokens in content using configured encoding."""
+        return len(self.encoding.encode(content))
+
+    def get_or_create_node(self, path: Path) -> TokenNode:
+        """Get existing node or create new one with proper hierarchy."""
+        str_path = str(path)
+
+        # Store the path for common prefix calculation
+        self.file_paths.append(str_path)
+
+        if str_path in self.node_cache:
+            return self.node_cache[str_path]
+
+        # Create parent first if needed
+        parent = None
+        if path.parent != path:
+            parent = self.get_or_create_node(path.parent)
+
+        node = TokenNode(path.name, parent)
+        self.node_cache[str_path] = node
+        return node
+
+    def process_file(self, filepath: Path, content: str) -> None:
+        """Process single file and update relevant counts."""
+        token_count = self.count_tokens(content)
+
+        # Update directory hierarchy
+        node = self.get_or_create_node(filepath.parent)
+        current = node
+        while current:
+            current.total_tokens += token_count
+            current = current.parent
+
+        # Update file type stats
+        ext = filepath.suffix.lower()
+        self.type_counts[ext] = self.type_counts.get(ext, 0) + token_count
+        self.total_tokens += token_count
+
+    def format_hierarchical_report(self, common_prefix: str) -> str:
+        """Generate hierarchical token distribution report."""
+        lines = ["Token Distribution by Directory:"]
+        lines.append("-" * 80)
+        lines.append(f"{'Directory':<50} {'Tokens':>10} {'% Parent':>10} {'% Total':>10}")
+        lines.append("-" * 80)
+
+        # Find common prefix to exclude from display
+        prefix_len = len(common_prefix) if common_prefix else 0
+
+        # Sort by path depth then alphabetically
+        paths = sorted(self.node_cache.keys(), key=lambda x: (len(Path(x).parts), x))
+
+        # Find the project root to use as base for display
+        for path in paths:
+            node = self.node_cache[path]
+            path_obj = Path(path)
+
+            # Skip the path if it's the common prefix or shorter
+            if path == common_prefix or len(path) < prefix_len:
+                continue
+
+            # Remove common prefix for display
+            display_path = path[prefix_len:] if prefix_len > 0 else path
+
+            # Calculate indent based on path depth
+            parts = [p for p in display_path.split(os.sep) if p]
+            indent = "  " * max(0, len(parts) - 1)
+
+            # Use the last part of the path as the name
+            name = path_obj.name or display_path
+
+            lines.append(
+                f"{indent}{name:<50} {node.total_tokens:>10} {node.pct_of_parent:>9.1f}% {node.pct_of_total:>9.1f}%"
+            )
+
+        return "\n".join(lines)
+
+    def format_type_report(self) -> str:
+        """Generate file type distribution report."""
+        lines = ["Token Distribution by File Type:"]
+        lines.append("-" * 60)
+        lines.append(f"{'Type':<20} {'Tokens':>10} {'% Total':>10}")
+        lines.append("-" * 60)
+
+        # Sort by token count descending
+        sorted_types = sorted(self.type_counts.items(), key=lambda x: x[1], reverse=True)
+
+        for ext, count in sorted_types:
+            ext_name = ext if ext else "(no extension)"
+            pct = count / self.total_tokens * 100 if self.total_tokens else 0
+            lines.append(f"{ext_name:<20} {count:>10} {pct:>9.1f}%")
+
+        return "\n".join(lines)
+
+
+def extract_files_from_context(context: str, raw: bool) -> Dict[str, str]:
+    """Extract file paths and contents from context string."""
+    files = {}
+
+    if raw:
+        # Parse raw format
+        pattern = r"(.*?)\n---\n(?:### README START ###\n)?(.*?)(?:\n### README END ###)?(?=\n---|\Z)"
+        matches = re.findall(pattern, context, re.DOTALL)
+        for path, content in matches:
+            path = path.strip()
+            if path:
+                files[path] = content
+    else:
+        # Parse XML format
+        pattern = (
+            r"<document .*?>\s*<source>(.*?)</source>.*?"
+            r"(?:<document_content>(.*?)</document_content>|<instructions>(.*?)</instructions>).*?</document>"
+        )
+        matches = re.findall(pattern, context, re.DOTALL)
+        for match in matches:
+            path = match[0].strip()
+            content = match[1] if match[1] else match[2]
+            files[path] = content
+
+    return files
+
+
+def profile_code_context(
+    paths: List[Union[str, Path]], raw: bool = False, extensions: Optional[Tuple[str, ...]] = None
+) -> Tuple[str, Dict]:
+    """
+    Profile token distribution for the given paths.
+
+    Args:
+        paths: List of paths to profile
+        raw: Whether context is in raw format or XML
+        extensions: Optional file extensions to filter by
+
+    Returns:
+        Tuple of (formatted report, profile data)
+    """
+    # Get the context first
+    context = get_context(paths=paths, raw=raw, extensions=extensions)
+
+    # Extract files from context
+    files = extract_files_from_context(context, raw)
+
+    if not files:
+        message = "No files found to profile. Check your paths and extensions."
+        return (message, {})
+
+    # Profile the files
+    profiler = TokenProfiler()
+    paths = list(files.keys())
+
+    for filepath, content in files.items():
+        profiler.process_file(Path(filepath), content)
+
+    # Find common path prefix for the title
+    common_prefix = os.path.commonprefix(paths)
+    base_dir = Path(common_prefix).name if common_prefix else "/"
+
+    # Summary statistics
+    total_tokens = profiler.total_tokens
+    total_files = len(files)
+
+    summary = [
+        f"{base_dir} Token Profile Summary:",
+        f"Total Files: {total_files}",
+        f"Total Tokens: {total_tokens:,}",
+        f"Avg Tokens per File: {total_tokens / total_files:.1f}",
+        f"Common Path Prefix: {common_prefix}",
+        "",
+    ]
+
+    report = (
+        "\n".join(summary)
+        + "\n\n"
+        + "\n\n".join([profiler.format_hierarchical_report(common_prefix), profiler.format_type_report()])
+    )
+
+    # Return both the formatted report and the profiler data
+    profile_data = {
+        "node_cache": profiler.node_cache,
+        "type_counts": profiler.type_counts,
+        "total_tokens": profiler.total_tokens,
+        "common_prefix": common_prefix,
+        "file_paths": profiler.file_paths,
+    }
+    return report, profile_data
+
+
+def generate_flamegraph(data: Dict[str, Any], output_path: str, title: str = "Flame Graph", width: int = 1200) -> None:
+    """
+    Generate an interactive flame graph visualization from hierarchical data.
+
+    Args:
+        data: Dictionary with node_cache, total_tokens and other profile data
+        output_path: Path to save the HTML file
+        title: Title for the visualization
+        width: Width of the flame graph in pixels
+    """
+    # Extract node cache and common prefix from profile data
+    node_cache = data.get("node_cache", {})
+    total_tokens = data.get("total_tokens", 0)
+    common_prefix = data.get("common_prefix", "")
+
+    logger = logging.getLogger("metta.setup.tools.code.token_profiler")
+    logger.debug(f"Using common prefix: {common_prefix}")
+
+    # Convert node cache to hierarchical dictionary with trimmed paths
+    flame_dict = {}
+
+    # Group nodes by parent path to build the hierarchy
+    for path, node in node_cache.items():
+        # Skip empty paths
+        path_str = str(path)
+        if not path_str:
+            continue
+
+        # Remove common prefix
+        if common_prefix:
+            if len(common_prefix) > len(path_str):
+                continue
+            elif path_str.startswith(common_prefix):
+                path_str = path_str[len(common_prefix) :]
+            else:
+                logger.debug(f"Path {path_str} doesn't start with common prefix {common_prefix}")
+
+        # Skip if empty after prefix removal
+        if not path_str:
+            continue
+
+        # Split path
+        path_parts = [part for part in path_str.split("/") if part]
+        if not path_parts:
+            continue
+
+        current_level = flame_dict
+
+        # Build the nested dictionary structure
+        for i, part in enumerate(path_parts):
+            if i == len(path_parts) - 1:
+                # Leaf node - store the token count
+                current_level[part] = node.total_tokens
+            else:
+                # Directory node - create/navigate to nested dict
+                if part not in current_level:
+                    current_level[part] = {}
+                elif not isinstance(current_level[part], dict):
+                    # If it's not a dict, make it one with a special _value key
+                    value = current_level[part]
+                    current_level[part] = {"_value": value}
+
+                current_level = current_level[part]
+
+    # Update title with token count and directory name
+    base_dir = Path(common_prefix).name if common_prefix else "Project"
+    full_title = f"{base_dir} Token Distribution - Total: {total_tokens:,} tokens"
+
+    # Generate the HTML
+    html = _generate_flamegraph_html(flame_dict, full_title, width)
+
+    # Write to file
+    with open(output_path, "w") as f:
+        f.write(html)
+
+
+def _generate_flamegraph_html(data_dict: Dict[str, Any], title: str = "Flame Graph", width: int = 1200) -> str:
+    """
+    Generate HTML with D3 flame graph from hierarchical dictionary.
+
+    Args:
+        data_dict: Hierarchical dictionary of token counts
+        title: Title for the visualization
+        width: Width of the flame graph in pixels
+
+    Returns:
+        HTML string for the flame graph visualization
+    """
+
+    # Convert nested dictionary to a d3 hierarchy
+    def dict_to_hierarchy(d, name="root"):
+        result = {"name": name, "children": []}
+
+        for key, value in d.items():
+            if isinstance(value, dict):
+                if "_value" in value:
+                    child = {"name": key, "value": value["_value"]}
+                    result["children"].append(child)
+
+                    # Add remaining items as children
+                    sub_dict = {k: v for k, v in value.items() if k != "_value"}
+                    if sub_dict:
+                        child["children"] = dict_to_hierarchy(sub_dict, key)["children"]
+                else:
+                    child = dict_to_hierarchy(value, key)
+                    result["children"].append(child)
+            else:
+                result["children"].append({"name": key, "value": value})
+
+        return result
+
+    # Convert to hierarchy
+    hierarchy_data = dict_to_hierarchy(data_dict)
+
+    # Generate HTML with embedded data
+    html = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{title}</title>
+    <style>
+        body {{
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 10px;
+        }}
+        #chart {{
+            width: {width}px;
+            margin-bottom: 20px;
+        }}
+        .controls {{
+            margin-bottom: 20px;
+        }}
+        button {{
+            padding: 8px 12px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-right: 8px;
+        }}
+        button:hover {{
+            background-color: #45a049;
+        }}
+        .d3-flame-graph-tip {{
+            line-height: 1.2;
+            padding: 12px;
+            background: rgba(0, 0, 0, 0.8);
+            color: #fff;
+            border-radius: 4px;
+            pointer-events: none;
+            z-index: 1000;
+        }}
+    </style>
+    <!-- Using the exact CDN references that are known to work -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@2.0.3/dist/d3-flamegraph.css">
+</head>
+<body>
+    <h1>{title}</h1>
+    <div class="controls">
+        <button id="resetZoom">Reset Zoom</button>
+        <button id="toggleColors">Toggle Colors</button>
+        <button id="toggleSort">Toggle Sort</button>
+    </div>
+    <div id="chart"></div>
+
+    <!-- Using the exact CDN references that are known to work -->
+    <script type="text/javascript" src="https://d3js.org/d3.v4.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.9.1/d3-tip.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/spiermar/d3-flame-graph@2.0.3/dist/d3-flamegraph.min.js"></script>
+
+    <script type="text/javascript">
+        // Set up the flame graph
+        var flamegraph = d3.flamegraph()
+            .width({width})
+            .cellHeight(20)
+            .transitionDuration(750)
+            .minFrameSize(5)
+            .sort(true);
+
+        // Create a custom color mapper for depth
+        function depthColorMapper(d) {{
+            // Color based on depth
+            var colorsByDepth = [
+                "#718dbf", // blue
+                "#e49444", // orange
+                "#d1615d", // red
+                "#85b6b2", // teal
+                "#6d8bba", // blue-purple
+                "#8e91b9", // purple
+                "#fe9ea8", // pink
+                "#b3dcab", // light green
+                "#c1c1c1"  // gray
+            ];
+
+            var depth = d.depth || 0;
+            var colorIndex = depth % colorsByDepth.length;
+            return colorsByDepth[colorIndex];
+        }}
+
+        // Apply the custom color mapper
+        flamegraph.color(depthColorMapper);
+
+        // Use a very simple tooltip function that just shows the name
+        // This avoids issues with accessing values in different formats
+        flamegraph.tooltip(function(d) {{
+            return d.name;
+        }});
+
+        // Load the data and render
+        var data = {json.dumps(hierarchy_data)};
+        d3.select("#chart")
+            .datum(data)
+            .call(flamegraph);
+
+        // Reset zoom button
+        document.getElementById("resetZoom").addEventListener("click", function() {{
+            flamegraph.resetZoom();
+        }});
+
+        // Toggle color schemes
+        var currentColorScheme = "depth";
+        document.getElementById("toggleColors").addEventListener("click", function() {{
+            if (currentColorScheme === "depth") {{
+                // Switch to a simpler color scheme
+                flamegraph.color(function(d) {{
+                    // Alternate colors based on depth
+                    return d.depth % 2 ? "#a1afc3" : "#7894cb";
+                }});
+                currentColorScheme = "simple";
+            }} else {{
+                flamegraph.color(depthColorMapper);
+                currentColorScheme = "depth";
+            }}
+
+            // Redraw with new colors
+            d3.select("#chart")
+                .datum(data)
+                .call(flamegraph);
+        }});
+
+        // Toggle sorting
+        var sorted = true;
+        document.getElementById("toggleSort").addEventListener("click", function() {{
+            sorted = !sorted;
+            flamegraph.sort(sorted);
+
+            // Redraw with new sort order
+            d3.select("#chart")
+                .datum(data)
+                .call(flamegraph);
+        }});
+    </script>
+</body>
+</html>
+    """
+
+    return html

--- a/metta/setup/tools/codeflow/pyproject.toml
+++ b/metta/setup/tools/codeflow/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "codeflow"
+version = "0.1.0"
+description = "Copy subsets of code for LLM contexts"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "click>=8.0",
+    "tiktoken>=0.9.0",
+]
+
+[project.scripts]
+codeflow = "codeflow.cli:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+packages = ["codeflow"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["codeflow"]

--- a/metta/setup/tools/codeflow/tests/test_cli.py
+++ b/metta/setup/tools/codeflow/tests/test_cli.py
@@ -1,0 +1,171 @@
+"""
+Tests for the codeflow CLI functionality.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from codeflow.cli import cli
+
+
+class TestCodeflowCLI(unittest.TestCase):
+    """Test cases for the codeflow CLI."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        self.test_dir.cleanup()
+
+    def _create_test_structure(self):
+        """Create a test directory structure."""
+        # Create test directories and files
+        dirs = {
+            "project1": {
+                "README.md": "# Project 1\n",
+                "main.py": "print('hello from project1')\n",
+                "lib.py": "def helper(): pass\n",
+                ".gitignore": "*.pyc\n__pycache__/\n",
+            },
+            "project2": {
+                "README.md": "# Project 2\n",
+                "app.py": "print('hello from project2')\n",
+                "utils.py": "def util(): pass\n",
+            },
+            "shared": {"config.py": "CONFIG = {}\n", "helpers.py": "def help(): pass\n"},
+        }
+
+        for dir_name, files in dirs.items():
+            dir_path = Path(self.test_dir.name) / dir_name
+            dir_path.mkdir(parents=True, exist_ok=True)
+            for file_name, content in files.items():
+                file_path = dir_path / file_name
+                file_path.write_text(content)
+
+    def test_multiple_directory_inputs(self):
+        """Test that multiple directory inputs are handled correctly."""
+        self._create_test_structure()
+
+        # Test with multiple directories
+        result = self.runner.invoke(cli, ["project1", "project2"])
+        self.assertEqual(result.exit_code, 0)
+
+        # Check that files from both directories are included
+        self.assertIn("project1/main.py", result.output)
+        self.assertIn("project1/lib.py", result.output)
+        self.assertIn("project2/app.py", result.output)
+        self.assertIn("project2/utils.py", result.output)
+
+    def test_pwd_relative_paths(self):
+        """Test that paths are resolved relative to pwd."""
+        self._create_test_structure()
+
+        # Create a subdirectory and change to it
+        subdir = Path(self.test_dir.name) / "subdir"
+        subdir.mkdir()
+        os.chdir(subdir)
+
+        # Test with relative path
+        result = self.runner.invoke(cli, ["../project1"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("project1/main.py", result.output)
+
+    def test_default_current_directory(self):
+        """Test that no arguments defaults to current directory."""
+        # Create files in current directory
+        Path("test.py").write_text("print('test')\n")
+        Path("README.md").write_text("# Test\n")
+
+        result = self.runner.invoke(cli, [])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("test.py", result.output)
+        self.assertIn("README.md", result.output)
+
+    def test_extension_filtering(self):
+        """Test file extension filtering."""
+        self._create_test_structure()
+
+        # Test filtering for Python files only
+        result = self.runner.invoke(cli, ["-e", "py", "project1", "project2"])
+        self.assertEqual(result.exit_code, 0)
+
+        # Should include .py files
+        self.assertIn("main.py", result.output)
+        self.assertIn("app.py", result.output)
+
+        # README.md files are always included even with extension filtering
+        self.assertIn("README.md", result.output)
+
+    def test_raw_output_format(self):
+        """Test raw output format."""
+        Path("test.py").write_text("print('test')\n")
+
+        # Test with raw format
+        result = self.runner.invoke(cli, ["-r"])
+        self.assertEqual(result.exit_code, 0)
+
+        # Should not have XML tags
+        self.assertNotIn("<file path=", result.output)
+        # Should have file content
+        self.assertIn("print('test')", result.output)
+
+    def test_xml_output_format(self):
+        """Test XML output format (default)."""
+        Path("test.py").write_text("print('test')\n")
+
+        result = self.runner.invoke(cli, [])
+        self.assertEqual(result.exit_code, 0)
+
+        # Should have XML tags (new format)
+        self.assertIn("<document index=", result.output)
+        self.assertIn("<source>", result.output)
+        self.assertIn("</document>", result.output)
+        self.assertIn("<document_content>", result.output)
+
+    def test_parent_readme_inclusion(self):
+        """Test that parent README files are included."""
+        # Create a parent README
+        Path("README.md").write_text("# Parent README\n")
+
+        # Create a subdirectory with files
+        subdir = Path("subdir")
+        subdir.mkdir()
+        (subdir / "code.py").write_text("print('code')\n")
+
+        result = self.runner.invoke(cli, ["subdir"])
+        self.assertEqual(result.exit_code, 0)
+
+        # Should include both the subdirectory file and parent README
+        self.assertIn("subdir/code.py", result.output)
+        self.assertIn("README.md", result.output)
+        self.assertIn("Parent README", result.output)
+
+    @patch("subprocess.Popen")
+    def test_pbcopy_integration(self, mock_popen):
+        """Test clipboard integration on macOS."""
+        Path("test.py").write_text("print('test')\n")
+
+        # Mock the process and communicate method
+        mock_process = MagicMock()
+        mock_process.communicate = MagicMock()
+        mock_popen.return_value = mock_process
+
+        result = self.runner.invoke(cli, ["-p"])
+        self.assertEqual(result.exit_code, 0)
+
+        # Check that pbcopy was called
+        mock_popen.assert_called_once_with(["pbcopy"], stdin=subprocess.PIPE)
+        mock_process.communicate.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/metta/setup/tools/codeflow/tests/test_file.py
+++ b/metta/setup/tools/codeflow/tests/test_file.py
@@ -1,0 +1,464 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from codeflow.file import (
+    _find_git_root,
+    _find_gitignore,
+    _find_parent_readmes,
+    _read_gitignore,
+    _should_ignore,
+    _should_ignore_file_type,
+    resolve_codebase_path,
+)
+
+
+class TestGitignoreHandling(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.base_path = Path(self.test_dir.name)
+
+        structure = {
+            "test.py": "",
+            "test.pyc": "",
+            "lib.so": "",
+            "subdir": {
+                "nested.py": "",
+                "nested.pyc": "",
+                "special.txt": "",
+                "special.py": "",
+                ".gitignore": "!special.py\n*.pyc\n",
+            },
+            "build": {
+                "build.py": "",
+                "lib.so": "",
+            },
+            "dist": {
+                "dist.so": "",
+            },
+            "wandb": {
+                "data.txt": "",
+            },
+            "train_dir": {
+                "model.pt": "",
+            },
+            "outputs": {
+                "output.log": "",
+            },
+            "cython_debug": {
+                "debug.log": "",
+            },
+            ".codeflowignore": (
+                "*.pyc\n__pycache__/\n/wandb/\ntrain_dir/\nreplays/\n*.egg-info\n"
+                "/build/\n/build_debug/\n.DS_Store\n.task\noutputs/\n*.so\n"
+                "cython_debug\nstats.profile\n/dist/\nplayer/dist/\nplayer/node_modules\n"
+            ),
+        }
+        self._create_structure(self.base_path, structure)
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def _create_structure(self, base, structure):
+        for name, content in structure.items():
+            path = base / name
+            if isinstance(content, dict):
+                path.mkdir(parents=True, exist_ok=True)
+                self._create_structure(path, content)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with open(path, "w") as f:
+                    f.write(content)
+
+    def test_read_gitignore(self):
+        """Test reading gitignore patterns from file."""
+        gitignore_path = self.base_path / ".codeflowignore"
+        rules = _read_gitignore(str(gitignore_path))
+
+        # Check that patterns were read correctly
+        self.assertIn("*.pyc", rules)
+        self.assertIn("__pycache__/", rules)
+        self.assertIn("/wandb/", rules)
+        self.assertIn("train_dir/", rules)
+        self.assertIn("*.so", rules)
+
+    def test_should_ignore_patterns(self):
+        """Test the ignore logic for various file patterns."""
+        gitignore_rules = _read_gitignore(str(self.base_path / ".codeflowignore"))
+
+        # Binary files should be ignored due to extension
+        self.assertTrue(_should_ignore(self.base_path / "test.pyc", gitignore_rules, self.base_path))
+        self.assertTrue(_should_ignore(self.base_path / "lib.so", gitignore_rules, self.base_path))
+        self.assertTrue(_should_ignore(self.base_path / "subdir/nested.pyc", gitignore_rules, self.base_path))
+        self.assertTrue(_should_ignore(self.base_path / "build/lib.so", gitignore_rules, self.base_path))
+        self.assertTrue(_should_ignore(self.base_path / "dist/dist.so", gitignore_rules, self.base_path))
+
+        # Data files should be ignored due to extension
+        self.assertTrue(_should_ignore(self.base_path / "outputs/output.log", gitignore_rules, self.base_path))
+        self.assertTrue(_should_ignore(self.base_path / "cython_debug/debug.log", gitignore_rules, self.base_path))
+
+        # Paths that should not be ignored
+        self.assertFalse(_should_ignore(self.base_path / "test.py", gitignore_rules, self.base_path))
+        self.assertFalse(_should_ignore(self.base_path / "subdir/nested.py", gitignore_rules, self.base_path))
+
+    def test_readme_never_ignored(self):
+        """Test that README.md files are never ignored."""
+        gitignore_rules = ["*.md", "README.md"]
+
+        # README.md should never be ignored even if explicitly in gitignore
+        self.assertFalse(_should_ignore(self.base_path / "README.md", gitignore_rules, self.base_path))
+        self.assertFalse(_should_ignore(self.base_path / "subdir/README.md", gitignore_rules, self.base_path))
+
+    def test_gitignore_with_lock_file(self):
+        """Test that lock files in gitignore are properly ignored."""
+        # Create a test directory with .gitignore containing uv.lock
+        test_dir = self.base_path / "lock_test"
+        test_dir.mkdir()
+
+        # Create .gitignore with uv.lock
+        gitignore_path = test_dir / ".gitignore"
+        with open(gitignore_path, "w") as f:
+            f.write("uv.lock\n*.pyc\n__pycache__/\n")
+
+        # Create uv.lock file
+        lock_file = test_dir / "uv.lock"
+        with open(lock_file, "w") as f:
+            f.write("# This is a lock file with many tokens\n" * 1000)
+
+        # Read gitignore rules
+        gitignore_rules = _read_gitignore(str(gitignore_path))
+
+        # Verify uv.lock is in the rules
+        self.assertIn("uv.lock", gitignore_rules)
+
+        # Test that uv.lock should be ignored
+        self.assertTrue(_should_ignore(lock_file, gitignore_rules, test_dir))
+
+    def test_read_gitignore_with_directory_path(self):
+        """Test that _read_gitignore fails when given a directory path instead of file path."""
+        # This test demonstrates the bug: _read_gitignore expects a file path
+        # but get_context passes it a directory path
+
+        # Create a test directory with .gitignore
+        test_dir = self.base_path / "gitignore_test"
+        test_dir.mkdir()
+
+        # Create .gitignore file
+        gitignore_path = test_dir / ".gitignore"
+        with open(gitignore_path, "w") as f:
+            f.write("uv.lock\n*.pyc\n")
+
+        # Test 1: Correct usage - pass the .gitignore file path
+        rules_correct = _read_gitignore(str(gitignore_path))
+        self.assertIn("uv.lock", rules_correct)
+        self.assertIn("*.pyc", rules_correct)
+
+        # Test 2: Incorrect usage (what get_context does) - pass directory path
+        rules_incorrect = _read_gitignore(str(test_dir))
+        self.assertEqual(
+            rules_incorrect, [], "Passing directory path to _read_gitignore returns empty list - this is the bug!"
+        )
+
+
+class TestGitRootAndReadmeHandling(unittest.TestCase):
+    """Test cases for git root detection and parent README finding."""
+
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.base_path = Path(self.test_dir.name)
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_find_git_root(self):
+        """Test finding git repository root."""
+        # Create a directory structure with nested git repo
+        repo_root = self.base_path / "myproject"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+
+        subdir = repo_root / "src" / "module"
+        subdir.mkdir(parents=True)
+
+        # Test from various locations
+        self.assertEqual(_find_git_root(subdir), repo_root)
+        self.assertEqual(_find_git_root(repo_root / "src"), repo_root)
+        self.assertEqual(_find_git_root(repo_root), repo_root)
+
+        # Test when not in a git repo
+        non_git_dir = self.base_path / "non_git"
+        non_git_dir.mkdir()
+        self.assertIsNone(_find_git_root(non_git_dir))
+
+    def test_find_parent_readmes_in_git_repo(self):
+        """Test finding parent READMEs up to git root."""
+        # Create a git repo structure
+        repo_root = self.base_path / "myproject"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+
+        # Create READMEs at various levels
+        (repo_root / "README.md").write_text("Root readme")
+
+        src_dir = repo_root / "src"
+        src_dir.mkdir()
+        (src_dir / "README.md").write_text("Src readme")
+
+        module_dir = src_dir / "module"
+        module_dir.mkdir()
+        (module_dir / "README.md").write_text("Module readme")
+
+        # Create a README outside the git repo (should not be included)
+        (self.base_path / "README.md").write_text("Outside readme")
+
+        # Test from deep directory
+        readmes = _find_parent_readmes(module_dir / "subdir")
+        readme_paths = [str(r.relative_to(repo_root)) for r in readmes]
+
+        # Should include READMEs up to git root, but not beyond
+        self.assertIn("README.md", readme_paths)
+        self.assertIn("src/README.md", readme_paths)
+        self.assertIn("src/module/README.md", readme_paths)
+        self.assertEqual(len(readmes), 3)
+
+    def test_find_parent_readmes_without_git(self):
+        """Test finding parent READMEs when not in a git repo."""
+        # Create directory structure without git
+        project_dir = self.base_path / "project"
+        project_dir.mkdir()
+
+        subdir = project_dir / "src" / "module"
+        subdir.mkdir(parents=True)
+
+        # Create some READMEs
+        (project_dir / "README.md").write_text("Project readme")
+        (project_dir / "src" / "README.md").write_text("Src readme")
+
+        # Test - should go all the way to root
+        readmes = _find_parent_readmes(subdir)
+
+        # Should find the READMEs we created
+        self.assertEqual(len(readmes), 2)
+        self.assertTrue(any("project/README.md" in str(r) for r in readmes))
+        self.assertTrue(any("project/src/README.md" in str(r) for r in readmes))
+
+
+class TestPathResolution(unittest.TestCase):
+    """Test cases for path resolution relative to pwd."""
+
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        self.test_dir.cleanup()
+
+    def test_relative_path_resolution(self):
+        """Test that relative paths are resolved against pwd."""
+        # Create a subdirectory
+        subdir = Path("subdir")
+        subdir.mkdir()
+
+        # Test resolving relative path
+        resolved = resolve_codebase_path("subdir")
+        expected = (Path(self.test_dir.name) / "subdir").resolve()
+        self.assertEqual(resolved, expected)
+
+    def test_absolute_path_resolution(self):
+        """Test that absolute paths are returned as-is."""
+        abs_path = Path("/tmp/test/path").resolve()
+        resolved = resolve_codebase_path(abs_path)
+        self.assertEqual(resolved, abs_path)
+
+    def test_dot_path_resolution(self):
+        """Test that '.' resolves to current directory."""
+        resolved = resolve_codebase_path(".")
+        expected = Path(self.test_dir.name).resolve()
+        self.assertEqual(resolved, expected)
+
+    def test_parent_path_resolution(self):
+        """Test that '..' resolves correctly."""
+        # Create and change to subdirectory
+        subdir = Path("subdir")
+        subdir.mkdir()
+        os.chdir(subdir)
+
+        resolved = resolve_codebase_path("..")
+        expected = Path(self.test_dir.name).resolve()
+        self.assertEqual(resolved, expected)
+
+    def test_nested_relative_path(self):
+        """Test nested relative path resolution."""
+        # Create nested structure
+        nested = Path("a/b/c")
+        nested.mkdir(parents=True)
+
+        resolved = resolve_codebase_path("a/b/c")
+        expected = (Path(self.test_dir.name) / "a" / "b" / "c").resolve()
+        self.assertEqual(resolved, expected)
+
+    def test_path_with_symlinks(self):
+        """Test that paths with symlinks are properly resolved."""
+        # Create a directory and a symlink to it
+        real_dir = Path("real_dir")
+        real_dir.mkdir()
+        link_dir = Path("link_dir")
+        link_dir.symlink_to(real_dir)
+
+        # Resolve through symlink
+        resolved = resolve_codebase_path("link_dir")
+        # Should resolve to the actual directory
+        self.assertTrue(resolved.exists())
+        self.assertTrue(resolved.is_dir())
+
+    def test_nonexistent_path_resolution(self):
+        """Test that nonexistent paths still resolve correctly."""
+        # Path doesn't need to exist to be resolved
+        resolved = resolve_codebase_path("nonexistent/path")
+        expected = (Path(self.test_dir.name) / "nonexistent" / "path").resolve()
+        self.assertEqual(resolved, expected)
+
+
+class TestFileTypeIgnoring(unittest.TestCase):
+    """Test cases for the unified file type ignoring system."""
+
+    def test_binary_extensions(self):
+        """Test that binary file extensions are properly ignored."""
+        # Python compiled
+        self.assertTrue(_should_ignore_file_type(Path("test.pyc")))
+        self.assertTrue(_should_ignore_file_type(Path("module.pyo")))
+        self.assertTrue(_should_ignore_file_type(Path("lib.pyd")))
+
+        # Native libraries
+        self.assertTrue(_should_ignore_file_type(Path("lib.so")))
+        self.assertTrue(_should_ignore_file_type(Path("module.dll")))
+        self.assertTrue(_should_ignore_file_type(Path("lib.dylib")))
+
+        # ML model files
+        self.assertTrue(_should_ignore_file_type(Path("model.pt")))
+        self.assertTrue(_should_ignore_file_type(Path("checkpoint.ckpt")))
+        self.assertTrue(_should_ignore_file_type(Path("weights.safetensors")))
+
+        # Database files
+        self.assertTrue(_should_ignore_file_type(Path("data.db")))
+        self.assertTrue(_should_ignore_file_type(Path("app.sqlite")))
+        self.assertTrue(_should_ignore_file_type(Path("test.sqlite3")))
+
+        # Images
+        self.assertTrue(_should_ignore_file_type(Path("image.jpg")))
+        self.assertTrue(_should_ignore_file_type(Path("photo.png")))
+        self.assertTrue(_should_ignore_file_type(Path("icon.svg")))
+
+    def test_data_extensions(self):
+        """Test that data file extensions are properly ignored."""
+        self.assertTrue(_should_ignore_file_type(Path("app.log")))
+        self.assertTrue(_should_ignore_file_type(Path("data.cache")))
+        self.assertTrue(_should_ignore_file_type(Path("temp.tmp")))
+        self.assertTrue(_should_ignore_file_type(Path("backup.bak")))
+        self.assertTrue(_should_ignore_file_type(Path(".file.swp")))
+
+    def test_lock_files(self):
+        """Test that lock files are properly ignored."""
+        self.assertTrue(_should_ignore_file_type(Path("uv.lock")))
+        self.assertTrue(_should_ignore_file_type(Path("package-lock.json")))
+        self.assertTrue(_should_ignore_file_type(Path("yarn.lock")))
+        self.assertTrue(_should_ignore_file_type(Path("poetry.lock")))
+        self.assertTrue(_should_ignore_file_type(Path("Cargo.lock")))
+
+    def test_cache_and_system_files(self):
+        """Test that cache and system files are ignored."""
+        self.assertTrue(_should_ignore_file_type(Path(".DS_Store")))
+        self.assertTrue(_should_ignore_file_type(Path("Thumbs.db")))
+        self.assertTrue(_should_ignore_file_type(Path("desktop.ini")))
+        self.assertTrue(_should_ignore_file_type(Path(".coverage")))
+        self.assertTrue(_should_ignore_file_type(Path("coverage.xml")))
+
+    def test_file_patterns(self):
+        """Test that file patterns are properly matched."""
+        self.assertTrue(_should_ignore_file_type(Path("gpu_names_cache.json")))
+        self.assertTrue(_should_ignore_file_type(Path("package.egg-info")))
+        self.assertTrue(_should_ignore_file_type(Path("file~")))  # Editor backup
+        self.assertTrue(_should_ignore_file_type(Path(".#lockfile")))  # Emacs lock
+
+    def test_allowed_files(self):
+        """Test that source files are not ignored."""
+        self.assertFalse(_should_ignore_file_type(Path("main.py")))
+        self.assertFalse(_should_ignore_file_type(Path("README.md")))
+        self.assertFalse(_should_ignore_file_type(Path("config.yaml")))
+        self.assertFalse(_should_ignore_file_type(Path("script.js")))
+        self.assertFalse(_should_ignore_file_type(Path("style.css")))
+        self.assertFalse(_should_ignore_file_type(Path("doc.txt")))  # .txt is allowed now
+
+    def test_case_insensitive_extensions(self):
+        """Test that extension checking is case-insensitive."""
+        self.assertTrue(_should_ignore_file_type(Path("IMAGE.JPG")))
+        self.assertTrue(_should_ignore_file_type(Path("Model.PT")))
+        self.assertTrue(_should_ignore_file_type(Path("data.LOG")))
+
+
+class TestGitignoreFinding(unittest.TestCase):
+    """Test cases for finding gitignore files in the directory tree."""
+
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.base_path = Path(self.test_dir.name)
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_find_gitignore_in_current_dir(self):
+        """Test finding .gitignore in the current directory."""
+        project_dir = self.base_path / "project"
+        project_dir.mkdir()
+        gitignore_path = project_dir / ".gitignore"
+        gitignore_path.write_text("*.pyc\n")
+
+        found = _find_gitignore(project_dir)
+        self.assertEqual(found, gitignore_path)
+
+    def test_find_gitignore_in_parent(self):
+        """Test finding .gitignore in a parent directory."""
+        project_dir = self.base_path / "project"
+        project_dir.mkdir()
+        gitignore_path = project_dir / ".gitignore"
+        gitignore_path.write_text("*.pyc\n")
+
+        subdir = project_dir / "src" / "module"
+        subdir.mkdir(parents=True)
+
+        found = _find_gitignore(subdir)
+        self.assertEqual(found, gitignore_path)
+
+    def test_find_gitignore_with_git_root(self):
+        """Test that search stops at git root."""
+        # Create a git repo
+        repo_dir = self.base_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+
+        # Create .gitignore outside repo (should not be found)
+        outer_gitignore = self.base_path / ".gitignore"
+        outer_gitignore.write_text("outer\n")
+
+        # Create subdir in repo
+        subdir = repo_dir / "src"
+        subdir.mkdir()
+
+        # Should not find the outer gitignore
+        found = _find_gitignore(subdir)
+        self.assertIsNone(found)
+
+        # Add gitignore inside repo
+        repo_gitignore = repo_dir / ".gitignore"
+        repo_gitignore.write_text("inner\n")
+
+        # Now should find the repo's gitignore
+        found = _find_gitignore(subdir)
+        self.assertEqual(found, repo_gitignore)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/metta/setup/tools/codeflow/tests/test_token_profiler.py
+++ b/metta/setup/tools/codeflow/tests/test_token_profiler.py
@@ -1,0 +1,31 @@
+"""
+Tests for token profiler functionality including common prefix detection.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codeflow.token_profiler import TokenProfiler
+
+
+class TestTokenProfiler(unittest.TestCase):
+    """Test cases for the TokenProfiler class."""
+
+    def test_process_file_stores_path(self):
+        """Test that process_file stores the file path for common prefix calculation."""
+        profiler = TokenProfiler()
+
+        # Mock the token counting functionality
+        profiler.count_tokens = MagicMock(return_value=100)
+
+        # Process a file
+        file_path = Path("/Users/jack/src/metta/test.py")
+        profiler.process_file(file_path, "content")
+
+        # Check that the path was stored
+        self.assertIn(str(file_path.parent), profiler.file_paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "notebook>=7.4.4",
   "jupyterlab>=4.4.4",
   "widgetsnbextension>=4.0.14",
+  "tiktoken>=0.9.0",
 ]
 name = "metta"
 version = "0.1"


### PR DESCRIPTION
# Add codeflow tool for collecting code for LLM contexts

codeflow is a tool, aliased at `metta code` for copying segments of the codebase, either to stdout or to the clipboard, for facilitating providing code-based context to LLMS.

Example: 

```
metta code -e .py metta/rl mettagrid/src/metta/mettagrid/curriculum/ -p
```

will copy only `.py` files in those subdirectories directly to the users clipboard

There are a few extra features:
- heavy ignoring (including everything .gitignored)
- promotion of parental README (e.g. metta/README.md always included, and generally all ancestor READMEs of any included files always included)
- profiling and flamegraphs for debugging token counts



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210885274586243)