### PR TITLE
Fix tools/map/gen.py

### DIFF
--- a/metta/map/utils/show.py
+++ b/metta/map/utils/show.py
@@ -6,6 +6,7 @@ from omegaconf import DictConfig
 from omegaconf.omegaconf import OmegaConf
 
 import mettascope.server
+from metta.common.util.config import config_from_path
 from metta.map.utils.storable_map import StorableMap, grid_to_lines
 from metta.mettagrid import MettaGridEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
@@ -22,7 +23,9 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
     if mode == "mettascope":
         num_agents = np.count_nonzero(np.char.startswith(storable_map.grid, "agent"))
 
-        env_cfg = OmegaConf.load("./configs/env/mettagrid/full.yaml")
+        with hydra.initialize(version_base=None, config_path="../../../configs"):
+            env_cfg = config_from_path("env/mettagrid/debug")
+
         env_cfg.game.num_agents = int(num_agents)
         OmegaConf.resolve(env_cfg)
         assert isinstance(env_cfg, DictConfig)


### PR DESCRIPTION
`tools/map/gen.py` got broken again, after `full.yaml` was refactored away.

(I don't use `tools/map/gen.py` that often anymore, because gridworks is more convenient, but it's still useful in some situations.)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210967728803608)