### PR TITLE
skypilot chart - stable cookie secret

### DIFF
--- a/devops/charts/helmfile.yaml
+++ b/devops/charts/helmfile.yaml
@@ -80,6 +80,13 @@ releases:
           config: |
             jobs:
               bucket: s3://skypilot-jobs/
+          resources:
+            requests:
+              cpu: "8"
+              memory: "16Gi"
+            limits:
+              cpu: "8"
+              memory: "16Gi"
         awsCredentials:
           enabled: true
         ingress:

--- a/devops/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/devops/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -94,6 +94,12 @@ spec:
                 {{- end }}
               {{- end }}
             {{- end }}
+          # Softmax patch - stable cookie secret
+          {{- else if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
+              key: cookie-secret
           {{- else }}
           # Generate a random cookie secret if no existing one is found
           value: {{ randAlphaNum 32 | b64enc | quote }}


### PR DESCRIPTION
`helmfile apply -i` was saying that oauth cookie secret was new every time.

I don't know if it's actually true or not (maybe in dry run it doesn't analyze the cluster correctly), but to make sure that the auth doesn't get stale on api server restarts I changed it to pick the cookie secret from the k8s secret.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210911031691849)