### PR TITLE
Fix trusted keys in flake file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     extra-substituters = [
       "https://nixpkgs-python.cachix.org"
     ];
-    trusted-public-keys = [
+    extra-trusted-public-keys = [
       "nixpkgs-python.cachix.org-1:hxjI7pFxTyuTHn2NkvWCrAUcNZLNS3ZAvfYNuYifcEU="
     ];
   };


### PR DESCRIPTION
- fix the flake to use extra-trusted-public-keys to match extra-substituters
- I think the first time I tested this I had added the trusted public key to my system outside of the flake, and didn't notice issues with it missing.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210891878782332)