### PR TITLE
Make learning progress curriculum thread-safe with shared memory

### DIFF
--- a/mettagrid/src/metta/mettagrid/curriculum/learning_progress.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/learning_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from multiprocessing import Array, Manager, Value
 from typing import Dict, Tuple
 
 import numpy as np
@@ -97,86 +98,238 @@ class BidirectionalLearningProgress:
             f"search_space must be a Discrete space or int, got {type(search_space)}"
         )
         self._search_space = search_space
-        self._num_tasks = max_num_levels = search_space.n
-        self._ema_timescale = ema_timescale
-        self.progress_smoothing = progress_smoothing
-        self.num_active_tasks = int(num_active_tasks)
-        self._rand_task_rate = rand_task_rate
-        self._sample_threshold = sample_threshold
-        self._memory = int(memory)
-        self._outcomes = {}
+        max_num_levels = int(search_space.n)  # Convert to int for Array
+
+        # Create multiprocessing manager for shared data structures
+        self._manager = Manager()
+
+        # Store simple values in shared memory
+        self._num_tasks = Value("i", max_num_levels)
+        self._ema_timescale = Value("d", ema_timescale)
+        self.progress_smoothing = Value("d", progress_smoothing)
+        self.num_active_tasks = Value("i", int(num_active_tasks))
+        self._rand_task_rate = Value("d", rand_task_rate)
+        self._sample_threshold = Value("i", sample_threshold)
+        self._memory = Value("i", int(memory))
+        self._stale_dist = Value("b", True)
+
+        # Use managed dict for outcomes
+        self._outcomes = self._manager.dict()
         for i in range(max_num_levels):
-            self._outcomes[i] = []
-        self._p_fast = None
-        self._p_slow = None
-        self._p_true = None
-        self._random_baseline = None
-        self._task_success_rate = np.zeros(max_num_levels)
-        self._mean_samples_per_eval = []
-        self._num_nans = []
-        self._update_mask = np.ones(max_num_levels).astype(bool)
-        self._sample_levels = np.arange(max_num_levels).astype(np.int32)
-        self._counter = {i: 0 for i in self._sample_levels}
-        self._task_dist = None
-        self._stale_dist = True
+            self._outcomes[i] = self._manager.list()
+
+        # Create shared arrays for numpy arrays
+        # Initialize as None first, will create shared memory when needed
+        self._p_fast_shm = None
+        self._p_slow_shm = None
+        self._p_true_shm = None
+        self._random_baseline_shm = None
+        self._task_dist_shm = None
+
+        # Create shared arrays that are always initialized
+        self._task_success_rate = Array("d", max_num_levels)
+        self._update_mask = Array("b", max_num_levels)
+
+        # Initialize update mask to all True
+        with self._update_mask.get_lock():
+            for i in range(max_num_levels):
+                self._update_mask[i] = True
+
+        # Use managed lists for variable-length data
+        self._mean_samples_per_eval = self._manager.list()
+        self._num_nans = self._manager.list()
+        self._sample_levels = Array("i", max_num_levels)
+
+        # Initialize sample levels
+        with self._sample_levels.get_lock():
+            for i in range(max_num_levels):
+                self._sample_levels[i] = i
+
+        # Use managed dict for counter
+        self._counter = self._manager.dict({i: 0 for i in range(max_num_levels)})
+
+        # Track dtypes for shared arrays
+        self._shared_array_dtypes = {}
+
+    def _get_num_tasks(self) -> int:
+        """Get the number of tasks from shared memory."""
+        return self._num_tasks.value
+
+    def _get_numpy_array_from_shared(self, shared_array, dtype=None, name=None):
+        """Convert shared array to numpy array."""
+        if shared_array is None:
+            return None
+
+        if dtype is None:
+            # Try to get stored dtype if name is provided
+            if name and name in self._shared_array_dtypes:
+                dtype = self._shared_array_dtypes[name]
+            else:
+                dtype = np.float64  # default
+
+        with shared_array.get_lock():
+            return np.frombuffer(shared_array.get_obj(), dtype=dtype)
+
+    def _create_or_update_shared_array(self, name: str, data: np.ndarray | None):
+        """Create or update a shared array."""
+        if data is None:
+            return None
+
+        # Get the shared memory attribute name
+        shm_attr = f"_{name}_shm"
+        existing_shared_array = getattr(self, shm_attr)
+
+        # If shared memory doesn't exist or size mismatch, create new array
+        if existing_shared_array is None or len(existing_shared_array) != len(data):
+            if data.dtype == np.float64:
+                shared_array = Array("d", len(data))
+                self._shared_array_dtypes[name] = np.float64
+            elif data.dtype == np.float32:
+                shared_array = Array("f", len(data))
+                self._shared_array_dtypes[name] = np.float32
+            else:
+                shared_array = Array("d", len(data))
+                self._shared_array_dtypes[name] = np.float64
+            setattr(self, shm_attr, shared_array)
+        else:
+            shared_array = existing_shared_array
+
+        # Update the shared array with data
+        with shared_array.get_lock():
+            # Use the stored dtype
+            array_dtype = self._shared_array_dtypes.get(name, np.float64)
+
+            np_array = np.frombuffer(shared_array.get_obj(), dtype=array_dtype)
+            # Convert data to the correct dtype before assignment
+            np_array[:] = data.astype(array_dtype)
+
+        return shared_array
 
     def add_stats(self) -> Dict[str, float]:
         """Return learning progress statistics for logging."""
         stats = {}
