### PR TITLE
improve dockerfile with a fix for pufferlib's virtualenv

### DIFF
--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /uvx /bin/
 WORKDIR /workspace/metta
 
 # Install dependencies
-ADD .python-version pyproject.toml uv.lock ./
+COPY .python-version pyproject.toml uv.lock ./
 COPY mettagrid/pyproject.toml mettagrid/
 COPY app_backend/pyproject.toml app_backend/
 COPY common/pyproject.toml common/
@@ -52,7 +52,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --no-install-workspace --frozen
 
 # Install sources
-ADD . .
+COPY . .
 
 # When building in CI, actions/checkout stores an auth token in .git/config that we need to remove
 RUN git config --remove-section http."https://github.com/" || true
@@ -67,6 +67,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-cache/${TARGETPLATFORM} \
     uv sync --locked
 
 ENV PATH="/workspace/metta/.venv/bin:$PATH"
+ENV VIRTUAL_ENV="/workspace/metta/.venv"
 
 RUN sed -i '\#cd /puffertank/pufferlib#d' /root/.bashrc \
  && echo 'cd /workspace/metta' >> /root/.bashrc


### PR DESCRIPTION
improved the dockerfile. this VIRTUAL_ENV environment variable stops skypilot tasks from printing warnings and should prevent future errors.