### PR TITLE
[MettaScope] fix pausing in demo mode, and fix hover bubbles

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
           uv
           cmake
           stdenv.cc.cc.lib
+          pnpm
           nodejs_22
           typescript
         ];

--- a/mettascope/src/demomode.ts
+++ b/mettascope/src/demomode.ts
@@ -49,6 +49,7 @@ export function initDemoMode() {}
 
 export function startDemoMode() {
   state.demoMode = true
+  state.isPlaying = true
   requestFrame()
 }
 
@@ -72,7 +73,6 @@ export function doDemoMode() {
   if (!state.demoMode || state.replay == null) {
     return
   }
-  state.isPlaying = true
 
   // Is the current shot over?
   if (shot == null || shot.startTime + shot.duration < epochTime()) {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -252,7 +252,11 @@ onEvent('pointermove', 'body', (_target: HTMLElement, e: Event) => {
     onTraceMinimapChange(event)
   }
 
-  if (!ui.mouseTargets.includes('#worldmap-panel') && !ui.mouseTargets.includes('.hover-panel')) {
+  // Start hide timer when: completely off worldmap/hover-panel OR on worldmap but no object being hovered
+  const shouldHide = (!ui.mouseTargets.includes('#worldmap-panel') && !ui.mouseTargets.includes('.hover-panel')) ||
+                     (ui.mouseTargets.includes('#worldmap-panel') && ui.hoverObject === null && ui.delayedHoverObject !== null)
+
+  if (shouldHide) {
     // Start a timer to hide the hover bubble after a delay
     if (ui.hideHoverTimer === null) {
       ui.hideHoverTimer = setTimeout(() => {

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -252,8 +252,12 @@ onEvent('pointermove', 'body', (_target: HTMLElement, e: Event) => {
     onTraceMinimapChange(event)
   }
 
-  // Hide bubble unless mouse is over the bubble itself or over an object
-  const shouldHide = !ui.mouseTargets.includes('.hover-panel') && ui.hoverObject === null && ui.delayedHoverObject !== null
+  const isOverBubble = ui.mouseTargets.includes('.hover-panel')
+  const isOverObject = ui.hoverObject !== null
+  const hasBubble = ui.delayedHoverObject !== null
+
+  const shouldKeepBubble = isOverBubble || isOverObject
+  const shouldHide = !shouldKeepBubble && hasBubble
 
   if (shouldHide) {
     // Start a timer to hide the hover bubble after a delay

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -252,9 +252,8 @@ onEvent('pointermove', 'body', (_target: HTMLElement, e: Event) => {
     onTraceMinimapChange(event)
   }
 
-  // Start hide timer when: completely off worldmap/hover-panel OR on worldmap but no object being hovered
-  const shouldHide = (!ui.mouseTargets.includes('#worldmap-panel') && !ui.mouseTargets.includes('.hover-panel')) ||
-                     (ui.mouseTargets.includes('#worldmap-panel') && ui.hoverObject === null && ui.delayedHoverObject !== null)
+  // Hide bubble unless mouse is over the bubble itself or over an object
+  const shouldHide = !ui.mouseTargets.includes('.hover-panel') && ui.hoverObject === null && ui.delayedHoverObject !== null
 
   if (shouldHide) {
     // Start a timer to hide the hover bubble after a delay

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -839,7 +839,7 @@ export function drawMap(panel: PanelInfo) {
           }
         }, Common.INFO_PANEL_POP_TIME)
       } else if (!objectUnderMouse && ui.hoverObject !== null) {
-        // Reset hover state when moving to empty space
+        // Reset hover state when moving to empty space.
         ui.hoverObject = null
         clearTimeout(ui.hoverTimer)
       }

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -838,6 +838,10 @@ export function drawMap(panel: PanelInfo) {
             updateHoverBubble(ui.delayedHoverObject)
           }
         }, Common.INFO_PANEL_POP_TIME)
+      } else if (!objectUnderMouse && ui.hoverObject !== null) {
+        // Reset hover state when moving to empty space
+        ui.hoverObject = null
+        clearTimeout(ui.hoverTimer)
       }
     }
   }


### PR DESCRIPTION
- adjusted demo mode to only set playing once, not every frame. it feels bad to not let the user pause while demo mode is running. this fix will make time controls work properly on demo mode.
- fixed issues around hover bubbles not going away when they should, also made the code a bit easier to read.
- I'm also sneaking in a flake change to add pnpm to the flake file

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210911412148749)