### PR TITLE
mapgen instance_map param

### DIFF
--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -1,10 +1,12 @@
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 from omegaconf import DictConfig, OmegaConf
+from pydantic import model_validator
 
 from metta.common.util.config import Config
-from metta.map.scene import Scene, load_class, make_scene, scene_cfg_to_dict
+from metta.map.scene import load_class, make_scene, scene_cfg_to_dict
+from metta.map.scenes.copy_grid import CopyGrid
 from metta.map.scenes.room_grid import RoomGrid, RoomGridParams
 from metta.map.scenes.transplant_scene import TransplantScene
 from metta.map.types import MapGrid
@@ -14,16 +16,7 @@ from .types import Area, AreaWhere, ChildrenAction, SceneCfg
 
 
 class MapGenParams(Config):
-    # Root scene configuration.
-    # In YAML configs, this is usually the dict with `type` and `params` keys, and possible children.
-    # This is the only required parameter.
-    root: SceneCfg
-
-    # Inner grid size. Doesn't take outer border into account.
-    # If `instances` is set, this is the size used for each instance.
-    # If width and height are not set, the root scene must provide an intrinsic size.
-    width: int | None = None
-    height: int | None = None
+    ########## Global parameters ##########
 
     # Default border_width value guarantees that agents don't see beyond the outer walls.
     # This value usually shouldn't be changed.
@@ -33,7 +26,26 @@ class MapGenParams(Config):
     # Seeds for root scene and all its children will be derived from this seed, unless they set their own seeds.
     seed: int | None = None
 
-    ##### Multiple instances parameters #####
+    ########## Single instance parameters ##########
+
+    # Root scene configuration.
+    # In YAML configs, this is usually the dict with `type` and `params` keys, and possible children.
+    root: SceneCfg | None = None
+
+    # Inner grid size. Doesn't take outer border into account.
+    # If `instances` is set, this is the size used for each instance.
+    # The map must have either `width`, `height` and `root` set, or `instance_map`.
+    width: int | None = None
+    height: int | None = None
+
+    # Alternative to `root`: Root map configuration.
+    # Either this or `root` must be set.
+    # The difference is that `root` doesn't have an intrinsic size, so you need to set `width` and `height` explicitly.
+    # `instance_map` must point to a `LevelBuilder` configuration, with the class name specified in `type`, and params
+    # specified in `params` dict.
+    instance_map: dict[str, Any] | None = None
+
+    ########## Multiple instances parameters ##########
 
     # MapGen can place multiple instances of the root scene on the grid. This is useful for additional parallelization.
     # By default, the map will be generated as a single root scene instance, with the given width and height.
@@ -56,15 +68,30 @@ class MapGenParams(Config):
     # Inner border width between instances. This value usually shouldn't be changed.
     instance_border_width: int = 5
 
+    @model_validator(mode="after")
+    def validate_required_fields(self) -> "MapGenParams":
+        """Validate that either (root, width, height) are all set, or instance_map is set."""
+        has_basic_config = self.root is not None
+        has_instance_map = self.instance_map is not None and self.width is None and self.height is None
+
+        # XOR-ing the two booleans to check if exactly one of them is True
+        if has_basic_config == has_instance_map:
+            raise ValueError("Either (root, width, height) must all be set, or instance_map must be set")
+
+        return self
+
 
 # Root map generator, based on scenes.
 class MapGen(LevelBuilder):
     def __init__(self, **kwargs):
         params = MapGenParams(**kwargs)
+        self.params = params
 
         self.root = params.root
         if isinstance(self.root, DictConfig):
-            self.root: SceneCfg = cast(dict, OmegaConf.to_container(self.root))
+            self.root = cast(dict, OmegaConf.to_container(self.root))
+
+        self.instance_map = params.instance_map
 
         self.width = params.width
         self.height = params.height
@@ -75,52 +102,118 @@ class MapGen(LevelBuilder):
         self.seed = params.seed
         self.rng = np.random.default_rng(self.seed)
 
