### PR TITLE
Agent initial inventory

### DIFF
--- a/configs/user/lsoros.yaml
+++ b/configs/user/lsoros.yaml
@@ -1,5 +1,5 @@
 # @package __global__
 
-run: test_test
+run: test-inv5
 trainer:
-  env: /env/mettagrid/arena/advanced
+  env: /env/mettagrid/debug

--- a/configs/user/lsoros.yaml
+++ b/configs/user/lsoros.yaml
@@ -1,5 +1,5 @@
 # @package __global__
 
-run: test-inv5
+run: test-inv0
 trainer:
   env: /env/mettagrid/debug

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -919,7 +919,8 @@ PYBIND11_MODULE(mettagrid_c, m) {
                     const std::map<InventoryItem, RewardType>&,
                     const std::map<std::string, RewardType>&,
                     const std::map<std::string, RewardType>&,
-                    float>(),
+                    float,
+                    const std::map<InventoryItem, InventoryQuantity>&>(),
            py::arg("type_id"),
            py::arg("type_name") = "agent",
            py::arg("group_id"),
@@ -931,7 +932,8 @@ PYBIND11_MODULE(mettagrid_c, m) {
            py::arg("resource_reward_max") = std::map<InventoryItem, RewardType>(),
            py::arg("stat_rewards") = std::map<std::string, RewardType>(),
            py::arg("stat_reward_max") = std::map<std::string, RewardType>(),
-           py::arg("group_reward_pct") = 0)
+           py::arg("group_reward_pct") = 0,
+           py::arg("initial_inventory") = std::map<InventoryItem, InventoryQuantity>())
       .def_readwrite("type_id", &AgentConfig::type_id)
       .def_readwrite("type_name", &AgentConfig::type_name)
       .def_readwrite("group_name", &AgentConfig::group_name)
@@ -943,7 +945,8 @@ PYBIND11_MODULE(mettagrid_c, m) {
       .def_readwrite("resource_reward_max", &AgentConfig::resource_reward_max)
       .def_readwrite("stat_rewards", &AgentConfig::stat_rewards)
       .def_readwrite("stat_reward_max", &AgentConfig::stat_reward_max)
-      .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct);
+      .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct)
+      .def_readwrite("initial_inventory", &AgentConfig::initial_inventory);
 
   py::class_<ConverterConfig, GridObjectConfig, std::shared_ptr<ConverterConfig>>(m, "ConverterConfig")
       .def(py::init<TypeId,

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.pyi
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.pyi
@@ -65,6 +65,7 @@ class AgentConfig(GridObjectConfig):
     resource_rewards: dict[int, float]
     resource_reward_max: dict[int, float]
     group_reward_pct: float
+    initial_inventory: dict[int, int]
 
 class ConverterConfig(GridObjectConfig):
     type_id: int

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -63,6 +63,12 @@ def convert_to_cpp_game_config(mettagrid_config_dict: dict):
                 stat_name = k[:-4]
                 stat_reward_max[stat_name] = v
 
+        # Process potential initial inventory
+        initial_inventory = {}
+        for k, v in agent_group_props["initial_inventory"].items():  # sus as hell
+            if v is not None and k in resource_name_to_id:
+                initial_inventory[resource_name_to_id[k]] = v
+
         agent_cpp_params = {
             "freeze_duration": agent_group_props["freeze_duration"],
             "group_id": group_config.id,
@@ -79,6 +85,7 @@ def convert_to_cpp_game_config(mettagrid_config_dict: dict):
             "group_reward_pct": group_config.group_reward_pct,
             "type_id": 0,
             "type_name": "agent",
+            "initial_inventory": initial_inventory,
         }
 
         objects_cpp_params["agent." + group_name] = CppAgentConfig(**agent_cpp_params)

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -90,6 +90,7 @@ class PyAgentConfig(BaseModelWithForbidExtra):
     freeze_duration: Optional[int] = Field(default=0, ge=-1)
     rewards: Optional[PyAgentRewards] = Field(default_factory=PyAgentRewards)
     action_failure_penalty: Optional[float] = Field(default=0, ge=0)
+    initial_inventory: Optional[dict[str, int]] = Field(default_factory=dict)
 
 
 class PyGroupConfig(BaseModelWithForbidExtra):

--- a/mettagrid/src/metta/mettagrid/objects/agent.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/agent.hpp
@@ -24,7 +24,8 @@ struct AgentConfig : public GridObjectConfig {
               const std::map<InventoryItem, RewardType>& resource_reward_max,
               const std::map<std::string, RewardType>& stat_rewards,
               const std::map<std::string, RewardType>& stat_reward_max,
-              float group_reward_pct)
+              float group_reward_pct,
+              const std::map<InventoryItem, InventoryQuantity>& initial_inventory = {})
       : GridObjectConfig(type_id, type_name),
         group_id(group_id),
         group_name(group_name),
