### PR TITLE
Improve metta install wandb and aws for softmax-docker

### DIFF
--- a/metta/setup/components/aws.py
+++ b/metta/setup/components/aws.py
@@ -1,6 +1,7 @@
 import json
 
 from metta.setup.components.base import SetupModule
+from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
 from metta.setup.utils import info
 
@@ -31,7 +32,11 @@ class AWSSetup(SetupModule):
         return result.returncode == 0
 
     def install(self) -> None:
-        if self.config.user_type.is_softmax:
+        if self.config.user_type == UserType.SOFTMAX_DOCKER:
+            info("AWS access for this profile should be provided via IAM roles or environment variables.")
+            info("Skipping AWS profile setup.")
+            return
+        if self.config.user_type == UserType.SOFTMAX:
             info("""
                 Your AWS access should have been provisioned.
                 If you don't have access, contact your team lead.

--- a/metta/setup/components/aws.py
+++ b/metta/setup/components/aws.py
@@ -1,5 +1,3 @@
-import os
-
 from metta.setup.components.base import SetupModule
 from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
@@ -52,15 +50,8 @@ class AWSSetup(SetupModule):
         try:
             import boto3
 
-            # Unset AWS_PROFILE temporarily to use IRSA/instance credentials if available
-            original_profile = os.environ.pop("AWS_PROFILE", None)
-            try:
-                sts = boto3.client("sts")
-                response = sts.get_caller_identity()
-                return response["Account"]
-            finally:
-                # Restore AWS_PROFILE if it was set
-                if original_profile:
-                    os.environ["AWS_PROFILE"] = original_profile
+            sts = boto3.client("sts")
+            response = sts.get_caller_identity()
+            return response["Account"]
         except Exception:
             return None

--- a/metta/setup/components/wandb.py
+++ b/metta/setup/components/wandb.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 from metta.setup.components.base import SetupModule
+from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
 from metta.setup.utils import info, success, warning
 
@@ -35,13 +36,16 @@ class WandbSetup(SetupModule):
             success("W&B already configured")
             return
 
-        if self.config.user_type.is_softmax:
+        if self.config.user_type == UserType.SOFTMAX:
             info("""
                 Your Weights & Biases access should have been provisioned.
                 If you don't have access, contact your team lead.
 
                 Visit https://wandb.ai/authorize to get your API key.
             """)
+        elif self.config.user_type == UserType.SOFTMAX_DOCKER:
+            info("Weights & Biases access should be provided via environment variables.")
+            info("Skipping W&B setup.")
         else:
             info("""
                 To use Weights & Biases, you'll need an account.


### PR DESCRIPTION
Metta install for softmax-docker profile should install wandb and aws and verify access. But should not go through interactive setup

Motivated by AWS_PROFILE being set by setup_aws_profiles.sh on eval task workers; not needed/got in the way because they're granted permissions through iam role

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211014567120578)