### PR TITLE
Corrects the names of 2 grid_object properties

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -671,8 +671,8 @@ py::dict MettaGrid::grid_objects() {
       obj_dict["inventory"] = inventory_dict;
       obj_dict["is_converting"] = converter->converting;
       obj_dict["is_cooling_down"] = converter->cooling_down;
-      obj_dict["conversion_remaining"] = converter->conversion_ticks;
-      obj_dict["cooldown_remaining"] = converter->cooldown;
+      obj_dict["conversion_duration"] = converter->conversion_ticks;
+      obj_dict["cooldown_duration"] = converter->cooldown;
       obj_dict["output_limit"] = converter->max_output;
       obj_dict["color"] = converter->color;
       py::dict input_resources_dict;


### PR DESCRIPTION
conversion_remaining and cooldown_remaining were incorrectly named -- they should be conversion_duration and cooldown_duration respectively, since the property involved is the total duration of these events, not the remaining duration.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210885355571361)