### PR TITLE
Increase the default number of eval episodes to 20

### DIFF
--- a/configs/sim/sim.yaml
+++ b/configs/sim/sim.yaml
@@ -1,3 +1,3 @@
-num_episodes: 1
+num_episodes: 20
 max_time_s: 60
 env_overrides: {}


### PR DESCRIPTION
So that our heatmaps on observatory give average scores rather than single episode scores