### PR TITLE
Fix for evals broken with NPC policies

### DIFF
--- a/agent/src/metta/agent/metta_agent.py
+++ b/agent/src/metta/agent/metta_agent.py
@@ -300,7 +300,6 @@ class MettaAgent(nn.Module):
         self.original_feature_mapping = mapping.copy()
         logger.info(f"Restored original feature mapping with {len(mapping)} features from metadata")
 
-    ##########################################################below
     def get_original_action_config(self) -> dict[str, list] | None:
         """Get the original action configuration for saving in metadata."""
         return getattr(self, "original_action_config", None)
@@ -315,13 +314,10 @@ class MettaAgent(nn.Module):
         self.original_action_config = {"names": config["names"].copy(), "max_params": config["max_params"].copy()}
         logger.info(f"Restored original action config with {len(config['names'])} actions from metadata")
 
-    ##########################################################
-
     def activate_actions(self, action_names: list[str], action_max_params: list[int], device):
         """Run this at the beginning of training."""
         assert isinstance(action_max_params, list), "action_max_params must be a list"
 
-        ##########################################################below
         # Store original action configuration on first activation
         if not hasattr(self, "original_action_config"):
             self.original_action_config = {"names": action_names.copy(), "max_params": action_max_params.copy()}
@@ -336,8 +332,6 @@ class MettaAgent(nn.Module):
                 # Use original actions to maintain compatibility
                 action_names = self.original_action_config["names"]
                 action_max_params = self.original_action_config["max_params"]
-
-        ##########################################################
 
         self.device = device
         self.action_max_params = action_max_params

--- a/agent/src/metta/agent/metta_agent.py
+++ b/agent/src/metta/agent/metta_agent.py
@@ -300,9 +300,44 @@ class MettaAgent(nn.Module):
         self.original_feature_mapping = mapping.copy()
         logger.info(f"Restored original feature mapping with {len(mapping)} features from metadata")
 
+    ##########################################################below
+    def get_original_action_config(self) -> dict[str, list] | None:
+        """Get the original action configuration for saving in metadata."""
+        return getattr(self, "original_action_config", None)
+
+    def restore_original_action_config(self, config: dict[str, list]) -> None:
+        """Restore the original action configuration from metadata.
+
+        This should be called after loading a model from checkpoint but before
+        calling activate_actions.
+        """
+        # Make a copy to avoid shared state between agents
+        self.original_action_config = {"names": config["names"].copy(), "max_params": config["max_params"].copy()}
+        logger.info(f"Restored original action config with {len(config['names'])} actions from metadata")
+
+    ##########################################################
+
     def activate_actions(self, action_names: list[str], action_max_params: list[int], device):
         """Run this at the beginning of training."""
         assert isinstance(action_max_params, list), "action_max_params must be a list"
+
+        ##########################################################below
+        # Store original action configuration on first activation
+        if not hasattr(self, "original_action_config"):
+            self.original_action_config = {"names": action_names.copy(), "max_params": action_max_params.copy()}
+            logger.info(f"Stored original action config with {len(action_names)} actions")
+        else:
+            # Check if current actions match original
+            if action_names != self.original_action_config["names"]:
+                logger.warning(
+                    f"Action mismatch - Original: {self.original_action_config['names']}, "
+                    f"Current: {action_names}. Using original action config for compatibility."
+                )
+                # Use original actions to maintain compatibility
+                action_names = self.original_action_config["names"]
+                action_max_params = self.original_action_config["max_params"]
+
+        ##########################################################
 
         self.device = device
         self.action_max_params = action_max_params

--- a/configs/sim/arena.yaml
+++ b/configs/sim/arena.yaml
@@ -15,11 +15,11 @@ simulations:
     env: /env/mettagrid/arena/tag
   arena/advanced_poor:
     env: /env/mettagrid/arena/advanced_poor
