### PR TITLE
Fix cost monitor and skypilot latency script

### DIFF
--- a/common/src/metta/common/util/cost_monitor.py
+++ b/common/src/metta/common/util/cost_monitor.py
@@ -131,9 +131,9 @@ def main():
     cost_info = get_cost_info()
     if cost_info:
         instance_hourly_cost = cost_info["instance_hourly_cost"]
-        num_nodes_env = os.environ.get("NUM_NODES")
+        num_nodes_env = os.environ.get("SKYPILOT_NUM_NODES")
         if num_nodes_env is None:
-            logger.warning("NUM_NODES environment variable not set; cost info will not be provided.")
+            logger.warning("SKYPILOT_NUM_NODES environment variable not set; cost info will not be provided.")
             return
         num_nodes = int(num_nodes_env)
         total_hourly_cost = instance_hourly_cost * num_nodes

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -58,7 +58,7 @@ run: |
 
   if [ -f common/src/metta/common/util/skypilot_latency.py ]; then
     echo "[RUN] Collecting skypilot latency..."
-    LATENCY_OUTPUT=$(python common/src/metta/common/util/skypilot_latency.py 2>&1) || true
+    LATENCY_OUTPUT=$(uv run python common/src/metta/common/util/skypilot_latency.py 2>&1) || true
     echo "$LATENCY_OUTPUT"
   else
     echo "[RUN] Latency script is missing!"
@@ -66,7 +66,7 @@ run: |
 
   if [ -f common/src/metta/common/util/cost_monitor.py ]; then
     echo "[RUN] Collecting instance cost..."
-    if python common/src/metta/common/util/cost_monitor.py; then
+    if uv run python common/src/metta/common/util/cost_monitor.py; then
       echo "[RUN] METTA_HOURLY_COST set to: $METTA_HOURLY_COST"
     else
       echo "[RUN] Cost monitor script failed to run."

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -47,7 +47,6 @@ setup: |
 
 run: |
   set -e
-  bash ./devops/skypilot/config/setup-common.sh
   echo "[RUN] Starting run..."
   echo "[RUN] METTA_RUN_ID: $METTA_RUN_ID"
   echo "[RUN] SKYPILOT_TASK_ID: $SKYPILOT_TASK_ID"

--- a/devops/skypilot/config/sk_train.yaml
+++ b/devops/skypilot/config/sk_train.yaml
@@ -47,6 +47,7 @@ setup: |
 
 run: |
   set -e
+  bash ./devops/skypilot/config/setup-common.sh
   echo "[RUN] Starting run..."
   echo "[RUN] METTA_RUN_ID: $METTA_RUN_ID"
   echo "[RUN] SKYPILOT_TASK_ID: $SKYPILOT_TASK_ID"


### PR DESCRIPTION
**Summary**
Cost monitor and skypilot latency script both have stopped working a few days ago. This PR fixes both scripts.

**Context**
One problem was #1822 which made the `NUM_NODES` env variable inaccessible to the script, but there must have been another change that I couldn't identify so far that prevented both scripts to be run by `uv`, which is a big problem as both scripts have dependencies that are added in the form of
```
#!/usr/bin/env python3
# /// script
# requires-python = ">=3.11"
# dependencies = [
#     "wandb",
# ]
# ///
```
which causes `uv` to then add these to the environment temporarily.

The logs also repeatedly show ```(setup pid=1958) warning: `VIRTUAL_ENV=/puffertank/venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead``` which leads me to believe that there still is a problem of some sorts.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210953407091208)