### PR TITLE
Trainer optionally calls out to policy evaluator

### DIFF
--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -19,6 +19,9 @@ checkpoint:
 simulation:
   evaluate_interval: 200
   replay_dir: s3://softmax-public/replays/${run}
+  evaluate_remote: false
+  git_hash: null
+  skip_git_check: false
 
 grad_mean_variance_interval: 0 # 0 to disable
 

--- a/configs/user/nishad.yaml
+++ b/configs/user/nishad.yaml
@@ -1,8 +1,17 @@
 # @package __global__
 
-trainer:
-  env: /env/mettagrid/arena/advanced
+device: cpu
+vectorization: serial
 
-replay_job:
-  sim:
-    env: /env/mettagrid/arena/advanced
+trainer:
+  batch_size: 1024
+  minibatch_size: 1024
+  forward_pass_minibatch_target_size: 2
+
+  simulation:
+    evaluate_remote: true
+    evaluate_interval: 10
+  checkpoint:
+    checkpoint_interval: 10
+    wandb_checkpoint_interval: 10
+  bptt_horizon: 8

--- a/devops/skypilot/utils.py
+++ b/devops/skypilot/utils.py
@@ -49,7 +49,6 @@ def launch_task(task: sky.Task, dry_run=False):
 
 def check_git_state(commit_hash: str) -> str | None:
     """Check that the commit has been pushed and there are no staged changes."""
-
     error_lines = []
 
     if has_unstaged_changes():

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -75,6 +75,9 @@ class SimulationConfig(BaseModelWithForbidExtra):
     # Interval at which to evaluate and generate replays: Type 2 arbitrary default
     evaluate_interval: int = Field(default=300, ge=0)  # 0 to disable
     replay_dir: str = Field(default="")
+    evaluate_remote: bool = Field(default=False)
+    skip_git_check: bool = Field(default=False)
+    git_hash: str | None = Field(default=None)
 
     @model_validator(mode="after")
     def validate_fields(self) -> "SimulationConfig":

--- a/metta/setup/local_commands.py
+++ b/metta/setup/local_commands.py
@@ -114,7 +114,7 @@ class LocalCommands:
             policy_records.extend(policy_store.policy_records(uri, selector_type="all", n=1, metric="top"))
         policy_ids = get_or_create_policy_ids(
             stats_client,
-            [(pr.run_name, pr.uri) for pr in policy_records],
+            [(pr.run_name, pr.uri, None) for pr in policy_records],
         )
         json_repr = json.dumps({name: str(pid) for name, pid in policy_ids.items()}, indent=2)
         print(f"Ensured {len(policy_ids)} policy IDs: {json_repr}")

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -34,7 +34,7 @@ from metta.mettagrid.stats_writer import StatsWriter
 from metta.rl.vecenv import make_vecenv
 from metta.sim.simulation_config import SingleEnvSimulationConfig
 from metta.sim.simulation_stats_db import SimulationStatsDB
-from metta.sim.utils import get_or_create_policy_ids
+from metta.sim.utils import get_or_create_policy_ids, wandb_policy_name_to_uri
 
 logger = logging.getLogger(__name__)
 
@@ -76,11 +76,7 @@ class Simulation:
         self._wandb_policy_name: str | None = None
         self._wandb_uri: str | None = None
         if wandb_policy_name is not None:
-            # wandb_policy_name is a qualified name like 'entity/project/artifact:version'
-            # we store the uris as 'wandb://project/artifact:version', so need to strip 'entity'
-            arr = wandb_policy_name.split("/")
-            self._wandb_policy_name = arr[2]
-            self._wandb_uri = "wandb://" + arr[1] + "/" + arr[2]
+            self._wandb_policy_name, self._wandb_uri = wandb_policy_name_to_uri(wandb_policy_name)
 
         # ---------------- env config ----------------------------------- #
         logger.info(f"config.env {config.env}")
@@ -401,9 +397,9 @@ class Simulation:
         if self._stats_client is not None:
             policy_name = self._get_policy_name()
             policy_uri = self._get_policy_uri()
-            policy_details: list[tuple[str, str]] = [(policy_name, policy_uri)]
+            policy_details: list[tuple[str, str, str | None]] = [(policy_name, policy_uri, None)]
             if self._npc_pr is not None:
-                policy_details.append((self._npc_pr.run_name, self._npc_pr.uri))
+                policy_details.append((self._npc_pr.run_name, self._npc_pr.uri, None))
 
             policy_ids = get_or_create_policy_ids(self._stats_client, policy_details, self._stats_epoch_id)
 

