### PR TITLE
fix: install aws to `devops/docker/Dockerfile.policy_evaluator`

### DIFF
--- a/devops/docker/Dockerfile.policy_evaluator
+++ b/devops/docker/Dockerfile.policy_evaluator
@@ -9,6 +9,9 @@ RUN brew install cmake ninja
 # Install kubectl for EKS/Kind testing
 RUN brew install kubectl
 
+# Install AWS CLI
+RUN brew install awscli
+
 WORKDIR /workspace
 
 # Copy the entire repo


### PR DESCRIPTION
```

#13 78.21 FileNotFoundError: [Errno 2] No such file or directory: 'aws'
#13 78.34 ERROR: Failed to install components
#13 ERROR: process "/bin/sh -c bash install.sh --profile=softmax-docker" did not complete successfully: exit code: 1
------
 > [8/9] RUN bash install.sh --profile=softmax-docker:
78.20            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
78.21   File "/home/linuxbrew/.local/share/uv/python/cpython-3.11.7-linux-x86_64-gnu/lib/python3.11/subprocess.py", line 548, in run
78.21     with Popen(*popenargs, **kwargs) as process:
78.21          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
78.21   File "/home/linuxbrew/.local/share/uv/python/cpython-3.11.7-linux-x86_64-gnu/lib/python3.11/subprocess.py", line 1026, in __init__
78.21     self._execute_child(args, executable, preexec_fn, close_fds,
78.21   File "/home/linuxbrew/.local/share/uv/python/cpython-3.11.7-linux-x86_64-gnu/lib/python3.11/subprocess.py", line 1950, in _execute_child
78.21     raise child_exception_type(errno_num, err_msg, err_filename)
78.21 FileNotFoundError: [Errno 2] No such file or directory: 'aws'
78.34 ERROR: Failed to install components
```
https://github.com/Metta-AI/metta/actions/runs/16533564363/job/46763833717#logs

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210893795205485)