### PR TITLE
Add representation learning module

### DIFF
--- a/metta/rl/modules.py
+++ b/metta/rl/modules.py
@@ -1,0 +1,40 @@
+"""Additional modules for representation learning."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+
+class ProjectionHead(nn.Module):
+    """MLP projection head for contrastive representation learning."""
+
+    def __init__(self, input_dim: int, proj_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, proj_dim),
+            nn.ReLU(),
+            nn.Linear(proj_dim, proj_dim),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.net(x)
+        return F.normalize(x, dim=-1)
+
+
+class DynamicsModel(nn.Module):
+    """Simple MLP dynamics model f(z_t, a_t) -> z_{t+1}."""
+
+    def __init__(self, latent_dim: int, action_dim: int, hidden_dim: int | None = None) -> None:
+        super().__init__()
+        hidden_dim = hidden_dim or latent_dim
+        self.net = nn.Sequential(
+            nn.Linear(latent_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, latent_dim),
+        )
+
+    def forward(self, z: Tensor, a: Tensor) -> Tensor:
+        x = torch.cat([z, a], dim=-1)
+        return self.net(x)

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -121,6 +121,19 @@ class TorchProfilerConfig(BaseModelWithForbidExtra):
         return self
 
 
+class RepresentationLearningConfig(BaseModelWithForbidExtra):
+    enabled: bool = False
+    lambda_contrast: float = Field(default=0.1, ge=0)
+    lambda_tc: float = Field(default=0.1, ge=0)
+    lambda_pred: float = Field(default=0.1, ge=0)
+    tau: float = Field(default=0.15, gt=0)
+    alpha: float = Field(default=0.8, ge=0, le=1.0)
+    num_negatives: int = Field(default=32, ge=0)
+    steps_per_batch: int = Field(default=1, ge=0)
+    loss_pred_type: Literal["cosine", "l2"] = "cosine"
+    loss_tc_type: Literal["cosine", "l2"] = "cosine"
+
+
 class TrainerConfig(BaseModelWithForbidExtra):
     # Core training parameters
     # Total timesteps: Type 2 arbitrary default
@@ -179,6 +192,9 @@ class TrainerConfig(BaseModelWithForbidExtra):
 
     # scheduler registry
     hyperparameter_scheduler: HyperparameterSchedulerConfig = Field(default_factory=HyperparameterSchedulerConfig)
+
+    # Representation learning
+    representation_learning: RepresentationLearningConfig = Field(default_factory=RepresentationLearningConfig)
 
     # Kickstart
     kickstart: KickstartConfig = Field(default_factory=KickstartConfig)

--- a/tests/metta/rl/test_rep_learning.py
+++ b/tests/metta/rl/test_rep_learning.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import torch
+
+from metta.rl.losses import RepresentationLoss
+from metta.rl.modules import DynamicsModel, ProjectionHead
+from metta.rl.trainer import rep_step
+from metta.rl.trainer_config import RepresentationLearningConfig
+
+
+def _make_rep_loss(
+    cfg: RepresentationLearningConfig | None = None,
+) -> tuple[RepresentationLoss, ProjectionHead, DynamicsModel]:
+    cfg = cfg or RepresentationLearningConfig()
+    proj = ProjectionHead(4, 4)
+    dyn = DynamicsModel(4, 2)
+    return RepresentationLoss(proj, dyn, cfg), proj, dyn
+
+
+def test_infonce_masking() -> None:
+    cfg = RepresentationLearningConfig()
+    rep_loss, _, _ = _make_rep_loss(cfg)
+    z = torch.randn(5, 2, 4)
+    mask = torch.ones(5, 2, dtype=torch.bool)
+    mask[-1, 0] = False
+    loss = rep_loss.compute_contrastive(z, mask)
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+
+
+def test_geometric_sampling_mean() -> None:
+    cfg = RepresentationLearningConfig(alpha=0.8)
+    rep_loss, _, _ = _make_rep_loss(cfg)
+    device = torch.device("cpu")
+    T = 1000
+    means = []
+    for _ in range(200):
+        ks = rep_loss.sample_positive_offsets(T, device)
+        means.append(ks.float().mean().item())
+    mean_k = sum(means) / len(means)
+    expected = cfg.alpha / (1 - cfg.alpha)
+    assert abs(mean_k - expected) < 0.5
+
+
+def test_tc_respects_dones() -> None:
+    cfg = RepresentationLearningConfig(loss_tc_type="l2")
+    rep_loss, _, _ = _make_rep_loss(cfg)
+    z = torch.tensor([[[0.0]], [[1.0]], [[10.0]], [[11.0]]])
+    mask = torch.tensor([[True], [True], [False], [True]])
+    loss = rep_loss.compute_tc(z, mask)
+    assert torch.allclose(loss, torch.tensor(1.0))
+
+
+def test_prediction_stopgrad() -> None:
+    cfg = RepresentationLearningConfig(loss_pred_type="l2")
+    rep_loss, _, _ = _make_rep_loss(cfg)
+    z = torch.randn(3, 1, 4, requires_grad=True)
+    a = torch.randn(3, 1, 2)
+    mask = torch.ones(3, 1, dtype=torch.bool)
+    loss = rep_loss.compute_pred(z, a, mask)
+    loss.backward()
+    assert z.grad is not None
+    assert torch.allclose(z.grad[-1], torch.zeros_like(z.grad[-1]))
+    assert z.grad[0].abs().sum() > 0
+
+
+def test_rep_step_freezes_policy_heads() -> None:
+    cfg = RepresentationLearningConfig()
+    rep_loss, proj, dyn = _make_rep_loss(cfg)
+
+    class SimplePolicy(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.encoder = torch.nn.Linear(3, 4)
+            self.actor = torch.nn.Linear(4, 2)
+            self.value = torch.nn.Linear(4, 1)
+
+        def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            z = self.encoder(x)
+            return z, self.actor(z), self.value(z)
+
+    policy = SimplePolicy()
+    policy_opt = torch.optim.Adam(policy.parameters(), lr=0.01)
+    rep_opt = torch.optim.Adam(
+        list(policy.encoder.parameters()) + list(proj.parameters()) + list(dyn.parameters()), lr=0.005
+    )
+
+    obs = torch.randn(4, 3)
+    z, logits, value = policy(obs)
+    target = torch.randint(0, 2, (4,))
+    policy_loss = torch.nn.functional.cross_entropy(logits, target)
+    value_loss = torch.nn.functional.mse_loss(value.squeeze(-1), torch.zeros_like(value.squeeze(-1)))
+    (policy_loss + value_loss).backward()
+    policy_opt.step()
+    policy_opt.zero_grad()
+
+    actor_before = {k: v.clone() for k, v in policy.actor.named_parameters()}
+    value_before = {k: v.clone() for k, v in policy.value.named_parameters()}
+    encoder_before = {k: v.clone() for k, v in policy.encoder.named_parameters()}
+    dyn_before = {k: v.clone() for k, v in dyn.named_parameters()}
+
+    z = policy.encoder(obs)
+    z_seq = z.view(2, 2, 4)
+    a_seq = torch.nn.functional.one_hot(target, num_classes=2).float().view(2, 2, 2)
+    mask = torch.ones(2, 2, dtype=torch.bool)
+    rep_step(rep_loss, rep_opt, z_seq, a_seq, mask, steps=1)
+
+    for k, v in policy.actor.named_parameters():
+        assert torch.allclose(v, actor_before[k])
+    for k, v in policy.value.named_parameters():
+        assert torch.allclose(v, value_before[k])
+
+    assert any(not torch.allclose(v, encoder_before[k]) for k, v in policy.encoder.named_parameters())
+    assert any(not torch.allclose(v, dyn_before[k]) for k, v in dyn.named_parameters())


### PR DESCRIPTION
## Summary
- add ProjectionHead and DynamicsModel modules
- implement RepresentationLoss with contrastive, temporal-consistency, and prediction terms
- integrate representation learning micro-step in trainer
- add configuration block and tests for rep learning

## Testing
- `ruff check metta/rl/modules.py metta/rl/losses.py metta/rl/trainer_config.py metta/rl/trainer.py tests/metta/rl/test_rep_learning.py`
- `mypy metta/rl/modules.py metta/rl/losses.py --ignore-missing-imports --follow-imports=skip`
- `ub run pytest -q tests/metta/rl/test_rep_learning.py` *(fails: command not found)*
- `uv run pytest -q tests/metta/rl/test_rep_learning.py`
- `ub run pytest -q` *(fails: command not found)*
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895751bb768832e8d8f7a47ea929470