### PR TITLE
Fix issues with play.py and mettascope tests

### DIFF
--- a/.github/workflows/test-mettascope.yml
+++ b/.github/workflows/test-mettascope.yml
@@ -84,14 +84,14 @@ jobs:
         run: |
           echo "::group::Training job"
           echo "Starting training job..."
-          uv run --no-sync tools/train.py trainer.total_timesteps=10 run=smoke_test +hardware=github wandb=off
+          uv run --no-sync tools/train.py trainer.total_timesteps=10 run=smoke_test +user=ci wandb=off
           echo "::endgroup::"
 
       - name: Generate replay
         run: |
           echo "::group::Replay generation"
           echo "Generating replay..."
-          uv run --no-sync tools/replay.py run=smoke_test +hardware=github wandb=off
+          uv run --no-sync tools/replay.py run=smoke_test +user=ci wandb=off
           echo "Replay generation completed"
           echo "::endgroup::"
 
@@ -104,7 +104,7 @@ jobs:
 
           # Start the backend with proper logging
           echo "Starting backend server..."
-          uv run --no-sync tools/play.py run=smoke_test +hardware=github wandb=off replay_job.open_browser_on_start=false > "$BACKEND_LOG" 2>&1 &
+          uv run --no-sync tools/play.py run=smoke_test +user=ci wandb=off replay_job.open_browser_on_start=false > "$BACKEND_LOG" 2>&1 &
           BACKEND_PID=$!
           echo "Backend started with PID: $BACKEND_PID"
 

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -20,3 +20,5 @@ device: cuda
 vectorization: multiprocessing
 
 stats_server_uri: https://api.observatory.softmax-research.net
+
+bypass_mac_overrides: false

--- a/configs/user/ci.yaml
+++ b/configs/user/ci.yaml
@@ -34,3 +34,5 @@ train_job:
 replay_job:
   policy_uri: ${run_dir}/checkpoints/
   replay_dir: ${run_dir}/replays/
+
+bypass_mac_overrides: true

--- a/mettascope/src/main.ts
+++ b/mettascope/src/main.ts
@@ -31,6 +31,11 @@ import { drawTrace, invalidateTrace } from './traces.js'
 import { Vec2f } from './vector_math.js'
 import { drawMap, focusFullMap } from './worldmap.js'
 
+// Expose state to window for testing purposes (e.g., Playwright tests)
+if (typeof window !== 'undefined') {
+  ;(window as any).state = state
+}
+
 /** A flag to prevent multiple calls to requestAnimationFrame. */
 let frameRequested = false
 

--- a/tools/play.py
+++ b/tools/play.py
@@ -8,14 +8,11 @@ from omegaconf import DictConfig, OmegaConf
 import mettascope.server as server
 from metta.common.util.constants import DEV_METTASCOPE_FRONTEND_URL
 from metta.util.metta_script import metta_script
-from tools.train import apply_mac_overrides
 
 
 def main(cfg: DictConfig):
     logger = logging.getLogger("tools.play")
     logger.info(f"tools.play job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
-
-    apply_mac_overrides(cfg)
 
     open_browser = OmegaConf.select(cfg, "replay_job.open_browser_on_start", default=True)
 

--- a/tools/play.py
+++ b/tools/play.py
@@ -8,11 +8,14 @@ from omegaconf import DictConfig, OmegaConf
 import mettascope.server as server
 from metta.common.util.constants import DEV_METTASCOPE_FRONTEND_URL
 from metta.util.metta_script import metta_script
+from tools.train import apply_mac_overrides
 
 
 def main(cfg: DictConfig):
     logger = logging.getLogger("tools.play")
     logger.info(f"tools.play job config:\n{OmegaConf.to_yaml(cfg, resolve=True)}")
+
+    apply_mac_overrides(cfg)
 
     open_browser = OmegaConf.select(cfg, "replay_job.open_browser_on_start", default=True)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -121,8 +121,6 @@ def _set_min(cfg: DictConfig, path: str, value: float) -> None:
 
 def apply_mac_overrides(cfg: DictConfig) -> None:
     if not cfg.bypass_mac_overrides and platform.system() == "Darwin":
-        cfg.device = "cpu"
-        cfg.vectorization = "serial"
         _set_min(cfg, "trainer.batch_size", 1024)
         _set_min(cfg, "trainer.minibatch_size", 1024)
         _set_min(cfg, "trainer.forward_pass_minibatch_target_size", 2)


### PR DESCRIPTION
- user=ci instead of +hardware=github in some tests
- apply mac device overrides when running any metta_script locally, which fixes running ./tools/play.py locally
- fix race condition with window.state creation by explicitly exposing the state object to window for
  Playwright tests to acces

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210953239485647)