-        stats["lp/num_active_tasks"] = len(self._sample_levels)
-        stats["lp/mean_sample_prob"] = np.mean(self._task_dist)
-        stats["lp/num_zeros_lp_dist"] = np.sum(self._task_dist == 0)
-        stats["lp/task_1_success_rate"] = self._task_success_rate[0]
-        stats[f"lp/task_{self._num_tasks // 2}_success_rate"] = self._task_success_rate[self._num_tasks // 2]
-        stats["lp/last_task_success_rate"] = self._task_success_rate[-1]
-        stats["lp/task_success_rate"] = np.mean(self._task_success_rate)
-        stats["lp/mean_evals_per_task"] = self._mean_samples_per_eval[-1]
-        stats["lp/num_nan_tasks"] = self._num_nans[-1]
+
+        # Get sample levels as numpy array
+        sample_levels = np.array(self._sample_levels[:])
+        stats["lp/num_active_tasks"] = len(sample_levels)
+
+        # Get task_dist as numpy array if it exists
+        if self._task_dist_shm is not None:
+            task_dist = self._get_numpy_array_from_shared(self._task_dist_shm, dtype=np.float32, name="task_dist")
+            if task_dist is not None:
+                stats["lp/mean_sample_prob"] = np.mean(task_dist)
+                stats["lp/num_zeros_lp_dist"] = np.sum(task_dist == 0)
+            else:
+                stats["lp/mean_sample_prob"] = 0.0
+                stats["lp/num_zeros_lp_dist"] = 0
+        else:
+            stats["lp/mean_sample_prob"] = 0.0
+            stats["lp/num_zeros_lp_dist"] = 0
+
+        # Get task success rate as numpy array
+        task_success_rate = np.array(self._task_success_rate[:])
+        stats["lp/task_1_success_rate"] = task_success_rate[0]
+        stats[f"lp/task_{self._get_num_tasks() // 2}_success_rate"] = task_success_rate[self._get_num_tasks() // 2]
+        stats["lp/last_task_success_rate"] = task_success_rate[-1]
+        stats["lp/task_success_rate"] = np.mean(task_success_rate)
+
+        if len(self._mean_samples_per_eval) > 0:
+            stats["lp/mean_evals_per_task"] = self._mean_samples_per_eval[-1]
+        else:
+            stats["lp/mean_evals_per_task"] = 0.0
+
+        if len(self._num_nans) > 0:
+            stats["lp/num_nan_tasks"] = self._num_nans[-1]
+        else:
+            stats["lp/num_nan_tasks"] = 0
+
         return stats
 
     def _update(self):
         """Update learning progress tracking with current task success rates."""
+        num_tasks = self._get_num_tasks()
         task_success_rates = np.array(
             [
                 np.mean(self._outcomes[i]) if len(self._outcomes[i]) > 0 else DEFAULT_SUCCESS_RATE
-                for i in range(self._num_tasks)
+                for i in range(num_tasks)
             ]
         )
         # Handle NaN values in task success rates (empty lists)
         task_success_rates = np.nan_to_num(task_success_rates, nan=DEFAULT_SUCCESS_RATE)
 
-        if self._random_baseline is None:
-            self._random_baseline = np.minimum(task_success_rates, RANDOM_BASELINE_CAP)
+        # Get arrays from shared memory
+        random_baseline = self._get_numpy_array_from_shared(self._random_baseline_shm, name="random_baseline")
+        update_mask_raw = np.array(self._update_mask[:])
+
+        # Ensure update_mask has the right size and only has True values for valid indices
+        if len(update_mask_raw) != num_tasks:
+            update_mask = np.ones(num_tasks).astype(bool)
+        else:
+            # Ensure no True values beyond num_tasks and convert to bool
+            update_mask = update_mask_raw[:num_tasks].astype(bool)
+
+        if random_baseline is None:
+            random_baseline = np.minimum(task_success_rates, RANDOM_BASELINE_CAP)
+            self._random_baseline_shm = self._create_or_update_shared_array("random_baseline", random_baseline)
+        elif len(random_baseline) != num_tasks:
+            # If size mismatch, recreate random_baseline
+            random_baseline = np.minimum(task_success_rates, RANDOM_BASELINE_CAP)
+            self._random_baseline_shm = self._create_or_update_shared_array("random_baseline", random_baseline)
+
+        # Ensure update_mask only has True values for indices that exist in random_baseline
+        if len(random_baseline) < num_tasks:
+            # Only keep True values for indices that exist
+            update_mask = update_mask & (np.arange(len(update_mask)) < len(random_baseline))
 
         # Handle division by zero in normalization
-        denominator = 1.0 - self._random_baseline[self._update_mask]
+        denominator = 1.0 - random_baseline[update_mask]
         denominator = np.where(denominator <= 0, 1.0, denominator)
 
         normalized_task_success_rates = (
             np.maximum(
-                task_success_rates[self._update_mask] - self._random_baseline[self._update_mask],
-                np.zeros(task_success_rates[self._update_mask].shape),
+                task_success_rates[update_mask] - random_baseline[update_mask],
+                np.zeros(task_success_rates[update_mask].shape),
             )
             / denominator
         )
 
-        if self._p_fast is None:
-            self._p_fast = normalized_task_success_rates[self._update_mask]
-            self._p_slow = normalized_task_success_rates[self._update_mask]
-            self._p_true = task_success_rates[self._update_mask]
-        else:
-            self._p_fast[self._update_mask] = (normalized_task_success_rates * self._ema_timescale) + (
-                self._p_fast[self._update_mask] * (1.0 - self._ema_timescale)
-            )
-            self._p_slow[self._update_mask] = (self._p_fast[self._update_mask] * self._ema_timescale) + (
-                self._p_slow[self._update_mask] * (1.0 - self._ema_timescale)
-            )
-            self._p_true[self._update_mask] = (task_success_rates[self._update_mask] * self._ema_timescale) + (
-                self._p_true[self._update_mask] * (1.0 - self._ema_timescale)
-            )
+        # Get current values from shared memory
+        p_fast = self._get_numpy_array_from_shared(self._p_fast_shm, name="p_fast")
+        p_slow = self._get_numpy_array_from_shared(self._p_slow_shm, name="p_slow")
+        p_true = self._get_numpy_array_from_shared(self._p_true_shm, name="p_true")
 
-        self._stale_dist = True
-        self._task_dist = None
+        if p_fast is None:
+            # First time initialization - create arrays with size matching update_mask
+            update_indices = np.where(update_mask)[0]
+            self._p_fast_shm = self._create_or_update_shared_array("p_fast", normalized_task_success_rates)
+            self._p_slow_shm = self._create_or_update_shared_array("p_slow", normalized_task_success_rates)
+            self._p_true_shm = self._create_or_update_shared_array("p_true", task_success_rates[update_mask])
+        else:
+            # Create arrays matching current sizes
+            update_indices = np.where(update_mask)[0]
+
+            # If sizes don't match, recreate arrays
+            if len(p_fast) != len(update_indices):
+                self._p_fast_shm = self._create_or_update_shared_array("p_fast", normalized_task_success_rates)
+                self._p_slow_shm = self._create_or_update_shared_array("p_slow", normalized_task_success_rates)
+                self._p_true_shm = self._create_or_update_shared_array("p_true", task_success_rates[update_mask])
+            else:
+                # Update shared arrays
+                p_fast[:] = (normalized_task_success_rates * self._ema_timescale.value) + (
+                    p_fast * (1.0 - self._ema_timescale.value)
+                )
+                p_slow[:] = (p_fast * self._ema_timescale.value) + (p_slow * (1.0 - self._ema_timescale.value))
+                p_true[:] = (task_success_rates[update_mask] * self._ema_timescale.value) + (
+                    p_true * (1.0 - self._ema_timescale.value)
+                )
+
+                # Write back to shared memory
+                self._create_or_update_shared_array("p_fast", p_fast)
+                self._create_or_update_shared_array("p_slow", p_slow)
+                self._create_or_update_shared_array("p_true", p_true)
+
+        self._stale_dist.value = True
+        self._task_dist_shm = None
 
         return task_success_rates
 
@@ -185,24 +338,48 @@ class BidirectionalLearningProgress:
         if not bool(infos):
             return
 
+        # Get sample levels as a list for membership checking
+        sample_levels_list = list(self._sample_levels[: self.num_active_tasks.value])
+
         for k, v in infos.items():
             if "tasks" in k:
                 task_id = int(k.split("/")[1])
                 for res in v:
                     self._outcomes[task_id].append(res)
-                    if task_id in self._sample_levels:
+                    if task_id in sample_levels_list:
+                        # Ensure task_id exists in counter before incrementing
+                        if task_id not in self._counter:
+                            self._counter[task_id] = 0
                         self._counter[task_id] += 1
 
     def _learning_progress(self, reweight: bool = True) -> np.ndarray:
         """Calculate learning progress as the difference between fast and slow moving averages."""
-        fast = self._reweight(self._p_fast) if reweight else self._p_fast
-        slow = self._reweight(self._p_slow) if reweight else self._p_slow
+        p_fast = self._get_numpy_array_from_shared(self._p_fast_shm, name="p_fast")
+        p_slow = self._get_numpy_array_from_shared(self._p_slow_shm, name="p_slow")
+
+        if p_fast is None or p_slow is None:
+            return np.zeros(self._get_num_tasks())
+
+        # If arrays don't match task count, return zeros for missing tasks
+        num_tasks = self._get_num_tasks()
+        if len(p_fast) < num_tasks:
+            # Pad with zeros
+            fast_padded = np.zeros(num_tasks)
+            slow_padded = np.zeros(num_tasks)
+            fast_padded[: len(p_fast)] = p_fast
+            slow_padded[: len(p_slow)] = p_slow
+            p_fast = fast_padded
+            p_slow = slow_padded
+
+        fast = self._reweight(p_fast) if reweight else p_fast
+        slow = self._reweight(p_slow) if reweight else p_slow
         return abs(fast - slow)
 
     def _reweight(self, probs: np.ndarray) -> np.ndarray:
         """Apply progress smoothing reweighting to probability values."""
-        numerator = probs * (1.0 - self.progress_smoothing)
-        denominator = probs + self.progress_smoothing * (1.0 - 2.0 * probs)
+        smoothing = self.progress_smoothing.value
+        numerator = probs * (1.0 - smoothing)
+        denominator = probs + smoothing * (1.0 - 2.0 * probs)
 
         # Handle division by zero
         denominator = np.where(denominator <= 0, 1.0, denominator)
@@ -215,10 +392,20 @@ class BidirectionalLearningProgress:
         return 1 / (1 + np.exp(-x))
 
     def _sample_distribution(self):
-        task_dist = np.ones(self._num_tasks) / self._num_tasks
+        task_dist = np.ones(self._get_num_tasks()) / self._get_num_tasks()
         learning_progress = self._learning_progress()
 
-        posidxs = [i for i, lp in enumerate(learning_progress) if lp > 0 or self._p_true[i] > 0]
+        # Get p_true array from shared memory
+        p_true = self._get_numpy_array_from_shared(self._p_true_shm, name="p_true")
+        if p_true is None:
+            p_true = np.zeros(self._get_num_tasks())
+        elif len(p_true) < self._get_num_tasks():
+            # Pad with zeros if p_true is smaller than expected
+            p_true_padded = np.zeros(self._get_num_tasks())
+            p_true_padded[: len(p_true)] = p_true
+            p_true = p_true_padded
+
+        posidxs = [i for i, lp in enumerate(learning_progress) if lp > 0 or p_true[i] > 0]
         any_progress = len(posidxs) > 0
         subprobs = learning_progress[posidxs] if any_progress else learning_progress
 
@@ -245,67 +432,107 @@ class BidirectionalLearningProgress:
         else:
             task_dist = subprobs
 
-        self._task_dist = task_dist.astype(np.float32)
-        self._stale_dist = False
+        self._task_dist_shm = self._create_or_update_shared_array("task_dist", task_dist.astype(np.float32))
+        self._stale_dist.value = False
 
         out_vec = [
             np.mean(self._outcomes[i]) if len(self._outcomes[i]) > 0 else DEFAULT_SUCCESS_RATE
-            for i in range(self._num_tasks)
+            for i in range(self._get_num_tasks())
         ]
         out_vec = [DEFAULT_SUCCESS_RATE if np.isnan(x) else x for x in out_vec]  # Handle NaN in outcomes
         self._num_nans.append(sum(np.isnan(out_vec)))
-        self._task_success_rate = np.array(out_vec)
-        self._mean_samples_per_eval.append(np.mean([len(self._outcomes[i]) for i in range(self._num_tasks)]))
 
-        for i in range(self._num_tasks):
-            self._outcomes[i] = self._outcomes[i][-self._memory :]
-        return self._task_dist
+        # Update task success rate shared array
+        with self._task_success_rate.get_lock():
+            task_success_rate_array = np.frombuffer(self._task_success_rate.get_obj(), dtype=np.float64)
+            task_success_rate_array[:] = out_vec
+
+        self._mean_samples_per_eval.append(np.mean([len(self._outcomes[i]) for i in range(self._get_num_tasks())]))
+
+        # Trim outcomes to memory limit
+        memory_limit = self._memory.value
+        for i in range(self._get_num_tasks()):
+            if len(self._outcomes[i]) > memory_limit:
+                # Convert to list, slice, and reassign
+                self._outcomes[i] = self._manager.list(list(self._outcomes[i])[-memory_limit:])
+
+        # Get task distribution as numpy array
+        task_dist_array = self._get_numpy_array_from_shared(self._task_dist_shm, dtype=np.float32, name="task_dist")
+        return task_dist_array
 
     def _sample_tasks(self):
         """Sample active tasks based on current task distribution."""
         sample_levels = []
-        self._update_mask = np.zeros(self._num_tasks).astype(bool)
+        num_tasks = self._get_num_tasks()
+
+        # Create new update mask array
+        update_mask = np.zeros(num_tasks).astype(bool)
+
+        # Get task distribution from shared memory
+        task_dist = self._get_numpy_array_from_shared(self._task_dist_shm, dtype=np.float32, name="task_dist")
 
         # Ensure task_dist is valid
-        if self._task_dist is None or len(self._task_dist) == 0:
+        if task_dist is None or len(task_dist) == 0:
             # Use uniform distribution if task_dist is not available
-            task_dist = np.ones(self._num_tasks) / self._num_tasks
-        else:
-            task_dist = self._task_dist.copy()
+            task_dist = np.ones(num_tasks) / num_tasks
 
         # Ensure task_dist sums to 1
         sum_dist = np.sum(task_dist)
         if sum_dist <= 0:
-            task_dist = np.ones(self._num_tasks) / self._num_tasks
+            task_dist = np.ones(num_tasks) / num_tasks
         else:
             task_dist = task_dist / sum_dist
 
-        for _i in range(self.num_active_tasks):
-            if np.random.rand() < self._rand_task_rate:
-                level = np.random.choice(range(self._num_tasks))
+        # Get values from shared memory
+        num_active_tasks = min(self.num_active_tasks.value, num_tasks)  # Can't have more active tasks than total tasks
+        rand_task_rate = self._rand_task_rate.value
+
+        for _i in range(num_active_tasks):
+            if np.random.rand() < rand_task_rate:
+                level = np.random.choice(range(num_tasks))
             else:
                 try:
-                    level = np.random.choice(range(self._num_tasks), p=task_dist)
+                    level = np.random.choice(range(num_tasks), p=task_dist)
                 except ValueError as e:
                     logger.warning(f"Error in np.random.choice: {e}, using uniform distribution")
-                    level = np.random.choice(range(self._num_tasks))
+                    level = np.random.choice(range(num_tasks))
             sample_levels.append(level)
-            self._update_mask[level] = True
-        self._sample_levels = np.array(sample_levels).astype(np.int32)
-        self._counter = {i: 0 for i in self._sample_levels}
-        return self._sample_levels
+            update_mask[level] = True
+
+        # Update shared arrays
+        with self._sample_levels.get_lock():
+            sample_levels_array = np.frombuffer(self._sample_levels.get_obj(), dtype=np.int32)
+            # Only update up to the size of the array
+            num_to_update = min(len(sample_levels), len(sample_levels_array))
+            sample_levels_array[:num_to_update] = sample_levels[:num_to_update]
+
+        with self._update_mask.get_lock():
+            update_mask_array = np.frombuffer(self._update_mask.get_obj(), dtype=bool)
+            update_mask_array[:] = update_mask
+
+        # Reset counters only for newly sampled tasks, preserving others
+        # This prevents KeyError in multiprocessing scenarios
+        for level in sample_levels:
+            self._counter[level] = 0
+        return np.array(sample_levels).astype(np.int32)
 
     def calculate_dist(self) -> Tuple[np.ndarray, np.ndarray]:
         """Calculate task distribution and sample levels based on learning progress."""
-        if all([v < self._sample_threshold for k, v in self._counter.items()]) and self._random_baseline is not None:
-            # Ensure we have valid task_dist and sample_levels
-            if self._task_dist is None or len(self._task_dist) == 0:
-                self._task_dist = np.ones(self._num_tasks) / self._num_tasks
-            if self._sample_levels is None or len(self._sample_levels) == 0:
-                self._sample_levels = np.arange(self._num_tasks).astype(np.int32)
-            return self._task_dist, self._sample_levels
+        # Check if we should update based on sample threshold
+        sample_threshold = self._sample_threshold.value
+        should_update = any([v >= sample_threshold for k, v in self._counter.items()])
 
-        self._task_success_rate = self._update()
+        if not should_update and self._random_baseline_shm is not None:
+            # Ensure we have valid task_dist and sample_levels
+            task_dist = self._get_numpy_array_from_shared(self._task_dist_shm, dtype=np.float32, name="task_dist")
+            if task_dist is None or len(task_dist) == 0:
+                task_dist = np.ones(self._get_num_tasks()) / self._get_num_tasks()
+
+            sample_levels = np.array(self._sample_levels[: self.num_active_tasks.value])
+            return task_dist, sample_levels
+
+        # Update without overwriting self._task_success_rate
+        self._update()
         task_dist = self._sample_distribution()
         tasks = self._sample_tasks()
 

--- a/mettagrid/tests/test_learning_progress.py
+++ b/mettagrid/tests/test_learning_progress.py
@@ -1,0 +1,432 @@
+"""
+Unit tests for learning progress curriculum with shared memory implementation.
+
+Tests the BidirectionalLearningProgress class and LearningProgressCurriculum
+to ensure shared memory functionality works correctly across processes.
+"""
+
+import multiprocessing as mp
+
+import numpy as np
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+from metta.mettagrid.curriculum.core import SingleTaskCurriculum
+from metta.mettagrid.curriculum.learning_progress import (
+    BidirectionalLearningProgress,
+    LearningProgressCurriculum,
+)
+
+
+class MockTask:
+    """Mock task for testing curriculum behavior."""
+
+    def __init__(self, task_id: str, cfg: DictConfig):
+        self._id = task_id
+        self._cfg = cfg
+        self._complete = False
+
+    def id(self):
+        return self._id
+
+    def short_name(self):
+        return self._id.split(":")[0] if ":" in self._id else self._id
+
+    def env_cfg(self):
+        return self._cfg
+
+    def is_complete(self):
+        return self._complete
+
+    def complete(self, score: float):
+        self._complete = True
+
+
+@pytest.fixture
+def mock_env_cfg():
+    """Create a mock environment configuration."""
+    return OmegaConf.create({"game": {"num_agents": 1, "map": {"width": 10, "height": 10}}})
+
+
+@pytest.fixture
+def mock_curriculum_from_config_path(monkeypatch, mock_env_cfg):
+    """Mock the curriculum_from_config_path function."""
+
+    def _mock(path, env_overrides=None):
+        cfg = OmegaConf.merge(mock_env_cfg, env_overrides or {})
+        return SingleTaskCurriculum(path, cfg)
+
+    monkeypatch.setattr("metta.mettagrid.curriculum.random.curriculum_from_config_path", _mock)
+    return _mock
+
+
+class TestBidirectionalLearningProgressSharedMemory:
+    """Test the shared memory implementation of BidirectionalLearningProgress."""
+
+    def test_initialization(self):
+        """Test that all shared memory structures are properly initialized."""
+        lp = BidirectionalLearningProgress(
+            search_space=4,
+            ema_timescale=0.01,
+            progress_smoothing=0.05,
+            num_active_tasks=4,
+            rand_task_rate=0.25,
+            sample_threshold=10,
+            memory=25,
+        )
+
+        # Check that shared memory values are accessible
+        assert lp._num_tasks.value == 4
+        assert lp._ema_timescale.value == 0.01
+        assert lp.progress_smoothing.value == 0.05
+        assert lp.num_active_tasks.value == 4
+        assert lp._rand_task_rate.value == 0.25
+        assert lp._sample_threshold.value == 10
+        assert lp._memory.value == 25
+        assert bool(lp._stale_dist.value)
+
+        # Check that shared arrays are initialized
+        assert len(lp._task_success_rate) == 4
+        assert len(lp._update_mask) == 4
+        assert len(lp._sample_levels) == 4
+
+        # Check that update mask is all True initially
+        update_mask = np.array(lp._update_mask[:])
+        assert np.all(update_mask)
+
+        # Check outcomes dict is initialized
+        assert len(lp._outcomes) == 4
+        for i in range(4):
+            assert i in lp._outcomes
+            assert len(lp._outcomes[i]) == 0
+
+    def test_collect_data(self):
+        """Test that data collection works with shared memory."""
+        lp = BidirectionalLearningProgress(search_space=3)
+
+        # Collect some data
+        infos = {"tasks/0": [0.5, 0.6], "tasks/1": [0.7], "tasks/2": [0.0, 0.1, 0.2]}
+        lp.collect_data(infos)
+
+        # Check that data was stored in shared memory
+        assert len(lp._outcomes[0]) == 2
+        assert list(lp._outcomes[0]) == [0.5, 0.6]
+        assert len(lp._outcomes[1]) == 1
+        assert list(lp._outcomes[1]) == [0.7]
+        assert len(lp._outcomes[2]) == 3
+        assert list(lp._outcomes[2]) == [0.0, 0.1, 0.2]
+
+    def test_update_with_shared_memory(self):
+        """Test that update function works with shared memory arrays."""
+        lp = BidirectionalLearningProgress(search_space=3, ema_timescale=0.1)
+
+        # Add some outcomes
+        lp._outcomes[0].extend([0.0, 0.1, 0.2])
+        lp._outcomes[1].extend([0.5, 0.6])
+        lp._outcomes[2].extend([1.0])
+
+        # Run update
+        task_success_rates = lp._update()
+
+        # Check that shared arrays were created/updated
+        assert lp._p_fast_shm is not None
+        assert lp._p_slow_shm is not None
+        assert lp._p_true_shm is not None
+        assert lp._random_baseline_shm is not None
+
+        # Check task success rates
+        np.testing.assert_almost_equal(task_success_rates[0], 0.1)  # mean of [0.0, 0.1, 0.2]
+        np.testing.assert_almost_equal(task_success_rates[1], 0.55)  # mean of [0.5, 0.6]
+        np.testing.assert_almost_equal(task_success_rates[2], 1.0)  # mean of [1.0]
+
+    def test_learning_progress_calculation(self):
+        """Test learning progress calculation with shared memory."""
+        lp = BidirectionalLearningProgress(search_space=3)
+
+        # Manually set up some shared arrays
+        p_fast = np.array([0.2, 0.5, 0.8])
+        p_slow = np.array([0.1, 0.4, 0.7])
+
+        lp._p_fast_shm = lp._create_or_update_shared_array("p_fast", p_fast)
+        lp._p_slow_shm = lp._create_or_update_shared_array("p_slow", p_slow)
+
+        # Calculate learning progress
+        progress = lp._learning_progress(reweight=False)
+
+        # Should be abs(fast - slow)
+        expected = np.abs(p_fast - p_slow)
+        np.testing.assert_array_almost_equal(progress, expected)
+
+    def test_sample_distribution(self):
+        """Test that sample distribution calculation works with shared memory."""
+        lp = BidirectionalLearningProgress(search_space=3)
+
+        # Set up some test data
+        lp._outcomes[0].extend([0.0, 0.1, 0.2])
+        lp._outcomes[1].extend([0.5, 0.6])
+        lp._outcomes[2].extend([1.0])
+
+        # Initialize arrays
+        lp._update()
+
+        # Calculate distribution
+        task_dist = lp._sample_distribution()
+
+        # Check that distribution was created and stored in shared memory
+        assert lp._task_dist_shm is not None
+        assert task_dist is not None
+        assert len(task_dist) == 3
+        assert np.sum(task_dist) == pytest.approx(1.0)
+        assert not lp._stale_dist.value
+
+    def test_add_stats(self):
+        """Test that stats collection works with shared memory."""
+        lp = BidirectionalLearningProgress(search_space=3)
+
+        # Set up some test data
+        lp._outcomes[0].extend([0.0, 0.1, 0.2])
+        lp._outcomes[1].extend([0.5, 0.6])
+        lp._outcomes[2].extend([1.0])
+
+        # Run update to initialize arrays
+        lp._update()
+        lp._sample_distribution()
+
+        # Get stats
+        stats = lp.add_stats()
+
+        # Check that stats are properly extracted from shared memory
+        assert "lp/num_active_tasks" in stats
+        assert "lp/mean_sample_prob" in stats
+        assert "lp/num_zeros_lp_dist" in stats
+        assert "lp/task_1_success_rate" in stats
+        assert "lp/task_success_rate" in stats
+        assert "lp/mean_evals_per_task" in stats
+        assert "lp/num_nan_tasks" in stats
+
+        # Verify some values
+        assert stats["lp/num_active_tasks"] == 3
+        assert stats["lp/mean_sample_prob"] > 0
+        assert stats["lp/task_success_rate"] == pytest.approx(0.55, rel=1e-2)  # mean of [0.1, 0.55, 1.0]
+
+
+def shared_memory_worker(task_queue, result_queue, num_steps):
+    """Worker process that interacts with shared memory curriculum."""
+    # Create curriculum (shares memory with parent)
+    tasks = {"task_0": 1.0, "task_1": 1.0, "task_2": 1.0}
+    curriculum = LearningProgressCurriculum(tasks=tasks, ema_timescale=0.01, num_active_tasks=3, sample_threshold=5)
+
+    # Run some steps
+    for i in range(num_steps):
+        # Get task
+        task = curriculum.get_task()
+        # Extract the base task name (remove curriculum prefix)
+        task_name = task.id().split(":")[0] if ":" in task.id() else task.id()
+
+        # Generate score (simple pattern for testing)
+        score = min(1.0, i * 0.1) if task_name == "task_0" else 0.0
+
+        # Complete task
+        curriculum.complete_task(task_name, score)
+
+        # Send result
+        result_queue.put((i, task_name, score))
+
+    # Send final stats
+    stats = curriculum.stats()
+    result_queue.put(("stats", stats))
+
+
+class TestLearningProgressCurriculumSharedMemory:
+    """Test the LearningProgressCurriculum with shared memory across processes."""
+
+    def test_basic_functionality(self, mock_curriculum_from_config_path):
+        """Test basic curriculum functionality with shared memory."""
+        tasks = {"task_0": 1.0, "task_1": 1.0, "task_2": 1.0}
+        curriculum = LearningProgressCurriculum(tasks=tasks, ema_timescale=0.01, num_active_tasks=3, sample_threshold=5)
+
+        # Run some steps
+        for _ in range(20):
+            task = curriculum.get_task()
+            # Extract the base task name (remove curriculum prefix)
+            task_name = task.id().split(":")[0] if ":" in task.id() else task.id()
+            score = 0.5 if "task_0" in task_name else 0.1
+            curriculum.complete_task(task_name, score)
+
+        # Get stats
+        stats = curriculum.stats()
+        assert "lp/num_active_tasks" in stats
+        assert "lp/task_success_rate" in stats
+
+        # Check task weights were updated
+        weights = curriculum.get_task_probs()
+        assert len(weights) == 3
+        assert sum(weights.values()) == pytest.approx(1.0)
+
+    @pytest.mark.skipif(mp.get_start_method() == "spawn", reason="Shared memory test requires fork or forkserver")
+    def test_multiprocess_shared_memory(self, mock_curriculum_from_config_path):
+        """Test that shared memory works across multiple processes."""
+        # Note: This test may need adjustment based on the multiprocessing start method
+        # On some systems (e.g., macOS), 'spawn' is default which doesn't share memory
+
+        # Create queues for communication
+        task_queue = mp.Queue()
+        result_queue = mp.Queue()
+
+        # Start worker process
+        num_steps = 30
+        worker = mp.Process(target=shared_memory_worker, args=(task_queue, result_queue, num_steps))
+        worker.start()
+
+        # Collect results
+        results = []
+        stats = None
+
+        for _ in range(num_steps + 1):  # +1 for stats
+            result = result_queue.get(timeout=5)
+            if result[0] == "stats":
+                stats = result[1]
+            else:
+                results.append(result)
+
+        worker.join(timeout=5)
+
+        # Verify results
+        assert len(results) == num_steps
+        assert stats is not None
+
+        # Check that learning happened
+        assert "lp/task_success_rate" in stats
+        assert stats["lp/task_success_rate"] > 0
+
+        # Check that task_0 (which improves) was preferred
+        task_0_count = sum(1 for _, task_id, _ in results if task_id == "task_0")
+        assert task_0_count > num_steps // 3  # Should be selected more than uniform
+
+    def test_curriculum_with_varying_success_rates(self, mock_curriculum_from_config_path):
+        """Test curriculum behavior with tasks of varying success rates."""
+        tasks = {"easy": 1.0, "medium": 1.0, "hard": 1.0, "impossible": 1.0}
+
+        curriculum = LearningProgressCurriculum(
+            tasks=tasks,
+            ema_timescale=0.05,  # Faster adaptation
+            num_active_tasks=4,
+            sample_threshold=3,  # Lower threshold for faster updates
+            rand_task_rate=0.5,  # Higher exploration rate to ensure all tasks are sampled
+            memory=25,  # Ensure we have enough memory for learning
+        )
+
+        # Define success rates for each task
+        success_rates = {
+            "easy": lambda step: 0.9,  # Always high
+            "medium": lambda step: min(0.8, step * 0.02),  # Gradual improvement
+            "hard": lambda step: min(0.5, step * 0.01),  # Slow improvement
+            "impossible": lambda step: 0.0,  # Never succeeds
+        }
+
+        task_counts = {task: 0 for task in tasks}
+
+        # First, ensure each task is sampled at least once to initialize the algorithm
+        for task_name in tasks:
+            for _ in range(3):  # Sample each task 3 times to reach the threshold
+                task = curriculum.get_task()
+                curriculum.complete_task(task_name, success_rates[task_name](0))
+
+        # Run simulation with more iterations for convergence
+        for step in range(200):
+            task = curriculum.get_task()
+            # Extract the base task name (remove curriculum prefix)
+            task_name = task.id().split(":")[0] if ":" in task.id() else task.id()
+
+            # Get score based on task difficulty
+            score = success_rates[task_name](step)
+
+            # Complete task
+            curriculum.complete_task(task_name, score)
+            task_counts[task_name] += 1
+
+        # Analyze results
+        print(f"Task counts after 200 steps: {task_counts}")
+
+        # With 50% random exploration, we should see at least some variety
+        explored_tasks = sum(1 for count in task_counts.values() if count > 0)
+        assert explored_tasks >= 2, (
+            f"With 50% random rate, at least 2 tasks should be explored, but only {explored_tasks} were"
+        )
+
+        # After convergence, tasks with better performance should get more samples
+        # Calculate ratios for clearer comparison
+        total_count = sum(task_counts.values())
+        task_ratios = {task: count / total_count for task, count in task_counts.items() if count > 0}
+        print(f"Task sampling ratios: {task_ratios}")
+
+        # The algorithm should show some preference
+        if len(task_ratios) > 1:
+            ratio_variance = np.var(list(task_ratios.values()))
+            max_min_diff = max(task_ratios.values()) - min(task_ratios.values())
+            assert ratio_variance > 0.0001 or max_min_diff > 0.05, (
+                f"Algorithm should show preference (variance: {ratio_variance:.6f}, diff: {max_min_diff:.3f})"
+            )
+
+        # At least one of the learning tasks (medium/hard) should get reasonable sampling
+        assert task_ratios["medium"] > 0.15 or task_ratios["hard"] > 0.15, (
+            "At least one learning task should get reasonable sampling"
+        )
+
+        # Get final stats
+        stats = curriculum.stats()
+        assert stats["lp/task_success_rate"] > 0
+        assert stats["lp/num_active_tasks"] == 4
+
+    def test_memory_limit(self, mock_curriculum_from_config_path):
+        """Test that memory limit for outcomes works correctly."""
+        tasks = {"task_0": 1.0}
+        memory_limit = 10
+
+        curriculum = LearningProgressCurriculum(
+            tasks=tasks,
+            memory=memory_limit,
+            sample_threshold=5,
+            num_active_tasks=1,  # Only 1 active task since we only have 1 task total
+        )
+
+        # Add more outcomes than memory limit
+        for _ in range(memory_limit * 3):  # Add 30 items
+            curriculum.get_task()
+            curriculum.complete_task("task_0", 0.5)
+
+        # Force the counter to exceed threshold to trigger an update
+        lp_tracker = curriculum._lp_tracker
+        lp_tracker._counter[0] = lp_tracker._sample_threshold.value
+
+        # Call calculate_dist to trigger memory trimming
+        lp_tracker.calculate_dist()
+
+        # Check that outcomes are limited to memory size
+        assert len(lp_tracker._outcomes[0]) <= memory_limit
+
+    def test_edge_cases(self, mock_curriculum_from_config_path):
+        """Test edge cases like empty outcomes, NaN values, etc."""
+        tasks = {"task_0": 1.0, "task_1": 1.0}
+        curriculum = LearningProgressCurriculum(tasks=tasks)
+
+        # Test with no data collected
+        stats = curriculum.stats()
+        assert stats["lp/mean_sample_prob"] == 0.0  # No distribution yet
+        assert stats["lp/num_zeros_lp_dist"] == 0
+
+        # Test with NaN prevention
+        task = curriculum.get_task()
+        # Extract the base task name (remove curriculum prefix)
+        task_name = task.id().split(":")[0] if ":" in task.id() else task.id()
+        curriculum.complete_task(task_name, float("inf"))  # Should be capped
+
+        # Test with negative scores (should be clamped to 0)
+        task = curriculum.get_task()
+        task_name = task.id().split(":")[0] if ":" in task.id() else task.id()
+        curriculum.complete_task(task_name, -1.0)
+
+        # Verify curriculum still works
+        stats = curriculum.stats()
+        assert not np.isnan(stats["lp/task_success_rate"])
+        assert 0 <= stats["lp/task_success_rate"] <= 1.0


### PR DESCRIPTION
### TL;DR

Implemented multiprocessing-safe shared memory for the learning progress curriculum to support parallel environments.

### What changed?

- Refactored `BidirectionalLearningProgress` class to use shared memory structures (`Array`, `Value`, and `Manager`) from the `multiprocessing` package
- Replaced numpy arrays and dictionaries with shared memory equivalents to ensure data consistency across processes
- Added helper methods to convert between shared memory structures and numpy arrays
- Removed the `instances` parameter from BBC curriculum agent configuration files
- Added comprehensive unit tests for the shared memory implementation

### How to test?

1. Run the new unit tests in `mettagrid/tests/test_learning_progress.py`
2. Verify that the curriculum works correctly in a multi-process environment
3. Check that task selection adapts properly based on learning progress across processes

### Why make this change?

The previous implementation used process-local memory structures, causing inconsistent curriculum behavior when running with multiple parallel environments. Each process had its own copy of the learning progress tracker, leading to different task distributions and inefficient learning. This change ensures all processes share the same curriculum state, improving learning efficiency and consistency in distributed training scenarios.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210913208174301)