### PR TITLE
Backport skypilot patch for service account user hash length

### DIFF
--- a/devops/charts/skypilot/files/ecr.patch
+++ b/devops/charts/skypilot/files/ecr.patch
@@ -48,3 +48,9 @@ diff -U0 -r sky/resources.py sky-patched/resources.py
 -        if self._docker_login_config is not None:
 -            config['_docker_login_config'] = dataclasses.asdict(
 -                self._docker_login_config)
+diff -U0 -r sky/users/server.py sky-patched/users/server.py
+--- sky/users/server.py	2025-07-28 13:24:57
++++ sky-patched/users/server.py	2025-07-29 19:56:03
+@@ -417 +417 @@
+-    random_suffix = secrets.token_hex(16)  # 16 character hex string
++    random_suffix = secrets.token_hex(8)  # 16 character hex string


### PR DESCRIPTION
Backport of https://github.com/skypilot-org/skypilot/pull/6425 (I deployed it to our production in 15 minutes after it was opened in upstream, where it's still not merged, heh).

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210922917896237)