### PR TITLE
remove getters

### DIFF
--- a/mettascope/src/context3d.ts
+++ b/mettascope/src/context3d.ts
@@ -613,26 +613,26 @@ export class Context3d {
 
     // Draw each mesh that has quads
     for (const mesh of this.meshes.values()) {
-      const quadCount = mesh.getQuadCount()
+      const quadCount = mesh.currentQuad
       if (quadCount === 0) {
         continue
       }
 
-      const vertexBuffer = mesh.getVertexBuffer()
-      const indexBuffer = mesh.getIndexBuffer()
+      const vertexBuffer = mesh.vertexBuffer
+      const indexBuffer = mesh.indexBuffer
 
       if (!vertexBuffer || !indexBuffer) {
         continue
       }
 
       // Calculate data sizes
-      const vertexDataCount = mesh.getCurrentVertexCount() * 8 // 8 floats per vertex
+      const vertexDataCount = mesh.currentVertex * 8 // 8 floats per vertex
       const indexDataCount = quadCount * 6 // 6 indices per quad
 
       // Update vertex buffer with current data only if dirty
       this.gl.bindBuffer(this.gl.ARRAY_BUFFER, vertexBuffer)
       if (mesh.isDirty) {
-        this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, mesh.getVertexData().subarray(0, vertexDataCount))
+        this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, mesh.vertexData.subarray(0, vertexDataCount))
         mesh.isDirty = false
       }
 

--- a/mettascope/src/mesh.ts
+++ b/mettascope/src/mesh.ts
@@ -4,17 +4,17 @@ import type { Vec2f } from './vector_math.js'
 export class Mesh {
   private name: string
   private gl: WebGLRenderingContext
-  private vertexBuffer: WebGLBuffer | null = null
-  private indexBuffer: WebGLBuffer | null = null
+  public vertexBuffer: WebGLBuffer | null = null
+  public indexBuffer: WebGLBuffer | null = null
 
   // Buffer management
   private maxQuads: number
   private vertexCapacity: number
   private indexCapacity: number
-  private vertexData: Float32Array
+  public vertexData: Float32Array
   private indexData: Uint32Array
-  private currentQuad = 0
-  private currentVertex = 0
+  public currentQuad = 0
+  public currentVertex = 0
 
   // Scissor properties
   public scissorEnabled = false
@@ -202,31 +202,6 @@ export class Mesh {
     this.currentVertex += 4
     this.currentQuad += 1
     this.isDirty = true
-  }
-
-  /** Get the number of quads in the mesh. */
-  getQuadCount(): number {
-    return this.currentQuad
-  }
-
-  /** Get the vertex data. */
-  getVertexData(): Float32Array {
-    return this.vertexData
-  }
-
-  /** Get the current vertex count. */
-  getCurrentVertexCount(): number {
-    return this.currentVertex
-  }
-
-  /** Get the vertex buffer. */
-  getVertexBuffer(): WebGLBuffer | null {
-    return this.vertexBuffer
-  }
-
-  /** Get the index buffer. */
-  getIndexBuffer(): WebGLBuffer | null {
-    return this.indexBuffer
   }
 
   /** Reset the counters. */

--- a/mettascope/src/mesh.ts
+++ b/mettascope/src/mesh.ts
@@ -2,17 +2,17 @@ import type { Vec2f } from './vector_math.js'
 
 /** Mesh class responsible for managing vertex data. */
 export class Mesh {
-  private name: string
-  private gl: WebGLRenderingContext
+  public name: string
+  public gl: WebGLRenderingContext
   public vertexBuffer: WebGLBuffer | null = null
   public indexBuffer: WebGLBuffer | null = null
 
   // Buffer management
-  private maxQuads: number
-  private vertexCapacity: number
-  private indexCapacity: number
+  public maxQuads: number
+  public vertexCapacity: number
+  public indexCapacity: number
   public vertexData: Float32Array
-  private indexData: Uint32Array
+  public indexData: Uint32Array
   public currentQuad = 0
   public currentVertex = 0
 


### PR DESCRIPTION
- Treeform suggested removing the mesh property getters. Let's just make the properties public so context3d can access them directly.
- There might be better patterns that could be applied here? but I'd rather just keep things simple rather than add complexity.