### PR TITLE
Prometheus stack on EKS; oauth cleanups

### DIFF
--- a/devops/charts/helm.values/prometheus-values.yaml
+++ b/devops/charts/helm.values/prometheus-values.yaml
@@ -1,0 +1,118 @@
+# Based on https://github.com/digitalocean/Kubernetes-Starter-Kit-Developers/blob/main/04-setup-observability/assets/manifests/prom-stack-values-v35.5.1.yaml
+
+# Managed by EKS
+
+namespaceOverride: monitoring
+
+kubeScheduler:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+
+defaultRules:
+  create: true
+  rules:
+    etcd: false
+    kubeControllerManager: false
+    kubeSchedulerAlerting: false
+
+alertmanager:
+  enabled: true
+  alertmanagerSpec:
+    # externalUrl: TODO
+    alertmanagerConfiguration:
+      name: global-config # TODO
+
+grafana:
+  enabled: true
+
+  grafana.ini:
+    # defaults from upstream values.yaml
+    paths:
+      data: /var/lib/grafana/
+      logs: /var/log/grafana
+      plugins: /var/lib/grafana/plugins
+      provisioning: /etc/grafana/provisioning
+    log:
+      mode: console
+    analytics:
+      check_for_updates: false
+    server:
+      root_url: https://grafana.softmax-research.net
+    auth.google:
+      enabled: true
+      allow_sign_up: true
+      auto_login: false
+      #
+      client_id: $__file{/etc/secrets/softmax-infra-oauth/client-id}
+      client_secret: $__file{/etc/secrets/softmax-infra-oauth/client-secret}
+      scopes: openid email profile
+      auth_url: https://accounts.google.com/o/oauth2/v2/auth
+      token_url: https://oauth2.googleapis.com/token
+      api_url: https://openidconnect.googleapis.com/v1/userinfo
+      allowed_domains: stem.ai softmax.com
+
+  extraSecretMounts:
+    # This secret is terraformed by devops/tf/eks
+    - name: softmax-infra-oauth
+      secretName: softmax-infra-oauth
+      defaultMode: 0440
+      mountPath: /etc/secrets/softmax-infra-oauth
+      readOnly: true
+
+  admin:
+    existingSecret: grafana-credentials # terraformed by devops/tf/eks
+
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+    hosts:
+      - grafana.softmax-research.net
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.softmax-research.net
+
+  persistence:
+    enabled: true
+    storageClassName: gp3
+    accessModes: ["ReadWriteOnce"]
+    size: 10Gi
+
+prometheusOperator:
+  enabled: true
+
+prometheus:
+  enabled: true
+
+  # additionalServiceMonitors:
+  # # Uncomment the following section to enable ingress-nginx service monitoring
+  #   - name: "ingress-nginx-monitor"
+  #     selector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: ingress-nginx
+  #     namespaceSelector:
+  #       matchNames:
+  #         - ingress-nginx
+  #     endpoints:
+  #       - port: "metrics"
+
+  prometheusSpec:
+    # via https://github.com/prometheus-community/helm-charts/issues/1911 (note that last comment has a few typos)
+    ruleSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+
+    # externalUrl: TODO
+
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi

--- a/devops/charts/helm.values/prometheus-values.yaml
+++ b/devops/charts/helm.values/prometheus-values.yaml
@@ -41,11 +41,12 @@ grafana:
       check_for_updates: false
     server:
       root_url: https://grafana.softmax-research.net
+    users:
+      auto_assign_org_role: Editor
     auth.google:
       enabled: true
       allow_sign_up: true
       auto_login: false
-      #
       client_id: $__file{/etc/secrets/softmax-infra-oauth/client-id}
       client_secret: $__file{/etc/secrets/softmax-infra-oauth/client-secret}
       scopes: openid email profile

