### PR TITLE
Fix sandbox cost calculation to use on-demand pricing

### DIFF
--- a/devops/skypilot/sandbox.py
+++ b/devops/skypilot/sandbox.py
@@ -72,9 +72,9 @@ def get_gpu_instance_info(num_gpus: int, gpu_type: str = "L4", region: str = "us
     else:
         estimated_multiplier = 1
 
-    # Calculate cost (using spot pricing as indicated in the original code)
+    # Calculate cost for on-demand instances, since sandboxes don't use spot.
     with spinner(f"Calculating cost for {instance_type}", style=cyan):
-        hourly_cost = get_instance_cost(instance_type=instance_type, region=region, use_spot=True)
+        hourly_cost = get_instance_cost(instance_type=instance_type, region=region, use_spot=False)
 
     if hourly_cost is not None:
         hourly_cost *= estimated_multiplier
@@ -147,9 +147,9 @@ def main():
 
     if hourly_cost is not None:
         print(f"Instance type: {bold(instance_type)} in {bold(region)}")
-        print(f"Approximate cost: {green(f'~${hourly_cost:.2f}/hour')} (spot pricing)")
+        print(f"Approximate cost: {green(f'~${hourly_cost:.2f}/hour')} (on-demand pricing)")
     else:
-        print("Unable to determine exact cost, but typical L4 spot instances cost ~$0.50-$1.50/hour per GPU")
+        print("Unable to determine exact cost, but typical L4 on-demand instances cost ~$0.70-$2.00/hour per GPU")
 
     autostop_hours = 48
 


### PR DESCRIPTION
Updates the cost estimator in `devops/skypilot/sandbox.py` to use on-demand pricing instead of spot pricing since sandboxes are always launched as on-demand instances.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210909882233501)