### PR TITLE
Fix the production GitHub action that builds the main app Docker image.

### DIFF
--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -39,10 +39,15 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /uvx /bin/
 WORKDIR /workspace/metta
 
 # Install dependencies
-ADD .python-version pyproject.toml uv.lock .
-ADD mettagrid/pyproject.toml mettagrid/
+ADD .python-version pyproject.toml uv.lock ./
+COPY mettagrid/pyproject.toml mettagrid/
+COPY app_backend/pyproject.toml app_backend/
+COPY common/pyproject.toml common/
+COPY agent/pyproject.toml agent/
+COPY experiments/pyproject.toml experiments/
 
 ENV UV_LINK_MODE=copy
+ENV UV_FREEZE=1
 ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --no-install-workspace

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -47,7 +47,7 @@ COPY agent/pyproject.toml agent/
 COPY experiments/pyproject.toml experiments/
 
 ENV UV_LINK_MODE=copy
-ENV UV_FREEZE=1
+ENV UV_FROZEN=1
 ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --no-install-workspace


### PR DESCRIPTION
This fixes `.github/workflows/build-image.yml`. Check https://github.com/Metta-AI/metta/actions/workflows/build-image.yml to see all the errors this bug has been causing.

Tested on a DigitalOcean droplet; building successfully on Linux now.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210921796797136)