### PR TITLE
Add temporal consistency encoder and tests

### DIFF
--- a/metta/rl/rep/dynamics.py
+++ b/metta/rl/rep/dynamics.py
@@ -1,0 +1,45 @@
+import torch
+import torch.nn as nn
+
+
+class LatentRollout(nn.Module):
+    """Latent dynamics model used for temporal consistency training."""
+
+    def __init__(
+        self,
+        latent_dim: int = 256,
+        act_dim: int = 2,
+        hidden: int = 256,
+        predict_reward: bool = True,
+    ) -> None:
+        super().__init__()
+        self.f = nn.Sequential(
+            nn.Linear(latent_dim + act_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, latent_dim),
+        )
+        self.predict_reward = predict_reward
+        if predict_reward:
+            self.r = nn.Sequential(
+                nn.Linear(latent_dim, hidden),
+                nn.ReLU(),
+                nn.Linear(hidden, 1),
+            )
+
+    def step(self, z: torch.Tensor, a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
+        z_next = self.f(torch.cat([z, a], dim=-1))
+        r = self.r(z_next) if self.predict_reward else None
+        return z_next, r
+
+    def rollout(self, z0: torch.Tensor, acts: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor | None]:
+        zs: list[torch.Tensor] = []
+        rs: list[torch.Tensor] = []
+        z = z0
+        for i in range(k):
+            z, r = self.step(z, acts[:, i])
+            zs.append(z)
+            if self.predict_reward and r is not None:
+                rs.append(r)
+        z_stack = torch.stack(zs, dim=1)
+        r_stack = torch.stack(rs, dim=1) if self.predict_reward else None
+        return z_stack, r_stack

--- a/metta/rl/rep/encoder.py
+++ b/metta/rl/rep/encoder.py
@@ -1,0 +1,29 @@
+import torch
+import torch.nn as nn
+
+
+class TCEncoder(nn.Module):
+    """Simple convolutional encoder for temporal consistency."""
+
+    def __init__(self, in_channels: int = 30, latent_dim: int = 256) -> None:
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_channels, 64, 3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(64, 64, 3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool2d(1),
+        )
+        self.head = nn.Sequential(
+            nn.Flatten(),
+            nn.LayerNorm(64),
+            nn.Linear(64, latent_dim),
+        )
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        """Encode observations to latent vectors."""
+
+        x = obs
+        if x.dim() == 4 and x.shape[-1] == 30:
+            x = x.permute(0, 3, 1, 2)
+        return self.head(self.conv(x))

--- a/metta/rl/rep/momentum.py
+++ b/metta/rl/rep/momentum.py
@@ -1,0 +1,10 @@
+import torch
+from torch import nn
+
+
+@torch.no_grad()
+def ema_update(target: nn.Module, online: nn.Module, tau: float) -> None:
+    """Exponential moving average update for target network parameters."""
+
+    for tp, op in zip(target.parameters(), online.parameters(), strict=False):
+        tp.data.mul_(tau).add_(op.data, alpha=1.0 - tau)

--- a/metta/rl/rep/tc_loss.py
+++ b/metta/rl/rep/tc_loss.py
@@ -1,0 +1,13 @@
+import torch
+import torch.nn.functional as F
+
+
+def cosine_tc(preds: torch.Tensor, tgts: torch.Tensor, gamma: float = 0.99) -> torch.Tensor:
+    """Temporal consistency cosine loss with discounting."""
+
+    preds = F.normalize(preds, dim=-1)
+    tgts = F.normalize(tgts, dim=-1)
+    cos = (preds * tgts).sum(dim=-1)
+    k = preds.size(1)
+    disc = (gamma ** torch.arange(k, device=preds.device)).view(1, k)
+    return ((1.0 - cos) * disc).mean()

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -121,6 +121,22 @@ class TorchProfilerConfig(BaseModelWithForbidExtra):
         return self
 
 
+class RepConfig(BaseModelWithForbidExtra):
+    """Configuration for representation learning with temporal consistency."""
+
+    enabled: bool = True
+    latent_dim: int = Field(default=256, gt=0)
+    tau: float = Field(default=0.998, ge=0.0, le=1.0)
+    K: int = Field(default=8, gt=0)
+    gamma: float = Field(default=0.99, ge=0.0, le=1.0)
+    reward_head: bool = True
+    lambda_r: float = Field(default=0.5, ge=0.0)
+    lr: float = Field(default=3e-4, gt=0.0)
+    tc_epochs: int = Field(default=1, gt=0)
+    ppo_epochs: int = Field(default=4, gt=0)
+    burn_in: int = Field(default=32, ge=0)
+
+
 class TrainerConfig(BaseModelWithForbidExtra):
     # Core training parameters
     # Total timesteps: Type 2 arbitrary default
@@ -169,6 +185,9 @@ class TrainerConfig(BaseModelWithForbidExtra):
     compile_mode: Literal["default", "reduce-overhead", "max-autotune"] = "reduce-overhead"
     # Profile every 10K epochs: Infrequent to minimize overhead
     profiler: TorchProfilerConfig = Field(default_factory=TorchProfilerConfig)
+
+    # Representation learning
+    rep: RepConfig = Field(default_factory=RepConfig)
 
     # Distributed training
     # Forward minibatch: Type 2 default chosen arbitrarily

--- a/tests/metta/rl/test_alternating_stub.py
+++ b/tests/metta/rl/test_alternating_stub.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import torch
+
+from metta.rl.rep.dynamics import LatentRollout
+from metta.rl.rep.encoder import TCEncoder
+from metta.rl.rep.momentum import ema_update
+from metta.rl.rep.tc_loss import cosine_tc
+
+
+# Light integration stub verifying TC step and encoder freezing.
+def test_alternating_tc_then_freeze() -> None:
+    cfg = SimpleNamespace(rep=SimpleNamespace(K=3, gamma=0.99, lambda_r=0.5, tau=0.998, reward_head=True))
+    device = "cpu"
+
+    encoder = TCEncoder(30, 32).to(device)
+    enc_mom = TCEncoder(30, 32).to(device).eval()
+    enc_mom.load_state_dict(encoder.state_dict())
+    for p in enc_mom.parameters():
+        p.requires_grad = False
+    dyn = LatentRollout(latent_dim=32, act_dim=2, predict_reward=True).to(device)
+    opt = torch.optim.Adam(list(encoder.parameters()) + list(dyn.parameters()), lr=1e-3)
+
+    b, t, a = 8, 10, 2
+    obs = torch.randn(b, t, 11, 11, 30)
+    acts = torch.randn(b, t, a)
+    rews = torch.randn(b, t, 1)
+
+    starts = torch.randint(0, t - cfg.rep.K - 1, (b,))
+
+    def gather_t(x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+        return x[torch.arange(b), idx]
+
+    def gather_range(x: torch.Tensor, idx: torch.Tensor, k: int) -> torch.Tensor:
+        return torch.stack([x[torch.arange(b), idx + i] for i in range(k)], dim=1)
+
+    o0 = gather_t(obs, starts)
+    ofut = gather_range(obs, starts + 1, cfg.rep.K)
+    afut = gather_range(acts, starts, cfg.rep.K)
+    rgt = gather_range(rews, starts + 1, cfg.rep.K)
+
+    z0 = encoder(o0)
+    with torch.no_grad():
+        z_tgt = enc_mom(ofut.view(-1, 11, 11, 30)).view(b, cfg.rep.K, -1)
+    z_pred, r_pred = dyn.rollout(z0, afut, cfg.rep.K)
+    loss = cosine_tc(z_pred, z_tgt, gamma=cfg.rep.gamma) + cfg.rep.lambda_r * torch.nn.functional.mse_loss(r_pred, rgt)
+    opt.zero_grad()
+    loss.backward()
+    opt.step()
+    ema_update(enc_mom, encoder, cfg.rep.tau)
+
+    for p in encoder.parameters():
+        p.requires_grad = False
+    x = torch.randn(b, 11, 11, 30)
+    with torch.no_grad():
+        z = encoder(x)
+    assert z.shape[0] == b
+    assert not any(p.requires_grad for p in encoder.parameters())

--- a/tests/metta/rl/test_dynamics.py
+++ b/tests/metta/rl/test_dynamics.py
@@ -1,0 +1,13 @@
+import torch
+
+from metta.rl.rep.dynamics import LatentRollout
+
+
+def test_latent_rollout_shapes() -> None:
+    b, k, d, a = 8, 5, 64, 3
+    z0 = torch.randn(b, d)
+    acts = torch.randn(b, k, a)
+    dyn = LatentRollout(latent_dim=d, act_dim=a, predict_reward=True)
+    z, r = dyn.rollout(z0, acts, k)
+    assert z.shape == (b, k, d)
+    assert r is not None and r.shape == (b, k, 1)

--- a/tests/metta/rl/test_momentum.py
+++ b/tests/metta/rl/test_momentum.py
@@ -1,0 +1,16 @@
+import torch
+
+from metta.rl.rep.encoder import TCEncoder
+from metta.rl.rep.momentum import ema_update
+
+
+def test_ema_update_moves_towards_online() -> None:
+    online = TCEncoder(30, 16)
+    target = TCEncoder(30, 16)
+    with torch.no_grad():
+        for p in online.parameters():
+            p.add_(torch.randn_like(p) * 0.1)
+    before = sum((t - o).abs().sum().item() for t, o in zip(target.parameters(), online.parameters(), strict=False))
+    ema_update(target, online, tau=0.9)
+    after = sum((t - o).abs().sum().item() for t, o in zip(target.parameters(), online.parameters(), strict=False))
+    assert after < before

--- a/tests/metta/rl/test_tc_encoder.py
+++ b/tests/metta/rl/test_tc_encoder.py
@@ -1,0 +1,13 @@
+import torch
+
+from metta.rl.rep.encoder import TCEncoder
+
+
+def test_tc_encoder_shapes() -> None:
+    enc = TCEncoder(in_channels=30, latent_dim=256)
+    x = torch.randn(32, 11, 11, 30)
+    z = enc(x)
+    assert z.shape == (32, 256)
+    x2 = torch.randn(32, 30, 11, 11)
+    z2 = enc(x2)
+    assert z2.shape == (32, 256)

--- a/tests/metta/rl/test_tc_loss.py
+++ b/tests/metta/rl/test_tc_loss.py
@@ -1,0 +1,13 @@
+import torch
+
+from metta.rl.rep.tc_loss import cosine_tc
+
+
+def test_cosine_tc_monotonicity() -> None:
+    b, k, d = 16, 4, 32
+    tgts = torch.randn(b, k, d)
+    preds_bad = -tgts.clone()
+    preds_good = tgts.clone()
+    loss_bad = cosine_tc(preds_bad, tgts, gamma=0.99)
+    loss_good = cosine_tc(preds_good, tgts, gamma=0.99)
+    assert loss_good < loss_bad


### PR DESCRIPTION
## Summary
- implement TCEncoder, EMA update, latent dynamics head, and cosine TC loss
- add RepConfig to trainer configuration for temporal consistency schedule
- include unit tests for encoder, momentum updates, dynamics rollout, and integration stub

## Testing
- `uv run ruff format metta/rl/rep metta/rl/trainer_config.py tests/metta/rl`
- `uv run ruff check metta/rl/rep metta/rl/trainer_config.py tests/metta/rl`
- `PYENV_VERSION=3.11.12 uv run mypy metta/rl/rep metta/rl/trainer_config.py tests/metta/rl --ignore-missing-imports`
- `ub run pytest -q` *(fails: command not found)*
- `uv run pytest -q` *(fails: 5 failed, 909 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68957052bd58832e838dff27cf1677eb