### PR TITLE
remove mapgen dependency in mettagrid

### DIFF
--- a/mettagrid/tests/test_bucketed_config.yaml
+++ b/mettagrid/tests/test_bucketed_config.yaml
@@ -10,19 +10,13 @@ env_cfg_template:
       - thing_2
 
     map_builder:
-      _target_: metta.map.mapgen.MapGen
+      _target_: metta.mettagrid.room.random.Random
       width: 30 # This will be overridden by buckets
       height: 30 # This will be overridden by buckets
-      border_width: 2
-
-      root:
-        type: metta.map.scenes.maze.Maze
-        params:
-          algorithm: kruskal
-          room_size: 2 # This will be overridden by buckets
-          wall_size: 1
+      objects:
+        altar: 1
 
 buckets:
   game.map_builder.width: [20, 40, 60]
   game.map_builder.height: [20, 40, 60]
-  game.map_builder.root.params.room_size: [1, 3, 5]
+  game.map_builder.objects.altar: [1, 3, 5]

--- a/mettagrid/tests/test_curriculum.py
+++ b/mettagrid/tests/test_curriculum.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig, OmegaConf
 
-from metta.map.mapgen import MapGen
+import metta.mettagrid.room.random
 from metta.mettagrid.curriculum.bucketed import BucketedCurriculum, _expand_buckets
 from metta.mettagrid.curriculum.core import Curriculum, SingleTaskCurriculum
 from metta.mettagrid.curriculum.learning_progress import LearningProgressCurriculum
@@ -147,16 +147,16 @@ def test_bucketed_curriculum_from_yaml_with_map_builder():
     task_id = task.id()
     assert "width=" in task_id, f"Task ID should contain width parameter: {task_id}"
     assert "height=" in task_id, f"Task ID should contain height parameter: {task_id}"
-    assert "room_size=" in task_id, f"Task ID should contain room_size parameter: {task_id}"
+    assert "altar=" in task_id, f"Task ID should contain altar parameter: {task_id}"
 
     # Verify the task config structure is correct
     task_cfg = task.env_cfg()
     assert hasattr(task_cfg.game, "map_builder")
-    assert isinstance(task_cfg.game.map_builder, MapGen)
+    assert isinstance(task_cfg.game.map_builder, metta.mettagrid.room.random.Random)
     assert task_cfg.game.num_agents == 5, f"num_agents should have been overridden to 5, got {task_cfg.game.num_agents}"
-    assert task_cfg.game.map_builder.params.width in [20, 40, 60]
-    assert task_cfg.game.map_builder.params.height in [20, 40, 60]
-    assert task_cfg.game.map_builder.root["params"]["room_size"] in [1, 3, 5]
+    assert task_cfg.game.map_builder._width in [20, 40, 60]
+    assert task_cfg.game.map_builder._height in [20, 40, 60]
+    assert task_cfg.game.map_builder._objects.altar in [1, 3, 5]
 
 
 def test_expand_buckets_values_and_range():


### PR DESCRIPTION
# Replace MapGen with Random Room Generator in Bucketed Curriculum

### TL;DR

Replace the maze-based map generator with a random room generator in the bucketed curriculum test configuration.

### What changed?

- Updated `test_bucketed_config.yaml` to use `metta.mettagrid.room.random.Random` instead of the maze-based `metta.map.mapgen.MapGen`
- Changed the bucketed parameter from `room_size` to `altar` count
- Updated the corresponding test assertions in `test_curriculum.py` to check for the new parameters and class types

### How to test?

Run the curriculum tests to verify that the bucketed curriculum correctly handles the new random room generator:

```bash
pytest mettagrid/tests/test_curriculum.py::test_bucketed_curriculum_from_yaml_with_map_builder
```

### Why make this change?

This change aligns the test configuration with the current architecture that uses the random room generator instead of the maze generator. It ensures that the bucketed curriculum functionality works correctly with the updated map generation approach.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211018346678039)