### PR TITLE
Add multi-trial episodes

### DIFF
--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -11,5 +11,5 @@ replay_job:
     env: /env/mettagrid/curriculum/navsequence/navsequence_all
 
 seed: null
-run_id: 20250730.11
+run_id: 20250730.12
 run: ${oc.env:USER}.local.${run_id}

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -11,5 +11,5 @@ replay_job:
     env: /env/mettagrid/curriculum/navsequence/navsequence_all
 
 seed: null
-run_id: 20250730.12
+run_id: 20250730.13
 run: ${oc.env:USER}.local.${run_id}

--- a/configs/user/sasmith.yaml
+++ b/configs/user/sasmith.yaml
@@ -4,12 +4,12 @@ defaults:
   - _self_
 
 trainer:
-  curriculum: /env/mettagrid/curriculum/all
+  curriculum: /env/mettagrid/curriculum/navigation/learning_progress
 
 replay_job:
   sim:
     env: /env/mettagrid/curriculum/navsequence/navsequence_all
 
 seed: null
-run_id: 20250730.13
+run_id: 20250730.17
 run: ${oc.env:USER}.local.${run_id}

--- a/metta/interface/environment.py
+++ b/metta/interface/environment.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import torch
 from omegaconf import DictConfig, OmegaConf
 
-from metta.mettagrid.curriculum.core import Curriculum, SingleTaskCurriculum, Task
+from metta.mettagrid.curriculum.core import Curriculum, SingleTaskCurriculum, SingleTrialTask, Task
 from metta.mettagrid.curriculum.util import curriculum_from_config_path
 from metta.rl.vecenv import make_vecenv
 
@@ -27,7 +27,7 @@ class PreBuiltConfigCurriculum(Curriculum):
 
     def get_task(self) -> Task:
         """Return a task with the pre-built config."""
-        return Task(f"prebuilt({self._env_name})", self, self._cfg_template)
+        return SingleTrialTask(f"prebuilt({self._env_name})", self, self._cfg_template)
 
     def get_task_probs(self) -> Dict[str, float]:
         """Return the current task probability for logging purposes."""
@@ -64,7 +64,7 @@ class NavigationBucketedCurriculum(Curriculum):
         # Create task name
         task_name = f"terrain={terrain_dir};altar={altar_count}"
 
-        return Task(task_name, self, task_config)
+        return SingleTrialTask(task_name, self, task_config)
 
     def get_task_probs(self) -> Dict[str, float]:
         """Return uniform probabilities for all terrain types."""

--- a/mettagrid/src/metta/mettagrid/base_env.py
+++ b/mettagrid/src/metta/mettagrid/base_env.py
@@ -324,7 +324,9 @@ class MettaGridEnv(ABC):
                 self._write_episode_stats(stats, episode_rewards, replay_url)
 
         # Update curriculum
-        self._task.complete(episode_rewards_mean)
+        # Note: mettagrid/src/metta/mettagrid/mettagrid_env.py has been updated to work with multiple trials per
+        # episode, but we haven't. That should be okay as long as we're only dealing with single-trial episodes.
+        self._task.complete_trial(episode_rewards_mean)
 
         # Add curriculum task probabilities
         infos["curriculum_task_probs"] = self._curriculum.get_task_probs()

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -42,7 +42,7 @@ class Task:
         self._name = id
         self._curricula = [(curriculum, id)]
 
