### PR TITLE
set custom axes for policy eval metris at wandb-log-submission time

### DIFF
--- a/metta/rl/stats.py
+++ b/metta/rl/stats.py
@@ -24,7 +24,12 @@ from metta.rl.kickstarter import Kickstarter
 from metta.rl.losses import Losses
 from metta.rl.trainer_config import TrainerConfig
 from metta.rl.utils import should_run
-from metta.rl.wandb import POLICY_EVALUATOR_EPOCH_METRIC, POLICY_EVALUATOR_METRIC_PREFIX, POLICY_EVALUATOR_STEP_METRIC
+from metta.rl.wandb import (
+    POLICY_EVALUATOR_EPOCH_METRIC,
+    POLICY_EVALUATOR_METRIC_PREFIX,
+    POLICY_EVALUATOR_STEP_METRIC,
+    setup_policy_evaluator_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -450,6 +455,12 @@ def process_policy_evaluator_stats(
         resume="must",
     )
     try:
+        try:
+            setup_policy_evaluator_metrics(run)
+        except Exception:
+            logger.warning("Failed to set default axes for policy evaluator metrics. Continuing")
+            pass
+
         run.log({**metrics_to_log, POLICY_EVALUATOR_STEP_METRIC: agent_step, POLICY_EVALUATOR_EPOCH_METRIC: epoch})
         logger.info(f"Logged {len(metrics_to_log)} metrics to wandb for policy {pr.uri}")
     finally:

--- a/metta/rl/wandb.py
+++ b/metta/rl/wandb.py
@@ -61,16 +61,19 @@ def setup_wandb_metrics(wandb_run: WandbRun) -> None:
     metrics = ["agent_step", "epoch", "total_time", "train_time"]
     for metric in metrics:
         wandb_run.define_metric(f"metric/{metric}")
-    wandb_run.define_metric(POLICY_EVALUATOR_STEP_METRIC)
 
     # Set agent_step as the default x-axis for all metrics
     wandb_run.define_metric("*", step_metric="metric/agent_step")
 
-    # Separate step metric for remote evaluation allows evaluation results to be logged without conflicts
-    wandb_run.define_metric(f"{POLICY_EVALUATOR_METRIC_PREFIX}/*", step_metric=POLICY_EVALUATOR_STEP_METRIC)
-
     # Define special metric for reward vs total time
     wandb_run.define_metric("overview/reward_vs_total_time", step_metric="metric/total_time")
+    setup_policy_evaluator_metrics(wandb_run)
+
+
+def setup_policy_evaluator_metrics(wandb_run: WandbRun) -> None:
+    # Separate step metric for remote evaluation allows evaluation results to be logged without conflicts
+    wandb_run.define_metric(POLICY_EVALUATOR_STEP_METRIC)
+    wandb_run.define_metric(f"{POLICY_EVALUATOR_METRIC_PREFIX}/*", step_metric=POLICY_EVALUATOR_STEP_METRIC)
 
 
 def log_model_parameters(policy: nn.Module, wandb_run: WandbRun) -> None:


### PR DESCRIPTION
so that it works on old runs