-    def build(self):
-        if not self.width or not self.height:
-            dict_cfg = scene_cfg_to_dict(self.root)
-            root_cls = load_class(dict_cfg["type"])
-            intrinsic_size = root_cls.intrinsic_size(dict_cfg.get("params", {}))
-            if not intrinsic_size:
-                raise ValueError("width and height must be provided if the root scene has no intrinsic size")
-            self.height, self.width = intrinsic_size
+    def prebuild_instances(self):
+        """
+        In some cases, we need to render individual instances in separate grids before we render the final grid.
 
-        single_instance_scene: Scene | None = None
-        if self.num_agents:
+        This is the case for:
+        1) Using `instance_map` (which is a map, not a scene, so it defines its own size).
+        2) Using `num_agents`, where we don't know the number of instances in advance.
+
+        In both of these cases, we render to the temporary grid first, and then copy ("transplant") the result into the
+        final grid.
+
+        This allows us to find the number of instances and the width/height of the final grid.
+
+        Note that we prefer _not_ to prebuild scenes in advance: this complicates the final scene tree and the
+        implementation logic. (It's also a little bit slower, but this part is negligible.)
+        """
+        self.instance_scene_factories: list[SceneCfg] = []
+
+        def continue_to_prerender():
+            if not self.width or not self.height:
+                # We haven't detected the instance size yet.
+                return True
+            if self.num_agents and not len(self.instance_scene_factories):
+                # We need to derive the number of instances from the number of agents by rendering at least one
+                # instance.
+                return True
+            if self.instance_map and self.instances and self.instances > len(self.instance_scene_factories):
+                # We need to prebuild all instances.
+                return True
+            return False
+
+        while continue_to_prerender():
             # Auto-detect the number of instances.
             # We'll render the first instance in a separate grid to count the number of agents.
             # Then we'll transplant it into the final multi-instance grid.
-            single_instance_grid = np.full((self.height, self.width), "empty", dtype="<U50")
-            single_instance_area = Area(
-                x=0, y=0, width=self.width, height=self.height, grid=single_instance_grid, tags=[]
-            )
-            single_instance_scene = make_scene(self.root, single_instance_area, rng=self.rng)
-            single_instance_scene.render_with_children()
-            single_instance_num_agents = int(np.count_nonzero(np.char.startswith(single_instance_grid, "agent")))
-            if self.num_agents % single_instance_num_agents != 0:
-                raise ValueError(
-                    f"Number of agents {self.num_agents} is not divisible by number of agents in a single instance"
-                    f" {single_instance_num_agents}"
-                )
-            instances = self.num_agents // single_instance_num_agents
 
-            # Usually, when num_agents is set, you don't need to set `instances` explicitly.
-            if self.instances and self.instances != instances:
-                raise ValueError(
-                    f"Derived number of instances {instances} does not match the explicitly requested"
-                    f" number of instances {self.instances}"
-                )
-            self.instances = instances
+            if self.root:
+                if not self.width or not self.height:
+                    dict_cfg = scene_cfg_to_dict(self.root)
+                    root_cls = load_class(dict_cfg["type"])
+                    intrinsic_size = root_cls.intrinsic_size(dict_cfg.get("params", {}))
+                    if not intrinsic_size:
+                        raise ValueError("width and height must be provided if the root scene has no intrinsic size")
+                    self.height, self.width = intrinsic_size
 
+                instance_grid = np.full((self.height, self.width), "empty", dtype="<U50")
+                instance_area = Area(x=0, y=0, width=self.width, height=self.height, grid=instance_grid, tags=[])
+                instance_scene = make_scene(self.root, instance_area, rng=self.rng)
+                instance_scene.render_with_children()
+                self.instance_scene_factories.append(
+                    TransplantScene.factory(
+                        {
+                            "scene": instance_scene,
+                            "get_grid": lambda: self.grid,
+                        }
+                    )
+                )
+            else:
+                assert self.instance_map is not None
+                # Instance is a map, not a scene, so it defines its own size.
+                # We need to prerender it to find the full size of our grid.
+                instance_map_cls = load_class(self.instance_map["type"], check_is_scene=False)
+                instance_map = instance_map_cls(**self.instance_map["params"])
+                if not isinstance(instance_map, LevelBuilder):
+                    raise ValueError("instance_map must be a LevelBuilder")
+
+                instance_level = instance_map.build()
+                instance_grid = instance_level.grid
+
+                self.instance_scene_factories.append(
+                    # TODO - if the instance_map class is MapGen, we want to transplant its scene tree too.
+                    CopyGrid.factory(
+                        {
+                            "grid": instance_grid,
+                        }
+                    )
+                )
+                self.width = max(self.width or 0, instance_grid.shape[1])
+                self.height = max(self.height or 0, instance_grid.shape[0])
+
+            if self.num_agents and len(self.instance_scene_factories) == 1:
+                # First prebuilt instance, let's derive the number of instances from the number of agents.
+                instance_num_agents = int(np.count_nonzero(np.char.startswith(instance_grid, "agent")))
+                if self.num_agents % instance_num_agents != 0:
+                    raise ValueError(
+                        f"Number of agents {self.num_agents} is not divisible by number of agents in a single instance"
+                        f" {instance_num_agents}"
+                    )
+                instances = self.num_agents // instance_num_agents
+
+                # Usually, when num_agents is set, you don't need to set `instances` explicitly.
+                if self.instances and self.instances != instances:
+                    raise ValueError(
+                        f"Derived number of instances {instances} does not match the explicitly requested"
+                        f" number of instances {self.instances}"
+                    )
+                self.instances = instances
+
+    def prepare_grid(self):
+        """
+        Prepare the full grid and its inner area.
+        """
         if self.instances is None:
