### PR TITLE
move test imports up and remove deprecated lr scheduler

### DIFF
--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -35,12 +35,6 @@ optimizer:
   learning_rate: 0.000457
   weight_decay: 0
 
-lr_scheduler:
-  enabled: false
-  anneal_lr: false
-  warmup_steps: null
-  schedule_type: null
-
 ppo:
   # Core PPO hyperparameters
   clip_coef: 0.1

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -22,17 +22,6 @@ class OptimizerConfig(BaseModelWithForbidExtra):
     weight_decay: float = Field(default=0, ge=0)
 
 
-class LRSchedulerConfig(BaseModelWithForbidExtra):
-    # LR scheduling disabled by default: Fixed LR often works well in RL
-    enabled: bool = False
-    # Annealing disabled: Common to use fixed LR for PPO
-    anneal_lr: bool = False
-    # No warmup by default: RL typically doesn't need warmup like supervised learning
-    warmup_steps: int | None = None
-    # Schedule type unset: Various options available when enabled
-    schedule_type: Literal["linear", "cosine", "exponential"] | None = None
-
-
 class PrioritizedExperienceReplayConfig(BaseModelWithForbidExtra):
     # Alpha=0 disables prioritization (uniform sampling), Type 2 default to be updated by sweep
     prio_alpha: float = Field(default=0.0, ge=0, le=1.0)
@@ -145,7 +134,6 @@ class TrainerConfig(BaseModelWithForbidExtra):
 
     # Optimizer and scheduler
     optimizer: OptimizerConfig = Field(default_factory=OptimizerConfig)
-    lr_scheduler: LRSchedulerConfig = Field(default_factory=LRSchedulerConfig)
 
     # Experience replay
     prioritized_experience_replay: PrioritizedExperienceReplayConfig = Field(

--- a/run.py
+++ b/run.py
@@ -271,13 +271,6 @@ losses = Losses()
 timer = Stopwatch(logger)
 timer.start()
 
-# Create learning rate scheduler
-lr_scheduler = None
-if getattr(trainer_config, "lr_scheduler", None) and trainer_config.lr_scheduler.enabled:
-    lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-        optimizer.optimizer, T_max=trainer_config.total_timesteps // trainer_config.batch_size
-    )
-
 # Memory and System Monitoring (master only)
 system_monitor = None
 memory_monitor = None
@@ -419,9 +412,6 @@ while agent_step < trainer_config.total_timesteps:
 
     if minibatch_idx > 0 and str(device).startswith("cuda"):
         torch.cuda.synchronize()
-
-    if lr_scheduler is not None:
-        lr_scheduler.step()
 
     losses.explained_variance = calculate_explained_variance(experience.values, advantages)
 

--- a/tests/rl/test_hyperparameter_scheduler.py
+++ b/tests/rl/test_hyperparameter_scheduler.py
@@ -1,5 +1,6 @@
 import logging
 