--- a/devops/charts/helm.values/skypilot-values.yaml
+++ b/devops/charts/helm.values/skypilot-values.yaml
@@ -1,0 +1,38 @@
+apiService:
+  config: |
+    jobs:
+      bucket: s3://skypilot-jobs/
+  resources:
+    requests:
+      cpu: "8"
+      memory: "16Gi"
+    limits:
+      cpu: "8"
+      memory: "16Gi"
+  metrics:
+    enabled: true
+awsCredentials:
+  enabled: true
+ingress:
+  certManager:
+    clusterIssuer: letsencrypt
+    enabled: true
+  host: skypilot-api.softmax-research.net
+  oauth2-proxy:
+    enabled: true
+    oidc-issuer-url: https://accounts.google.com
+    use-https: true
+    email-domain: stem.ai,softmax.com
+    # Skypilot uses `redis` by default, but its redis chart doesn't have persistence, so loses sessions on restart.
+    session-store-type: cookie
+    # This secret is terraformed by devops/tf/eks
+    client-details-from-secret: softmax-infra-oauth
+# managed as a separate chart, see above
+ingress-nginx:
+  enabled: false
+lambdaCredentials:
+  enabled: true
+  # created by terraform
+  lambdaSecretName: lambda-ai-credentials
+storage:
+  size: 50Gi

--- a/devops/charts/helmfile.yaml
+++ b/devops/charts/helmfile.yaml
@@ -83,43 +83,7 @@ releases:
     version: 0.0.8
     namespace: skypilot
     values:
-      - apiService:
-          config: |
-            jobs:
-              bucket: s3://skypilot-jobs/
-          resources:
-            requests:
-              cpu: "8"
-              memory: "16Gi"
-            limits:
-              cpu: "8"
-              memory: "16Gi"
-        awsCredentials:
-          enabled: true
-        ingress:
-          certManager:
-            clusterIssuer: letsencrypt
-            enabled: true
-          host: skypilot-api.softmax-research.net
-          oauth2-proxy:
-            enabled: true
-            oidc-issuer-url: https://accounts.google.com
-            use-https: true
-            email-domain: stem.ai,softmax.com
-            # Skypilot uses `redis` by default, but its redis chart doesn't have persistence, so loses sessions on restart.
-            session-store-type: cookie
-            # This secret must be created manually.
-            # (it's not possible to automate it because it's not possible to terraform oauth clients in GCP)
-            client-details-from-secret: skypilot-oauth2-proxy-details
-        # managed as a separate chart, see above
-        ingress-nginx:
-          enabled: false
-        lambdaCredentials:
-          enabled: true
-          # created by terraform
-          lambdaSecretName: lambda-ai-credentials
-        storage:
-          size: 50Gi
+      - ./helm.values/skypilot-values.yaml
 
   ########## Softmax apps ##########
   - name: orchestrator

--- a/devops/charts/helmfile.yaml
+++ b/devops/charts/helmfile.yaml
@@ -70,6 +70,13 @@ releases:
     version: 3.12.2
     namespace: metrics-server
 
+  - name: prometheus
+    chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
+    version: 75.15.1
+    namespace: monitoring
+    values:
+      - ./helm.values/prometheus-values.yaml
+
   ########## Skypilot ##########
   - name: skypilot
     chart: ./skypilot
@@ -114,6 +121,7 @@ releases:
         storage:
           size: 50Gi
 
+  ########## Softmax apps ##########
   - name: orchestrator
     chart: ./orchestrator
     version: 0.1.0
@@ -122,3 +130,5 @@ releases:
       - events: ["presync"]
         command: "kubectl"
         args: ["create", "namespace", "orchestrator", "--dry-run=client"]
+
+  # Note: Observatory is deployed automatically by Github Actions.

--- a/devops/charts/observatory/templates/oauth2-proxy.yaml
+++ b/devops/charts/observatory/templates/oauth2-proxy.yaml
@@ -24,9 +24,36 @@ spec:
         {{- range .Values.oauth2_proxy.email_domains | required "oauth2_proxy.email_domains is required" }}
         - --email-domain={{ . }}
         {{- end }}