-  # arena/combat_npc:
-  #   env: /env/mettagrid/arena/combat
-  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
-  #   policy_agents_pct: 0.5
-  # arena/advanced_npc:
-  #   env: /env/mettagrid/arena/advanced
-  #   npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
-  #   policy_agents_pct: 0.5
+  arena/combat_npc:
+     env: /env/mettagrid/arena/combat
+     npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+     policy_agents_pct: 0.5
+  arena/advanced_npc:
+     env: /env/mettagrid/arena/advanced
+     npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+     policy_agents_pct: 0.5

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -42,7 +42,7 @@ trainer:
     evaluate_remote: false        # Keep it local for testing
 
   # Short training run for quick testing
-  total_timesteps: 1000000
+  total_timesteps: 10000000
   batch_size: 65536  # Reasonable batch for testing
   minibatch_size: 1024
   bptt_horizon: 8  # Sequence length for RNN

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -1,0 +1,85 @@
+# @package __global__
+
+# User config for testing checkpoint loading with NPC policies
+# This config is designed to test the original_action_config preservation fixes
+
+defaults:
+  - /common
+  - /agent/fast
+  - /trainer/trainer
+  - /sim/arena@evals  # Arena evaluation suite with NPC configs
+  - _self_
+
+# Basic run configuration
+run: ${oc.env:USER,test}_checkpoint_npc_test
+cmd: train
+
+data_dir: ${oc.env:DATA_DIR,./train_dir}
+run_dir: ${data_dir}/${run}
+policy_uri: file://${run_dir}/checkpoints
+
+trainer:
+  # Use arena combat with learning progress curriculum
+  curriculum: /env/mettagrid/curriculum/arena/learning_progress
+
+  # Train WITH NPCs using daveey's policy (read-only, won't modify his files!)
+  env_overrides:
+    npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+    policy_agents_pct: 0.5  # 50% of agents are NPCs during training
+
+  # Small number of workers for local testing
+  num_workers: 2
+
+  # Very frequent checkpoints for testing
+  checkpoint:
+    checkpoint_dir: ${run_dir}/checkpoints
+    checkpoint_interval: 10      # Save every 10 steps for quick testing
+    wandb_checkpoint_interval: 10  # Disable wandb uploads for testing
+
+  # Frequent evaluations to test NPC loading
+  simulation:
+    evaluate_interval: 50         # Evaluate every 20 steps
+    evaluate_remote: false        # Keep it local for testing
+
+  # Short training run for quick testing
+  total_timesteps: 100000
+  batch_size: 512
+  minibatch_size: 512
+
+  # Load from previous checkpoint if specified
+  initial_policy:
+    uri: ${oc.env:CHECKPOINT_URI,null}  # Can override with CHECKPOINT_URI env var
+    type: top
+    range: 1
+    metric: epoch
+
+# Override evaluations to include NPC simulations
+evals:
+  simulations:
+    # Basic arena tests
+    arena/basic:
+      env: /env/mettagrid/arena/basic
+    arena/combat:
+      env: /env/mettagrid/arena/combat
+
+    # NPC policy tests - these are the key tests for your fixes
+    arena/combat_npc:
+      env: /env/mettagrid/arena/combat
+      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2  # Use daveey's policy
+      policy_agents_pct: 0.5          # 50% of agents use the policy
+
+    arena/advanced_npc:
+      env: /env/mettagrid/arena/advanced
+      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2  # Use daveey's policy
+      policy_agents_pct: 0.5
+
+# Disable wandb for local testing
+wandb:
+  enabled: true
+
+# Device configuration
+device: ${oc.env:DEVICE,gpu}  # Default to CPU for testing
+
+# Add verbose logging for debugging
+trainer:
+  verbose: true

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -42,7 +42,7 @@ trainer:
     evaluate_remote: false        # Keep it local for testing
 
   # Short training run for quick testing
-  total_timesteps: 100000
+  total_timesteps: 1000000
   batch_size: 65536  # Reasonable batch for testing
   minibatch_size: 1024
   bptt_horizon: 8  # Sequence length for RNN

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -19,8 +19,8 @@ run_dir: ${data_dir}/${run}
 policy_uri: file://${run_dir}/checkpoints
 
 trainer:
