### PR TITLE
Add IRSA support for orchestrator service account

### DIFF
--- a/app_backend/src/metta/app_backend/container_managers/k8s.py
+++ b/app_backend/src/metta/app_backend/container_managers/k8s.py
@@ -41,6 +41,7 @@ class K8sPodManager(AbstractContainerManager):
             },
             "spec": {
                 "restartPolicy": "Never",
+                "serviceAccountName": os.getenv("KUBERNETES_SERVICE_ACCOUNT", f"orchestrator-{self._namespace}"),
                 "containers": [
                     {
                         "name": "eval-worker",

--- a/devops/charts/orchestrator/templates/deployment.yaml
+++ b/devops/charts/orchestrator/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SERVICE_ACCOUNT
+          value: {{ include "orchestrator.serviceAccountName" . }}
         - name: WANDB_API_KEY
           valueFrom:
             secretKeyRef:

--- a/devops/charts/orchestrator/templates/serviceaccount.yaml
+++ b/devops/charts/orchestrator/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ include "orchestrator.fullname" . }}
   labels:
     {{- include "orchestrator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/devops/charts/orchestrator/values.yaml
+++ b/devops/charts/orchestrator/values.yaml
@@ -8,6 +8,8 @@ image:
 
 serviceAccount:
   create: true
+  annotations: {}
+  # Fill this in with the role ARN from orchestrator_irsa_role_arn once Terraform is applied
 
 env:
   BACKEND_URL: "https://api.observatory.softmax-research.net"

--- a/devops/charts/orchestrator/values.yaml
+++ b/devops/charts/orchestrator/values.yaml
@@ -8,8 +8,8 @@ image:
 
 serviceAccount:
   create: true
-  annotations: {}
-  # Fill this in with the role ARN from orchestrator_irsa_role_arn once Terraform is applied
+  annotations:
+    eks.amazonaws.com/role-arn: # Fill this in with the role ARN from orchestrator_irsa_role_arn once Terraform is applied
 
 env:
   BACKEND_URL: "https://api.observatory.softmax-research.net"

--- a/devops/charts/orchestrator/values.yaml
+++ b/devops/charts/orchestrator/values.yaml
@@ -9,7 +9,7 @@ image:
 serviceAccount:
   create: true
   annotations:
-    eks.amazonaws.com/role-arn: # Fill this in with the role ARN from orchestrator_irsa_role_arn once Terraform is applied
+    eks.amazonaws.com/role-arn: arn:aws:iam::751442549699:role/orchestrator-eval-worker
 
 env:
   BACKEND_URL: "https://api.observatory.softmax-research.net"

--- a/devops/tf/eks/orchestrator.tf
+++ b/devops/tf/eks/orchestrator.tf
@@ -1,0 +1,44 @@
+# IRSA role for orchestrator and eval workers to access S3
+module "orchestrator_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.34"
+
+  role_name = "orchestrator-eval-worker"
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["orchestrator:orchestrator-orchestrator"]
+    }
+  }
+
+  role_policy_arns = {
+    policy = aws_iam_policy.orchestrator_s3.arn
+  }
+}
+
+resource "aws_iam_policy" "orchestrator_s3" {
+  name = "orchestrator-s3-access"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::softmax-public/*",
+        ]
+      }
+    ]
+  })
+}
+
+# Output the role ARN for reference
+output "orchestrator_irsa_role_arn" {
+  value = module.orchestrator_irsa.iam_role_arn
+  description = "ARN of the IAM role for orchestrator service account"
+}

--- a/devops/tf/eks/orchestrator.tf
+++ b/devops/tf/eks/orchestrator.tf
@@ -30,6 +30,7 @@ resource "aws_iam_policy" "orchestrator_s3" {
           "s3:ListBucket",
         ]
         Resource = [
+          "arn:aws:s3:::softmax-public",
           "arn:aws:s3:::softmax-public/*",
         ]
       }


### PR DESCRIPTION
Policy evaluator workers were briefly able to write replays to s3 -- see https://wandb.ai/metta-research/metta/runs/nishad.test-policy-eval-0810.local-run.2?nw=nwusernishadsingh

But now (possibly due to a redeploy? but i'm not certain) they don't. They have aws perms inherited from the eks node, which don't include s3 read/write permissions.

I'm not confident this is the right way to solve the issue, but this PR:
  - Add serviceAccountName to worker pods
  - Pass service account name from orchestrator to workers
  - Add tf files for an orchestrator IRSA with S3 access

After terraform is applied, we'd update the devops/charts/orchestrator/values.yaml with the role ARN

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211014722294346)