### PR TITLE
Pass skypilot secrets with env

### DIFF
--- a/devops/skypilot/config/sandbox.yaml
+++ b/devops/skypilot/config/sandbox.yaml
@@ -6,10 +6,6 @@ resources:
   image_id: docker:metta:latest
 
 file_mounts:
-  # Wandb Credentials
-  ~/.netrc: ~/.netrc
-  ~/.metta: ~/.metta
-
   /mnt/s3/softmax-public:
     source: s3://softmax-public
     mode: MOUNT_CACHED
@@ -40,6 +36,11 @@ setup: |
   echo 'export NODE_INDEX=${SKYPILOT_NODE_RANK}' >> ~/.bashrc
   echo 'export NCCL_SHM_DISABLE=1' >> ~/.bashrc
 
+  echo "[SETUP] Creating job secrets..."
+  ./devops/skypilot/create_job_secrets.py \
+    --wandb-password $WANDB_PASSWORD \
+    --observatory-token $OBSERVATORY_TOKEN
+
   echo "Sandbox is ready"
 
 run: |
@@ -48,6 +49,10 @@ run: |
 envs:
   METTA_GIT_REF: main
   WANDB_DIR: ./wandb
+
+  # configured by launch script based on local credentials
+  WANDB_PASSWORD: ""
+  OBSERVATORY_TOKEN: ""
 
   # username and password are acquired automatically by our skypilot-api-server patch, see skypilot-chart/files/ecr.patch
   SKYPILOT_DOCKER_USERNAME: ""

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -42,6 +42,11 @@ setup: |
   uv sync
   mkdir -p $WANDB_DIR
 
+  echo "[SETUP] Creating job secrets..."
+  ./devops/skypilot/create_job_secrets.py \
+    --wandb-password $WANDB_PASSWORD \
+    --observatory-token $OBSERVATORY_TOKEN
+
   echo "[SETUP] Setup complete."
 
 run: |
@@ -92,8 +97,6 @@ run: |
   exit $TRAIN_EXIT
 
 file_mounts:
-  ~/.netrc: ~/.netrc
-  ~/.metta: ~/.metta
   /mnt/s3/softmax-public:
     source: s3://softmax-public
     mode: MOUNT_CACHED
@@ -109,6 +112,10 @@ envs:
   METTA_GIT_REF: main
   WANDB_DIR: ./wandb
   HEARTBEAT_TIMEOUT: 600
+
+  # configured by launch script based on local credentials
+  WANDB_PASSWORD: ""
+  OBSERVATORY_TOKEN: ""
 
   # s3 mount slows down uv, so we put DATA_DIR outside of /workspace/metta
   DATA_DIR: /mnt/s3/train_dir

