### PR TITLE
fix: Add timeout for `torch.distributed.barrier()`

### DIFF
--- a/common/src/metta/common/util/lock.py
+++ b/common/src/metta/common/util/lock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import timedelta
 from typing import Callable, TypeVar
 
 import torch.distributed as dist
@@ -18,6 +19,7 @@ def _init_process_group() -> bool:
     rank = int(os.environ.get("RANK", os.environ.get("NODE_INDEX", "0")))
     dist.init_process_group(
         backend="nccl",
+        timeout=timedelta(seconds=30),
         init_method=os.environ.get("DIST_URL", "env://"),
         world_size=world_size,
         rank=rank,
@@ -25,7 +27,7 @@ def _init_process_group() -> bool:
     return True
 
 
-def run_once(fn: Callable[[], T]) -> T:
+def run_once(fn: Callable[[], T]) -> T | None:
     """Run ``fn`` only on rank 0 and broadcast the result.
 
     If ``torch.distributed`` is not initialized, this function will attempt to


### PR DESCRIPTION

* Adds a 30-second timeout to `torch.distributed.init_process_group`, ensuring `torch.distributed.barrier()` will not hang indefinitely in case of stalled ranks.
* Updated `run_once` to return `T | None` to accurately reflect that no result may be returned when not running on rank 0.

This change improves fault tolerance in distributed runs and clarifies type annotations.