-  # Use arena combat with learning progress curriculum
-  curriculum: /env/mettagrid/curriculum/arena/learning_progress
+  # Use basic arena curriculum (simpler, no special objects - avoiding lasery/armory errors)
+  curriculum: /env/mettagrid/arena/basic
 
   # Train WITH NPCs using daveey's policy (read-only, won't modify his files!)
   env_overrides:
@@ -43,8 +43,9 @@ trainer:
 
   # Short training run for quick testing
   total_timesteps: 100000
-  batch_size: 512
+  batch_size: 2048  # Reasonable batch for testing
   minibatch_size: 512
+  bptt_horizon: 8  # Sequence length for RNN
 
   # Load from previous checkpoint if specified
   initial_policy:

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -43,8 +43,8 @@ trainer:
 
   # Short training run for quick testing
   total_timesteps: 100000
-  batch_size: 65280  # Reasonable batch for testing
-  minibatch_size: 512
+  batch_size: 65536  # Reasonable batch for testing
+  minibatch_size: 1024
   bptt_horizon: 8  # Sequence length for RNN
 
   # Load from previous checkpoint if specified

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -43,7 +43,7 @@ trainer:
 
   # Short training run for quick testing
   total_timesteps: 100000
-  batch_size: 2048  # Reasonable batch for testing
+  batch_size: 65280  # Reasonable batch for testing
   minibatch_size: 512
   bptt_horizon: 8  # Sequence length for RNN
 

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -81,4 +81,4 @@ wandb:
   enabled: true
 
 # Device configuration
-device: ${oc.env:DEVICE,gpu}  # Default to CPU for testing
+device: ${oc.env:DEVICE,cpu}  # Default to CPU for testing

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -1,16 +1,10 @@
-# @package __global__
-
-# User config for testing checkpoint loading with NPC policies
-# This config is designed to test the original_action_config preservation fixes
-
 defaults:
   - /common
   - /agent/fast
   - /trainer/trainer
-  - /sim/arena@evals  # Arena evaluation suite with NPC configs
+  - /sim/arena@evals
   - _self_
 
-# Basic run configuration
 run: ${oc.env:USER,test}_checkpoint_npc_test
 cmd: train
 
@@ -19,67 +13,54 @@ run_dir: ${data_dir}/${run}
 policy_uri: file://${run_dir}/checkpoints
 
 trainer:
-  # Use basic arena curriculum (simpler, no special objects - avoiding lasery/armory errors)
   curriculum: /env/mettagrid/arena/basic
 
-  # Train WITH NPCs using daveey's policy (read-only, won't modify his files!)
   env_overrides:
     npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
-    policy_agents_pct: 0.5  # 50% of agents are NPCs during training
+    policy_agents_pct: 0.5
 
-  # Small number of workers for local testing
   num_workers: 2
 
-  # Very frequent checkpoints for testing
   checkpoint:
     checkpoint_dir: ${run_dir}/checkpoints
-    checkpoint_interval: 10      # Save every 10 steps for quick testing
-    wandb_checkpoint_interval: 10  # Disable wandb uploads for testing
+    checkpoint_interval: 10
+    wandb_checkpoint_interval: 10
 
-  # Frequent evaluations to test NPC loading
   simulation:
-    evaluate_interval: 50         # Evaluate every 20 steps
-    evaluate_remote: false        # Keep it local for testing
+    evaluate_interval: 50
+    evaluate_remote: false
 
-  # Short training run for quick testing
   total_timesteps: 10000000
-  batch_size: 65536  # Reasonable batch for testing
+  batch_size: 65536
   minibatch_size: 1024
-  bptt_horizon: 8  # Sequence length for RNN
+  bptt_horizon: 8
 
-  # Load from previous checkpoint if specified
   initial_policy:
-    uri: ${oc.env:CHECKPOINT_URI,null}  # Can override with CHECKPOINT_URI env var
+    uri: ${oc.env:CHECKPOINT_URI,null}
     type: top
     range: 1
     metric: epoch
 
-  # Enable verbose logging for debugging
   verbose: true
 
-# Override evaluations to include NPC simulations
 evals:
   simulations:
