### PR TITLE
Fix to support torch compile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -537,7 +537,7 @@ jobs:
         continue-on-error: true
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          POLICY: wandb://run/m.av.replay.probe.601
+          POLICY: wandb://run/m.av.replay.probe.751
         run: |
           uv run .github/scripts/validate-wandb-run.py && echo "result=success" >> "$GITHUB_OUTPUT" || echo "result=skipped" >> "$GITHUB_OUTPUT"
 

--- a/agent/src/metta/agent/lib/lstm.py
+++ b/agent/src/metta/agent/lib/lstm.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import torch
 import torch.nn as nn
+from einops import rearrange
 from tensordict import TensorDict
 
 from metta.agent.lib.metta_layer import LayerBase
@@ -74,8 +75,7 @@ class LSTM(LayerBase):
         TT = td["bptt"][0]
         B = td["batch"][0]
 
-        h_size = hidden.shape[-1]
-        hidden = hidden.view(B, TT, h_size).transpose(0, 1)
+        hidden = rearrange(hidden, "(b t) h -> t b h", b=B, t=TT)
 
         training_env_id_start = td.get("training_env_id_start", torch.tensor([0]))[0].item()
 
@@ -98,7 +98,7 @@ class LSTM(LayerBase):
         self.lstm_h[training_env_id_start] = h_n.detach()
         self.lstm_c[training_env_id_start] = c_n.detach()
 
-        hidden = hidden.transpose(0, 1).reshape(B * TT, h_size)
+        hidden = rearrange(hidden, "t b h -> (b t) h")
 
         td[self._name] = hidden
 

--- a/agent/src/metta/agent/lib/lstm.py
+++ b/agent/src/metta/agent/lib/lstm.py
@@ -72,15 +72,13 @@ class LSTM(LayerBase):
     def _forward(self, td: TensorDict):
         hidden = td[self._sources[0]["name"]]  # → (2, num_layers, batch, hidden_size)
 
-        TT = td.bptt
-        B = td.batch
+        TT = td["bptt"]
+        B = td["batch"]
 
         hidden = rearrange(hidden, "(b t) h -> t b h", b=B, t=TT)
 
-        if hasattr(td, "training_env_id"):
-            training_env_id = td.training_env_id.start
-        else:
-            training_env_id = 0
+        raw_training_env_id = td.get("training_env_id")
+        training_env_id = raw_training_env_id.data.start if raw_training_env_id is not None else 0
 
         if training_env_id in self.lstm_h and training_env_id in self.lstm_c:
             h_0 = self.lstm_h[training_env_id]

--- a/agent/src/metta/agent/lib/obs_token_to_box_shaper.py
+++ b/agent/src/metta/agent/lib/obs_token_to_box_shaper.py
@@ -54,7 +54,7 @@ class ObsTokenToBoxShaper(LayerBase):
             dtype=atr_values.dtype,
             device=token_observations.device,
         )
-        batch_indices = torch.arange(B_TT, device=token_observations.device).unsqueeze(-1).expand_as(atr_values)
+        # Create mask for valid tokens
 
         valid_tokens = coords_byte != 0xFF
 
@@ -73,12 +73,22 @@ class ObsTokenToBoxShaper(LayerBase):
                 stacklevel=2,
             )
 
-        box_obs[
-            batch_indices[valid_mask],
-            atr_indices[valid_mask],
-            x_coord_indices[valid_mask],
-            y_coord_indices[valid_mask],
-        ] = atr_values[valid_mask]
+        # Use scatter-based write to avoid multi-dim advanced indexing that triggers index_put_
+        # Compute flattened spatial index and a combined index that encodes (layer, x, y)
+        flat_spatial_index = x_coord_indices * self.out_height + y_coord_indices  # [B_TT, M]
+        dim_per_layer = self.out_width * self.out_height
+        combined_index = atr_indices * dim_per_layer + flat_spatial_index  # [B_TT, M]
+
+        # Mask out invalid entries by directing them to index 0 with value 0
+        safe_index = torch.where(valid_mask, combined_index, torch.zeros_like(combined_index))
+        safe_values = torch.where(valid_mask, atr_values, torch.zeros_like(atr_values))
+
+        # Scatter values into a flattened buffer, then reshape to [B_TT, L, W, H]
+        box_flat = torch.zeros(
+            (B_TT, self.num_layers * dim_per_layer), dtype=atr_values.dtype, device=token_observations.device
+        )
+        box_flat.scatter_(1, safe_index, safe_values)
+        box_obs = box_flat.view(B_TT, self.num_layers, self.out_width, self.out_height)
 
         td[self._name] = box_obs
         return td

