### PR TITLE
Prevent metta install from hanging on interactive pnpm prompts

### DIFF
--- a/metta/setup/components/nodejs.py
+++ b/metta/setup/components/nodejs.py
@@ -40,9 +40,14 @@ class NodejsSetup(SetupModule):
         try:
             env = os.environ.copy()
             env["NODE_NO_WARNINGS"] = "1"
-            self.run_command(["pnpm", "--version"], capture_output=True, env=env)
-            return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+            result = subprocess.run(
+                ["pnpm", "--version"],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            return result.returncode == 0
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
             return False
 
     def _enable_corepack_with_cleanup(self):


### PR DESCRIPTION
This should resolve the issue you ran into @KrishnaKanthVN -- thanks for pointing it out!

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210911194476048)