-    # Basic arena tests
     arena/basic:
       env: /env/mettagrid/arena/basic
     arena/combat:
       env: /env/mettagrid/arena/combat
 
-    # NPC policy tests - these are the key tests for your fixes
     arena/combat_npc:
       env: /env/mettagrid/arena/combat
-      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2  # Use daveey's policy
-      policy_agents_pct: 0.5          # 50% of agents use the policy
+      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
+      policy_agents_pct: 0.5
 
     arena/advanced_npc:
       env: /env/mettagrid/arena/advanced
-      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2  # Use daveey's policy
+      npc_policy_uri: wandb://run/daveey.lp.16x4.ue2
       policy_agents_pct: 0.5
 
-# Disable wandb for local testing
 wandb:
   enabled: true
 
-# Device configuration
-device: ${oc.env:DEVICE,cpu}  # Default to CPU for testing
+device: ${oc.env:DEVICE,cpu}

--- a/configs/user/krishnakanth.yaml
+++ b/configs/user/krishnakanth.yaml
@@ -53,6 +53,9 @@ trainer:
     range: 1
     metric: epoch
 
+  # Enable verbose logging for debugging
+  verbose: true
+
 # Override evaluations to include NPC simulations
 evals:
   simulations:
@@ -79,7 +82,3 @@ wandb:
 
 # Device configuration
 device: ${oc.env:DEVICE,gpu}  # Default to CPU for testing
-
-# Add verbose logging for debugging
-trainer:
-  verbose: true

--- a/metta/rl/checkpoint_manager.py
+++ b/metta/rl/checkpoint_manager.py
@@ -191,6 +191,15 @@ class CheckpointManager:
                     f"Saving original_feature_mapping with {len(original_feature_mapping)} features to metadata"
                 )
 
+            ##########################################################below
+            original_action_config = policy_to_save.get_original_action_config()
+            if original_action_config is not None:
+                metadata["original_action_config"] = original_action_config
+                logger.info(
+                    f"Saving original_action_config with {len(original_action_config['names'])} actions to metadata"
+                )
+            ##########################################################
+
         # Create and save policy record
         policy_record = self.policy_store.create_empty_policy_record(
             name=name, checkpoint_dir=self.checkpoint_cfg.checkpoint_dir

--- a/metta/rl/checkpoint_manager.py
+++ b/metta/rl/checkpoint_manager.py
@@ -191,14 +191,12 @@ class CheckpointManager:
                     f"Saving original_feature_mapping with {len(original_feature_mapping)} features to metadata"
                 )
 
-            ##########################################################below
             original_action_config = policy_to_save.get_original_action_config()
             if original_action_config is not None:
                 metadata["original_action_config"] = original_action_config
                 logger.info(
                     f"Saving original_action_config with {len(original_action_config['names'])} actions to metadata"
                 )
