### PR TITLE
gridworks: correctly classify curriculums vs maps

### DIFF
--- a/gridworks/README.md
+++ b/gridworks/README.md
@@ -22,6 +22,17 @@ pnpm run gen:encoding
 
 `gen:encoding` calls a small Python snippet in the `mettagrid` package and writes the resulting JSON file to `src/lib/encoding.json`. Run it again whenever you change the encoder definitions.
 
+## File System Access
+
+Gridworks accesses your local file system through the FastAPI backend server (`metta/metta/gridworks/server.py`). The backend:
+
+- Scans the `configs/env/mettagrid/` directory for YAML configuration files
+- Categorizes files as "env", "curriculum", "map", or "unknown" based on their content and path
+- Provides REST API endpoints that the Next.js frontend calls to display and interact with these files
+- Can read and parse YAML files to extract map configurations and generate previews
+
+The backend runs on port 8001 and communicates with the frontend running on port 3000.
+
 ## Running the app
 
 From the repository root run:

--- a/gridworks/src/app/mettagrid-cfgs/page.tsx
+++ b/gridworks/src/app/mettagrid-cfgs/page.tsx
@@ -2,23 +2,43 @@ import Link from "next/link";
 
 import { listMettagridCfgsMetadata } from "../../lib/api";
 
+const KIND_DESCRIPTIONS = {
+  env: "Environment configurations - define game rules, agent behavior, and environment settings",
+  curriculum:
+    "Training curriculums - define learning progression and task selection for training",
+  map: "Map generators - define how to create and structure the game world",
+  unknown: "Unknown configuration type",
+} as const;
+
 export default async function EnvsPage() {
   const cfgs = await listMettagridCfgsMetadata();
 
   return (
     <div className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">MettaGrid Configs</h1>
+      <h1 className="mb-3 text-2xl font-bold">MettaGrid Configs</h1>
+      <p className="mb-4 text-gray-600">
+        These are configuration files that define different aspects of the
+        MettaGrid environment. Click on any config to view its details and
+        preview the generated map.
+      </p>
+
       {Object.keys(cfgs).map((kind) => {
+        const configs = cfgs[kind as keyof typeof cfgs];
+        if (!configs || configs.length === 0) return null;
+
         return (
-          <div key={kind} className="mb-4">
-            <h2 className="text-lg font-bold">{kind}</h2>
-            <ul className="space-y-2">
-              {cfgs[kind as keyof typeof cfgs]?.map((cfg) => {
+          <div key={kind} className="mb-6">
+            <h2 className="mb-1 text-lg font-bold capitalize">{kind}</h2>
+            <p className="mb-2 text-sm text-gray-600">
+              {KIND_DESCRIPTIONS[kind as keyof typeof KIND_DESCRIPTIONS]}
+            </p>
+            <ul className="space-y-1">
+              {configs.map((cfg) => {
                 return (
                   <li key={cfg.path}>
                     <Link
                       href={`/mettagrid-cfgs/view?path=${cfg.path}`}
-                      className="text-blue-600 hover:text-blue-800 hover:underline"
+                      className="block py-0.5 text-blue-600 hover:text-blue-800 hover:underline"
                     >
                       {cfg.path}
                     </Link>

--- a/gridworks/src/app/mettagrid-cfgs/view/MapSection.tsx
+++ b/gridworks/src/app/mettagrid-cfgs/view/MapSection.tsx
@@ -45,9 +45,12 @@ export const MapSection: FC<{ cfg: MettagridCfgFile }> = ({ cfg }) => {
       )}
       {map.type === "map" && <StorableMapViewer map={map.map} />}
       {map.type === "error" && (
-        <pre className="text-sm text-red-500">
-          Error loading map: {map.error.message}
-        </pre>
+        <div className="rounded-md border border-red-200 bg-red-50 p-4">
+          <h3 className="mb-2 text-sm font-medium text-red-800">
+            Error loading map
+          </h3>
+          <p className="text-sm text-red-700">{map.error.message}</p>
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
previously gridworks would try to open & render curriculum files (& show errors).  Fixed this.