### PR TITLE
[MettaScope] Trace cache fixes

### DIFF
--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -27,7 +27,7 @@ import { initObjectMenu } from './objmenu.js'
 import { fetchReplay, initWebSocket, readFile } from './replay.js'
 import { drawTimeline, initTimeline, onScrubberChange, onTraceMinimapChange, updateTimeline } from './timeline.js'
 import { initializeTooltips } from './tooltips.js'
-import { drawTrace } from './traces.js'
+import { drawTrace, invalidateTrace } from './traces.js'
 import { Vec2f } from './vector_math.js'
 import { drawMap, focusFullMap } from './worldmap.js'
 
@@ -153,6 +153,7 @@ function hideUi() {
   state.showTraces = false
   state.showAgentPanel = false
   state.showActionButtons = false
+  invalidateTrace()
   onResize()
 }
 
@@ -517,6 +518,7 @@ onEvent('keydown', 'body', (_target: HTMLElement, e: Event) => {
       state.showTraces = false
       localStorage.setItem('showTraces', state.showTraces.toString())
       toggleOpacity(html.tracesToggle, state.showTraces)
+      invalidateTrace()
       onResize()
     } else if (state.showActionButtons) {
       state.showActionButtons = false
@@ -1016,6 +1018,12 @@ onEvent('click', '#traces-toggle', () => {
   state.showTraces = !state.showTraces
   localStorage.setItem('showTraces', state.showTraces.toString())
   toggleOpacity(html.tracesToggle, state.showTraces)
+
+  // Invalidate trace cache when hiding to ensure proper regeneration when shown again
+  if (!state.showTraces) {
+    invalidateTrace()
+  }
+
   onResize()
   requestFrame()
 })
@@ -1049,6 +1057,7 @@ onEvent('click', '#trace-panel .close', () => {
   state.showTraces = false
   localStorage.setItem('showTraces', state.showTraces.toString())
   toggleOpacity(html.tracesToggle, state.showTraces)
+  invalidateTrace()
   onResize()
   requestFrame()
 })

--- a/mettascope/src/traces.ts
+++ b/mettascope/src/traces.ts
@@ -12,6 +12,13 @@ const lastCachedState = {
   selection: null as any,
   zoomLevel: -1,
   panPos: null as Vec2f | null,
+  width: -1,
+  height: -1,
+}
+
+/** Forces the trace to redraw on next call to drawTrace. */
+export function invalidateTrace() {
+  lastCachedState.step = -1 // Just invalidate one key field to force regeneration
 }
 
 /** Draws the trace panel. */
@@ -82,6 +89,8 @@ export function drawTrace(panel: PanelInfo) {
     state.step !== lastCachedState.step ||
     state.selectedGridObject !== lastCachedState.selection ||
     panel.zoomLevel !== lastCachedState.zoomLevel ||
+    panel.width !== lastCachedState.width ||
+    panel.height !== lastCachedState.height ||
     lastCachedState.panPos === null ||
     panel.panPos.x() !== lastCachedState.panPos.x() ||
     panel.panPos.y() !== lastCachedState.panPos.y()
@@ -90,6 +99,8 @@ export function drawTrace(panel: PanelInfo) {
     lastCachedState.step = state.step
     lastCachedState.selection = state.selectedGridObject
     lastCachedState.zoomLevel = panel.zoomLevel
+    lastCachedState.width = panel.width
+    lastCachedState.height = panel.height
     lastCachedState.panPos = new Vec2f(panel.panPos.x(), panel.panPos.y())
   }
 

--- a/mettascope/src/traces.ts
+++ b/mettascope/src/traces.ts
@@ -16,9 +16,9 @@ const lastCachedState = {
   height: -1,
 }
 
-/** Forces the trace to redraw on next call to drawTrace. */
+/** Invalidate the trace cache to force regeneration on next call to drawTrace. */
 export function invalidateTrace() {
-  lastCachedState.step = -1 // Just invalidate one key field to force regeneration
+  lastCachedState.step = -1
 }
 
 /** Draws the trace panel. */


### PR DESCRIPTION
- if the trace panel is resized, we need to re-draw it.
- If the trace panel is closed and opened again, we should track the state.