-    def complete_trial(self, score: float) -> bool:
+    def complete(self, score: float) -> bool:
         """Lets the task know that a trial has been completed.
 
         Based on this, the task should expose a new trial, or become complete.
@@ -90,7 +90,7 @@ class SingleTrialTask(Task):
         self._episode_idx = 0
         self._scores = []
 
-    def complete_trial(self, score: float):
+    def complete(self, score: float):
         assert not self._is_complete, "Task is already complete"
         self._is_complete = True
         for curriculum, id in self._curricula:

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Tuple
 
 import hydra
 from omegaconf import DictConfig
@@ -33,21 +33,68 @@ class Curriculum:
 
 
 class Task:
-    def __init__(self, id: str, curriculum: "Curriculum", env_cfg: DictConfig):
+    _name: str
+    _id: str
+    _curricula: List[Tuple[Curriculum, str]]
+
+    def __init__(self, id: str, curriculum: Curriculum):
         self._id = id
-        self._is_complete = False
+        self._name = id
         self._curricula = [(curriculum, id)]
+
+    def complete_trial(self, score: float) -> bool:
+        """Lets the task know that a trial has been completed.
+
+        Based on this, the task should expose a new trial, or become complete.
+
+        Returns true if the task is complete, false otherwise.
+        """
+        pass
+
+    def is_complete(self):
+        """True if the task is complete, false otherwise."""
+        pass
+
+    def env_cfg(self) -> DictConfig:
+        """Returns the environment configuration for the current trial."""
+        # TODO: ideally we'd have a separate config for the task itself (same for a separate config for the curriculum)
+        pass
+
+    def id(self) -> str:
+        """Returns the id of the task."""
+        return self._id
+
+    def name(self) -> str:
+        """Returns the name of the task."""
+        return self._name
+
+    def short_name(self) -> str:
+        """Returns the short name of the task."""
+        return self.name().split("/")[-1]
+
+    def add_parent(self, parent_curriculum: Curriculum, parent_id: str):
+        """Adds a parent to the task. Parents are notified when the task is completed."""
+        self._curricula.append((parent_curriculum, parent_id))
+        self._name = f"{parent_id}:{self._name}"
+
+
+class SingleTrialTask(Task):
+    """A task that only has a single trial."""
+
+    def __init__(self, id: str, curriculum: Curriculum, env_cfg: DictConfig):
+        super().__init__(id, curriculum)
+        self._is_complete = False
         # We may have been lazy about instantiation up to this point, since that allows us to
         # override the config. Now we complete the instantiation.
         self._env_cfg = hydra.utils.instantiate(env_cfg)
-        self._name = self._id
+        self._episode_idx = 0
+        self._scores = []
 
-    def complete(self, score: float):
+    def complete_trial(self, score: float):
         assert not self._is_complete, "Task is already complete"
-        for curriculum, id in self._curricula:
-            curriculum.complete_task(id, score)
         self._is_complete = True
-        # logger.info(f"Task completed: {self.name()} -> {score:.5f}")
+        for curriculum, id in self._curricula:
+            curriculum.complete_task(id, sum(self._scores))
 
     def is_complete(self):
         return self._is_complete
@@ -55,19 +102,6 @@ class Task:
     def env_cfg(self) -> DictConfig:
         assert self._env_cfg is not None, "Task has no environment configuration"
         return self._env_cfg
-
-    def id(self) -> str:
-        return self._id
-
-    def name(self) -> str:
-        return self._name
-
-    def short_name(self) -> str:
-        return self._name.split("/")[-1]
-
-    def add_parent(self, parent_curriculum: "Curriculum", parent_id: str):
-        self._curricula.append((parent_curriculum, parent_id))
-        self._name = f"{parent_id}:{self._name}"
 
 
 class SingleTaskCurriculum(Curriculum):
@@ -78,7 +112,7 @@ class SingleTaskCurriculum(Curriculum):
         self._task_cfg = task_cfg
 
     def get_task(self) -> Task:
-        return Task(self._task_id, self, self._task_cfg)
+        return SingleTrialTask(self._task_id, self, self._task_cfg)
 
     def get_task_probs(self) -> dict[str, float]:
         return {self._task_id: 1.0}

--- a/mettagrid/src/metta/mettagrid/curriculum/random.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/random.py
@@ -28,6 +28,8 @@ class RandomCurriculum(MultiTaskCurriculum):
     def get_task(self) -> Task:
         task_id = random.choices(list(self._curricula.keys()), weights=list(self._task_weights.values()))[0]
         task = self._curricula[task_id].get_task()
+        # Note that tasks are ephemeral (which they have to be, since they get completed), so there's no concern
+        # about adding parents to the same task multiple times.
         task.add_parent(self, task_id)
         logger.debug(f"Task selected: {task.name()}")
         return task

--- a/mettagrid/src/metta/mettagrid/curriculum/sampling.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/sampling.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import numpy as np
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
-from metta.mettagrid.curriculum.core import Curriculum, Task
+from metta.mettagrid.curriculum.core import Curriculum, SingleTrialTask, Task
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class SampledTaskCurriculum(Curriculum):
         cfg = self._task_cfg_template.copy()
         for k, v in self._sampling_parameters.items():
             OmegaConf.update(cfg, k, _sample(v), merge=False)
-        return Task(self._task_id, self, cfg)
+        return SingleTrialTask(self._task_id, self, cfg)
 
 
 def _sample(dist: Any) -> Any:

--- a/mettagrid/src/metta/mettagrid/mettagrid_env.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_env.py
@@ -34,6 +34,22 @@ from metta.mettagrid.util.dict_utils import unroll_nested_dict
 # Additionally the actions that are sent to the C environment will be int32 (because PufferEnv
 # controls the type of self.actions) -- creating an opportunity for type confusion.
 
+# Vocab:
+#   We aim to match the ADA paper for trial and episode.
+#   trial: the unit of environmental reset. The MettaGrid C env lasts for one trial.
+#   episode: a sequence of trials.
+#   epoch: the unit of a training batch. At the time of writing, this is made up of segments of 64 agent steps. This
+#     many agents each taking 64 steps steps, or fewer agents taking higher multiples of 64 steps.
+#   curriculum: dispenses Tasks. A curriculum's duration is a training run. A curriculum is shared across processes
+#     / MettaGridEnvs.
+#   Task: dispenses trials. A task's duration is one episode.
+#   lifetime: the unit of agent reset. Ideally this would be a single episode -- that's very much the intent. However,
+#     we currently reset the agent (i.e., its LSTM state) every epoch. So the agent's lifetime is actually much shorter
+#     than a typical episode / trial.
+#
+#   We originally didn't have a distinction between trials and episodes. I.e., all episodes were a single trial.
+#   Because of this, in some places we use the term "episode" where we would now use "trial".
+
 dtype_observations = np.dtype(np.uint8)
 dtype_terminals = np.dtype(bool)
 dtype_truncations = np.dtype(bool)
@@ -57,6 +73,11 @@ class MettaGridEnv(PufferEnv, GymEnv):
     truncations: np.ndarray
     rewards: np.ndarray
     actions: np.ndarray
+    _current_step: int = 0  # reset every trial
+    _current_trial: int = 0  # reset every episode
+    _current_episode: int = 0  # not reset for the duration of this MettaGridEnv
+    # a reset is a new episode.
+    _should_reset: bool = False
 
     @validate_call(config={"arbitrary_types_allowed": True})
     def __init__(
@@ -73,8 +94,6 @@ class MettaGridEnv(PufferEnv, GymEnv):
         self.timer = Stopwatch(logger)
         self.timer.start()
         self.timer.start("thread_idle")
-        self._steps = 0
-        self._resets = 0
 
         self._render_mode = render_mode
         self._curriculum = curriculum
@@ -84,12 +103,12 @@ class MettaGridEnv(PufferEnv, GymEnv):
         self._map_labels: list[str] = []
         self._stats_writer = stats_writer
         self._replay_writer = replay_writer
-        self._episode_id: str | None = None
-        self._reset_at = datetime.datetime.now()
+        self._trial_id: str | None = None
+        self._trial_reset_at: datetime.datetime | None = None
         self._current_seed: int = 0  # must be unsigned
 
+        # This isn't great, since the env_cfg can change between trials / episodes.
         self.labels: list[str] = self._task.env_cfg().get("labels", [])
-        self._should_reset = False
 
         self._is_training = is_training
 
@@ -122,12 +141,16 @@ class MettaGridEnv(PufferEnv, GymEnv):
                     logger.info("Raylib renderer disabled in CI/Docker environment")
                     self._renderer = None
 
-    def _make_episode_id(self):
+    def _make_id(self):
         return str(uuid.uuid4())
 
     @with_instance_timer("_initialize_c_env")
     def _initialize_c_env(self) -> None:
-        """Initialize the C++ environment."""
+        """Initialize the C++ environment.
+
+        This creates a new c environment with a fixed configuration / map, which will last for one trial. This should
+        be called whenever a new trial starts.
+        """
         task = self._task
         task_cfg = task.env_cfg()
         level = self._level
@@ -148,7 +171,7 @@ class MettaGridEnv(PufferEnv, GymEnv):
         # During training, we run a lot of envs in parallel, and it's better if they are not
         # all synced together. The desync_episodes flag is used to desync the episodes.
         # Ideally vecenv would have a way to desync the episodes, but it doesn't.
-        if self._is_training and self._resets == 0:
+        if self._is_training and self._current_trial == 0 and self._current_episode == 0:
             max_steps = game_config_dict["max_steps"]
             game_config_dict["max_steps"] = int(np.random.randint(1, max_steps + 1))
 
@@ -172,13 +195,31 @@ class MettaGridEnv(PufferEnv, GymEnv):
     @override  # pufferlib.PufferEnv.reset
     @with_instance_timer("reset")
     def reset(self, seed: int | None = None) -> tuple[np.ndarray, dict]:
+        """Reset the environment.
+
+        This is called by PufferLib, to get a new episode.
+        """
         self.timer.stop("thread_idle")
 
-        self._task = self._curriculum.get_task()
+        self._current_trial = 0
+        self._current_episode += 1
 
+        self._task = self._curriculum.get_task()
+        self._should_reset = False
+        self._current_seed = seed or 0
+
+        obs, infos = self.reset_trial()
+
+        self.timer.start("thread_idle")
+
+        return obs, infos
+
+    @with_instance_timer("reset_trial")
+    def reset_trial(self) -> tuple[np.ndarray, dict]:
+        """Reset the environment for a new trial."""
         self._initialize_c_env()
-        self._steps = 0
-        self._resets += 1
+        self._current_step = 0
+        self._current_trial += 1
 
         assert self.observations.dtype == dtype_observations
         assert self.terminals.dtype == dtype_terminals
@@ -187,16 +228,15 @@ class MettaGridEnv(PufferEnv, GymEnv):
 
         self._c_env.set_buffers(self.observations, self.terminals, self.truncations, self.rewards)
 
-        self._episode_id = self._make_episode_id()
-        self._current_seed = seed or 0
-        self._reset_at = datetime.datetime.now()
+        self._trial_id = self._make_id()
+        self._trial_reset_at = datetime.datetime.now()
         if self._replay_writer:
-            self._replay_writer.start_episode(self._episode_id, self)
+            # The replay writer only knows about single-trial episodes, so we say we're starting an episode.
+            # Ideally we'd have a smoother way to string replays together.
+            self._replay_writer.start_episode(self._trial_id, self)
 
         obs, infos = self._c_env.reset()
-        self._should_reset = False
 
-        self.timer.start("thread_idle")
         return obs, infos
 
     @override  # pufferlib.PufferEnv.step
@@ -223,28 +263,22 @@ class MettaGridEnv(PufferEnv, GymEnv):
 
         with self.timer("_c_env.step"):
             self._c_env.step(actions)
-            self._steps += 1
+            self._current_step += 1
 
-        if self._replay_writer and self._episode_id:
+        if self._replay_writer and self._trial_id:
             with self.timer("_replay_writer.log_step"):
-                self._replay_writer.log_step(self._episode_id, actions, self.rewards)
+                self._replay_writer.log_step(self._trial_id, actions, self.rewards)
 
         infos = {}
         if self.terminals.all() or self.truncations.all():
-            # TODO: re-enable diversity bonus
-            # if self._task.env_cfg().game.diversity_bonus.enabled:
-            #     self.rewards *= calculate_diversity_bonus(
-            #         self._c_env.get_episode_rewards(),
-            #         self._task.env_cfg().game.diversity_bonus.similarity_coef,
-            #         self._task.env_cfg().game.diversity_bonus.diversity_coef,
-            #     )
-
-            self.process_episode_stats(infos)
-            self._should_reset = True
-            self._task.complete(self._c_env.get_episode_rewards().mean())
-
-            # Add curriculum task probabilities to infos for distributed logging
-            infos["curriculum_task_probs"] = self._curriculum.get_task_probs()
+            self.process_trial_stats(infos)
+            self._task.complete_trial(self._c_env.get_episode_rewards().mean())
+            if self._task.is_complete():
+                self._should_reset = True
+                # Add curriculum task probabilities to infos for distributed logging
+                infos["curriculum_task_probs"] = self._curriculum.get_task_probs()
+            else:
+                self.reset_trial()
 
         self.timer.start("thread_idle")
         return self.observations, self.rewards, self.terminals, self.truncations, infos
@@ -253,17 +287,18 @@ class MettaGridEnv(PufferEnv, GymEnv):
     def close(self):
         pass
 
-    def process_episode_stats(self, infos: Dict[str, Any]):
-        self.timer.start("process_episode_stats")
+    def process_trial_stats(self, infos: Dict[str, Any]):
+        self.timer.start("process_trial_stats")
 
         infos.clear()
 
-        episode_rewards = self._c_env.get_episode_rewards()
-        episode_rewards_sum = episode_rewards.sum()
-        episode_rewards_mean = episode_rewards_sum / self._c_env.num_agents
+        # The c env calls this "episode" but we call it "trial"
+        trial_rewards = self._c_env.get_episode_rewards()
+        trial_rewards_sum = trial_rewards.sum()
+        trial_rewards_mean = trial_rewards_sum / self._c_env.num_agents
 
         for label in self._map_labels + self.labels:
-            infos[f"map_reward/{label}"] = episode_rewards_mean
+            infos[f"map_reward/{label}"] = trial_rewards_mean
 
         infos.update(self._curriculum.get_completion_rates())
 
@@ -288,8 +323,9 @@ class MettaGridEnv(PufferEnv, GymEnv):
             "map_w": self.map_width,
             "map_h": self.map_height,
             "initial_grid_hash": self.initial_grid_hash,
-            "steps": self._steps,
-            "resets": self._resets,
+            "steps": self._current_step,
+            "trials": self._current_trial,
+            "resets": self._current_episode,
             "max_steps": self.max_steps,
             "completion_time": int(time.time()),
         }
@@ -299,13 +335,13 @@ class MettaGridEnv(PufferEnv, GymEnv):
 
         with self.timer("_replay_writer"):
             if self._replay_writer:
-                assert self._episode_id is not None, "Episode ID must be set before writing a replay"
-                replay_url = self._replay_writer.write_replay(self._episode_id)
+                assert self._trial_id is not None, "Trial ID must be set before writing a replay"
+                replay_url = self._replay_writer.write_replay(self._trial_id)
                 infos["replay_url"] = replay_url
 
         with self.timer("_stats_writer"):
             if self._stats_writer:
-                assert self._episode_id is not None, "Episode ID must be set before writing stats"
+                assert self._trial_id is not None, "Trial ID must be set before writing stats"
 
                 env_cfg_flattened: dict[str, str] = {}
                 env_cfg = OmegaConf.to_container(self._task.env_cfg(), resolve=False)
@@ -315,7 +351,7 @@ class MettaGridEnv(PufferEnv, GymEnv):
                 agent_metrics = {}
                 for agent_idx, agent_stats in enumerate(stats["agent"]):
                     agent_metrics[agent_idx] = {}
-                    agent_metrics[agent_idx]["reward"] = float(episode_rewards[agent_idx])
+                    agent_metrics[agent_idx]["reward"] = float(trial_rewards[agent_idx])
                     for k, v in agent_stats.items():
                         agent_metrics[agent_idx][k] = float(v)
 
@@ -326,16 +362,16 @@ class MettaGridEnv(PufferEnv, GymEnv):
                 }
 
                 self._stats_writer.record_episode(
-                    self._episode_id,
+                    self._trial_id,
                     env_cfg_flattened,
                     agent_metrics,
                     agent_groups,
                     self.max_steps,
                     replay_url,
-                    self._reset_at,
+                    self._trial_reset_at,
                 )
 
-        self.timer.stop("process_episode_stats")
+        self.timer.stop("process_trial_stats")
 
         elapsed_times = self.timer.get_all_elapsed()
         thread_idle_time = elapsed_times.pop("thread_idle", 0)
@@ -367,12 +403,12 @@ class MettaGridEnv(PufferEnv, GymEnv):
         task_init_time_msec = lap_times.get("_initialize_c_env", 0) * 1000
         infos.update(
             {
-                f"task_reward/{self._task.short_name()}/rewards.mean": episode_rewards_mean,
+                f"task_reward/{self._task.short_name()}/rewards.mean": trial_rewards_mean,
                 f"task_timing/{self._task.short_name()}/init_time_msec": task_init_time_msec,
             }
         )
 
-        self._episode_id = None
+        self._trial_id = None
 
     @property
     def max_steps(self) -> int:
@@ -418,7 +454,7 @@ class MettaGridEnv(PufferEnv, GymEnv):
     def render(self) -> str | None:
         # Use the configured renderer if available
         if self._renderer is not None and hasattr(self._renderer, "render"):
-            return self._renderer.render(self._steps, self.grid_objects)
+            return self._renderer.render(self._current_step, self.grid_objects)
 
         return None
 

--- a/mettagrid/tests/test_curriculum.py
+++ b/mettagrid/tests/test_curriculum.py
@@ -67,10 +67,10 @@ def test_single_task_curriculum(env_cfg):
     assert task.id() == "task"
     assert task.env_cfg() == env_cfg
     assert not task.is_complete()
-    task.complete(0.5)
+    task.complete_trial(0.5)
     assert task.is_complete()
     with pytest.raises(AssertionError):
-        task.complete(0.1)
+        task.complete_trial(0.1)
 
 
 def test_random_curriculum_selects_task(monkeypatch, env_cfg):


### PR DESCRIPTION
Refactors tasks and MettaGridEnv to allow episodes to consist of multiple trials.

* Having discussed with @Barraketh , we collect stats at the trial level, rather than the episode level.
* This doesn't touch the naming of of MettaGridEnv. So a lot of places (e.g., cpp) will call things episodes that are now trials.
* After this, we'll need to figure out how to specify multiple [different] trials in a config file.
* This will presumably run afoul of the refactoring the @teodorionita is doing, since I'm only touching one copy of MettaGridEnv.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210936549692325)