-        envFrom:
-        - secretRef:
-            name: {{ .Values.oauth2_proxy.secret_name | required "oauth2_proxy.secret_name is required" }}
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.oauth2_proxy.secret_name | required "oauth2_proxy.secret_name is required" }}
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.oauth2_proxy.secret_name | required "oauth2_proxy.secret_name is required" }}
+              key: client-secret
+        # idea from skypilot chart: generate a stable cookie secret if no existing one is found
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          {{- /* Look up existing deployment to get the current cookie secret if available */}}
+          {{- $deploymentName := printf "%s-oauth2-proxy" .Release.Name }}
+          {{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace $deploymentName }}
+          {{- if and $existingDeployment $existingDeployment.spec.template.spec.containers }}
+            {{- range $container := $existingDeployment.spec.template.spec.containers }}
+              {{- if eq $container.name "oauth2-proxy" }}
+                {{- range $env := $container.env }}
+                  {{- if eq $env.name "OAUTH2_PROXY_COOKIE_SECRET" }}
+          value: {{ $env.value }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- else }}
+          # Generate a random cookie secret if no existing one is found
+          value: {{ randAlphaNum 32 | b64enc | quote }}
+          {{- end }}
         ports:
         - containerPort: 4180
           protocol: TCP

--- a/devops/charts/observatory/templates/oauth2-proxy.yaml
+++ b/devops/charts/observatory/templates/oauth2-proxy.yaml
@@ -35,25 +35,11 @@ spec:
             secretKeyRef:
               name: {{ .Values.oauth2_proxy.secret_name | required "oauth2_proxy.secret_name is required" }}
               key: client-secret
-        # idea from skypilot chart: generate a stable cookie secret if no existing one is found
         - name: OAUTH2_PROXY_COOKIE_SECRET
-          {{- /* Look up existing deployment to get the current cookie secret if available */}}
-          {{- $deploymentName := printf "%s-oauth2-proxy" .Release.Name }}
-          {{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace $deploymentName }}
-          {{- if and $existingDeployment $existingDeployment.spec.template.spec.containers }}
-            {{- range $container := $existingDeployment.spec.template.spec.containers }}
-              {{- if eq $container.name "oauth2-proxy" }}
-                {{- range $env := $container.env }}
-                  {{- if eq $env.name "OAUTH2_PROXY_COOKIE_SECRET" }}
-          value: {{ $env.value }}
-                  {{- end }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
-          {{- else }}
-          # Generate a random cookie secret if no existing one is found
-          value: {{ randAlphaNum 32 | b64enc | quote }}
-          {{- end }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.oauth2_proxy.secret_name | required "oauth2_proxy.secret_name is required" }}
+              key: cookie-secret
         ports:
         - containerPort: 4180
           protocol: TCP

--- a/devops/charts/observatory/values.yaml
+++ b/devops/charts/observatory/values.yaml
@@ -13,15 +13,8 @@ cert_manager_issuer: letsencrypt
 
 oauth2_proxy:
   email_domains:
-  - stem.ai
-  - softmax.com
+    - stem.ai
+    - softmax.com
 
-  # This secret must be created manually.
-  # (it's not possible to automate it because it's not possible to terraform oauth clients in GCP)
-  #
-  # The secret contains the following keys:
-  # - OAUTH2_PROXY_CLIENT_ID
-  # - OAUTH2_PROXY_CLIENT_SECRET
-  # - OAUTH2_PROXY_COOKIE_SECRET
-  # First two fields are from Google Cloud console. The third one can be generated randomly by hand.
-  secret_name: observatory-oauth2-proxy-env
+  # This secret is terraformed by devops/tf/eks
+  secret_name: softmax-infra-oauth

--- a/devops/charts/skypilot/templates/api-deployment.yaml
+++ b/devops/charts/skypilot/templates/api-deployment.yaml
@@ -85,6 +85,10 @@ spec:
         - name: SKYPILOT_AUTH_USER_HEADER
           value: {{ .Values.apiService.authUserHeaderName | quote }}
         {{- end }}
+        {{- if .Values.apiService.metrics.enabled }}
+        - name: SKY_API_SERVER_METRICS_ENABLED
+          value: "true"
+        {{- end }}
         - name: SKYPILOT_GRACE_PERIOD_SECONDS
           value: {{ .Values.apiService.terminationGracePeriodSeconds | quote}}
         # Use tini as the init process