@@ -35,7 +36,8 @@ struct AgentConfig : public GridObjectConfig {
         resource_reward_max(resource_reward_max),
         stat_rewards(stat_rewards),
         stat_reward_max(stat_reward_max),
-        group_reward_pct(group_reward_pct) {}
+        group_reward_pct(group_reward_pct),
+        initial_inventory(initial_inventory) {}
   unsigned char group_id;
   std::string group_name;
   short freeze_duration;
@@ -46,6 +48,7 @@ struct AgentConfig : public GridObjectConfig {
   std::map<std::string, RewardType> stat_rewards;
   std::map<std::string, RewardType> stat_reward_max;
   float group_reward_pct;
+  std::map<InventoryItem, InventoryQuantity> initial_inventory;
 };
 
 class Agent : public GridObject {
@@ -94,10 +97,19 @@ public:
         current_stat_reward(0),
         reward(nullptr) {
     GridObject::init(config.type_id, config.type_name, GridLocation(r, c, GridLayer::AgentLayer));
+    populate_initial_inventory(config.initial_inventory);
   }
 
   void init(RewardType* reward_ptr) {
     this->reward = reward_ptr;
+  }
+
+  void populate_initial_inventory(const std::map<InventoryItem, InventoryQuantity>& initial_inventory) {
+    for (const auto& [item, amount] : initial_inventory) {
+      if (amount > 0) {
+        this->inventory[item] = amount;
+      }
+    }
   }
 
   InventoryDelta update_inventory(InventoryItem item, InventoryDelta attempted_delta) {

--- a/mettagrid/tests/test_mettagrid.cpp
+++ b/mettagrid/tests/test_mettagrid.cpp
@@ -75,7 +75,8 @@ protected:
                        create_test_resource_reward_max(),  // resource_reward_max
                        {},                                 // stat_rewards
                        {},                                 // stat_reward_max
-                       0.0f);                              // group_reward_pct
+                       0.0f,                               // group_reward_pct
+                       {});                                // initial_inventory
   }
 };
 
@@ -137,7 +138,7 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_RewardCappingBehavior) {
   resource_reward_max[TestItems::ORE] = 2.0f;  // Cap at 2.0 instead of 10.0
 
   AgentConfig agent_cfg(
-      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
+      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f, {});
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
   float agent_reward = 0.0f;
@@ -198,7 +199,7 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_MultipleItemCaps) {
   // LASER and ARMOR have no caps
 
   AgentConfig agent_cfg(
-      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
+      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f, {});
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
   float agent_reward = 0.0f;
@@ -244,7 +245,7 @@ TEST_F(MettaGridCppTest, AgentInventoryUpdate_RewardToZero) {
   resource_reward_max[TestItems::ORE] = 2.0f;
 
   AgentConfig agent_cfg(
-      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f);
+      0, "agent", 1, "test_group", 100, 0.0f, resource_limits, rewards, resource_reward_max, {}, {}, 0.0f, {});
 
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
   float agent_reward = 0.0f;


### PR DESCRIPTION
This PR introduces support for agents optionally starting training with some items in their inventory. This is specified by adding an extra parameter to game config files. Specifically, agent configs can now accept an initial_inventory list corresponding to types and quantities of inventory items. 

For instance, a game config might begin with

 agent:
    initial_inventory:
      ore_red: 2
      laser: 1
      armor: 1
      
Tested with a config file containing no initial inventory parameters, and also a config file containing the parameter set listed above.
