### PR TITLE
devops/train.sh heartbeat python bug

### DIFF
--- a/devops/train.sh
+++ b/devops/train.sh
@@ -13,7 +13,7 @@ HEARTBEAT_TIMEOUT=${HEARTBEAT_TIMEOUT:-600} # Read from env or default to 600
 
 if [ "$HEARTBEAT_TIMEOUT" -ne 0 ]; then
   echo "[INFO] Starting heartbeat monitor with timeout ${HEARTBEAT_TIMEOUT}s for file $HEARTBEAT_FILE"
-  python -m metta.common.util.heartbeat monitor "$HEARTBEAT_FILE" --pid $$ --timeout "$HEARTBEAT_TIMEOUT" &
+  uv run python -m metta.common.util.heartbeat monitor "$HEARTBEAT_FILE" --pid $$ --timeout "$HEARTBEAT_TIMEOUT" &
   HEARTBEAT_PID=$!
   trap 'kill $HEARTBEAT_PID 2>/dev/null || true' EXIT
 else


### PR DESCRIPTION
this is so skypilot tasks (docker containers based on pufferlib image) will use the virtualenv we setup with uv when training in the cloud. without `uv run` the docker container will use the system python, which doesn't have our packages installed.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211004656395253)