### PR TITLE
Make episode desync configurable

### DIFF
--- a/mettagrid/src/metta/mettagrid/mettagrid_env.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_env.py
@@ -245,7 +245,7 @@ class MettaGridEnv(MettaGridPufferBase):
             New MettaGridCpp instance
         """
         # Handle episode desyncing for training
-        if self._is_training and self._resets == 0:
+        if self._task.env_cfg().get("desync_episodes", True) and self._is_training and self._resets == 0:
             max_steps = game_config_dict["max_steps"]
             # Recreate with random max_steps
             game_config_dict = game_config_dict.copy()  # Don't modify original


### PR DESCRIPTION
If you train with trainer.env_overrides.episode_desync=false then the episodes will all be in sync