### PR TITLE
modify the fetch_metrics function to allow for no subsampling (FULL metrics)

### DIFF
--- a/experiments/marimo/mettabook-example.py
+++ b/experiments/marimo/mettabook-example.py
@@ -111,7 +111,21 @@ def _(mo):
 
 @app.cell
 def _(fetch_metrics, run_names):
+    # Option 1: Fetch with sampling (fast, returns 500 data points)
     metrics_dfs = fetch_metrics(run_names, samples=500)
+
+    # Option 2: Fetch many samples without full scan (good balance)
+    # metrics_dfs = fetch_metrics(run_names, samples=10000)
+
+    # Option 3: Fetch only specific metrics (much faster)
+    # metrics_dfs = fetch_metrics(run_names, samples=5000, keys=["overview/reward", "_step", "losses/policy_loss"])
+
+    # Option 4: Fetch specific step range
+    # metrics_dfs = fetch_metrics(run_names, samples=None, min_step=1000, max_step=5000)
+
+    # Option 5: Fetch ALL data points (slowest, complete data)
+    # metrics_dfs = fetch_metrics(run_names, samples=None)
+
     return (metrics_dfs,)
 
 

--- a/experiments/notebooks/utils/metrics.py
+++ b/experiments/notebooks/utils/metrics.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import wandb
-from wandb.apis.public.runs import Run
-
 from metta.common.util.constants import METTA_WANDB_ENTITY, METTA_WANDB_PROJECT