+import torch
 from omegaconf import DictConfig
 
 from metta.rl.hyperparameter_scheduler import (
@@ -48,12 +49,16 @@ class TestSchedules:
         assert abs(schedule(1.0) - 0.0) < 1e-6
 
 
-class MockTrainer:
-    """Mock trainer for testing hyperparameter scheduler."""
+# Integration tests for the HyperparameterScheduler no longer rely on a mock trainer.
+# Instead, they construct the minimal objects actually consumed by the scheduler:
+# 1. a DictConfig with the relevant PPO and optimizer fields
+# 2. a real `torch.optim.Optimizer` instance whose `param_groups` will be updated.
 
-    def __init__(self):
-        self.optimizer = type("Optimizer", (), {"param_groups": [{"lr": 0.001}]})()
-        self.trainer_cfg = DictConfig(
+
+class TestHyperparameterScheduler:
+    def test_scheduler_integration(self):
+        # Build a minimal trainer configuration
+        trainer_cfg = DictConfig(
             {
                 "ppo": {
                     "clip_coef": 0.2,
@@ -61,74 +66,71 @@ class MockTrainer:
                     "ent_coef": 0.01,
                     "l2_reg_loss_coef": 0.0,
                     "l2_init_loss_coef": 0.0,
-                }
+                },
+                "optimizer": {
+                    "learning_rate": 0.001,
+                },
             }
         )
 
-
-class TestHyperparameterScheduler:
-    def test_scheduler_integration(self):
-        # Create mock trainer
-        trainer = MockTrainer()
-
-        # Create scheduler config
-        scheduler_cfg = DictConfig(
+        # Scheduler sub-configuration
+        trainer_cfg.hyperparameter_scheduler = DictConfig(
             {
-                "hyperparameter_scheduler": {
-                    "learning_rate_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.LinearSchedule",
-                        "initial_value": 0.001,
-                        "min_value": 0.0001,
-                    },
-                    "ppo_clip_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
-                        "initial_value": 0.2,
-                    },
-                    "ppo_vf_clip_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
-                        "initial_value": 0.1,
-                    },
-                    "ppo_ent_coef_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.LinearSchedule",
-                        "initial_value": 0.01,
-                        "min_value": 0.0,
-                    },
-                    "ppo_l2_reg_loss_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
-                        "initial_value": 0.0,
-                    },
-                    "ppo_l2_init_loss_schedule": {
-                        "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
-                        "initial_value": 0.0,
-                    },
-                }
+                "learning_rate_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.LinearSchedule",
+                    "initial_value": 0.001,
+                    "min_value": 0.0001,
+                },
+                "ppo_clip_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
+                    "initial_value": 0.2,
+                },
+                "ppo_vf_clip_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
+                    "initial_value": 0.1,
+                },
+                "ppo_ent_coef_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.LinearSchedule",
+                    "initial_value": 0.01,
+                    "min_value": 0.0,
+                },
+                "ppo_l2_reg_loss_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
+                    "initial_value": 0.0,
+                },
+                "ppo_l2_init_loss_schedule": {
+                    "_target_": "metta.rl.hyperparameter_scheduler.ConstantSchedule",
+                    "initial_value": 0.0,
+                },
             }
         )
 
-        # Add scheduler config to trainer config
-        trainer.trainer_cfg.hyperparameter_scheduler = scheduler_cfg.hyperparameter_scheduler
+        # Simple model and optimizer for testing updates to learning rate
+        model = torch.nn.Linear(1, 1)
+        optimizer = torch.optim.Adam(model.parameters(), lr=trainer_cfg.optimizer.learning_rate)
 
-        # Create scheduler
         total_timesteps = 1000
-        scheduler = HyperparameterScheduler(trainer.trainer_cfg, trainer, total_timesteps, logging)
+        scheduler = HyperparameterScheduler.from_trainer_config(trainer_cfg, optimizer, total_timesteps, logging)
 
-        # Test initial values
-        assert trainer.optimizer.param_groups[0]["lr"] == 0.001
-        assert trainer.trainer_cfg.ppo.clip_coef == 0.2
-        assert trainer.trainer_cfg.ppo.ent_coef == 0.01
+        # Create update callbacks to update trainer_cfg
+        update_callbacks = {
+            "ppo_clip_coef": lambda v: setattr(trainer_cfg.ppo, "clip_coef", v),
+            "ppo_vf_clip_coef": lambda v: setattr(trainer_cfg.ppo, "vf_clip_coef", v),
+            "ppo_ent_coef": lambda v: setattr(trainer_cfg.ppo, "ent_coef", v),
+            "ppo_l2_reg_loss_coef": lambda v: setattr(trainer_cfg.ppo, "l2_reg_loss_coef", v),
+            "ppo_l2_init_loss_coef": lambda v: setattr(trainer_cfg.ppo, "l2_init_loss_coef", v),
+        }
 
-        # Step halfway through training
-        scheduler.step(500)
+        # Halfway through training
+        scheduler.step(500, update_callbacks)
 
-        # Check values have been updated appropriately
-        assert abs(trainer.optimizer.param_groups[0]["lr"] - 0.00055) < 1e-6  # Linear from 0.001 to 0.0001
-        assert trainer.trainer_cfg.ppo.clip_coef == 0.2  # Constant
-        assert abs(trainer.trainer_cfg.ppo.ent_coef - 0.005) < 1e-6  # Linear from 0.01 to 0.0
+        assert abs(optimizer.param_groups[0]["lr"] - 0.00055) < 1e-6  # Linear schedule
+        assert trainer_cfg.ppo.clip_coef == 0.2  # Constant schedule
+        assert abs(trainer_cfg.ppo.ent_coef - 0.005) < 1e-6  # Linear schedule
 