-            # neither `instances` nor `num_agents` were set, so we'll generate a single instance
             self.instances = 1
 
-        ######### Prepare the full grid and its inner area #########
-        instance_rows = int(np.ceil(np.sqrt(self.instances)))
-        instance_cols = int(np.ceil(self.instances / instance_rows))
+        self.instance_rows = int(np.ceil(np.sqrt(self.instances)))
+        self.instance_cols = int(np.ceil(self.instances / self.instance_rows))
 
-        self.inner_width = self.width * instance_cols + (instance_cols - 1) * self.instance_border_width
-        self.inner_height = self.height * instance_rows + (instance_rows - 1) * self.instance_border_width
+        assert self.width is not None and self.height is not None
+
+        self.inner_width = self.width * self.instance_cols + (self.instance_cols - 1) * self.instance_border_width
+        self.inner_height = self.height * self.instance_rows + (self.instance_rows - 1) * self.instance_border_width
 
         bw = self.border_width
 
@@ -142,52 +235,70 @@ class MapGen(LevelBuilder):
             bw : bw + self.inner_width,
         ]
 
-        inner_area = Area(x=bw, y=bw, width=self.inner_width, height=self.inner_height, grid=inner_grid, tags=[])
+        self.inner_area = Area(x=bw, y=bw, width=self.inner_width, height=self.inner_height, grid=inner_grid, tags=[])
 
-        ######### Prepare the root scene #########
-        root_scene_cfg = self.root
+    def get_root_scene_cfg(self) -> SceneCfg:
+        """
+        Create the full root scene, which might contain multiple instances.
+        """
+        assert self.instances is not None
 
