### PR TITLE
[MettaScope] improve string validation

### DIFF
--- a/mettagrid/src/metta/mettagrid/replay_writer.py
+++ b/mettagrid/src/metta/mettagrid/replay_writer.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from metta.mettagrid.core import MettaGridCore
-
 import json
+import logging
 import zlib
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from metta.mettagrid.grid_object_formatter import format_grid_object
 from metta.mettagrid.util.file import http_url, write_data
+
+if TYPE_CHECKING:
+    from metta.mettagrid.core import MettaGridCore
+
+
+logger = logging.getLogger("ReplayWriter")
 
 
 class ReplayWriter:
@@ -115,9 +118,18 @@ class EpisodeReplay:
 
     @staticmethod
     def _validate_non_empty_string_list(values: list[str], field_name: str) -> None:
-        """Ensure the provided iterable is a list of non-empty strings."""
+        """Ensure the provided iterable is a list of strings, warn on empty strings with index."""
         if not isinstance(values, list):
             raise ValueError(f"{field_name} must be a list of strings, got {type(values)}")
         for index, value in enumerate(values):
-            if not isinstance(value, str) or value == "":
-                raise ValueError(f"{field_name}[{index}] must be a non-empty string, got {repr(value)}")
+            if not isinstance(value, str):
+                raise ValueError(f"{field_name}[{index}] must be a string, got {type(value)}: {repr(value)}")
+            if value == "":
+                logger.warning(
+                    (
+                        "%s contains an empty string at index %d; "
+                        "frontend tolerates empty names but backend discourages them"
+                    ),
+                    field_name,
+                    index,
+                )

--- a/mettagrid/src/metta/mettagrid/replay_writer.py
+++ b/mettagrid/src/metta/mettagrid/replay_writer.py
@@ -45,6 +45,11 @@ class EpisodeReplay:
         self.step = 0
         self.objects = []
         self.total_rewards = np.zeros(env.num_agents)
+
+        self._validate_non_empty_string_list(env.action_names, "action_names")
+        self._validate_non_empty_string_list(env.inventory_item_names, "item_names")
+        self._validate_non_empty_string_list(env.object_type_names, "type_names")
+
         self.replay_data = {
             "version": 2,
             "action_names": env.action_names,
@@ -107,3 +112,12 @@ class EpisodeReplay:
         compressed_data = zlib.compress(replay_bytes)  # Compress the bytes
 
         write_data(path, compressed_data, content_type="application/x-compress")
+
+    @staticmethod
+    def _validate_non_empty_string_list(values: list[str], field_name: str) -> None:
+        """Ensure the provided iterable is a list of non-empty strings."""
+        if not isinstance(values, list):
+            raise ValueError(f"{field_name} must be a list of strings, got {type(values)}")
+        for index, value in enumerate(values):
+            if not isinstance(value, str) or value == "":
+                raise ValueError(f"{field_name}[{index}] must be a non-empty string, got {repr(value)}")

--- a/mettascope/src/agentpanel.ts
+++ b/mettascope/src/agentpanel.ts
@@ -361,6 +361,9 @@ export function updateAvailableColumns() {
 
 /** Get the amount of an item in the inventory. */
 function getInventoryAmount(agent: any, itemName: string, step: number) {
+  if (itemName === '') {
+    throw new Error('Item name must be a non-empty string')
+  }
   const itemId = state.replay.itemNames.indexOf(itemName)
   const inventory = agent.inventory.get(step)
   for (const [inventoryId, inventoryAmount] of inventory) {
@@ -374,6 +377,9 @@ function getInventoryAmount(agent: any, itemName: string, step: number) {
 
 /** Try to load a value from the agent or return 0. */
 function getColumnValue(agent: any, field: string, step: number) {
+  if (field === '') {
+    throw new Error('Field name must be a non-empty string')
+  }
   if (state.replay.itemNames.includes(field)) {
     return getInventoryAmount(agent, field, step)
   }

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -673,6 +673,9 @@ export function sendAction(actionName: string, actionParam: number) {
   if (state.selectedGridObject === null) {
     return
   }
+  if (actionName === '') {
+    throw new Error('Action name must be a non-empty string')
+  }
   const agentId = state.selectedGridObject.agentId
   if (agentId != null) {
     const actionId = state.replay.actionNames.indexOf(actionName)
@@ -711,6 +714,9 @@ export function propertyName(key: string) {
 
 /** Gets the icon of a resource, type or any other property. */
 export function propertyIcon(key: string) {
+  if (key === '') {
+    console.error('propertyIcon() called with empty string!')
+  }
   if (state.replay.typeNames.includes(key)) {
     return `data/atlas/objects/${key}.png`
   } else if (state.replay.itemNames.includes(key)) {

--- a/mettascope/src/validation.ts
+++ b/mettascope/src/validation.ts
@@ -55,7 +55,12 @@ function validateNonNegativeNumber(value: any, fieldName: string, issues: Valida
   }
 }
 
-function validateStringList(lst: any, fieldName: string, issues: ValidationIssue[], allowEmpty: boolean = false): void {
+function validateStringList(
+  lst: any,
+  fieldName: string,
+  issues: ValidationIssue[],
+  allowEmpty: boolean = false
+): void {
   validateType(lst, 'array', fieldName, issues)
 
   if (Array.isArray(lst)) {
@@ -64,8 +69,8 @@ function validateStringList(lst: any, fieldName: string, issues: ValidationIssue
     }
 
     for (const item of lst) {
-      if (typeof item !== 'string' || item === '') {
-        issues.push({ message: `'${fieldName}' must contain non-empty strings`, field: fieldName })
+      if (typeof item !== 'string') {
+        issues.push({ message: `'${fieldName}' must contain strings`, field: fieldName })
         break
       }
     }


### PR DESCRIPTION
- assert that types, items and actions do not have empty string names (very confusing)
- on the frontend, throw errors if we try to use invalid string names (if empty strings exist in a replay we shouldn't fail, but if they get used, that's a problem as we don't know how to handle them properly)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211028949817335)