+from wandb.apis.public.runs import Run
 
 
 def get_run(
@@ -22,7 +21,29 @@ def get_run(
         return None
 
 
-def fetch_metrics(run_names: list[str], samples: int = 1000) -> dict[str, pd.DataFrame]:
+def fetch_metrics(
+    run_names: list[str],
+    samples: int | None = 1000,
+    keys: list[str] | None = None,
+    min_step: int | None = None,
+    max_step: int | None = None,
+    show_progress: bool = True,
+) -> dict[str, pd.DataFrame]:
+    """Fetch metrics from wandb runs.
+
+    Args:
+        run_names: List of wandb run names to fetch metrics from
+        samples: Number of samples to return. If None, fetches all data points without subsampling.
+                Set to a large number (e.g., 10000) for more data without full scan.
+                Default is 1000 for backwards compatibility.
+        keys: Optional list of specific metric keys to fetch (speeds up fetching)
+        min_step: Optional minimum step to fetch from
+        max_step: Optional maximum step to fetch to
+        show_progress: Show progress indicator for large fetches
+
+    Returns:
+        Dictionary mapping run names to pandas DataFrames containing the metrics
+    """
     metrics_dfs = {}
 
     for run_name in run_names:
@@ -35,7 +56,53 @@ def fetch_metrics(run_names: list[str], samples: int = 1000) -> dict[str, pd.Dat
         )
 
         try:
-            metrics_df: pd.DataFrame = run.history(samples=samples, pandas=True)  # type: ignore
+            if samples is None:
+                # Full scan - warn about potential slowness
+                print(
+                    "  ⚠️  Fetching ALL data points using scan_history (this may be slow for large runs)"
+                )
+                print(
+                    "  Tip: Use samples=10000 for faster fetching of many points, or specify 'keys' to fetch only specific metrics"
+                )
+
+                if show_progress:
+                    # Fetch with progress indicator
+
+                    history_records = []
+                    count = 0
+                    print("    Scanning for records...", end="", flush=True)
+                    for record in run.scan_history(
+                        keys=keys, min_step=min_step, max_step=max_step
+                    ):
+                        history_records.append(record)
+                        count += 1
+                        if (
+                            count == 1 or count % 100 == 0
+                        ):  # Show first record and every 100th
+                            print(
+                                f"\r    Fetched {count} records...", end="", flush=True
+                            )
+                    print(
+                        f"\r    Fetched {count} records total" + " " * 20
+                    )  # Clear the line with spaces
+                else:
+                    history_records = list(
+                        run.scan_history(
+                            keys=keys, min_step=min_step, max_step=max_step
+                        )
+                    )
+
+                metrics_df = pd.DataFrame(history_records)
+            else:
+                # Use sampled history for faster retrieval
+                if keys:
+                    print(f"  Fetching {samples} samples for keys: {keys}")
+                else:
+                    print(f"  Fetching {samples} sampled data points")
+                metrics_df: pd.DataFrame = run.history(
+                    samples=samples, keys=keys, pandas=True
+                )  # type: ignore
+
             metrics_dfs[run_name] = metrics_df
             print(f"  Fetched {len(metrics_df)} data points.")
 


### PR DESCRIPTION
it also shows progress, accepts keys, and has min and max steps. examples commented out in the marimo mettabook.

there is a problem with this though.. it's slow. here's what `claude code` said:
```
The Problem:

  - scan_history() iterates through ALL records sequentially, even with filters
  - For runs with millions of data points, this is extremely slow
  - The progress indicator works (shows "Fetched X records...") but the operation
  itself takes too long

  Recommended Solutions:

  1. Use higher sampling instead of scan_history:
      # Instead of samples=None, use a large sample size
      fetch_metrics(runs, samples=50000)  # Gets up to 50k evenly distributed points
  2. Use key filtering to reduce data:
      # Only fetch the metrics you need
      fetch_metrics(runs, samples=10000, keys=["overview/reward", "_step"])
  3. Avoid samples=None for large runs - it's just too slow with wandb's API
  4. For complete data export, consider using wandb's export API or downloading
      artifacts directly rather than using scan_history

  The fetch_metrics function now has all these options, but for runs with millions
  of points, sampling is really the only practical approach. The wandb API's
  scan_history() method just isn't optimized for large-scale data retrieval.
```

@ whoever reviews this PR, here's a script to test it really quickly:

```python
#!/usr/bin/env python3
"""Test different fetch_metrics options for performance."""

import time

from experiments.notebooks.utils.metrics import fetch_metrics

# Use a real run name that might have lots of data
run_name = "zfogg.skypilot.learning_progress.07-30.0"

print("=" * 70)
print("Testing different fetch_metrics strategies")
print("=" * 70)

# Test 1: Default sampling (fast)
print("\n1. Default sampling (samples=1000):")
start = time.time()
try:
    metrics_sampled = fetch_metrics([run_name], samples=1000)
    elapsed = time.time() - start
    if run_name in metrics_sampled:
        print(f"   ✓ Fetched {len(metrics_sampled[run_name])} points in {elapsed:.2f} seconds")
except Exception as e:
    print(f"   ✗ Error: {e}")

# Test 2: Large sampling (balanced)
print("\n2. Large sampling (samples=10000):")
start = time.time()
try:
    metrics_large = fetch_metrics([run_name], samples=10000)
    elapsed = time.time() - start
    if run_name in metrics_large:
        print(f"   ✓ Fetched {len(metrics_large[run_name])} points in {elapsed:.2f} seconds")
except Exception as e:
    print(f"   ✗ Error: {e}")

# Test 3: Specific keys only (faster)
print("\n3. Specific keys with sampling (samples=5000, keys=['overview/reward', '_step']):")
start = time.time()
try:
    metrics_keys = fetch_metrics([run_name], samples=5000, keys=["overview/reward", "_step"])
    elapsed = time.time() - start
    if run_name in metrics_keys:
        print(f"   ✓ Fetched {len(metrics_keys[run_name])} points in {elapsed:.2f} seconds")
        print(f"   Columns: {list(metrics_keys[run_name].columns)}")
except Exception as e:
    print(f"   ✗ Error: {e}")

# Test 4: Step range (if you know the range you need)
# Using realistic step values from this run (in millions)
print("\n4. Specific step range (min_step=8000000, max_step=10000000):")
start = time.time()
try:
    metrics_range = fetch_metrics(
        [run_name], keys=["overview/reward"], samples=None, min_step=8000000, max_step=10000000, show_progress=True
    )
    elapsed = time.time() - start
    if run_name in metrics_range:
        print(f"   ✓ Fetched {len(metrics_range[run_name])} points in {elapsed:.2f} seconds")
        if len(metrics_range[run_name]) > 0:
            steps = metrics_range[run_name]["_step"] if "_step" in metrics_range[run_name].columns else None
            if steps is not None:
                print(f"   Step range in data: {steps.min():,.0f} to {steps.max():,.0f}")
except Exception as e:
    print(f"   ✗ Error: {e}")

# # Test 5: All data (slowest)
# print("\n5. All data (samples=None):")
# start = time.time()
# try:
#     metrics_range = fetch_metrics([run_name], keys=["overview/reward"], samples=None, show_progress=True)
#     elapsed = time.time() - start
#     if run_name in metrics_range:
#         print(f"   ✓ Fetched {len(metrics_range[run_name])} points in {elapsed:.2f} seconds")
# except Exception as e:
#     print(f"   ✗ Error: {e}")

print("\n" + "=" * 70)
print("Recommendations:")
print("- Use samples=1000-10000 for most use cases (fast)")
print("- Use 'keys' parameter to fetch only needed metrics (faster)")
print("- Use min_step/max_step if you know the range you need")
print("- Only use samples=None for complete data export (slowest)")
print("=" * 70)
```