-        if self.instances > 1:
-            children_actions: list[ChildrenAction] = []
-            if single_instance_scene:
-                # first instance is already rendered, so we want to transplant it into our larger grid
-                children_actions.append(
-                    ChildrenAction(
-                        scene=TransplantScene.factory(
-                            {
-                                "scene": single_instance_scene,
-                                "grid": self.grid,
-                            }
-                        ),
-                        where=AreaWhere(tags=["room"]),
-                        limit=1,
-                        order_by="first",
-                        lock="lock",
-                    )
+        if self.instances == 1:
+            if self.instance_scene_factories:
+                # We need just one instance and it's already prebuilt.
+                assert len(self.instance_scene_factories) == 1, (
+                    "Internal logic error: MapGen wants 1 instance but prebuilt more"
                 )
+                return self.instance_scene_factories[0]
+            else:
+                assert self.root, "Internal logic error: no root config but no prebuilt instances either"
+                return self.root
 
+        # We've got more than one instance, so we'll need a RoomGrid.
+
+        children_actions: list[ChildrenAction] = []
+        for instance_scene_factory in self.instance_scene_factories:
             children_actions.append(
                 ChildrenAction(
-                    scene=self.root,
+                    scene=instance_scene_factory,
                     where=AreaWhere(tags=["room"]),
-                    limit=self.instances - (1 if single_instance_scene else 0),
+                    limit=1,
                     order_by="first",
                     lock="lock",
                 )
             )
 
-            root_scene_cfg = RoomGrid.factory(
-                RoomGridParams(
-                    rows=instance_rows,
-                    columns=instance_cols,
-                    border_width=self.instance_border_width,
-                ),
-                children_actions=children_actions,
+        remaining_instances = self.instances - len(self.instance_scene_factories)
+
+        if remaining_instances > 0:
+            assert self.root, "Internal logic error: MapGen failed to prebuild enough instances"
+
+            children_actions.append(
+                ChildrenAction(
+                    scene=self.root,
+                    where=AreaWhere(tags=["room"]),
+                    limit=remaining_instances,
+                    order_by="first",
+                    lock="lock",
+                )
             )
 
-        ######### Render the root scene #########
-        self.root_scene = make_scene(root_scene_cfg, inner_area, rng=self.rng)
+        return RoomGrid.factory(
+            RoomGridParams(
+                rows=self.instance_rows,
+                columns=self.instance_cols,
+                border_width=self.instance_border_width,
+            ),
+            children_actions=children_actions,
+        )
 
+    def build(self):
+        self.prebuild_instances()
+        self.prepare_grid()
+
+        root_scene_cfg = self.get_root_scene_cfg()
+
+        self.root_scene = make_scene(root_scene_cfg, self.inner_area, rng=self.rng)
         self.root_scene.render_with_children()
 
         labels = self.root_scene.get_labels()

--- a/metta/map/scene.py
+++ b/metta/map/scene.py
@@ -278,11 +278,11 @@ class Scene(Generic[ParamsT]):
             child_scene.transplant_to_grid(grid, shift_x, shift_y, is_root=False)
 
 
-def load_class(full_class_name: str) -> type[Scene]:
+def load_class(full_class_name: str, check_is_scene=True) -> type[Scene]:
     module_name, class_name = full_class_name.rsplit(".", 1)
     module = importlib.import_module(module_name)
     cls = getattr(module, class_name)
-    if not issubclass(cls, Scene):
+    if check_is_scene and not issubclass(cls, Scene):
         raise ValueError(f"Class {cls} does not inherit from Scene")
     return cls
 

--- a/metta/map/scenes/copy_grid.py
+++ b/metta/map/scenes/copy_grid.py
@@ -1,0 +1,36 @@
+from pydantic import ConfigDict, Field
+
+from metta.common.util.config import Config
+from metta.map.scene import Scene
+from metta.map.types import MapGrid
+
+
+class CopyGridParams(Config):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    grid: MapGrid = Field(exclude=True)  # full outer grid
+
+
+class CopyGrid(Scene[CopyGridParams]):
+    """
+    This is a helper scene that allows us to use the preexisting grid as a scene.
+
+    It's main purpose is for MapGen's `instance_map` parameter.
+    """
+
+    def render(self):
+        if self.width < self.params.grid.shape[1] or self.height < self.params.grid.shape[0]:
+            # Shouldn't happen if MapGen is implemented correctly.
+            raise ValueError("The area is too small to copy the given grid into it")
+
+        self.grid[:] = "wall"
+
+        # Calculate center position for placing the grid
+        source_height, source_width = self.params.grid.shape
+        start_row = (self.height - source_height) // 2
+        end_row = start_row + source_height
+        start_col = (self.width - source_width) // 2
+        end_col = start_col + source_width
+
+        # Place the grid at the center
+        self.grid[start_row:end_row, start_col:end_col] = self.params.grid

--- a/metta/map/scenes/inline_ascii.py
+++ b/metta/map/scenes/inline_ascii.py
@@ -26,7 +26,7 @@ class InlineAscii(Scene[InlineAsciiParams]):
         if self.width < ascii_width + params.column or self.height < ascii_height + params.row:
             raise ValueError(
                 f"ASCII grid size {ascii_width}x{ascii_height} is too large"
-                f" for scene size {self.width}x{self.height} at "
+                f" for area size {self.width}x{self.height} at "
                 f"({params.column},{params.row})"
             )
 

--- a/metta/map/scenes/transplant_scene.py
+++ b/metta/map/scenes/transplant_scene.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Callable
 
 from pydantic import ConfigDict, Field
 
@@ -10,11 +11,24 @@ from metta.map.types import MapGrid
 class TransplantSceneParams(Config):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    scene: Scene = Field(exclude=True)  # scene that will be transplanted
-    grid: MapGrid = Field(exclude=True)  # full outer grid
+    # Scene that will be transplanted.
+    scene: Scene = Field(exclude=True)
+
+    # Callback to get the full outer grid.
+    # Why? Because in MapGen class it's convenient to pass scene factories around, and we don't have the final grid yet
+    # when we construct the factory for this scene.
+    # Sorry about the complexity; it might be possible to implement `transplant_to_grid` without having the full outer
+    # grid object, but it's *much* easier when we have it.
+    get_grid: Callable[[], MapGrid] = Field(exclude=True)
 
 
 class TransplantScene(Scene[TransplantSceneParams]):
+    """
+    This is a helper scene that allows us to salvage the scene tree from a scene that was rendered on an external grid.
+
+    See the logic about prebuilt instances in MapGen to understand why this is needed.
+    """
+
     def render(self):
         if self.width != self.params.scene.width or self.height != self.params.scene.height:
             raise ValueError(
@@ -23,7 +37,7 @@ class TransplantScene(Scene[TransplantSceneParams]):
 
         scene_copy = copy.deepcopy(self.params.scene)
         scene_copy.transplant_to_grid(
-            self.params.grid, self.area.x - self.params.scene.area.x, self.area.y - self.params.scene.area.y
+            self.params.get_grid(), self.area.x - self.params.scene.area.x, self.area.y - self.params.scene.area.y
         )
         self.children.append(scene_copy)
 

--- a/metta/map/terrain_from_numpy.py
+++ b/metta/map/terrain_from_numpy.py
@@ -1,0 +1,156 @@
+import logging
+import os
+import random
+import zipfile
+
+import boto3
+import numpy as np
+from botocore.exceptions import NoCredentialsError
+from filelock import FileLock
+
+from metta.common.util.config import Config
+from metta.mettagrid.level_builder import Level, LevelBuilder
+
+logger = logging.getLogger("terrain_from_numpy")
+
+
+def pick_random_file(path):
+    chosen = None
+    count = 0
+    with os.scandir(path) as it:
+        for entry in it:
+            count += 1
+            # with probability 1/count, pick this entry
+            if random.randrange(count) == 0:
+                chosen = entry.name
+    return chosen
+
+
+def download_from_s3(s3_path: str, save_path: str):
+    if not s3_path.startswith("s3://"):
+        raise ValueError(f"Invalid S3 path: {s3_path}. Must start with s3://")
+
+    s3_parts = s3_path[5:].split("/", 1)
+    if len(s3_parts) < 2:
+        raise ValueError(f"Invalid S3 path: {s3_path}. Must be in format s3://bucket/path")
+
+    bucket = s3_parts[0]
+    key = s3_parts[1]
+
+    try:
+        # Create directory if it doesn't exist
+        os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+        # Download the file directly to disk
+        s3_client = boto3.client("s3")
+        s3_client.download_file(Bucket=bucket, Key=key, Filename=save_path)
+        print(f"Successfully downloaded s3://{bucket}/{key} to {save_path}")
+
+    except NoCredentialsError as e:
+        raise e
+    except Exception as e:
+        raise e
+
+
+class TerrainFromNumpyParams(Config):
+    objects: dict[str, int] = {}
+    agents: int | dict[str, int] = 0
+    dir: str
+    file: str | None = None
+
+
+class TerrainFromNumpy(LevelBuilder):
+    """
+    This class is used to load a terrain environment from numpy arrays on s3.
+
+    It's not a MapGen scene, because we don't know the grid size until we load the file.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.params = TerrainFromNumpyParams(**kwargs)
+
+    def get_valid_positions(self, level):
+        # Create a boolean mask for empty cells
+        empty_mask = level == "empty"
+
+        # Use numpy's roll to check adjacent cells efficiently
+        has_empty_neighbor = (
+            np.roll(empty_mask, 1, axis=0)  # Check up
+            | np.roll(empty_mask, -1, axis=0)  # Check down
+            | np.roll(empty_mask, 1, axis=1)  # Check left
+            | np.roll(empty_mask, -1, axis=1)  # Check right
+        )
+
+        # Valid positions are empty cells with at least one empty neighbor
+        # Exclude border cells (indices 0 and -1)
+        valid_mask = empty_mask & has_empty_neighbor
+        valid_mask[0, :] = False
+        valid_mask[-1, :] = False
+        valid_mask[:, 0] = False
+        valid_mask[:, -1] = False
+
+        # Get coordinates of valid positions
+        valid_positions = list(zip(*np.where(valid_mask), strict=False))
+        return valid_positions
+
+    def get_labels(self) -> list[str]:
+        return [self.params.dir.split("/")[0]]
+
+    def build(self):
+        root = self.params.dir.split("/")[0]
+
+        map_dir = f"train_dir/{self.params.dir}"
+        root_dir = f"train_dir/{root}"
+
+        s3_path = f"s3://softmax-public/maps/{root}.zip"
+        local_zipped_dir = root_dir + ".zip"
+        # Only one process can hold this lock at a time:
+        with FileLock(local_zipped_dir + ".lock"):
+            if not os.path.exists(map_dir) and not os.path.exists(local_zipped_dir):
+                download_from_s3(s3_path, local_zipped_dir)
+            if not os.path.exists(root_dir) and os.path.exists(local_zipped_dir):
+                with zipfile.ZipFile(local_zipped_dir, "r") as zip_ref:
+                    zip_ref.extractall(os.path.dirname(root_dir))
+                os.remove(local_zipped_dir)
+                logger.info(f"Extracted {local_zipped_dir} to {root_dir}")
+
+        if self.params.file is None:
+            uri = pick_random_file(map_dir)
+        else:
+            uri = self.params.file
+
+        grid = np.load(f"{map_dir}/{uri}", allow_pickle=True)
+
+        # remove agents to then repopulate
+        grid[grid == "agent.agent"] = "empty"
+
+        # Prepare agent labels
+        if isinstance(self.params.agents, int):
+            agent_labels = ["agent.agent"] * self.params.agents
+        else:
+            agent_labels = [f"agent.{name}" for name, count in self.params.agents.items() for _ in range(count)]
+
+        num_agents = len(agent_labels)
+
+        valid_positions = self.get_valid_positions(grid)
+        random.shuffle(valid_positions)
+
+        # Place agents in first slice
+        agent_positions = valid_positions[:num_agents]
+        for pos, label in zip(agent_positions, agent_labels, strict=False):
+            grid[pos] = label
+
+        # Convert to set for O(1) removal operations
+        valid_positions_set = set(valid_positions[num_agents:])
+
+        for obj_name, count in self.params.objects.items():
+            count = count - np.where(grid == obj_name, 1, 0).sum()
+            if count < 0:
+                continue
+            # Sample from remaining valid positions
+            positions = random.sample(list(valid_positions_set), min(count, len(valid_positions_set)))
+            for pos in positions:
+                grid[pos] = obj_name
+                valid_positions_set.remove(pos)
+
+        return Level(grid=grid, labels=self.get_labels())


### PR DESCRIPTION
This PR is for the sake of integrating `TerrainFromNumpy` with MapGen.

While porting it, I realized that `TerrainFromNumpy` can't be represented as a scene, because scenes don't have sizes (there's some rudimentary support for `intrinsic_size` but it's limited and it's not a good fit for `TerrainFromNumpy`).

So I had to do it in a different way: now, when configuring mapgen, you have a choice between the existing syntax:

```
_target_: metta.map.mapgen.MapGen
width: 10
height: 10
instances: 4
root:
  type: metta.map.scenes.my_scene.MyScene
  ...
```

And using `instance_map` instead of `root`, where `instance_map` points to another `LevelBuilder`, that produces its own grid:

```
_target_: metta.map.mapgen.MapGen
instances: 4
instance_map:
  type: metta.map.terrain_from_numpy.TerrainFromNumpy
  ...
```

Similar to [num_agents](https://github.com/Metta-AI/metta/pull/1650) parameter, when using `instance_map`, MapGen instantiates the instance grids separately at first, and then copies them into the final grid.

---

The behavior of borders around instances in this PR is slightly different from what we had before.

Before:

![Screenshot 2025-08-05 at 12.30.34 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/evCtXUW5JNyNfqWDHydW/f1bb980d-3de3-448b-b396-820b3041d460.png)

After (all empty space around instances is filled):

![Screenshot 2025-08-05 at 12.31.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/evCtXUW5JNyNfqWDHydW/8877242c-086c-411f-ba20-d3df78aae69f.png)

I'm 99% sure this won't affect anything.

---

More thoughts on this:

I don't love the amount of complexity that I had to introduce to achieve this, but it's the best tradeoff I could find.

Why bother with this at all? Could I keep `TerrainFromNumpy` separate from mapgen? I wasn't sure at first, but:
- `instances` and `num_agents` in mapgen are still useful, and we want to retire `mettagrid.room` completely as a matter of principle, so it's still a minor win compared to `mettagrid.room.multi_room` that we used before
- I hope to trickle down rng seeds from mapgen to instance maps, so that maps will stay fully deterministic (this PR doesn't implement this yet)
- I hope to transplant the scene tree from `instance_map` to the main grid when the instance map has its own scene (not implemented yet; minor but will make some APIs more consistent)
- I'm considering removing `Scene.intrinsic_size` API, so it's less of "one more extra workaround for mapgen limitations", and more like "replacing one workaround with another that's more flexible"

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1210977451949448)