### PR TITLE
Skypilot improvements: auth stability, no-spot, faster jobs controller cleanup

### DIFF
--- a/devops/charts/helmfile.yaml
+++ b/devops/charts/helmfile.yaml
@@ -99,6 +99,8 @@ releases:
             oidc-issuer-url: https://accounts.google.com
             use-https: true
             email-domain: stem.ai,softmax.com
+            # Skypilot uses `redis` by default, but its redis chart doesn't have persistence, so loses sessions on restart.
+            session-store-type: cookie
             # This secret must be created manually.
             # (it's not possible to automate it because it's not possible to terraform oauth clients in GCP)
             client-details-from-secret: skypilot-oauth2-proxy-details

--- a/devops/charts/skypilot/files/ecr.patch
+++ b/devops/charts/skypilot/files/ecr.patch
@@ -43,8 +43,11 @@ diff -U0 -r sky/provision/docker_utils.py sky-patched/provision/docker_utils.py
 +                            f'mv /tmp/docker_config.json ~/.docker/config.json')
 diff -U0 -r sky/resources.py sky-patched/resources.py
 --- sky/resources.py	2025-07-28 13:24:57
-+++ sky-patched/resources.py	2025-07-28 13:26:34
-@@ -2197,3 +2196,0 @@
++++ sky-patched/resources.py	2025-07-30 17:22:13
+@@ -1732,0 +1733,2 @@
++        if blocked.use_spot is not None and self.use_spot != blocked.use_spot:
++            is_matched = False
+@@ -2197,3 +2198,0 @@
 -        if self._docker_login_config is not None:
 -            config['_docker_login_config'] = dataclasses.asdict(
 -                self._docker_login_config)

--- a/devops/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/devops/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -94,12 +94,6 @@ spec:
                 {{- end }}
               {{- end }}
             {{- end }}
-          # Softmax patch - stable cookie secret
-          {{- else if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
-              key: cookie-secret
           {{- else }}
           # Generate a random cookie secret if no existing one is found
           value: {{ randAlphaNum 32 | b64enc | quote }}

--- a/devops/skypilot/files/controller.crontab
+++ b/devops/skypilot/files/controller.crontab
@@ -1,5 +1,5 @@
 # This crontab is installed by running `./devops/skypilot/configure_jobs_controller.py`.
 
-0 * * * * find /tmp -maxdepth 1 -type d -mtime +1 -name 'tmp*' | xargs rm -rf
+0 * * * * find /tmp -maxdepth 1 -type d -mmin +600 -name 'tmp*' | xargs rm -rf
 1 * * * * find /home/ubuntu/sky_logs -maxdepth 1 -type d -mtime +30 -name 'sky-*'  | xargs rm -rf
 2 * * * * find /home/ubuntu/sky_logs/managed_jobs -maxdepth 1 -type d -mtime +14 -name 'sky-*' | xargs rm -rf


### PR DESCRIPTION
Multiple changes here, all already applied in prod:

1. Switch skypilot oauth2-proxy to cookie store; it uses redis by default, but they haven't configured persistence for redis, so it signed everyone out on every deployment.

2. Backport no-spot fix (https://github.com/skypilot-org/skypilot/pull/6248)

3. `/tmp` cleanup 10h time window on jobs-controller (previously was 24 hours, not enough)

4. Revert softmax oauth patch for skypilot - it never applied anyway, and the upstream version is good enough (the reason for auth instability was redis).

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210940926384330)