### PR TITLE
[MettaScope] RTS style camera controls

### DIFF
--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -123,8 +123,8 @@ export function processActions(event: KeyboardEvent) {
       // Get the output.
       sendAction('get_items', 0)
     }
-    if (event.key == 'x') {
-      // No-op.
+    if (event.key == 'x' || event.code == 'Numpad5') {
+      // No-op / wait.
       sendAction('noop', 0)
     }
     if (event.key >= '1' && event.key <= '9') {

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -67,7 +67,7 @@ export function processActions(event: KeyboardEvent) {
   if (state.selectedGridObject != null) {
     const agent = state.selectedGridObject
     const orientation = getAttr(agent, 'agent:orientation')
-    // Support WASD, arrow keys, and numpad (2,4,6,8) for movement/rotation.
+    // Support WASD, arrow keys, and all numpad keys for movement/rotation.
     const key = event.key
     const code = event.code
 
@@ -123,6 +123,32 @@ export function processActions(event: KeyboardEvent) {
       // Get the output.
       sendAction('get_items', 0)
     }
+    // Diagonal movement with numpad (4-action approach for true diagonal in one press)
+    if (event.code == 'Numpad7') { // Up-Left
+      sendAction('rotate', 0)  // Rotate up
+      sendAction('move', 0)    // Move up
+      sendAction('rotate', 2)  // Rotate left
+      sendAction('move', 0)    // Move left
+    }
+    if (event.code == 'Numpad9') { // Up-Right
+      sendAction('rotate', 0)  // Rotate up
+      sendAction('move', 0)    // Move up
+      sendAction('rotate', 3)  // Rotate right
+      sendAction('move', 0)    // Move right
+    }
+    if (event.code == 'Numpad1') { // Down-Left
+      sendAction('rotate', 1)  // Rotate down
+      sendAction('move', 0)    // Move down
+      sendAction('rotate', 2)  // Rotate left
+      sendAction('move', 0)    // Move left
+    }
+    if (event.code == 'Numpad3') { // Down-Right
+      sendAction('rotate', 1)  // Rotate down
+      sendAction('move', 0)    // Move down
+      sendAction('rotate', 3)  // Rotate right
+      sendAction('move', 0)    // Move right
+    }
+
     if (event.key == 'x' || event.code == 'Numpad5') {
       // No-op / wait.
       sendAction('noop', 0)

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -67,10 +67,11 @@ export function processActions(event: KeyboardEvent) {
   if (state.selectedGridObject != null) {
     const agent = state.selectedGridObject
     const orientation = getAttr(agent, 'agent:orientation')
-    // Support both WASD and arrow keys for movement/rotation.
+    // Support WASD, arrow keys, and numpad (2,4,6,8) for movement/rotation.
     const key = event.key
+    const code = event.code
 
-    if (key == 'w' || key == 'ArrowUp') {
+    if (key == 'w' || key == 'ArrowUp' || code == 'Numpad8') {
       if (orientation != 0) {
         // Rotate up.
         sendAction('rotate', 0)
@@ -79,7 +80,7 @@ export function processActions(event: KeyboardEvent) {
         sendAction('move', 0)
       }
     }
-    if (key == 'a' || key == 'ArrowLeft') {
+    if (key == 'a' || key == 'ArrowLeft' || code == 'Numpad4') {
       if (orientation != 2) {
         // Rotate left.
         sendAction('rotate', 2)
@@ -88,7 +89,7 @@ export function processActions(event: KeyboardEvent) {
         sendAction('move', 0)
       }
     }
-    if (key == 's' || key == 'ArrowDown') {
+    if (key == 's' || key == 'ArrowDown' || code == 'Numpad2') {
       if (orientation != 1) {
         // Rotate down.
         sendAction('rotate', 1)
@@ -97,7 +98,7 @@ export function processActions(event: KeyboardEvent) {
         sendAction('move', 0)
       }
     }
-    if (key == 'd' || key == 'ArrowRight') {
+    if (key == 'd' || key == 'ArrowRight' || code == 'Numpad6') {
       if (orientation != 3) {
         // Rotate right.
         sendAction('rotate', 3)

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -511,6 +511,60 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
     updateSelection(null)
     setFollowSelection(false)
   }
+  // WASD, numpad, and arrow keys for RTS style camera movement (when no unit is focused)
+  if (!state.selectedGridObject && !state.followSelection) {
+    const panSpeed = 150 / ui.mapPanel.zoomLevel // Adjust speed based on zoom level
+
+    if (event.key == 'w' || event.key == 'W' || event.key == 'ArrowUp') {
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(0, panSpeed))
+    }
+    if (event.key == 'a' || event.key == 'A' || event.key == 'ArrowLeft') {
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(panSpeed, 0))
+    }
+    if (event.key == 's' || event.key == 'S' || event.key == 'ArrowDown') {
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(0, -panSpeed))
+    }
+    if (event.key == 'd' || event.key == 'D' || event.key == 'ArrowRight') {
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(-panSpeed, 0))
+    }
+
+    // Numpad directional controls (classic 8-directional layout)
+    if (event.code == 'Numpad8') { // Up
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(0, panSpeed))
+    }
+    if (event.code == 'Numpad2') { // Down
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(0, -panSpeed))
+    }
+    if (event.code == 'Numpad4') { // Left
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(panSpeed, 0))
+    }
+    if (event.code == 'Numpad6') { // Right
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(-panSpeed, 0))
+    }
+    if (event.code == 'Numpad7') { // Up-Left
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(panSpeed * 0.707, panSpeed * 0.707))
+    }
+    if (event.code == 'Numpad9') { // Up-Right
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(-panSpeed * 0.707, panSpeed * 0.707))
+    }
+    if (event.code == 'Numpad1') { // Down-Left
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(panSpeed * 0.707, -panSpeed * 0.707))
+    }
+    if (event.code == 'Numpad3') { // Down-Right
+      ui.mapPanel.panPos = ui.mapPanel.panPos.add(new Vec2f(-panSpeed * 0.707, -panSpeed * 0.707))
+    }
+  }
+
+  // Numpad 5 - advance simulation one frame
+  if (event.code == 'Numpad5') {
+    setIsPlaying(false)
+    if (state.ws !== null) {
+      state.ws.send(JSON.stringify({ type: 'advance' }))
+    } else {
+      updateStep(Math.min(state.step + 1, state.replay.max_steps - 1))
+    }
+  }
+
   // '[' and ']' scrub forward and backward.
   if (event.key == '[') {
     setIsPlaying(false)
@@ -519,6 +573,16 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
   if (event.key == ']') {
     setIsPlaying(false)
     updateStep(Math.min(state.step + 1, state.replay.max_steps - 1))
+  }
+
+  // '<' and '>' for zoom out/in on keyboard
+  if (event.key == '<') {
+    const zoomSpeed = 0.05
+    ui.mapPanel.zoomLevel = Math.max(ui.mapPanel.zoomLevel - zoomSpeed, Common.MIN_ZOOM_LEVEL)
+  }
+  if (event.key == '>') {
+    const zoomSpeed = 0.05
+    ui.mapPanel.zoomLevel = Math.min(ui.mapPanel.zoomLevel + zoomSpeed, Common.MAX_ZOOM_LEVEL)
   }
   // '<' and '>' control the playback speed.
   if (event.key == ',') {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -584,7 +584,7 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
     const zoomSpeed = 0.06
     ui.mapPanel.zoomLevel = Math.min(ui.mapPanel.zoomLevel + zoomSpeed, Common.MAX_ZOOM_LEVEL)
   }
-  // '<' and '>' control the playback speed.
+  // ',' and '.' control the playback speed.
   if (event.key == ',') {
     state.playbackSpeed = Math.max(state.playbackSpeed * 0.9, 0.01)
   }

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -556,7 +556,7 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
   }
 
   // Numpad 5 - advance simulation one frame
-  if (event.code == 'Numpad5') {
+  if (event.code == 'Numpad5' && state.selectedGridObject == null) {
     setIsPlaying(false)
     if (state.ws !== null) {
       state.ws.send(JSON.stringify({ type: 'advance' }))

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -577,11 +577,11 @@ onEvent('keydown', 'body', (target: HTMLElement, e: Event) => {
 
   // '<' and '>' for zoom out/in on keyboard
   if (event.key == '<') {
-    const zoomSpeed = 0.05
+    const zoomSpeed = 0.06
     ui.mapPanel.zoomLevel = Math.max(ui.mapPanel.zoomLevel - zoomSpeed, Common.MIN_ZOOM_LEVEL)
   }
   if (event.key == '>') {
-    const zoomSpeed = 0.05
+    const zoomSpeed = 0.06
     ui.mapPanel.zoomLevel = Math.min(ui.mapPanel.zoomLevel + zoomSpeed, Common.MAX_ZOOM_LEVEL)
   }
   // '<' and '>' control the playback speed.


### PR DESCRIPTION
- when no units are selected, we can use classic roguelike / rts movement controls!
- wasd, arrows, or numpad to move the camera (including diagonals)
- `5` on the numpad will advance the simulation one step, in true roguelike style.
- `<` and `>` (actual angle brackets, pressing shift as well) to zoom in and out (normally this should be 'move up or down one z-level' but we don't have z levels and `[]` are already taken)
- roguelike movement controls! numpad 5 will have the agent no-op like a true roguelike. numpad for arrows, including diagonals (however diagonals take multiple steps to achieve)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210892085090629)