--- a/devops/skypilot/create_job_secrets.py
+++ b/devops/skypilot/create_job_secrets.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env -S uv run
+
+import argparse
+import os
+
+
+def main():
+    """
+    Create ~/.netrc and ~/.metta/observatory_tokens.yaml files with the given credentials.
+
+    We pass the secrets to the job via environment variables, but we need to create the files for the job to use them.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wandb-password", type=str)
+    parser.add_argument("--observatory-token", type=str)
+    args = parser.parse_args()
+
+    if os.path.exists(os.path.expanduser("~/.netrc")):
+        print("~/.netrc already exists")
+    else:
+        with open(os.path.expanduser("~/.netrc"), "w") as f:
+            f.write(f"machine api.wandb.ai\n  login user\n  password {args.wandb_password}\n")
+        os.chmod(os.path.expanduser("~/.netrc"), 0o600)  # Restrict to owner read/write only
+        print("~/.netrc created")
+
+    if os.path.exists(os.path.expanduser("~/.metta/observatory_tokens.yaml")):
+        print("~/.metta/observatory_tokens.yaml already exists")
+    else:
+        os.makedirs(os.path.expanduser("~/.metta"), exist_ok=True)
+        with open(os.path.expanduser("~/.metta/observatory_tokens.yaml"), "w") as f:
+            f.write(f"https://api.observatory.softmax-research.net: {args.observatory_token}\n")
+            f.write(f"https://observatory.softmax-research.net/api: {args.observatory_token}\n")
+        print("~/.metta/observatory_tokens.yaml created")
+
+
+if __name__ == "__main__":
+    main()

--- a/devops/skypilot/launch.py
+++ b/devops/skypilot/launch.py
@@ -11,6 +11,7 @@ from devops.skypilot.utils import (
     check_git_state,
     display_job_summary,
     launch_task,
+    set_task_secrets,
 )
 from metta.common.util.cli import get_user_confirmation
 from metta.common.util.fs import cd_repo_root
@@ -159,6 +160,7 @@ def main():
         no_spot=args.no_spot,
         timeout_hours=args.max_runtime_hours,
     )
+    set_task_secrets(task)
 
     if args.confirm:
         extra_details = {}

--- a/devops/skypilot/sandbox.py
+++ b/devops/skypilot/sandbox.py
@@ -8,6 +8,7 @@ import sky
 import sky.exceptions
 import yaml
 
+from devops.skypilot.utils import set_task_secrets
 from metta.common.util.cli import spinner
 from metta.common.util.cost_monitor import get_instance_cost
 from metta.common.util.text_styles import blue, bold, cyan, green, red, yellow
@@ -155,6 +156,7 @@ def main():
 
     with spinner("Preparing task configuration", style=cyan):
         task = sky.Task.from_yaml(config_path)
+        set_task_secrets(task)
         task.set_resources_override({"accelerators": f"{gpu_type}:{args.gpus}"})
         time.sleep(1)
 

--- a/devops/skypilot/utils.py
+++ b/devops/skypilot/utils.py
@@ -1,4 +1,5 @@
-import re
+import netrc
+import os
 import sys
 from pathlib import Path
 
@@ -6,8 +7,9 @@ import sky
 import sky.jobs
 import sky.server.common
 
+import metta.common.util.stats_client_cfg
 from metta.common.util.git import get_commit_message, get_matched_pr, has_unstaged_changes, is_commit_pushed
-from metta.common.util.text_styles import blue, bold, cyan, green, magenta, red, yellow
+from metta.common.util.text_styles import blue, bold, cyan, green, red, yellow
 
 
 def get_jobs_controller_name() -> str:
@@ -19,13 +21,6 @@ def get_jobs_controller_name() -> str:
 
 def print_tip(text: str):
     print(blue(text), file=sys.stderr)
-
-
-def dashboard_url() -> str:
-    url = sky.server.common.get_server_url()
-    # strip username and password from server_url
-    url = re.sub("https://.*@", "https://", url)
-    return url
 
 
 def launch_task(task: sky.Task, dry_run=False):
@@ -41,10 +36,9 @@ def launch_task(task: sky.Task, dry_run=False):
 
     short_request_id = request_id.split("-")[0]
 
-    print(f"- Check logs with: {magenta(f'sky api logs {short_request_id}')}")
-    print(f"- Or, visit: {yellow(f'{dashboard_url()}/api/stream?request_id={short_request_id}')}")
-    print(f"  - To sign in, use credentials from your {cyan('~/.sky/config.yaml')} file.")
-    print(f"- To cancel the request, run: {magenta(f'sky api cancel {short_request_id}')}")
+    print(f"- Check logs with: {yellow(f'sky api logs {short_request_id}')}")
+    dashboard_url = sky.server.common.get_server_url() + "/dashboard/jobs"
+    print(f"- Or, visit: {yellow(dashboard_url)}")
 
 
 def check_git_state(commit_hash: str) -> str | None:
@@ -215,3 +209,24 @@ def display_job_summary(
                 print(f"  {i + 1}. {yellow(arg)}")
 
     print(f"\n{divider}")
+
+
+def set_task_secrets(task: sky.Task) -> None:
+    """Write job secrets to task envs."""
+
+    # Note: we can't mount these with `file_mounts` because of skypilot bug with service accounts.
+    # Also, copying the entire `.netrc` is too much (it could contain other credentials).
+
+    wandb_password = netrc.netrc(os.path.expanduser("~/.netrc")).hosts["api.wandb.ai"][2]
+    observatory_token = metta.common.util.stats_client_cfg.get_machine_token(
+        "https://observatory.softmax-research.net/api"
+    )
+    if not wandb_password or not observatory_token:
+        raise ValueError("Failed to get wandb password or observatory token, run 'metta install' to fix")
+
+    task.update_envs(
+        dict(
+            WANDB_PASSWORD=wandb_password,
+            OBSERVATORY_TOKEN=observatory_token,
+        )
+    )


### PR DESCRIPTION
Previously, we mounted `.netrc` and `.metta/observatory_tokens.yaml`, but mounts don't work correctly with skypilot service accounts.

So I had to pass secrets through env, and then restore config files in job container.

One downside of this approach is that we're leaking secret values in skypilot dahsboard:

![Screenshot 2025-07-29 at 8.26.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/evCtXUW5JNyNfqWDHydW/4fe23d24-9ac3-4b70-a6d3-4fb5fd60116a.png)

But that's not a big deal, there were ways to steal these even before. And there's some benefit in not sending the entire `.netrc` file to skypilot, because it could contain other credentials.

The combination of this PR and #1803 (which is already deployed) will fix the service accounts.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210922922355367)