### PR TITLE
Allow python observatory client to use sql routes

### DIFF
--- a/app_backend/src/metta/app_backend/clients/base_client.py
+++ b/app_backend/src/metta/app_backend/clients/base_client.py
@@ -31,7 +31,7 @@ class BaseAppBackendClient:
     async def close(self):
         await self._http_client.aclose()
 
-    async def _make_request(self, response_type: Type[T], method: str, url: str, **kwargs) -> T:
+    async def _make_request(self, response_type: Type[T], method: str, url: str, **kwargs):
         headers = remove_none_values({"X-Auth-Token": self._machine_token})
         response = await self._http_client.request(method, url, headers=headers, **kwargs)
         response.raise_for_status()

--- a/app_backend/src/metta/app_backend/clients/scorecard_client.py
+++ b/app_backend/src/metta/app_backend/clients/scorecard_client.py
@@ -10,6 +10,7 @@ from metta.app_backend.routes.scorecard_routes import (
     ScorecardData,
     ScorecardRequest,
 )
+from metta.app_backend.routes.sql_routes import AIQueryRequest, AIQueryResponse, SQLQueryRequest, SQLQueryResponse
 
 
 class ListModel(RootModel[list]):
@@ -19,6 +20,20 @@ class ListModel(RootModel[list]):
 class ScorecardClient(BaseAppBackendClient):
     async def get_policies(self):
         return await self._make_request(PoliciesResponse, "GET", "/scorecard/policies")
+
+    async def sql_query(self, sql: str):
+        payload = SQLQueryRequest(
+            query=sql,
+        )
+        return await self._make_request(SQLQueryResponse, "POST", "/sql/query", json=payload.model_dump(mode="json"))
+
+    async def generate_ai_query(self, description: str):
+        payload = AIQueryRequest(
+            description=description,
+        )
+        return await self._make_request(
+            AIQueryResponse, "POST", "/sql/generate-query", json=payload.model_dump(mode="json")
+        )
 
     async def get_eval_names(self, training_run_ids: list[str], run_free_policy_ids: list[str]) -> list:
         payload = EvalsRequest(


### PR DESCRIPTION
Allow python observatory client to use sql routes

Fix some other things about types in clients