-            ##########################################################
 
         # Create and save policy record
         policy_record = self.policy_store.create_empty_policy_record(

--- a/metta/rl/policy_management.py
+++ b/metta/rl/policy_management.py
@@ -228,8 +228,7 @@ def load_or_initialize_policy(
         #      if isinstance(policy_record.policy, MettaAgent) and "original_feature_mapping" in policy_record.metadata:
         #          policy_record.policy.restore_original_feature_mapping(policy_record.metadata["original_feature_mapping"])
         #          logger.info("Restored original_feature_mapping")
-        #
-        ##########################################################below
+
         if isinstance(policy_record.policy, MettaAgent):
             if "original_feature_mapping" in policy_record.metadata:
                 policy_record.policy.restore_original_feature_mapping(
@@ -241,7 +240,6 @@ def load_or_initialize_policy(
             if "original_action_config" in policy_record.metadata:
                 policy_record.policy.restore_original_action_config(policy_record.metadata["original_action_config"])
                 logger.info("Restored original_action_config")
-        ##########################################################
 
         policy = policy_record.policy
         initial_policy_record = policy_record

--- a/metta/rl/policy_management.py
+++ b/metta/rl/policy_management.py
@@ -224,9 +224,24 @@ def load_or_initialize_policy(
     # If we found an existing policy, all ranks use it
     if policy_record:
         # Restore original_feature_mapping from metadata if available
-        if isinstance(policy_record.policy, MettaAgent) and "original_feature_mapping" in policy_record.metadata:
-            policy_record.policy.restore_original_feature_mapping(policy_record.metadata["original_feature_mapping"])
-            logger.info("Restored original_feature_mapping")
+        #
+        #      if isinstance(policy_record.policy, MettaAgent) and "original_feature_mapping" in policy_record.metadata:
+        #          policy_record.policy.restore_original_feature_mapping(policy_record.metadata["original_feature_mapping"])
+        #          logger.info("Restored original_feature_mapping")
+        #
+        ##########################################################below
+        if isinstance(policy_record.policy, MettaAgent):
+            if "original_feature_mapping" in policy_record.metadata:
+                policy_record.policy.restore_original_feature_mapping(
+                    policy_record.metadata["original_feature_mapping"]
+                )
+                logger.info("Restored original_feature_mapping")
+
+            # Restore original_action_config from metadata if available
+            if "original_action_config" in policy_record.metadata:
+                policy_record.policy.restore_original_action_config(policy_record.metadata["original_action_config"])
+                logger.info("Restored original_action_config")
+        ##########################################################
 
         policy = policy_record.policy
         initial_policy_record = policy_record

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -169,12 +169,10 @@ class Simulation:
         ):
             policy.restore_original_feature_mapping(self._policy_pr.metadata["original_feature_mapping"])
 
-        ##########################################################below
         # Restore original_action_config from metadata if available
         if hasattr(policy, "restore_original_action_config") and "original_action_config" in self._policy_pr.metadata:
             policy.restore_original_action_config(self._policy_pr.metadata["original_action_config"])
             logger.info("Restored original_action_config for main policy")
-        ##########################################################
 
         # Initialize policy to environment
         features = metta_grid_env.get_observation_features()
@@ -191,11 +189,9 @@ class Simulation:
             ):
                 npc_policy.restore_original_feature_mapping(self._npc_pr.metadata["original_feature_mapping"])
 
-            ##########################################################below
             if "original_action_config" in self._npc_pr.metadata:
                 npc_policy.restore_original_action_config(self._npc_pr.metadata["original_action_config"])
                 logger.info("Restored original_action_config")
-            ##########################################################
 
             # Initialize NPC policy to environment
             features = metta_grid_env.get_observation_features()

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -169,6 +169,13 @@ class Simulation:
         ):
             policy.restore_original_feature_mapping(self._policy_pr.metadata["original_feature_mapping"])
 
+        ##########################################################below
+        # Restore original_action_config from metadata if available
+        if hasattr(policy, "restore_original_action_config") and "original_action_config" in self._policy_pr.metadata:
+            policy.restore_original_action_config(self._policy_pr.metadata["original_action_config"])
+            logger.info("Restored original_action_config for main policy")
+        ##########################################################
+
         # Initialize policy to environment
         features = metta_grid_env.get_observation_features()
         # Simulations are generally used for evaluation, not training
@@ -183,6 +190,12 @@ class Simulation:
                 and "original_feature_mapping" in self._npc_pr.metadata
             ):
                 npc_policy.restore_original_feature_mapping(self._npc_pr.metadata["original_feature_mapping"])
+
+            ##########################################################below
+            if "original_action_config" in self._npc_pr.metadata:
+                npc_policy.restore_original_action_config(self._npc_pr.metadata["original_action_config"])
+                logger.info("Restored original_action_config")
+            ##########################################################
 
             # Initialize NPC policy to environment
             features = metta_grid_env.get_observation_features()


### PR DESCRIPTION
Previously only the features were getting stored and mapped but not the actions. I just added relevant pieces of code to store and map the actions as well. 

This is a test run: https://wandb.ai/metta-research/metta/runs/root_checkpoint_npc_test?nw=nwuserkrishnakanth

This was tested with the configs/user/krishnakanth.yaml config file.