### PR TITLE
Early termination 

### DIFF
--- a/configs/env/mettagrid/mettagrid.yaml
+++ b/configs/env/mettagrid/mettagrid.yaml
@@ -66,3 +66,8 @@ game:
     change_glyph:
       enabled: false
       number_of_glyphs: 4
+
+  termination:
+    max_reward: null #if set, terminate when overall reward = max_reward
+    end_of_episode_boost: 1.0 #if set, boost reward at end of episode
+    condition: null #if set, terminate when condition is met

--- a/configs/env/mettagrid/navigation/training/terrain_from_numpy_defaults.yaml
+++ b/configs/env/mettagrid/navigation/training/terrain_from_numpy_defaults.yaml
@@ -29,3 +29,6 @@ game:
     altar:
       cooldown: 1000
       initial_resource_count: 1
+  termination:
+    max_reward: ${game.map_builder.room.objects.altar}
+    condition: 0.5

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -179,6 +179,9 @@ def convert_to_cpp_game_config(mettagrid_config_dict: dict):
         else:
             actions_cpp_params[action_name] = CppActionConfig(**action_cpp_params)
 
+    # Termination is handled in Python, so we don't need to pass it to C++
+    del game_cpp_params["termination"]
+
     game_cpp_params["actions"] = actions_cpp_params
     game_cpp_params["objects"] = objects_cpp_params
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -175,6 +175,14 @@ class PyConverterConfig(BaseModelWithForbidExtra):
     color: int = Field(default=0, ge=0, le=255)
 
 
+class PyTerminationConfig(BaseModelWithForbidExtra):
+    """Python termination configuration."""
+
+    max_reward: Optional[int] = Field(default=None)
+    end_of_episode_boost: Optional[float] = Field(default=None)
+    condition: Optional[float] = Field(default=None)
+
+
 class PyGameConfig(BaseModelWithForbidExtra):
     """Python game configuration."""
 
@@ -194,6 +202,7 @@ class PyGameConfig(BaseModelWithForbidExtra):
     global_obs: PyGlobalObsConfig = Field(default_factory=PyGlobalObsConfig)
     recipe_details_obs: bool = Field(default=False)
     objects: dict[str, PyConverterConfig | PyWallConfig]
+    termination: PyTerminationConfig = Field(default_factory=PyTerminationConfig)
     # these are not used in the C++ code, but we allow them to be set for other uses.
     # E.g., templates can use params as a place where values are expected to be written,
     # and other parts of the template can read from there.

--- a/mettagrid/src/metta/mettagrid/mettagrid_env.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_env.py
@@ -105,6 +105,28 @@ class MettaGridEnv(PufferEnv, GymEnv):
 
                 self._renderer = MiniscopeRenderer(self.object_type_names)
 
+    def _check_reward_termination(self) -> bool:
+        """Check if episode should terminate based on total reward threshold."""
+        if self._task.env_cfg().game.termination.max_reward:
+            # Check if any agent has reached the reward threshold
+            per_agent_rewards = self._c_env.get_episode_rewards()
+            termination_condition = self._task.env_cfg().game.termination.condition
+
+            if termination_condition == "any":
+                return any(r >= self._task.env_cfg().game.termination.max_reward for r in per_agent_rewards)
+            elif termination_condition == "all":
+                return all(r >= self._task.env_cfg().game.termination.max_reward for r in per_agent_rewards)
+            # percent of agents that got all the reward
+            elif isinstance(termination_condition, float):
+                return (
+                    sum(r >= self._task.env_cfg().game.termination.max_reward for r in per_agent_rewards)
+                    >= termination_condition * self._c_env.num_agents
+                )
+            else:
+                raise ValueError(f"Invalid termination condition: {termination_condition}")
+
+        return False
+
     def _make_episode_id(self):
         return str(uuid.uuid4())
 


### PR DESCRIPTION
We can now terminate episodes early given an **agent-specific** max reward
Max reward can be defaulted to number of altars in a room 

We also have a condition which is how many agents having gotten the max reward is sufficient to terminate the episode 