--- a/agent/src/metta/agent/metta_agent.py
+++ b/agent/src/metta/agent/metta_agent.py
@@ -434,8 +434,16 @@ class MettaAgent(nn.Module):
             - In inference mode, this contains data to be stored in the experience buffer.
             - In training mode, this contains data for loss calculation.
         """
-
-        td, B, TT = self._reshape_td(td)
+        if td.batch_dims > 1:
+            B, TT = td.batch_size[0], td.batch_size[1]
+            td = td.reshape(B * TT)
+            td.set("bptt", torch.full((B * TT,), TT, device=td.device, dtype=torch.long))
+            td.set("batch", torch.full((B * TT,), B, device=td.device, dtype=torch.long))
+        else:
+            B = td.batch_size.numel()
+            TT = 1
+            td.set("bptt", torch.full((B,), 1, device=td.device, dtype=torch.long))
+            td.set("batch", torch.full((B,), B, device=td.device, dtype=torch.long))
 
         # Forward pass through value network. This will also run the core network.
         self.components["_value_"](td)
@@ -452,21 +460,6 @@ class MettaAgent(nn.Module):
             output_td = output_td.reshape(B, TT)
 
         return output_td
-
-    @torch.compile(disable=True)
-    def _reshape_td(self, td: TensorDict) -> tuple[TensorDict, int, int]:
-        """This is entirely to allow torch compile to work."""
-        if td.batch_dims > 1:
-            B, TT = td.batch_size[0], td.batch_size[1]
-            td = td.reshape(B * TT)
-            td.set("bptt", torch.full((B * TT,), TT, device=td.device, dtype=torch.long))
-            td.set("batch", torch.full((B * TT,), B, device=td.device, dtype=torch.long))
-        else:
-            B = td.batch_size.numel()
-            TT = 1
-            td.set("bptt", torch.full((B,), 1, device=td.device, dtype=torch.long))
-            td.set("batch", torch.full((B,), B, device=td.device, dtype=torch.long))
-        return td, B, TT
 
     def _convert_action_to_logit_index(self, flattened_action: torch.Tensor) -> torch.Tensor:
         """

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -70,7 +70,7 @@ bptt_horizon: 64
 update_epochs: 1
 
 cpu_offload: false
-compile: true
+compile: false
 compile_mode: reduce-overhead
 profiler:
   interval_epochs: 10000

--- a/configs/trainer/trainer.yaml
+++ b/configs/trainer/trainer.yaml
@@ -70,7 +70,7 @@ bptt_horizon: 64
 update_epochs: 1
 
 cpu_offload: false
-compile: false
+compile: true
 compile_mode: reduce-overhead
 profiler:
   interval_epochs: 10000

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -33,7 +33,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 2501
+run_id: 2502
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -4,10 +4,10 @@ seed: null
 
 defaults:
   # - override /env/mettagrid@env: simple
-  - override /agent: fast
+  # - override /agent: fast
   - _self_
 
-policy_uri: pytorch:///tmp/puffer_metta.pt
+policy_uri: wandb://run/m.av.replay.probe.601
 npc_policy_uri: null
 
 # env_overrides:
@@ -33,7 +33,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 2405
+run_id: 2501
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -33,7 +33,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 2502
+run_id: 2601
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/configs/user/alex.yaml
+++ b/configs/user/alex.yaml
@@ -33,7 +33,7 @@ wandb:
   enabled: true
   # checkpoint_interval: 1
 
-run_id: 2601
+run_id: 2708
 run: ${oc.env:USER}.local.${run_id}
 trained_policy_uri: ${run_dir}/checkpoints
 sweep_name: "${oc.env:USER}.local.sweep.${run_id}"

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -8,7 +8,6 @@ import torch
 import torch.distributed
 from heavyball import ForeachMuon
 from omegaconf import DictConfig, OmegaConf
-from tensordict import NonTensorData
 from torchrl.data import Composite
 
 from metta.agent.metta_agent import PolicyAgent
@@ -313,7 +312,15 @@ def train(
                     td["rewards"] = r
                     td["dones"] = d.float()
                     td["truncateds"] = t.float()
-                    td.set("training_env_id", NonTensorData(training_env_id))
+                    td.set(
+                        "training_env_id_start",
+                        torch.full(
+                            td.batch_size,
+                            training_env_id.start,
+                            device=td.device,
+                            dtype=torch.long,
+                        ),
+                    )
 
                     # Inference
                     with torch.no_grad():

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed
 from heavyball import ForeachMuon
 from omegaconf import DictConfig, OmegaConf
+from tensordict import NonTensorData
 from torchrl.data import Composite
 
 from metta.agent.metta_agent import PolicyAgent
@@ -312,7 +313,7 @@ def train(
                     td["rewards"] = r
                     td["dones"] = d.float()
                     td["truncateds"] = t.float()
-                    td.training_env_id = training_env_id
+                    td.set("training_env_id", NonTensorData(training_env_id))
 
                     # Inference
                     with torch.no_grad():


### PR DESCRIPTION
Adjusted how non-tensor information is stored in the tensordict. Code is longer but it's what's needed to support compile. Note that I tried NonTensorData but compile caused it to hang - no error message. Switched back to viewing the data as a tensor with the appropriate size. Requires more lines of code but works.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211010867626691)