--- a/devops/tf/eks/monitoring.tf
+++ b/devops/tf/eks/monitoring.tf
@@ -1,0 +1,25 @@
+resource "random_password" "grafana_password" {
+  length  = 40
+  special = false
+}
+
+# In the process of deploying everything from scratch, this terraform stack would run before we install charts.
+# So we need to create the namespace first.
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+}
+
+resource "kubernetes_secret" "grafana" {
+  metadata {
+    # must be in sync with prometheus chart values
+    name      = "grafana-credentials"
+    namespace = "monitoring"
+  }
+
+  data = {
+    admin-user     = "admin"
+    admin-password = random_password.grafana_password.result
+  }
+}

--- a/devops/tf/eks/secrets.tf
+++ b/devops/tf/eks/secrets.tf
@@ -1,0 +1,18 @@
+data "aws_secretsmanager_secret" "oauth_secret" {
+  arn = var.oauth_secret_arn
+}
+
+data "aws_secretsmanager_secret_version" "oauth_secret_version" {
+  secret_id = data.aws_secretsmanager_secret.oauth_secret.id
+}
+
+resource "kubernetes_secret" "oauth_secret" {
+  for_each = var.oauth_secret_namespaces
+
+  metadata {
+    name      = "softmax-infra-oauth"
+    namespace = each.value
+  }
+
+  data = jsondecode(data.aws_secretsmanager_secret_version.oauth_secret_version.secret_string)
+}

--- a/devops/tf/eks/secrets.tf
+++ b/devops/tf/eks/secrets.tf
@@ -14,5 +14,11 @@ resource "kubernetes_secret" "oauth_secret" {
     namespace = each.value
   }
 
+  # The data includes three fields:
+  # - client-id
+  # - client-secret
+  # - cookie-secret
+  # The cookie secret is useful as a value for OAUTH2_PROXY_COOKIE_SECRET.
+  # Technically, each oauth-proxy deployment could have its own cookie secret, but it's easier to reuse it.
   data = jsondecode(data.aws_secretsmanager_secret_version.oauth_secret_version.secret_string)
 }

--- a/devops/tf/eks/secrets.tf
+++ b/devops/tf/eks/secrets.tf
@@ -7,7 +7,7 @@ data "aws_secretsmanager_secret_version" "oauth_secret_version" {
 }
 
 resource "kubernetes_secret" "oauth_secret" {
-  for_each = var.oauth_secret_namespaces
+  for_each = toset(var.oauth_secret_namespaces)
 
   metadata {
     name      = "softmax-infra-oauth"

--- a/devops/tf/eks/variables.tf
+++ b/devops/tf/eks/variables.tf
@@ -9,3 +9,12 @@ variable "cluster_name" {
 variable "cluster_version" {
   default = "1.32"
 }
+
+variable "oauth_secret_arn" {
+  default = "arn:aws:secretsmanager:us-east-1:751442549699:secret:softmax-infra-oauth-rLFTw6"
+}
+
+variable "oauth_secret_namespaces" {
+  default     = ["skypilot", "monitoring", "observatory"]
+  description = "The secret with google oauth credentials will be created in these namespaces"
+}

--- a/devops/tf/eks/variables.tf
+++ b/devops/tf/eks/variables.tf
@@ -15,6 +15,7 @@ variable "oauth_secret_arn" {
 }
 
 variable "oauth_secret_namespaces" {
+  type        = list(string)
   default     = ["skypilot", "monitoring", "observatory"]
   description = "The secret with google oauth credentials will be created in these namespaces"
 }


### PR DESCRIPTION
- install prometheus/grafana/alertmanager stack
- configure oauth for grafana
- terraform `softmax-infra-oauth` secret in multiple namespaces (previously I created secrets for each oauth2-proxy manually, now the manual part is AWS secrets manager and everything else is automated; I'll remove old manually created secrets for oauth after this PR is merged)
- attempt to enable metrics on Skypilot API server, but it's not working yet due to upstream deficiencies (reported to Skypilot slack)

Grafana is available at https://grafana.softmax-research.net/.

Alertmanager is not yet configured nor exposed with ingress, I'll do this in a separate PR.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210945446533160)