### PR TITLE
more of less hydra

### DIFF
--- a/metta/rl/policy_management.py
+++ b/metta/rl/policy_management.py
@@ -12,6 +12,7 @@ from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.common.util.fs import wait_for_file
 from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.rl.env_config import EnvConfig
 from metta.rl.trainer_checkpoint import TrainerCheckpoint
 from metta.rl.trainer_config import TrainerConfig
 
@@ -187,7 +188,9 @@ def maybe_load_checkpoint(
 
 
 def load_or_initialize_policy(
-    hydra_cfg: DictConfig,
+    agent_cfg: dict,
+    env_cfg: EnvConfig,
+    trainer_cfg: TrainerConfig,
     checkpoint: TrainerCheckpoint | None,
     policy_store: PolicyStore,
     metta_grid_env: MettaGridEnv,
@@ -195,7 +198,6 @@ def load_or_initialize_policy(
     rank: int,
 ) -> tuple[PolicyAgent, PolicyRecord, PolicyRecord]:
     """Load or initialize policy with distributed coordination."""
-    trainer_cfg = hydra_cfg.trainer
 
     # Check if policy already exists at default path - all ranks check this
     default_path = os.path.join(trainer_cfg.checkpoint.checkpoint_dir, policy_store.make_model_name(0))
@@ -261,7 +263,7 @@ def load_or_initialize_policy(
         logger.info("No existing policy found, creating new one")
         name = policy_store.make_model_name(0)
         pr = policy_store.create_empty_policy_record(name)
-        pr.policy = make_policy(metta_grid_env, hydra_cfg)
+        pr.policy = make_policy(metta_grid_env, env_cfg, agent_cfg)
         saved_pr = policy_store.save(pr)
         logger.info(f"Created and saved new policy to {saved_pr.uri}")
 

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -80,8 +80,8 @@ logger = logging.getLogger(f"trainer-{rank}-{local_rank}")
 def train(
     run_dir: str,
     run: str,
-    hydra_cfg: DictConfig,
     env_cfg: EnvConfig,
+    agent_cfg: dict,
     device: torch.device,
     trainer_cfg: TrainerConfig,
     wandb_run: WandbRun | None,
@@ -160,7 +160,9 @@ def train(
     # Load or initialize policy with distributed coordination
     policy: PolicyAgent
     policy, initial_policy_record, latest_saved_policy_record = load_or_initialize_policy(
-        hydra_cfg=hydra_cfg,
+        agent_cfg=agent_cfg,
+        env_cfg=env_cfg,
+        trainer_cfg=trainer_cfg,
         checkpoint=checkpoint,
         policy_store=policy_store,
         metta_grid_env=metta_grid_env,

--- a/tools/train.py
+++ b/tools/train.py
@@ -108,6 +108,7 @@ def handle_train(cfg: DictConfig, wandb_run: WandbRun | None, logger: Logger):
     train(
         hydra_cfg=cfg,
         env_cfg=env_cfg,
+        agent_cfg=OmegaConf.to_container(cfg.agent, resolve=True),
         device=torch.device(env_cfg.device),
         trainer_cfg=create_trainer_config(cfg),
         run_dir=cfg.run_dir,


### PR DESCRIPTION
### TL;DR

Refactored policy initialization to use explicit config types instead of DictConfig.

### What changed?

- Modified `make_policy()` to accept `EnvConfig` and a dictionary for agent configuration instead of a DictConfig
- Updated `load_or_initialize_policy()` to take separate parameters for agent, environment, and trainer configs
- Adjusted the `train()` function to accept the agent config as a dictionary
- Updated the `tools/train.py` script to convert the agent config to a container before passing it to the train function

### How to test?

1. Run the training script to ensure policy initialization works correctly:
   ```
   python tools/train.py
   ```
2. Verify that policies are correctly loaded or initialized with the new parameter structure
3. Confirm that training proceeds normally with the refactored configuration handling

### Why make this change?

This change improves type safety by using explicit config types rather than the generic DictConfig. It makes the code more maintainable by clearly separating different configuration concerns (agent, environment, trainer) and passing them as separate parameters. This approach reduces dependencies on the Hydra configuration structure and makes the interfaces between components clearer.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210953754850311)