-        # Step to end of training
-        scheduler.step(1000)
+        # End of training
+        scheduler.step(1000, update_callbacks)
 
-        # Check final values
-        assert abs(trainer.optimizer.param_groups[0]["lr"] - 0.0001) < 1e-6
-        assert trainer.trainer_cfg.ppo.clip_coef == 0.2
-        assert abs(trainer.trainer_cfg.ppo.ent_coef - 0.0) < 1e-6
+        assert abs(optimizer.param_groups[0]["lr"] - 0.0001) < 1e-6
+        assert trainer_cfg.ppo.clip_coef == 0.2
+        assert abs(trainer_cfg.ppo.ent_coef - 0.0) < 1e-6

--- a/tests/rl/test_trainer_config.py
+++ b/tests/rl/test_trainer_config.py
@@ -54,12 +54,6 @@ valid_trainer_config = {
         "target_kl": None,
     },
     "optimizer": valid_optimizer_config,
-    "lr_scheduler": {
-        "enabled": False,
-        "anneal_lr": False,
-        "warmup_steps": None,
-        "schedule_type": None,
-    },
     "prioritized_experience_replay": {
         "prio_alpha": 0.0,
         "prio_beta0": 0.6,

--- a/tests/sweep/test_integration_sweep_pipeline.py
+++ b/tests/sweep/test_integration_sweep_pipeline.py
@@ -20,6 +20,8 @@ import wandb
 from omegaconf import OmegaConf
 
 from metta.sweep.protein_metta import MettaProtein
+from metta.sweep.wandb_utils import create_wandb_sweep
+from tools.sweep_config_utils import save_train_job_override_config
 from tools.sweep_prepare_run import apply_protein_suggestion
 
 
@@ -139,10 +141,6 @@ class TestSweepPipelineIntegration:
                         "eps": 1e-8,
                         "weight_decay": 0.0,
                     },
-                    "lr_scheduler": {
-                        "schedule_type": "constant",
-                        "warmup_steps": 0,
-                    },
                     "env": "/env/mettagrid/simple",
                     "env_overrides": {},
                     "initial_policy": {},
@@ -160,8 +158,6 @@ class TestSweepPipelineIntegration:
         # Mock sweep creation to avoid API calls
         with patch("wandb.sweep") as mock_sweep:
             mock_sweep.return_value = "test_sweep_123"
-
-            from metta.sweep.wandb_utils import create_wandb_sweep
 
             # Test sweep creation
             sweep_id = create_wandb_sweep(
@@ -246,8 +242,6 @@ class TestSweepPipelineIntegration:
             suggestion, _ = metta_protein.suggest()
 
             # Apply suggestion to config (simulate sweep_init.py behavior)
-            from tools.sweep_prepare_run import apply_protein_suggestion
-
             # Create a copy of the base config for testing
             test_config = OmegaConf.create({"trainer": base_train_config.trainer})
 
@@ -312,8 +306,6 @@ class TestSweepPipelineIntegration:
         test_overrides = {"trainer": {"optimizer": {"learning_rate": 0.005}, "batch_size": 96}}
 
         # Save overrides
-        from tools.sweep_config_utils import save_train_job_override_config
-
         test_config = OmegaConf.create(base_train_config)
         test_config.run_dir = run_dir
 
@@ -504,8 +496,6 @@ class TestSweepPipelineIntegration:
         # Patch wandb.sweep to avoid real API calls and verify parameters
         with patch("wandb.sweep") as mock_sweep:
             mock_sweep.return_value = "e2e_test_sweep_id"
-
-            from metta.sweep.wandb_utils import create_wandb_sweep
 
             result = create_wandb_sweep(
                 sweep_name="e2e_test_sweep",


### PR DESCRIPTION
This is in favor of the hyperparameter scheduler if people want to use that. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210920381936147)