### PR TITLE
Use cast for torch.compile to preserve type information

### DIFF
--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -2,7 +2,7 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -177,7 +177,7 @@ def train(
 
     if trainer_cfg.compile:
         logger.info("Compiling policy")
-        policy = torch.compile(policy, mode=trainer_cfg.compile_mode)
+        policy = cast("MettaAgent | DistributedMettaAgent", torch.compile(policy, mode=trainer_cfg.compile_mode))
 
     # Create kickstarter
     kickstarter = Kickstarter(


### PR DESCRIPTION
`torch.compile(model)` returns a proxy object, which causes static type checkers to lose the original model's type information (`MettaAgent | DistributedMettaAgent`), resulting in a type mismatch error.

Although the compiled model maintains the same public interface and can be used as a drop-in replacement, the type checker is not able to infer this automatically.

This change uses `typing.cast` to explicitly inform the static type checker that the compiled object retains the original `MettaAgent | DistributedMettaAgent` type. This resolves the type error while correctly reflecting the runtime behavior and preserving type safety for subsequent code. This approach is preferred over `# type: ignore` as it is more explicit about the intended type.