### PR TITLE
Reduce usage of SamplingCurriculum

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,12 +4,12 @@ defaults:
   - _self_
 
 trainer:
-  curriculum: /env/mettagrid/curriculum/navsequence/navsequence_all
+  curriculum: /env/mettagrid/curriculum/all
 
 replay_job:
   sim:
     env: /env/mettagrid/curriculum/navsequence/navsequence_all
 
 seed: null
-run_id: 20250729.02
+run_id: 20250730.11
 run: ${oc.env:USER}.local.${run_id}

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -79,3 +79,6 @@ class SingleTaskCurriculum(Curriculum):
 
     def get_task(self) -> Task:
         return Task(self._task_id, self, self._task_cfg)
+
+    def get_task_probs(self) -> dict[str, float]:
+        return {self._task_id: 1.0}

--- a/mettagrid/src/metta/mettagrid/curriculum/util.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/util.py
@@ -1,19 +1,21 @@
 import hydra
 from omegaconf import DictConfig, OmegaConf
 
-from metta.mettagrid.curriculum.core import Curriculum
-from metta.mettagrid.curriculum.sampling import SamplingCurriculum
+from metta.mettagrid.curriculum.core import Curriculum, SingleTaskCurriculum
 from metta.mettagrid.util.hydra import config_from_path
 
 
 def curriculum_from_config_path(config_path: str, env_overrides: DictConfig) -> "Curriculum":
     if "_target_" in config_from_path(config_path, None):
         return hydra.utils.instantiate(
-            # Don't recurse here. We want one level of instantiation so we get the curriculum object, but we don't
-            # want to instantiate sub-curricula or map builders, since we may still want to override their
+            # (a) Don't recurse here. We want one level of instantiation so we get the curriculum object, but
+            # we don't want to instantiate sub-curricula or map builders, since we may still want to override their
             # config.
+            # (b) Notice that we're wrapping env_overrides in an extra layer. This means we're overriding the
+            # overrides, so we carry them forward, rather than trying to apply them now.
             config_from_path(config_path, OmegaConf.create({"env_overrides": env_overrides})),
             _recursive_=False,
         )
     else:
-        return SamplingCurriculum(config_path, env_overrides)
+        config = config_from_path(config_path, env_overrides)
+        return SingleTaskCurriculum(config_path, config)


### PR DESCRIPTION
Our resolvers should be deterministic at this point, so we shouldn't need a SamplingCurriculum vs a SingleTaskCurriculum. So let's get rid of the former!

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210931065762687)