### PR TITLE
fix env file in observatory docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,6 +39,7 @@ mettascope/dist
 **/node_modules
 **/.next
 /observatory/.vite/
+/observatory/dist/
 
 wandb
 

--- a/observatory/Dockerfile
+++ b/observatory/Dockerfile
@@ -33,6 +33,8 @@ COPY --from=pruned-source /metta/out/json/ .
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruned-source /metta/out/full/ .
+# turbo's pruned sources don't include .env files
+COPY observatory ./observatory
 
 WORKDIR /metta/observatory
 


### PR DESCRIPTION
### TL;DR

Copy the observatory directory to include .env files in the Docker image.

### What changed?

Added a `COPY observatory ./observatory` command in the Dockerfile to ensure .env files are included in the Docker image, as turbo's pruned sources don't include these files.


### Why make this change?

Turbo's pruned sources mechanism doesn't include .env files by default, which can cause environment configuration issues when running the application in Docker. This change ensures that all necessary configuration files are available in the container at runtime.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210893958101181)