### PR TITLE
Fix EnvConfig validation - allow any device string

### DIFF
--- a/metta/rl/env_config.py
+++ b/metta/rl/env_config.py
@@ -12,7 +12,7 @@ class EnvConfig(BaseModelWithForbidExtra):
     vectorization: Literal["serial", "multiprocessing"] = "multiprocessing"
     seed: int = Field(default_factory=lambda: np.random.randint(0, 1000000))
     torch_deterministic: bool = Field(default=True)
-    device: Literal["cpu", "cuda"] = "cuda"
+    device: str = "cuda"
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid",


### PR DESCRIPTION
Training jobs currently fail because train.py replaces `cuda` device with `cuda:0`.

We use `device: str` in other parts of the codebase, and I've checked that pytorch allows any string there, so while I could add a more complex validation with regexes, I feel like using `str` is the easiest solution.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210954213330970)