--- a/metta/sim/utils.py
+++ b/metta/sim/utils.py
@@ -6,17 +6,26 @@ from metta.app_backend.stats_client import StatsClient
 
 
 def get_or_create_policy_ids(
-    stats_client: StatsClient, policies: list[tuple[str, str]], epoch_id: uuid.UUID | None = None
+    stats_client: StatsClient, policies: list[tuple[str, str, str | None]], epoch_id: uuid.UUID | None = None
 ) -> bidict[str, uuid.UUID]:
     """
     policies is a list of tuples of (policy_name, policy_uri)
     """
-    policy_names = [name for (name, _) in policies]
+    policy_names = [name for (name, _, __) in policies]
     policy_ids_response = stats_client.get_policy_ids(policy_names)
     policy_ids = bidict(policy_ids_response.policy_ids)
 
-    for name, uri in policies:
+    for name, uri, description in policies:
         if name not in policy_ids:
-            policy_response = stats_client.create_policy(name=name, description=None, url=uri, epoch_id=epoch_id)
+            policy_response = stats_client.create_policy(name=name, description=description, url=uri, epoch_id=epoch_id)
             policy_ids[name] = policy_response.id
     return policy_ids
+
+
+def wandb_policy_name_to_uri(wandb_policy_name: str) -> tuple[str, str]:
+    # wandb_policy_name is a qualified name like 'entity/project/artifact:version'
+    # we store the uris as 'wandb://project/artifact:version', so need to strip 'entity'
+    arr = wandb_policy_name.split("/")
+    internal_wandb_policy_name = arr[2]
+    wandb_uri = "wandb://" + arr[1] + "/" + arr[2]
+    return (internal_wandb_policy_name, wandb_uri)

--- a/tools/request_eval.py
+++ b/tools/request_eval.py
@@ -81,7 +81,7 @@ async def _create_remote_eval_tasks(
     }
     all_policy_records = {pr.run_name: pr for prs in policy_records_by_uri.values() for pr in prs}
     policy_ids = get_or_create_policy_ids(
-        stats_client, [(pr.run_name, pr.uri) for pr in all_policy_records.values() if pr.uri is not None]
+        stats_client, [(pr.run_name, pr.uri, None) for pr in all_policy_records.values() if pr.uri is not None]
     )
     if not policy_ids:
         warning("No policies found")

--- a/tools/train.py
+++ b/tools/train.py
@@ -13,6 +13,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 from metta.agent.policy_store import PolicyStore
 from metta.app_backend.stats_client import StatsClient
 from metta.common.util.config import Config
+from metta.common.util.git import get_git_hash_for_remote_task
 from metta.common.util.heartbeat import record_heartbeat
 from metta.common.util.stats_client_cfg import get_stats_client
 from metta.common.wandb.wandb_context import WandbContext, WandbRun
@@ -62,8 +63,20 @@ def train(cfg: DictConfig | ListConfig, wandb_run: WandbRun | None, logger: Logg
     # set by _calculate_default_num_workers, and the validation will fail
     if not cfg.trainer.num_workers:
         cfg.trainer.num_workers = _calculate_default_num_workers(cfg.vectorization == "serial")
-    cfg = validate_train_job_config(cfg)
 
+    # Determine git hash for remote simulations
+    if cfg.trainer.simulation.evaluate_remote and not cfg.trainer.simulation.git_hash:
+        cfg.trainer.simulation.git_hash = get_git_hash_for_remote_task(
+            skip_git_check=cfg.trainer.simulation.skip_git_check,
+            skip_cmd="trainer.simulation.skip_git_check=true",
+            logger=logger,
+        )
+        if cfg.trainer.simulation.git_hash:
+            logger.info(f"Git hash for remote evaluations: {cfg.trainer.simulation.git_hash}")
+        else:
+            logger.info("No git hash available for remote evaluations")
+
+    cfg = validate_train_job_config(cfg)
     logger.info("Trainer config after overrides:\n%s", OmegaConf.to_yaml(cfg.trainer, resolve=True))
 
     if os.environ.get("RANK", "0") == "0":


### PR DESCRIPTION
  - Trainer sends policy evaluator tasks if `trainer.simulation.evaluate_remote=true`
  - Specifies git hash for the eval task using logic similar to skypilot

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210897853242509)