### PR TITLE
refactor:  Introduce EnvConfig, i.e. pydantic-based MettaGrid env configuation

### DIFF
--- a/agent/src/metta/agent/metta_agent.py
+++ b/agent/src/metta/agent/metta_agent.py
@@ -20,12 +20,12 @@ from metta.rl.env_config import EnvConfig
 from metta.rl.puffer_policy import PytorchAgent
 
 if TYPE_CHECKING:
-    from metta.mettagrid import MettaGridEnv
+    from metta.mettagrid import CurriculumEnv
 
 logger = logging.getLogger("metta_agent")
 
 
-def make_policy(env: "MettaGridEnv", env_cfg: EnvConfig, agent_cfg: DictConfig) -> "MettaAgent":
+def make_policy(env: "CurriculumEnv", env_cfg: EnvConfig, agent_cfg: DictConfig) -> "MettaAgent":
     obs_space = gym.spaces.Dict(
         {
             "grid_obs": env.single_observation_space,

--- a/common/src/metta/common/util/mettagrid_cfgs.py
+++ b/common/src/metta/common/util/mettagrid_cfgs.py
@@ -115,7 +115,7 @@ class MettagridCfgFile:
             with hydra.initialize(config_path="../../../../../configs", version_base=None):
                 curriculum = curriculum_from_config_path(hydra_path, OmegaConf.create({}))
             task = curriculum.get_task()
-            map_cfg = task.original_env_cfg().game.map_builder
+            map_cfg = task.unresolved_dict_cfg().game.map_builder
         else:
             raise ValueError(f"Config {self.metadata.path} is not a map or env")
 

--- a/metta/map/load.py
+++ b/metta/map/load.py
@@ -5,7 +5,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from metta.map.scene import make_scene
 from metta.map.utils.storable_map import StorableMap
-from metta.mettagrid.level_builder import Level
+from metta.mettagrid.level_builder import LevelMap
 from metta.mettagrid.room.room import Room
 
 from .types import Area, SceneCfg
@@ -41,4 +41,4 @@ class Load(Room):
             root_scene = make_scene(self._extra_root, area, rng=np.random.default_rng())
             root_scene.render_with_children()
 
-        return Level(grid=grid, labels=[])
+        return LevelMap(grid=grid, labels=[])

--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -10,7 +10,7 @@ from metta.map.scenes.copy_grid import CopyGrid
 from metta.map.scenes.room_grid import RoomGrid, RoomGridParams
 from metta.map.scenes.transplant_scene import TransplantScene
 from metta.map.types import MapGrid
-from metta.mettagrid.level_builder import Level, LevelBuilder
+from metta.mettagrid.level_builder import LevelBuilder, LevelMap
 
 from .types import Area, AreaWhere, ChildrenAction, SceneCfg
 
@@ -319,7 +319,7 @@ class MapGen(LevelBuilder):
         else:
             labels.append("large")
 
-        return Level(self.grid, labels=labels)
+        return LevelMap(self.grid, labels=labels)
 
     def get_scene_tree(self) -> dict:
         return self.root_scene.get_scene_tree()

--- a/metta/map/terrain_from_numpy.py
+++ b/metta/map/terrain_from_numpy.py
@@ -9,7 +9,7 @@ from botocore.exceptions import NoCredentialsError
 from filelock import FileLock
 
 from metta.common.util.config import Config
-from metta.mettagrid.level_builder import Level, LevelBuilder
+from metta.mettagrid.level_builder import LevelBuilder, LevelMap
 
 logger = logging.getLogger(__name__)
 
@@ -153,4 +153,4 @@ class TerrainFromNumpy(LevelBuilder):
                 grid[pos] = obj_name
                 valid_positions_set.remove(pos)
 
-        return Level(grid=grid, labels=self.get_labels())
+        return LevelMap(grid=grid, labels=self.get_labels())

--- a/metta/map/utils/show.py
+++ b/metta/map/utils/show.py
@@ -9,6 +9,7 @@ import mettascope.server
 from metta.common.util.config import config_from_path
 from metta.map.utils.storable_map import StorableMap, grid_to_lines
 from metta.mettagrid import AutoResetEnv
+from metta.mettagrid.config import EnvConfig
 from metta.mettagrid.level_builder import LevelMap
 from metta.sim.map_preview import write_local_map_preview
 
@@ -31,8 +32,6 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
 
         level = LevelMap(storable_map.grid, [])
         # Create EnvConfig from the DictConfig and LevelMap
-        from metta.mettagrid.config import EnvConfig
-
         env_config = EnvConfig.from_dict_config(env_cfg)
         env_config.level_map = level
         env = AutoResetEnv(env_config=env_config, render_mode="none")

--- a/metta/map/utils/show.py
+++ b/metta/map/utils/show.py
@@ -8,9 +8,8 @@ from omegaconf.omegaconf import OmegaConf
 import mettascope.server
 from metta.common.util.config import config_from_path
 from metta.map.utils.storable_map import StorableMap, grid_to_lines
-from metta.mettagrid import MettaGridEnv
-from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.level_builder import Level
+from metta.mettagrid import AutoResetEnv
+from metta.mettagrid.level_builder import LevelMap
 from metta.sim.map_preview import write_local_map_preview
 
 ShowMode = Literal["mettascope", "ascii", "ascii_border", "none"]
@@ -30,8 +29,13 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
         OmegaConf.resolve(env_cfg)
         assert isinstance(env_cfg, DictConfig)
 
-        level = Level(storable_map.grid, [])
-        env = MettaGridEnv(SingleTaskCurriculum("show_map", env_cfg), level=level, render_mode="none")
+        level = LevelMap(storable_map.grid, [])
+        # Create EnvConfig from the DictConfig and LevelMap
+        from metta.mettagrid.config import EnvConfig
+
+        env_config = EnvConfig.from_dict_config(env_cfg)
+        env_config.level_map = level
+        env = AutoResetEnv(env_config=env_config, render_mode="none")
 
         file_path = write_local_map_preview(env)
 

--- a/metta/rl/checkpoint_manager.py
+++ b/metta/rl/checkpoint_manager.py
@@ -16,7 +16,7 @@ from metta.common.util.fs import wait_for_file
 from metta.common.util.heartbeat import record_heartbeat
 from metta.common.wandb.wandb_context import WandbRun
 from metta.eval.eval_request_config import EvalRewardSummary
-from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.mettagrid import CurriculumEnv
 from metta.rl.env_config import EnvConfig
 from metta.rl.kickstarter import Kickstarter
 from metta.rl.policy_management import cleanup_old_policies, validate_policy_environment_match
@@ -174,7 +174,7 @@ class CheckpointManager:
         env_cfg: EnvConfig,
         trainer_cfg: TrainerConfig,
         checkpoint: TrainerCheckpoint | None,
-        metta_grid_env: MettaGridEnv,
+        metta_grid_env: CurriculumEnv,
     ) -> PolicyRecord:
         """
         Load or initialize policy with distributed coordination.

--- a/metta/rl/kickstarter.py
+++ b/metta/rl/kickstarter.py
@@ -4,7 +4,7 @@ from torch import Tensor, nn
 
 from metta.agent.metta_agent import PolicyAgent
 from metta.agent.policy_store import PolicyStore
-from metta.mettagrid import MettaGridEnv
+from metta.mettagrid import CurriculumEnv
 from metta.rl.kickstarter_config import KickstartConfig, KickstartTeacherConfig
 
 
@@ -20,7 +20,7 @@ class KickstartTeacher:
 
 class Kickstarter:
     def __init__(
-        self, cfg: KickstartConfig, device: torch.device, policy_store: PolicyStore, metta_grid_env: MettaGridEnv
+        self, cfg: KickstartConfig, device: torch.device, policy_store: PolicyStore, metta_grid_env: CurriculumEnv
     ):
         """
         Kickstarting is a technique to initialize a student policy with the knowledge of one or more teacher policies.

--- a/metta/rl/policy_management.py
+++ b/metta/rl/policy_management.py
@@ -7,14 +7,14 @@ import torch
 
 from metta.agent.metta_agent import DistributedMettaAgent, MettaAgent, PolicyAgent
 from metta.agent.policy_record import PolicyRecord
-from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.mettagrid import CurriculumEnv
 
 logger = logging.getLogger(__name__)
 
 
 def initialize_policy_for_environment(
     policy_record: PolicyRecord,
-    metta_grid_env: MettaGridEnv,
+    metta_grid_env: CurriculumEnv,
     device: torch.device,
     restore_feature_mapping: bool = True,
 ) -> None:
@@ -55,7 +55,7 @@ def cleanup_old_policies(checkpoint_dir: str, keep_last_n: int = 5) -> None:
         logger.warning(f"Error during policy cleanup: {e}")
 
 
-def validate_policy_environment_match(policy: PolicyAgent, env: MettaGridEnv) -> None:
+def validate_policy_environment_match(policy: PolicyAgent, env: CurriculumEnv) -> None:
     """Validate that policy's observation shape matches environment's."""
     # Extract agent from distributed wrapper if needed
     if isinstance(policy, MettaAgent):

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -23,7 +23,7 @@ from metta.core.monitoring import (
 )
 from metta.eval.eval_request_config import EvalRewardSummary
 from metta.eval.eval_service import evaluate_policy
-from metta.mettagrid import MettaGridEnv, dtype_actions
+from metta.mettagrid import CurriculumEnv, dtype_actions
 from metta.mettagrid.curriculum.util import curriculum_from_config_path
 from metta.rl.advantage import compute_advantage
 from metta.rl.checkpoint_manager import CheckpointManager, maybe_establish_checkpoint
@@ -131,7 +131,7 @@ def train(
 
     vecenv.async_reset(env_cfg.seed + rank)
 
-    metta_grid_env: MettaGridEnv = vecenv.driver_env  # type: ignore[attr-defined]
+    metta_grid_env: CurriculumEnv = vecenv.driver_env  # type: ignore[attr-defined]
 
     # Initialize state containers
     eval_scores = EvalRewardSummary()  # Initialize eval_scores with empty summary

--- a/metta/rl/vecenv.py
+++ b/metta/rl/vecenv.py
@@ -7,7 +7,7 @@ from pydantic import validate_call
 
 from metta.common.util.logging_helpers import init_logging
 from metta.common.util.resolvers import register_resolvers
-from metta.mettagrid import MettaGridEnv
+from metta.mettagrid import CurriculumEnv
 from metta.mettagrid.curriculum.core import Curriculum
 from metta.mettagrid.replay_writer import ReplayWriter
 from metta.mettagrid.stats_writer import StatsWriter
@@ -32,9 +32,9 @@ def make_env_func(
         register_resolvers()
         init_logging(run_dir=run_dir)
 
-    # Create the environment instance
-    env = MettaGridEnv(
-        curriculum,
+    # Create the environment instance with CurriculumEnv wrapper
+    env = CurriculumEnv(
+        curriculum=curriculum,
         render_mode=render_mode,
         buf=buf,
         stats_writer=stats_writer,
@@ -44,7 +44,7 @@ def make_env_func(
     )
     # Ensure the environment is properly initialized
     if hasattr(env, "_c_env") and env._c_env is None:
-        raise ValueError("MettaGridEnv._c_env is None after hydra instantiation")
+        raise ValueError("Environment._c_env is None after hydra instantiation")
     return env
 
 

--- a/metta/sim/map_preview.py
+++ b/metta/sim/map_preview.py
@@ -9,14 +9,14 @@ import wandb
 from wandb.sdk import wandb_run
 
 from metta.common.util.constants import METTASCOPE_REPLAY_URL
-from metta.mettagrid import MettaGridEnv
+from metta.mettagrid import AutoResetEnv
 from metta.mettagrid.curriculum.core import Curriculum
 from metta.mettagrid.util.file import write_file
 
 logger = logging.getLogger(__name__)
 
 
-def write_map_preview_file(preview_path: str, env: MettaGridEnv, gzipped: bool):
+def write_map_preview_file(preview_path: str, env: AutoResetEnv, gzipped: bool):
     logger.info("Building map preview...")
 
     preview = {
@@ -39,7 +39,7 @@ def write_map_preview_file(preview_path: str, env: MettaGridEnv, gzipped: bool):
         f.write(preview_data)
 
 
-def write_local_map_preview(env: MettaGridEnv):
+def write_local_map_preview(env: AutoResetEnv):
     maps_dir = "./outputs/maps"
     os.makedirs(maps_dir, exist_ok=True)
 
@@ -66,7 +66,9 @@ def upload_map_preview(
         wandb_run: Weights & Biases run object for logging
     """
 
-    env = MettaGridEnv(curriculum, render_mode=None)
+    from metta.mettagrid import AutoResetEnv
+
+    env = AutoResetEnv(curriculum, render_mode=None)
 
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         # Create directory and save compressed file

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -26,7 +26,7 @@ from tensordict import TensorDict
 from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.app_backend.clients.stats_client import StatsClient
-from metta.mettagrid import MettaGridEnv, dtype_actions
+from metta.mettagrid import CurriculumEnv, dtype_actions
 from metta.mettagrid.curriculum.core import Curriculum, SingleTrialTask, Task
 from metta.mettagrid.curriculum.util import curriculum_from_config_path
 from metta.mettagrid.replay_writer import ReplayWriter
@@ -174,8 +174,8 @@ class Simulation:
         self._stats_client: StatsClient | None = stats_client
         self._stats_epoch_id: uuid.UUID | None = stats_epoch_id
 
-        metta_grid_env: MettaGridEnv = self._vecenv.driver_env  # type: ignore
-        assert isinstance(metta_grid_env, MettaGridEnv)
+        metta_grid_env: CurriculumEnv = self._vecenv.driver_env  # type: ignore
+        assert isinstance(metta_grid_env, CurriculumEnv)
 
         # Initialize policy to environment
         initialize_policy_for_environment(

--- a/mettagrid/benchmarks/test_mettagrid_env_benchmark.py
+++ b/mettagrid/benchmarks/test_mettagrid_env_benchmark.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from omegaconf import OmegaConf
 
-from metta.mettagrid import MettaGridEnv
+from metta.mettagrid import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
 from metta.mettagrid.util.actions import generate_valid_random_actions
 from metta.mettagrid.util.hydra import get_cfg
@@ -48,7 +48,7 @@ def environment(cfg, num_agents):
     print(OmegaConf.to_yaml(cfg))
 
     curriculum = SingleTaskCurriculum("test", task_cfg=cfg)
-    env = MettaGridEnv(curriculum, render_mode="human", recursive=False)
+    env = AutoResetEnv(curriculum, render_mode="human", recursive=False)
 
     assert env.initial_grid_hash == expected_grid_hash
 
@@ -156,7 +156,7 @@ def test_create_env_performance(benchmark, cfg):
     def create_and_reset():
         """Create a new environment and reset it."""
         curriculum = SingleTaskCurriculum("test", task_cfg=cfg)
-        env = MettaGridEnv(curriculum, render_mode="human", recursive=False)
+        env = AutoResetEnv(curriculum, render_mode="human", recursive=False)
         obs = env.reset()
         # Cleanup
         del env

--- a/mettagrid/demos/demo_config.py
+++ b/mettagrid/demos/demo_config.py
@@ -1,0 +1,37 @@
+"""Shared configuration utilities for mettagrid demos.
+
+This module provides a single, shared configuration that works across
+all demo environments (Gymnasium, PettingZoo, PufferLib).
+"""
+
+from metta.mettagrid.config import EnvConfig, arena
+
+
+def create_demo_config(**overrides) -> EnvConfig:
+    """Create a demo EnvConfig that works for all demo environments.
+
+    This single configuration is optimized to work well across all training
+    environments: Gymnasium (single-agent), PettingZoo (multi-agent), and
+    PufferLib (vectorized training).
+
+    Args:
+        **overrides: Any parameter overrides to customize the config
+
+    Returns:
+        EnvConfig ready for use in any demo environment
+    """
+    # Default parameters that work well for all demo types
+    defaults = {
+        "num_agents": 2,  # Works for both single-agent (uses 1) and multi-agent
+        "combat": False,  # Keep it simple by default
+        "max_steps": 80,  # Reasonable episode length
+        "map_width": 10,  # Good size for visualization and learning
+        "map_height": 10,
+        "obs_width": 5,  # Standard observation window
+        "obs_height": 5,
+    }
+
+    # Apply any overrides
+    defaults.update(overrides)
+
+    return arena(**defaults)

--- a/mettagrid/demos/demo_render.py
+++ b/mettagrid/demos/demo_render.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "numpy",
+#     "gymnasium",
+#     "omegaconf",
+#     "typing-extensions",
+#     "pydantic",
+#     "rich",
+# ]
+# ///
+
+"""Rendering Demo - Visual MettaGrid environment demonstration.
+
+This demo shows how to use MettaGrid environments with visual rendering enabled,
+including both text-based (nethack-style) and pygame rendering modes.
+
+Run with: uv run python mettagrid/demos/demo_render.py (from project root)
+"""
+
+import argparse
+import time
+
+import numpy as np
+
+# Shared demo configuration
+from demo_config import create_demo_config
+from rich.console import Console
+from rich.text import Text
+
+# MettaGrid imports
+from metta.mettagrid import AutoResetEnv
+from metta.mettagrid.config import EnvConfig
+from metta.mettagrid.room.random import Random as RandomRoomBuilder
+from metta.mettagrid.room.utils import make_level_map
+
+
+def create_visual_demo_config() -> EnvConfig:
+    """Create a demo config optimized for visual rendering with guaranteed visible objects."""
+    # Use the shared demo config as base
+    base_config = create_demo_config(
+        num_agents=2, map_width=15, map_height=15, max_steps=200, obs_width=7, obs_height=7
+    )
+
+    # Create a custom level with explicit object placement to ensure visibility
+    map_builder = RandomRoomBuilder(
+        agents=2,
+        width=15,
+        height=15,
+        border_width=2,
+        objects={
+            "mine_red": 4,  # More resource sources
+            "generator_red": 3,  # More generators
+            "altar": 2,  # Multiple altars
+        },
+    )
+
+    # Build the level map
+    level_map = map_builder.build()
+
+    # Create new config with the explicit level
+    return EnvConfig(game=base_config.game, level_map=level_map)
+
+
+def demo_text_rendering():
+    """Demonstrate text-based (nethack-style) rendering."""
+    print("TEXT-BASED RENDERING DEMO")
+    print("=" * 60)
+    print("This demo shows nethack-style text rendering in the terminal.")
+    print("Press Ctrl+C to stop the demo.")
+    print()
+
+    try:
+        env_config = create_visual_demo_config()
+
+        # Create environment with text rendering
+        env = AutoResetEnv(
+            env_config=env_config,
+            render_mode="human",  # Text-based rendering mode using NethackRenderer
+            is_training=False,
+        )
+
+        print("Created text-based environment:")
+        map_shape = env_config.level_map.grid.shape
+        print(f"   - Map size: {map_shape[1]}x{map_shape[0]}")
+        print(f"   - Agents: {env.num_agents}")
+        print(f"   - Max steps: {env.max_steps}")
+        print("   - Render mode: human (text via NethackRenderer)")
+        print(f"   - Objects in game config: {list(env_config.game.objects.keys())}")
+        print()
+
+        # Create console for rich text rendering
+        console = Console()
+        console.clear()
+
+        # Reset and run simulation
+        observations, _ = env.reset(seed=42)
+
+        steps = 0
+        max_demo_steps = 100
+        total_rewards = np.zeros(env.num_agents)
+
+        print("Starting text-based simulation...")
+
+        # Show initial state
+        initial_render = env.render()
+        if initial_render:
+            print("Initial state:")
+            print(initial_render)
+            print("=" * 50)
+        else:
+            print("Warning: No initial rendering output")
+
+        while steps < max_demo_steps:
+            # Take random actions
+            actions = env.action_space.sample()
+            observations, rewards, terminals, truncations, _ = env.step(actions)
+
+            total_rewards += rewards
+
+            # Get text rendering
+            rendered_text = env.render()
+            if rendered_text:
+                # Clear screen and display with Rich
+                console.clear()
+                console.print(Text("MettaGrid Text Rendering Demo", style="bold magenta"))
+                console.print(Text("=" * 50, style="dim"))
+                console.print(Text(rendered_text, style="cyan"))
+                console.print(Text("-" * 50, style="dim"))
+                console.print(f"Step: {steps:3d} | Rewards: {rewards} | Total: {total_rewards}")
+                console.print(Text("=" * 50, style="dim"))
+                console.print("Press Ctrl+C to stop")
+
+            # Add delay to make it watchable
+            time.sleep(0.2)
+            steps += 1
+
+            # Reset if episode ends
+            if terminals.any() or truncations.any():
+                print(f"\nEpisode completed at step {steps}")
+                observations, _ = env.reset()
+                total_rewards = np.zeros(env.num_agents)
+                steps = 0
+                time.sleep(1)  # Pause between episodes
+
+        env.close()
+        print("\nText rendering demo completed")
+
+    except KeyboardInterrupt:
+        print("\nDemo stopped by user")
+        env.close()
+    except Exception as e:
+        print(f"Text rendering failed: {e}")
+        print("Note: Text rendering may require specific terminal capabilities")
+
+
+def demo_pygame_rendering():
+    """Demonstrate pygame-based rendering with AutoResetEnv."""
+    print("\nPYGAME RENDERING DEMO")
+    print("=" * 60)
+    print("This demo will open a pygame window showing the environment.")
+    print("Close the window or press Ctrl+C to continue.")
+    print()
+
+    try:
+        env_config = create_visual_demo_config()
+
+        # Create environment with pygame rendering
+        env = AutoResetEnv(
+            env_config=env_config,
+            render_mode="human",  # This enables pygame rendering
+            is_training=False,
+        )
+
+        print("Created visual environment:")
+        map_shape = env_config.level_map.grid.shape
+        print(f"   - Map size: {map_shape[1]}x{map_shape[0]}")
+        print(f"   - Agents: {env.num_agents}")
+        print(f"   - Max steps: {env.max_steps}")
+        print("   - Render mode: human (pygame)")
+
+        # Reset and run for a while
+        observations, _ = env.reset(seed=42)
+        print("Environment reset, starting visual demonstration...")
+
+        steps = 0
+        max_demo_steps = 300  # Run for 300 steps or until episode ends
+
+        while steps < max_demo_steps:
+            # Take random actions
+            actions = env.action_space.sample()
+            observations, rewards, terminals, truncations, _ = env.step(actions)
+
+            # Add a small delay to make it watchable
+            time.sleep(0.05)
+            steps += 1
+
+            # Print occasional updates
+            if steps % 50 == 0:
+                print(f"   Step {steps}: reward sum = {rewards.sum():.2f}")
+
+            # Reset if episode ends
+            if terminals.any() or truncations.any():
+                print(f"   Episode completed at step {steps}")
+                observations, _ = env.reset()
+                steps = 0
+
+        env.close()
+        print("Pygame rendering demo completed")
+
+    except Exception as e:
+        print(f"Pygame rendering failed: {e}")
+        print("Note: pygame rendering requires pygame to be installed")
+        print("Install with: pip install pygame")
+
+
+def demo_custom_visual_level():
+    """Demonstrate rendering with a custom designed level."""
+    print("\nCUSTOM VISUAL LEVEL DEMO")
+    print("=" * 60)
+
+    try:
+        # Create a more interesting custom level
+        grid = np.array(
+            [
+                ["wall", "wall", "wall", "wall", "wall", "wall", "wall", "wall", "wall"],
+                ["wall", "empty", "empty", "mine_red", "empty", "mine_red", "empty", "empty", "wall"],
+                ["wall", "empty", "agent.agent", "empty", "empty", "empty", "generator_red", "empty", "wall"],
+                ["wall", "empty", "empty", "empty", "wall", "empty", "empty", "empty", "wall"],
+                ["wall", "mine_red", "empty", "empty", "altar", "empty", "empty", "empty", "wall"],
+                ["wall", "empty", "empty", "empty", "wall", "empty", "empty", "empty", "wall"],
+                ["wall", "empty", "generator_red", "empty", "empty", "empty", "agent.agent", "empty", "wall"],
+                ["wall", "empty", "empty", "mine_red", "empty", "mine_red", "empty", "empty", "wall"],
+                ["wall", "wall", "wall", "wall", "wall", "wall", "wall", "wall", "wall"],
+            ],
+            dtype="<U50",
+        )
+
+        # Create level map
+        level_map = make_level_map(grid, labels=["custom_visual_level"])
+
+        # Create environment config with custom level
+        base_config = create_demo_config(num_agents=2, max_steps=150)
+        env_config = EnvConfig(game=base_config.game, level_map=level_map)
+
+        # Create environment with rendering
+        env = AutoResetEnv(
+            env_config=env_config,
+            render_mode="human",  # Use text rendering for custom level
+            is_training=False,
+        )
+
+        print("Created custom visual level:")
+        print(f"   - Grid shape: {grid.shape}")
+        print(f"   - Labels: {level_map.labels}")
+        print(f"   - Agents: {env.num_agents}")
+
+        # Reset and demonstrate
+        observations, _ = env.reset(seed=123)
+        print("Custom level rendering - agents will move around the designed map...")
+
+        # Show initial state
+        initial_render = env.render()
+        if initial_render:
+            print("\nInitial state:")
+            print(initial_render)
+            print("\nRunning simulation...")
+            time.sleep(2)
+
+        for step in range(75):  # Shorter demo
+            actions = env.action_space.sample()
+            observations, rewards, terminals, truncations, _ = env.step(actions)
+
+            # Render every few steps
+            if step % 10 == 0:
+                rendered = env.render()
+                if rendered:
+                    print(f"\nStep {step}:")
+                    print(rendered)
+
+            time.sleep(0.1)
+
+            if step % 25 == 0:
+                print(f"   Step {step}: total reward = {rewards.sum():.2f}")
+
+            if terminals.any() or truncations.any():
+                print(f"   Episode completed at step {step}")
+                break
+
+        env.close()
+        print("Custom visual level demo completed")
+
+    except Exception as e:
+        print(f"Custom visual level failed: {e}")
+
+
+def run_interactive_simulation(render_mode: str = "ansi"):
+    """Run an interactive simulation with the specified render mode."""
+    print(f"\nINTERACTIVE SIMULATION ({render_mode.upper()} MODE)")
+    print("=" * 60)
+
+    env_config = create_visual_demo_config()
+
+    # Create environment with specified render mode
+    env = AutoResetEnv(
+        env_config=env_config,
+        render_mode=render_mode,
+        is_training=False,
+    )
+
+    print(f"Environment created with {render_mode} rendering")
+    print(f"Number of agents: {env.num_agents}")
+    print(f"Action space: {env.action_space}")
+
+    # Get action space info for random sampling
+    num_agents = env.num_agents
+    action_space = env.action_space
+
+    # Reset environment
+    obs, info = env.reset(seed=42)
+
+    # Show initial render if available
+    initial_render = env.render()
+    if initial_render and render_mode == "human":
+        print("\nInitial state:")
+        print(initial_render)
+
+    # Run simulation
+    done = False
+    step_count = 0
+    total_rewards = np.zeros(num_agents)
+
+    try:
+        while not done and step_count < 150:
+            # Generate random actions
+            actions = action_space.sample()
+
+            # Step environment
+            obs, rewards, terminals, truncations, info = env.step(actions)
+
+            # Track rewards
+            total_rewards += rewards
+
+            # Render if text mode and every few steps
+            if render_mode == "human" and step_count % 10 == 0:
+                rendered_text = env.render()
+                if rendered_text:
+                    print(f"\nStep {step_count}:")
+                    print(rendered_text)
+                    print(f"Rewards: {rewards} | Total: {total_rewards}")
+
+            # Check if done
+            done = np.all(terminals) or np.all(truncations)
+            step_count += 1
+
+            # Add delay
+            time.sleep(0.1)
+
+            # Print progress
+            if step_count % 25 == 0:
+                print(f"Step {step_count}: Rewards = {rewards}, Total = {total_rewards}")
+
+        print(f"\nSimulation complete after {step_count} steps")
+        print(f"Final total rewards: {total_rewards}")
+
+    except KeyboardInterrupt:
+        print("\nSimulation stopped by user")
+
+    finally:
+        env.close()
+
+
+def main():
+    """Run visual rendering demos."""
+    parser = argparse.ArgumentParser(description="Run MettaGrid visual rendering demos")
+    parser.add_argument(
+        "--mode",
+        choices=["text", "pygame", "custom", "interactive", "all"],
+        default="all",
+        help="Which rendering demo to run",
+    )
+    parser.add_argument(
+        "--render-mode", choices=["human", "miniscope"], default="human", help="Rendering mode for interactive demo"
+    )
+
+    args = parser.parse_args()
+
+    print("METTAGRID VISUAL RENDERING DEMO")
+    print("=" * 80)
+    print("This demo showcases MettaGrid's rendering capabilities.")
+    print()
+
+    try:
+        if args.mode in ["text", "all"]:
+            demo_text_rendering()
+
+        if args.mode in ["pygame", "all"]:
+            demo_pygame_rendering()
+
+        if args.mode in ["custom", "all"]:
+            demo_custom_visual_level()
+
+        if args.mode == "interactive":
+            run_interactive_simulation(args.render_mode)
+
+        if args.mode == "all":
+            print("\n" + "=" * 80)
+            print("ALL RENDERING DEMOS COMPLETED")
+            print("=" * 80)
+            print("Rendering demonstrations completed successfully!")
+            print()
+            print("Key features demonstrated:")
+            print("   - Text-based (ansi) rendering for terminal display")
+            print("   - Pygame-based (human) rendering for graphical display")
+            print("   - Custom level visualization")
+            print("   - Interactive simulation with real-time rendering")
+            print()
+            print("Usage patterns:")
+            print("   - Use render_mode='human' for text-based rendering (NethackRenderer)")
+            print("   - Use render_mode='miniscope' for miniscope visualization")
+            print("   - Custom levels work with any render mode")
+            print("=" * 80)
+
+    except KeyboardInterrupt:
+        print("\nRendering demos interrupted by user")
+    except Exception as e:
+        print(f"\nRendering demo failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mettagrid/demos/demo_train_pettingzoo.py
+++ b/mettagrid/demos/demo_train_pettingzoo.py
@@ -13,9 +13,9 @@
 # ]
 # ///
 
-"""PettingZoo Demo - Pure PettingZoo ecosystem integration.
+"""PettingZoo Demo - EnvConfig-based PettingZoo ecosystem integration.
 
-This demo shows how to use MettaGridPettingZooEnv with ONLY PettingZoo
+This demo shows how to use MettaGridPettingZooEnv with EnvConfig and ONLY PettingZoo
 and external multi-agent libraries, without any Metta training infrastructure.
 
 Run with: uv run python mettagrid/demos/demo_train_pettingzoo.py (from project root)
@@ -24,72 +24,32 @@ Run with: uv run python mettagrid/demos/demo_train_pettingzoo.py (from project r
 import time
 
 import numpy as np
+
+# Shared demo configuration
+from demo_config import create_demo_config
 from gymnasium import spaces
-from omegaconf import DictConfig
 from pettingzoo.test import parallel_api_test
 
 # PettingZoo adapter imports
 from metta.mettagrid import MettaGridPettingZooEnv
-from metta.mettagrid.curriculum.core import SingleTaskCurriculum
+from metta.mettagrid.config import EnvConfig
 
 
-def create_test_config() -> DictConfig:
-    """Create test configuration for PettingZoo integration."""
-    return DictConfig(
-        {
-            "game": {
-                "max_steps": 50,
-                "num_agents": 2,
-                "obs_width": 3,
-                "obs_height": 3,
-                "num_observation_tokens": 9,
-                "inventory_item_names": ["heart"],
-                "groups": {"agent": {"id": 0, "sprite": 0}},
-                "agent": {
-                    "default_resource_limit": 5,
-                    "resource_limits": {"heart": 255},
-                    "freeze_duration": 0,
-                    "rewards": {"heart": 1.0},
-                    "action_failure_penalty": 0.0,
-                },
-                "actions": {
-                    "noop": {"enabled": True},
-                    "move": {"enabled": True},
-                    "rotate": {"enabled": True},
-                    "put_items": {"enabled": True},
-                    "get_items": {"enabled": True},
-                    "attack": {"enabled": True},
-                    "swap": {"enabled": True},
-                    "change_color": {"enabled": False},
-                    "change_glyph": {"enabled": False, "number_of_glyphs": 0},
-                },
-                "objects": {
-                    "wall": {"type_id": 1, "swappable": False},
-                },
-                "map_builder": {
-                    "_target_": "metta.mettagrid.room.random.Random",
-                    "agents": 2,
-                    "width": 6,
-                    "height": 6,
-                    "border_width": 1,
-                    "objects": {},
-                },
-            }
-        }
-    )
+def create_test_env_config() -> EnvConfig:
+    """Create test EnvConfig for PettingZoo integration."""
+    return create_demo_config(num_agents=2, max_steps=50, map_width=6, map_height=6, obs_width=3, obs_height=3)
 
 
 def demo_pettingzoo_api():
-    """Demonstrate PettingZoo API compliance and basic usage."""
+    """Demonstrate PettingZoo API compliance and basic usage with EnvConfig."""
     print("PETTINGZOO API DEMO")
     print("=" * 60)
 
-    config = create_test_config()
-    curriculum = SingleTaskCurriculum("pettingzoo_demo", config)
+    env_config = create_test_env_config()
 
     # Create PettingZoo environment
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
         is_training=False,
     )
@@ -111,12 +71,11 @@ def demo_random_rollout():
     print("\nRANDOM ROLLOUT DEMO")
     print("=" * 60)
 
-    config = create_test_config()
-    curriculum = SingleTaskCurriculum("pettingzoo_rollout", config)
+    env_config = create_test_env_config()
 
     # Create PettingZoo environment
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
         is_training=True,
     )
@@ -165,11 +124,10 @@ def demo_simple_marl_training():
     print("\nSIMPLE MULTI-AGENT TRAINING DEMO")
     print("=" * 60)
 
-    config = create_test_config()
-    curriculum = SingleTaskCurriculum("marl_training", config)
+    env_config = create_test_env_config()
 
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
         is_training=True,
     )
@@ -254,10 +212,11 @@ def demo_simple_marl_training():
 
 def main():
     """Run PettingZoo adapter demo."""
-    print("PETTINGZOO ADAPTER DEMO")
+    print("PETTINGZOO + ENVCONFIG ADAPTER DEMO")
     print("=" * 80)
-    print("This demo shows MettaGridPettingZooEnv integration with")
+    print("This demo shows MettaGridPettingZooEnv with EnvConfig integration with")
     print("the PettingZoo multi-agent ecosystem (no internal training code).")
+    print("EnvConfig is the primary configuration method, combining PyGameConfig + LevelMap.")
     print()
 
     try:

--- a/mettagrid/demos/demo_train_puffer.py
+++ b/mettagrid/demos/demo_train_puffer.py
@@ -238,7 +238,7 @@ def demo_env_config_modification():
     env_config_large = create_demo_config(num_agents=1, max_steps=60, map_width=12, map_height=12)
 
     # Set new configuration for next reset
-    env.set_env_cfg(env_config_large)
+    env.set_env_config(env_config_large)
 
     print("\nSecond configuration (12x12 map):")
     obs, info = env.reset(seed=123)

--- a/mettagrid/src/metta/mettagrid/__init__.py
+++ b/mettagrid/src/metta/mettagrid/__init__.py
@@ -3,7 +3,8 @@ MettaGrid - Multi-agent reinforcement learning grid environments.
 
 This module provides various environment adapters for different RL frameworks:
 - MettaGridCore: Core C++ wrapper (no training features)
-- MettaGridEnv: Training environment (PufferLib-based with stats/replay)
+- AutoResetEnv: Training environment with auto-reset (PufferLib-based with stats/replay)
+- CurriculumEnv: Wrapper that adds curriculum support to AutoResetEnv
 - MettaGridGymEnv: Gymnasium adapter
 - MettaGridPettingZooEnv: PettingZoo adapter
 
@@ -13,13 +14,17 @@ For PufferLib integration, use PufferLib's MettaPuff wrapper directly.
 
 from __future__ import annotations
 
+from metta.mettagrid.auto_reset_env import AutoResetEnv
+from metta.mettagrid.config import EnvConfig
+
 # Import environment classes
 from metta.mettagrid.core import MettaGridCore
 
 # Import other commonly used classes
 from metta.mettagrid.curriculum.core import Curriculum
+from metta.mettagrid.curriculum_env import CurriculumEnv
 from metta.mettagrid.gym_env import MettaGridGymEnv, SingleAgentMettaGridGymEnv
-from metta.mettagrid.level_builder import Level
+from metta.mettagrid.level_builder import LevelMap
 
 # Import data types from C++ module (source of truth)
 from metta.mettagrid.mettagrid_c import (
@@ -31,7 +36,6 @@ from metta.mettagrid.mettagrid_c import (
     dtype_terminals,
     dtype_truncations,
 )
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.pettingzoo_env import MettaGridPettingZooEnv
 from metta.mettagrid.replay_writer import ReplayWriter
 from metta.mettagrid.stats_writer import StatsWriter
@@ -39,8 +43,11 @@ from metta.mettagrid.stats_writer import StatsWriter
 __all__ = [
     # Core classes
     "MettaGridCore",
-    # Main environment (backward compatible)
-    "MettaGridEnv",
+    # Main environments
+    "AutoResetEnv",
+    "CurriculumEnv",
+    # Configuration
+    "EnvConfig",
     # Environment adapters
     "MettaGridGymEnv",
     "SingleAgentMettaGridGymEnv",
@@ -55,7 +62,7 @@ __all__ = [
     "dtype_success",
     # Supporting classes
     "Curriculum",
-    "Level",
+    "LevelMap",
     "ReplayWriter",
     "StatsWriter",
 ]

--- a/mettagrid/src/metta/mettagrid/config/__init__.py
+++ b/mettagrid/src/metta/mettagrid/config/__init__.py
@@ -1,0 +1,55 @@
+"""MettaGrid configuration module.
+
+This module provides all configuration classes and utilities for MettaGrid environments:
+- Core Pydantic configuration models
+- Predefined common objects
+- Builder functions for creating configurations easily
+"""
+
+# Core configuration classes
+# Predefined objects for common use
+from metta.mettagrid.config import objects
+
+# Builder functions for easy configuration creation
+from metta.mettagrid.config.builder import arena, combat_arena, empty_arena, simple_arena
+from metta.mettagrid.config.mettagrid_config import (
+    EnvConfig,
+    PyActionConfig,
+    PyActionsConfig,
+    PyAgentConfig,
+    PyAgentRewards,
+    PyAttackActionConfig,
+    PyChangeGlyphActionConfig,
+    PyConverterConfig,
+    PyGameConfig,
+    PyGlobalObsConfig,
+    PyGroupConfig,
+    PyInventoryRewards,
+    PyStatsRewards,
+    PyWallConfig,
+)
+
+__all__ = [
+    # Core config classes
+    "EnvConfig",
+    "PyGameConfig",
+    "PyAgentConfig",
+    "PyAgentRewards",
+    "PyInventoryRewards",
+    "PyStatsRewards",
+    "PyGroupConfig",
+    "PyActionsConfig",
+    "PyActionConfig",
+    "PyAttackActionConfig",
+    "PyChangeGlyphActionConfig",
+    "PyGlobalObsConfig",
+    "PyWallConfig",
+    "PyConverterConfig",
+    # Objects module
+    "objects",
+    # Builder functions
+    "arena",
+    "simple_arena",
+    "combat_arena",
+    "empty_arena",
+]

--- a/mettagrid/src/metta/mettagrid/config/builder.py
+++ b/mettagrid/src/metta/mettagrid/config/builder.py
@@ -1,8 +1,4 @@
-"""Compact configuration builders for MettaGrid demos.
-
-This module provides simple, compact ways to create common MettaGrid configurations,
-similar to the old config/builder.py approach but using the new Pydantic models.
-"""
+"""Compact configuration builders for EnvConfig."""
 
 from metta.mettagrid.config import objects
 from metta.mettagrid.config.mettagrid_config import (

--- a/mettagrid/src/metta/mettagrid/config/builder.py
+++ b/mettagrid/src/metta/mettagrid/config/builder.py
@@ -1,0 +1,189 @@
+"""Compact configuration builders for MettaGrid demos.
+
+This module provides simple, compact ways to create common MettaGrid configurations,
+similar to the old config/builder.py approach but using the new Pydantic models.
+"""
+
+from metta.mettagrid.config import objects
+from metta.mettagrid.config.mettagrid_config import (
+    EnvConfig,
+    PyActionConfig,
+    PyActionsConfig,
+    PyAgentConfig,
+    PyAgentRewards,
+    PyAttackActionConfig,
+    PyChangeGlyphActionConfig,
+    PyGameConfig,
+    PyGroupConfig,
+    PyInventoryRewards,
+)
+from metta.mettagrid.room.random import Random as RandomRoomBuilder
+
+
+def arena(
+    num_agents: int = 2,
+    combat: bool = False,
+    max_steps: int = 500,
+    map_width: int = 20,
+    map_height: int = 20,
+    obs_width: int = 5,
+    obs_height: int = 5,
+) -> EnvConfig:
+    """Create an arena-style environment configuration.
+
+    Args:
+        num_agents: Number of agents
+        combat: Whether to include combat objects and actions
+        max_steps: Maximum steps per episode
+        map_width: Map width
+        map_height: Map height
+        obs_width: Observation width
+        obs_height: Observation height
+
+    Returns:
+        Complete EnvConfig ready for use
+    """
+    # Basic objects for resource collection
+    game_objects = {
+        "wall": objects.wall,
+        "altar": objects.altar,
+        "mine_red": objects.mine_red,
+        "generator_red": objects.generator_red,
+    }
+
+    # Basic actions
+    actions = PyActionsConfig(
+        noop=PyActionConfig(enabled=True),
+        move=PyActionConfig(enabled=True),
+        rotate=PyActionConfig(enabled=True),
+        put_items=PyActionConfig(enabled=True),
+        get_items=PyActionConfig(enabled=True),
+        swap=PyActionConfig(enabled=True),
+        change_color=PyActionConfig(enabled=False),
+        change_glyph=PyChangeGlyphActionConfig(enabled=False, number_of_glyphs=0),
+    )
+
+    # Add combat if requested
+    if combat:
+        game_objects["lasery"] = objects.lasery
+        game_objects["armory"] = objects.armory
+
+        actions.attack = PyAttackActionConfig(
+            enabled=True, required_resources={"laser": 1}, defense_resources={"armor": 1}
+        )
+
+    # Set up inventory items
+    inventory_items = ["heart", "ore_red", "battery_red"]
+    if combat:
+        inventory_items.extend(["laser", "armor"])
+
+    # Create rewards
+    inventory_rewards = PyInventoryRewards(heart=1.0)
+    agent_rewards = PyAgentRewards(inventory=inventory_rewards)
+
+    # Create agent config
+    agent_config = PyAgentConfig(
+        default_resource_limit=50,
+        resource_limits={"heart": 255},
+        freeze_duration=0,
+        rewards=agent_rewards,
+        action_failure_penalty=0.0,
+    )
+
+    # Create group config
+    group_config = PyGroupConfig(id=0, sprite=0, props=agent_config)
+
+    # Create game config
+    game_config = PyGameConfig(
+        max_steps=max_steps,
+        num_agents=num_agents,
+        obs_width=obs_width,
+        obs_height=obs_height,
+        num_observation_tokens=obs_width * obs_height,
+        inventory_item_names=inventory_items,
+        groups={"agent": group_config},
+        agent=agent_config,
+        actions=actions,
+        objects=game_objects,
+    )
+
+    # Create map with appropriate objects
+    map_objects = {"mine_red": 3, "generator_red": 2, "altar": 2}
+    if combat:
+        map_objects.update({"lasery": 1, "armory": 1})
+
+    map_builder = RandomRoomBuilder(
+        agents=num_agents, width=map_width, height=map_height, border_width=2, objects=map_objects
+    )
+
+    level_map = map_builder.build()
+
+    return EnvConfig(game=game_config, level_map=level_map)
+
+
+def simple_arena(num_agents: int = 1) -> EnvConfig:
+    """Create a simple single-agent arena for quick testing."""
+    return arena(
+        num_agents=num_agents, combat=False, max_steps=100, map_width=12, map_height=12, obs_width=5, obs_height=5
+    )
+
+
+def combat_arena(num_agents: int = 2) -> EnvConfig:
+    """Create a combat arena with weapons and armor."""
+    return arena(
+        num_agents=num_agents, combat=True, max_steps=200, map_width=16, map_height=16, obs_width=7, obs_height=7
+    )
+
+
+def empty_arena(num_agents: int = 2, map_width: int = 10, map_height: int = 10, max_steps: int = 50) -> EnvConfig:
+    """Create an empty arena for basic multi-agent interaction."""
+    # Minimal objects
+    game_objects = {
+        "wall": objects.wall,
+    }
+
+    actions = PyActionsConfig(
+        noop=PyActionConfig(enabled=True),
+        move=PyActionConfig(enabled=True),
+        rotate=PyActionConfig(enabled=True),
+        put_items=PyActionConfig(enabled=True),
+        get_items=PyActionConfig(enabled=True),
+        attack=PyAttackActionConfig(enabled=True),
+        swap=PyActionConfig(enabled=True),
+        change_color=PyActionConfig(enabled=False),
+        change_glyph=PyChangeGlyphActionConfig(enabled=False, number_of_glyphs=0),
+    )
+
+    # Simple rewards
+    inventory_rewards = PyInventoryRewards(heart=1.0)
+    agent_rewards = PyAgentRewards(inventory=inventory_rewards)
+
+    agent_config = PyAgentConfig(
+        default_resource_limit=5,
+        resource_limits={"heart": 255},
+        freeze_duration=0,
+        rewards=agent_rewards,
+        action_failure_penalty=0.0,
+    )
+
+    group_config = PyGroupConfig(id=0, sprite=0, props=agent_config)
+
+    game_config = PyGameConfig(
+        max_steps=max_steps,
+        num_agents=num_agents,
+        obs_width=3,
+        obs_height=3,
+        num_observation_tokens=9,
+        inventory_item_names=["heart"],
+        groups={"agent": group_config},
+        agent=agent_config,
+        actions=actions,
+        objects=game_objects,
+    )
+
+    # Empty map
+    map_builder = RandomRoomBuilder(agents=num_agents, width=map_width, height=map_height, border_width=1, objects={})
+
+    level_map = map_builder.build()
+
+    return EnvConfig(game=game_config, level_map=level_map)

--- a/mettagrid/src/metta/mettagrid/config/objects.py
+++ b/mettagrid/src/metta/mettagrid/config/objects.py
@@ -1,0 +1,84 @@
+"""Predefined MettaGrid objects for demos.
+
+This module provides common MettaGrid objects with sensible defaults,
+similar to the old config/object.py approach but using the new Pydantic models.
+"""
+
+from metta.mettagrid.config.mettagrid_config import PyConverterConfig, PyWallConfig
+
+# Basic objects
+wall = PyWallConfig(type_id=1, swappable=False)
+block = PyWallConfig(type_id=14, swappable=True)
+
+# Altar - converts batteries to hearts
+altar = PyConverterConfig(
+    type_id=8,
+    input_resources={"battery_red": 2},
+    output_resources={"heart": 1},
+    max_output=5,
+    conversion_ticks=1,
+    cooldown=20,
+    initial_resource_count=1,
+    color=2,
+)
+
+
+def make_mine(color: str, type_id: int) -> PyConverterConfig:
+    """Create a mine that produces ore of the specified color."""
+    return PyConverterConfig(
+        type_id=type_id,
+        output_resources={f"ore_{color}": 1},
+        max_output=-1,
+        conversion_ticks=1,
+        cooldown=3,
+        initial_resource_count=0,
+        color=0,
+    )
+
+
+def make_generator(color: str, type_id: int) -> PyConverterConfig:
+    """Create a generator that converts ore to batteries of the specified color."""
+    return PyConverterConfig(
+        type_id=type_id,
+        input_resources={f"ore_{color}": 1},
+        output_resources={f"battery_{color}": 1},
+        max_output=-1,
+        conversion_ticks=1,
+        cooldown=2,
+        initial_resource_count=0,
+        color=0,
+    )
+
+
+# Mines
+mine_red = make_mine("red", 2)
+mine_blue = make_mine("blue", 3)
+mine_green = make_mine("green", 4)
+
+# Generators
+generator_red = make_generator("red", 5)
+generator_blue = make_generator("blue", 6)
+generator_green = make_generator("green", 7)
+
+# Combat objects
+lasery = PyConverterConfig(
+    type_id=15,
+    input_resources={"battery_red": 1, "ore_red": 2},
+    output_resources={"laser": 1},
+    max_output=-1,
+    conversion_ticks=1,
+    cooldown=10,
+    initial_resource_count=0,
+    color=0,
+)
+
+armory = PyConverterConfig(
+    type_id=16,
+    input_resources={"ore_red": 3},
+    output_resources={"armor": 1},
+    max_output=-1,
+    conversion_ticks=1,
+    cooldown=10,
+    initial_resource_count=0,
+    color=0,
+)

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -4,6 +4,8 @@ from typing import List, Tuple
 import hydra
 from omegaconf import DictConfig
 
+from metta.mettagrid.config import EnvConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,7 +63,23 @@ class Task:
         raise NotImplementedError("Subclasses must implement this method")
 
     def original_env_cfg(self) -> DictConfig:
+        """Returns the original DictConfig before hydra instantiation (for backward compatibility)."""
         raise NotImplementedError("Subclasses must implement this method")
+
+    def original_env_config(self) -> EnvConfig:
+        """Returns the original EnvConfig before any modifications.
+
+        This converts the original DictConfig to an EnvConfig.
+        """
+        return EnvConfig.from_dict_config(self.original_env_cfg())
+
+    def env_config(self) -> EnvConfig:
+        """Returns the EnvConfig for the current trial.
+
+        Converts the task's DictConfig to an EnvConfig using the centralized
+        conversion logic in EnvConfig.from_dict_config().
+        """
+        return EnvConfig.from_dict_config(self.env_cfg())
 
     def id(self) -> str:
         """Returns the id of the task."""
@@ -108,6 +126,7 @@ class SingleTrialTask(Task):
         return self._env_cfg
 
     def original_env_cfg(self) -> DictConfig:
+        """Returns the original DictConfig before hydra resolution."""
         return self._original_env_cfg
 
 

--- a/mettagrid/src/metta/mettagrid/curriculum/core.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/core.py
@@ -62,16 +62,9 @@ class Task:
         # TODO: ideally we'd have a separate config for the task itself (same for a separate config for the curriculum)
         raise NotImplementedError("Subclasses must implement this method")
 
-    def original_env_cfg(self) -> DictConfig:
+    def unresolved_dict_cfg(self) -> DictConfig:
         """Returns the original DictConfig before hydra instantiation (for backward compatibility)."""
         raise NotImplementedError("Subclasses must implement this method")
-
-    def original_env_config(self) -> EnvConfig:
-        """Returns the original EnvConfig before any modifications.
-
-        This converts the original DictConfig to an EnvConfig.
-        """
-        return EnvConfig.from_dict_config(self.original_env_cfg())
 
     def env_config(self) -> EnvConfig:
         """Returns the EnvConfig for the current trial.
@@ -109,7 +102,7 @@ class SingleTrialTask(Task):
         self._current_trial = 0
         # We may have been lazy about instantiation up to this point, since that allows us to
         # override the config. Now we complete the instantiation.
-        self._original_env_cfg = env_cfg
+        self._unresolved_dict_cfg = env_cfg
         self._env_cfg = hydra.utils.instantiate(env_cfg)
 
     def complete_trial(self, score: float):
@@ -125,9 +118,9 @@ class SingleTrialTask(Task):
         assert self._env_cfg is not None, "Task has no environment configuration"
         return self._env_cfg
 
-    def original_env_cfg(self) -> DictConfig:
+    def unresolved_dict_cfg(self) -> DictConfig:
         """Returns the original DictConfig before hydra resolution."""
-        return self._original_env_cfg
+        return self._unresolved_dict_cfg
 
 
 class SingleTaskCurriculum(Curriculum):

--- a/mettagrid/src/metta/mettagrid/curriculum/sequential_trial_task.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/sequential_trial_task.py
@@ -59,3 +59,7 @@ class SequentialTrialTask(Task):
     def env_cfg(self) -> DictConfig:
         cfg = OmegaConf.merge(self._base_cfg, self._trial_overrides[self._current_trial_idx])
         return hydra.utils.instantiate(cfg)
+
+    def original_env_cfg(self) -> DictConfig:
+        """Returns the original base config without trial overrides or instantiation."""
+        return self._base_cfg

--- a/mettagrid/src/metta/mettagrid/curriculum/sequential_trial_task.py
+++ b/mettagrid/src/metta/mettagrid/curriculum/sequential_trial_task.py
@@ -60,6 +60,6 @@ class SequentialTrialTask(Task):
         cfg = OmegaConf.merge(self._base_cfg, self._trial_overrides[self._current_trial_idx])
         return hydra.utils.instantiate(cfg)
 
-    def original_env_cfg(self) -> DictConfig:
+    def unresolved_dict_cfg(self) -> DictConfig:
         """Returns the original base config without trial overrides or instantiation."""
         return self._base_cfg

--- a/mettagrid/src/metta/mettagrid/curriculum_env.py
+++ b/mettagrid/src/metta/mettagrid/curriculum_env.py
@@ -1,0 +1,125 @@
+"""
+CurriculumEnv - Wrapper for AutoResetEnv that adds curriculum support.
+
+This class wraps AutoResetEnv and handles curriculum-based task selection,
+converting curriculum tasks to EnvConfig for the underlying environment.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+from metta.mettagrid.auto_reset_env import AutoResetEnv
+from metta.mettagrid.curriculum.core import Curriculum
+from metta.mettagrid.level_builder import LevelMap
+from metta.mettagrid.replay_writer import ReplayWriter
+from metta.mettagrid.stats_writer import StatsWriter
+
+
+class CurriculumEnv(AutoResetEnv):
+    """
+    Wrapper for AutoResetEnv that adds curriculum support.
+
+    This class handles:
+    - Getting tasks from curriculum
+    - Converting task configs to EnvConfig
+    - Passing EnvConfig to AutoResetEnv
+    - Managing task completion
+    """
+
+    def __init__(
+        self,
+        curriculum: Curriculum,
+        render_mode: Optional[str] = None,
+        level: Optional[LevelMap] = None,
+        buf: Optional[Any] = None,
+        stats_writer: Optional[StatsWriter] = None,
+        replay_writer: Optional[ReplayWriter] = None,
+        is_training: bool = False,
+        **kwargs: Any,
+    ):
+        """
+        Initialize CurriculumEnv wrapper.
+
+        Args:
+            curriculum: Curriculum for task management
+            render_mode: Rendering mode
+            level: Optional pre-built level
+            buf: PufferLib buffer object
+            stats_writer: Optional stats writer
+            replay_writer: Optional replay writer
+            is_training: Whether this is for training
+            **kwargs: Additional arguments
+        """
+        self._curriculum = curriculum
+        self._current_task = None
+        self._level = level
+
+        # Get initial task and convert to EnvConfig
+        self._current_task = self._curriculum.get_task()
+        env_config = self._current_task.env_config()
+
+        # Initialize base class with the environment config
+        super().__init__(
+            env_config=env_config,
+            render_mode=render_mode,
+            buf=buf,
+            stats_writer=stats_writer,
+            replay_writer=replay_writer,
+            is_training=is_training,
+            **kwargs,
+        )
+
+        # Store references for curriculum management
+        self._stats_writer = stats_writer
+        self._replay_writer = replay_writer
+        self._is_training = is_training
+
+    def reset(self, seed: Optional[int] = None) -> Tuple[np.ndarray, Dict[str, Any]]:
+        """
+        Reset the environment with a new task from curriculum.
+
+        Args:
+            seed: Random seed
+
+        Returns:
+            Tuple of (observations, info)
+        """
+        # Get next task from curriculum
+        self._current_task = self._curriculum.get_task()
+        env_config = self._current_task.env_config()
+
+        # Update environment config (set_env_cfg will assert episode is finished)
+        # This ensures we don't accidentally change config mid-episode
+        self.set_env_cfg(env_config)
+
+        # Call parent's reset which will use the updated env_config
+        return super().reset(seed=seed)
+
+    def step(self, action: np.ndarray) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
+        """
+        Execute one timestep of the environment dynamics.
+
+        Args:
+            action: Action array
+
+        Returns:
+            Tuple of (observation, reward, terminated, truncated, info)
+        """
+        obs, reward, terminated, truncated, info = super().step(action)
+
+        # Handle task completion (terminated and truncated are arrays)
+        if (
+            (isinstance(terminated, np.ndarray) and terminated.any())
+            or (isinstance(truncated, np.ndarray) and truncated.any())
+            or (not isinstance(terminated, np.ndarray) and terminated)
+            or (not isinstance(truncated, np.ndarray) and truncated)
+        ):
+            if self._current_task:
+                # Calculate score from cumulative reward or info
+                score = info.get("episode_return", reward if not isinstance(reward, np.ndarray) else reward.sum())
+                self._current_task.complete_trial(score)
+
+        return obs, reward, terminated, truncated, info

--- a/mettagrid/src/metta/mettagrid/gym_env.py
+++ b/mettagrid/src/metta/mettagrid/gym_env.py
@@ -11,12 +11,10 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from gymnasium import Env as GymEnv
-from omegaconf import OmegaConf
 from typing_extensions import override
 
+from metta.mettagrid.config import EnvConfig
 from metta.mettagrid.core import MettaGridCore
-from metta.mettagrid.curriculum.core import Curriculum
-from metta.mettagrid.level_builder import Level
 
 # Data types for Gymnasium - import from C++ module
 from metta.mettagrid.mettagrid_c import (
@@ -44,9 +42,8 @@ class MettaGridGymEnv(MettaGridCore, GymEnv):
 
     def __init__(
         self,
-        curriculum: Curriculum,
+        env_config: EnvConfig,
         render_mode: Optional[str] = None,
-        level: Optional[Level] = None,
         single_agent: bool = False,
         **kwargs: Any,
     ):
@@ -54,34 +51,15 @@ class MettaGridGymEnv(MettaGridCore, GymEnv):
         Initialize Gymnasium environment.
 
         Args:
-            curriculum: Curriculum for task management
+            env_config: Environment configuration
             render_mode: Rendering mode
-            level: Optional pre-built level
             single_agent: Whether to use single-agent mode
             **kwargs: Additional arguments
         """
-        # Get level from curriculum if not provided
-        if level is None:
-            task = curriculum.get_task()
-            level = task.env_cfg().game.map_builder.build()
-
-        # Ensure we have a level
-        assert level is not None, "Level must be provided or generated from curriculum"
-
-        # Store curriculum for reset operations
-        self._curriculum = curriculum
-        self._task = self._curriculum.get_task()
-
-        # Get game config for core initialization
-        task_cfg = self._task.env_cfg()
-        game_config_dict = OmegaConf.to_container(task_cfg.game)
-        assert isinstance(game_config_dict, dict), "Game config must be a dictionary"
-
         # Initialize core functionality
         MettaGridCore.__init__(
             self,
-            level=level,
-            game_config_dict=game_config_dict,
+            env_config=env_config,
             render_mode=render_mode,
             **kwargs,
         )
@@ -128,14 +106,8 @@ class MettaGridGymEnv(MettaGridCore, GymEnv):
         Returns:
             Tuple of (observations, info)
         """
-        # Get new task from curriculum and its config
-        self._task = self._curriculum.get_task()
-        task_cfg = self._task.env_cfg()
-        game_config_dict = OmegaConf.to_container(task_cfg.game)
-        assert isinstance(game_config_dict, dict), "Game config must be a dictionary"
-
-        # Call the base reset method
-        obs, info = super().reset(game_config_dict, seed)
+        # Call the base reset method with stored env_config
+        obs, info = super().reset(seed=seed)
 
         # Handle single-agent return format
         if self._single_agent and obs is not None:
@@ -225,24 +197,21 @@ class SingleAgentMettaGridGymEnv(MettaGridGymEnv):
 
     def __init__(
         self,
-        curriculum: Curriculum,
+        env_config: EnvConfig,
         render_mode: Optional[str] = None,
-        level: Optional[Level] = None,
         **kwargs: Any,
     ):
         """
         Initialize single-agent Gymnasium environment.
 
         Args:
-            curriculum: Curriculum for task management
+            env_config: Environment configuration
             render_mode: Rendering mode
-            level: Optional pre-built level
             **kwargs: Additional arguments
         """
         super().__init__(
-            curriculum=curriculum,
+            env_config=env_config,
             render_mode=render_mode,
-            level=level,
             single_agent=True,
             **kwargs,
         )

--- a/mettagrid/src/metta/mettagrid/level_builder.py
+++ b/mettagrid/src/metta/mettagrid/level_builder.py
@@ -6,11 +6,11 @@ import numpy.typing as npt
 
 
 @dataclass
-class Level:
+class LevelMap:
     """
-    Represents a level in the MettaGrid game.
+    Represents a level map in the MettaGrid game.
 
-    Note: this is intentionally called "Level" instead of "Map" because `map` is a reserved word in Python.
+    Note: Previously called "Level", renamed to "LevelMap" for clarity.
     """
 
     # Two-dimensional grid of strings.
@@ -34,4 +34,4 @@ class LevelBuilder(ABC):
     """
 
     @abstractmethod
-    def build(self) -> Level: ...
+    def build(self) -> LevelMap: ...

--- a/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c_config.py
@@ -1,5 +1,6 @@
 import copy
 
+from metta.mettagrid.config import PyConverterConfig, PyGameConfig, PyWallConfig
 from metta.mettagrid.mettagrid_c import ActionConfig as CppActionConfig
 from metta.mettagrid.mettagrid_c import AgentConfig as CppAgentConfig
 from metta.mettagrid.mettagrid_c import AttackActionConfig as CppAttackActionConfig
@@ -8,7 +9,6 @@ from metta.mettagrid.mettagrid_c import ConverterConfig as CppConverterConfig
 from metta.mettagrid.mettagrid_c import GameConfig as CppGameConfig
 from metta.mettagrid.mettagrid_c import GlobalObsConfig as CppGlobalObsConfig
 from metta.mettagrid.mettagrid_c import WallConfig as CppWallConfig
-from metta.mettagrid.mettagrid_config import PyConverterConfig, PyGameConfig, PyWallConfig
 
 
 def convert_to_cpp_game_config(mettagrid_config_dict: dict):

--- a/mettagrid/src/metta/mettagrid/puffer_base.py
+++ b/mettagrid/src/metta/mettagrid/puffer_base.py
@@ -23,13 +23,11 @@ from __future__ import annotations
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
-from omegaconf import OmegaConf
 from pufferlib import PufferEnv
 from typing_extensions import override
 
+from metta.mettagrid.config import EnvConfig
 from metta.mettagrid.core import MettaGridCore
-from metta.mettagrid.curriculum.core import Curriculum
-from metta.mettagrid.level_builder import Level
 from metta.mettagrid.mettagrid_c import (
     dtype_actions,
     dtype_observations,
@@ -63,9 +61,8 @@ class MettaGridPufferBase(MettaGridCore, PufferEnv):
 
     def __init__(
         self,
-        curriculum: Curriculum,
+        env_config: EnvConfig,
         render_mode: Optional[str] = None,
-        level: Optional[Level] = None,
         buf: Optional[Any] = None,
         **kwargs: Any,
     ):
@@ -73,33 +70,16 @@ class MettaGridPufferBase(MettaGridCore, PufferEnv):
         Initialize PufferLib base environment.
 
         Args:
-            curriculum: Curriculum for task management
+            env_config: Environment configuration
             render_mode: Rendering mode
-            level: Optional pre-built level
             buf: PufferLib buffer object
             **kwargs: Additional arguments
         """
-        # Store curriculum
-        self._curriculum = curriculum
-        self._task = curriculum.get_task()
-
-        # Get level from curriculum if not provided
-        if level is None:
-            level = self._task.env_cfg().game.map_builder.build()
-
-        # Ensure we have a level
-        assert level is not None, "Level must be provided or generated from curriculum"
-
-        # Get game config for core initialization
-        task_cfg = self._task.env_cfg()
-        game_config_dict = OmegaConf.to_container(task_cfg.game)
-        assert isinstance(game_config_dict, dict), "Game config must be a dictionary"
 
         # Initialize core environment
         MettaGridCore.__init__(
             self,
-            level=level,
-            game_config_dict=game_config_dict,
+            env_config=env_config,
             render_mode=render_mode,
             **kwargs,
         )
@@ -137,14 +117,8 @@ class MettaGridPufferBase(MettaGridCore, PufferEnv):
         Returns:
             Initial observations array
         """
-        # Get task config for reset
-        assert self._task is not None, "Task not set"
-        task_cfg = self._task.env_cfg()
-        game_config_dict = OmegaConf.to_container(task_cfg.game)
-        assert isinstance(game_config_dict, dict), "Game config must be a dictionary"
-
         # Reset the environment to get initial observations
-        observations, _ = super().reset(game_config_dict)
+        observations, _ = super().reset()
         return observations
 
     @override
@@ -158,14 +132,7 @@ class MettaGridPufferBase(MettaGridCore, PufferEnv):
         Returns:
             Tuple of (observations, info)
         """
-        # Get new task from curriculum and its config
-        assert self._curriculum is not None, "Curriculum not set"
-        self._task = self._curriculum.get_task()
-        task_cfg = self._task.env_cfg()
-        game_config_dict = OmegaConf.to_container(task_cfg.game)
-        assert isinstance(game_config_dict, dict), "Game config must be a dictionary"
-
-        return super().reset(game_config_dict, seed)
+        return super().reset(env_config=None, seed=seed)
 
     @override
     def step(self, actions: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, Dict[str, Any]]:

--- a/mettagrid/src/metta/mettagrid/room/room.py
+++ b/mettagrid/src/metta/mettagrid/room/room.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 import numpy.typing as npt
 
-from metta.mettagrid.level_builder import Level, LevelBuilder
+from metta.mettagrid.level_builder import LevelBuilder, LevelMap
 
 
 class Room(LevelBuilder):
@@ -21,10 +21,10 @@ class Room(LevelBuilder):
         else:
             self.labels.append("large")
 
-    def build(self) -> Level:
+    def build(self) -> LevelMap:
         grid = self._build()
         bordered_grid = self._add_border(grid)
-        return Level(bordered_grid, self.labels)
+        return LevelMap(bordered_grid, self.labels)
 
     def _add_border(self, room):
         b = self._border_width

--- a/mettagrid/src/metta/mettagrid/room/utils.py
+++ b/mettagrid/src/metta/mettagrid/room/utils.py
@@ -90,3 +90,21 @@ def set_position(x, upper_bound):
     if x >= upper_bound:
         return upper_bound - 1 if x % 2 == 0 else upper_bound - 2
     return x
+
+
+def make_level_map(grid: np.ndarray, labels: Optional[List[str]] = None):
+    """Create a LevelMap from a grid and optional labels.
+
+    Args:
+        grid: 2D numpy array representing the game grid
+        labels: Optional list of labels for the level
+
+    Returns:
+        LevelMap object
+    """
+    from metta.mettagrid.level_builder import LevelMap
+
+    if labels is None:
+        labels = []
+
+    return LevelMap(grid=grid, labels=labels)

--- a/mettagrid/src/metta/mettagrid/util/actions.py
+++ b/mettagrid/src/metta/mettagrid/util/actions.py
@@ -3,10 +3,8 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
-from metta.mettagrid import (
-    MettaGridEnv,
-    dtype_actions,
-)
+from metta.mettagrid import dtype_actions
+from metta.mettagrid.auto_reset_env import AutoResetEnv
 from metta.mettagrid.mettagrid_c import MettaGrid
 
 
@@ -48,7 +46,7 @@ class Orientation(Enum):
 
 
 def generate_valid_random_actions(
-    env: MettaGridEnv,
+    env: AutoResetEnv,
     num_agents: int,
     force_action_type: Optional[int] = None,
     force_action_arg: Optional[int] = None,
@@ -58,7 +56,7 @@ def generate_valid_random_actions(
     Generate valid actions for all agents, respecting maximum argument values.
 
     Args:
-        env: MettaGridEnv instance
+        env: AutoResetEnv instance
         num_agents: Number of agents to generate actions for
         force_action_type: If provided, use this action type for all agents
         force_action_arg: If provided, use this action arg (clamped to valid range) for all agents

--- a/mettagrid/tests/renderer/test_nethack.py
+++ b/mettagrid/tests/renderer/test_nethack.py
@@ -6,16 +6,23 @@ This module contains unit tests for the NethackRenderer, ensuring proper
 ASCII rendering, alignment, and NetHack-style conversion functionality.
 """
 
+import os
+
+# Import test helper from parent directory
+import sys
 from unittest.mock import patch
 
 import pytest
 from omegaconf import OmegaConf
 
+from metta.mettagrid.auto_reset_env import AutoResetEnv
 from metta.mettagrid.char_encoder import CHAR_TO_NAME
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.renderer.nethack import NethackRenderer
 from metta.mettagrid.util.hydra import get_cfg
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from test_helpers import create_env_config_from_curriculum
 
 
 class TestNethackRenderer:
@@ -205,7 +212,7 @@ class TestNethackRenderer:
 
 
 class TestRendererIntegration:
-    """Test renderer integration with MettaGridEnv and tools.sim style setup."""
+    """Test renderer integration with AutoResetEnv and tools.sim style setup."""
 
     @patch("builtins.print")
     def test_environment_rendering_workflow(self, mock_print):
@@ -226,7 +233,8 @@ class TestRendererIntegration:
         )
 
         curriculum = SingleTaskCurriculum("test", cfg)
-        env = MettaGridEnv(curriculum, render_mode="human")
+        env_config = create_env_config_from_curriculum(curriculum)
+        env = AutoResetEnv(env_config=env_config, render_mode="human")
 
         # Reset and render
         obs, info = env.reset()
@@ -269,7 +277,8 @@ class TestRendererIntegration:
         )
 
         curriculum = SingleTaskCurriculum("test", cfg)
-        env = MettaGridEnv(curriculum, render_mode="human")
+        env_config = create_env_config_from_curriculum(curriculum)
+        env = AutoResetEnv(env_config=env_config, render_mode="human")
 
         obs, info = env.reset()
 
@@ -310,10 +319,11 @@ class TestRendererIntegration:
         )
 
         curriculum = SingleTaskCurriculum("test", cfg)
+        env_config = create_env_config_from_curriculum(curriculum)
 
         # The key: render_mode="human" enables NethackRenderer
         with patch("builtins.print"):
-            env = MettaGridEnv(curriculum, render_mode="human")
+            env = AutoResetEnv(env_config=env_config, render_mode="human")
             assert env._renderer is not None
             assert env._renderer.__class__.__name__ == "NethackRenderer"
 

--- a/mettagrid/tests/test_buffer_reuse.py
+++ b/mettagrid/tests/test_buffer_reuse.py
@@ -1,16 +1,17 @@
-"""Test that MettaGridEnv properly reuses buffers across resets."""
+"""Test that AutoResetEnv properly reuses buffers across resets."""
 
 import numpy as np
+from test_helpers import create_env_config_from_curriculum
 
+from metta.mettagrid import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.util.hydra import get_cfg
 
 
 def test_buffer_reuse_across_resets():
     """
     Test that:
-    1. Creates an MettaGridEnv
+    1. Creates an AutoResetEnv
     2. Sets buffers on it
     3. Resets it
     4. Makes sure it has a new cpp env, but uses the same buffers
@@ -21,8 +22,11 @@ def test_buffer_reuse_across_resets():
     # Create curriculum with task name and config
     curriculum = SingleTaskCurriculum("buffer_test", task_cfg=cfg)
 
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     # Create environment
-    env = MettaGridEnv(curriculum=curriculum, render_mode=None)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
 
     # Get initial C++ environment reference
     initial_cpp_env = env.c_env
@@ -94,8 +98,11 @@ def test_buffer_consistency_during_episode():
     # Create curriculum with task name and config
     curriculum = SingleTaskCurriculum("buffer_test", task_cfg=cfg)
 
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     # Create environment
-    env = MettaGridEnv(curriculum=curriculum, render_mode=None)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
 
     # Reset environment
     obs, info = env.reset(seed=42)

--- a/mettagrid/tests/test_buffer_sharing_regression.py
+++ b/mettagrid/tests/test_buffer_sharing_regression.py
@@ -14,7 +14,7 @@ import time
 import numpy as np
 import pytest
 
-from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.mettagrid import AutoResetEnv
 
 
 class TestBufferSharingRegression:
@@ -75,15 +75,15 @@ class TestBufferSharingRegression:
 
     def test_step_method_signature_stability(self):
         """
-        Test that MettaGridEnv.step method signature hasn't changed unexpectedly.
+        Test that AutoResetEnv.step method signature hasn't changed unexpectedly.
 
         This catches regressions where the step method is accidentally modified
         in a way that could break buffer sharing.
         """
         # Verify step method exists and has expected signature
-        assert hasattr(MettaGridEnv, "step"), "MettaGridEnv missing step method"
+        assert hasattr(AutoResetEnv, "step"), "AutoResetEnv missing step method"
 
-        step_method = MettaGridEnv.step
+        step_method = AutoResetEnv.step
         sig = inspect.signature(step_method)
         params = list(sig.parameters.keys())
 

--- a/mettagrid/tests/test_env_map.py
+++ b/mettagrid/tests/test_env_map.py
@@ -1,7 +1,7 @@
 from omegaconf import OmegaConf
 
-from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.mettagrid import AutoResetEnv
+from metta.mettagrid.config import EnvConfig, PyGameConfig
 from metta.mettagrid.room.random import Random
 from metta.mettagrid.util.hydra import get_cfg
 
@@ -16,8 +16,12 @@ def test_env_map():
     level_builder = Random(width=3, height=4, objects=OmegaConf.create({}), agents=1, border_width=1)
     level = level_builder.build()
 
-    curriculum = SingleTaskCurriculum("benchmark", cfg)
-    env = MettaGridEnv(curriculum, render_mode="human", level=level)
+    # Create EnvConfig directly
+    game_config_dict = OmegaConf.to_container(cfg.game)
+    game_config = PyGameConfig(**game_config_dict)
+    env_config = EnvConfig(game=game_config, level_map=level)
+
+    env = AutoResetEnv(env_config=env_config, render_mode="human")
 
     assert env.map_width == 3 + 2 * 1
     assert env.map_height == 4 + 2 * 1

--- a/mettagrid/tests/test_gym_env.py
+++ b/mettagrid/tests/test_gym_env.py
@@ -7,6 +7,7 @@ This module tests the MettaGridGymEnv with Gymnasium's standard environment inte
 import numpy as np
 import pytest
 from omegaconf import DictConfig
+from test_helpers import create_env_config_from_curriculum
 
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
 from metta.mettagrid.gym_env import MettaGridGymEnv, SingleAgentMettaGridGymEnv
@@ -67,11 +68,13 @@ def test_multi_agent_gym_env(simple_config):
     # Create config and curriculum
     curriculum = SingleTaskCurriculum("gym_multi_test", simple_config)
 
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     # Create environment
     env = MettaGridGymEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
         single_agent=False,
     )
 
@@ -107,11 +110,13 @@ def test_single_agent_gym_env(simple_config):
     simple_config.game.map_builder.agents = 1
     curriculum = SingleTaskCurriculum("gym_single_test", simple_config)
 
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     # Create environment
     env = SingleAgentMettaGridGymEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Test environment properties
@@ -142,10 +147,13 @@ def test_single_agent_gym_env(simple_config):
 def test_gym_env_episode_termination(simple_config):
     """Test that environment terminates properly."""
     curriculum = SingleTaskCurriculum("gym_termination_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridGymEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
         single_agent=False,
     )
 

--- a/mettagrid/tests/test_helpers.py
+++ b/mettagrid/tests/test_helpers.py
@@ -1,0 +1,47 @@
+"""Test helpers for converting between old and new environment configurations."""
+
+from typing import Optional
+
+from omegaconf import OmegaConf
+
+from metta.mettagrid.config import EnvConfig, PyGameConfig
+from metta.mettagrid.curriculum.core import Curriculum
+from metta.mettagrid.level_builder import LevelMap
+
+
+def create_env_config_from_curriculum(curriculum: Curriculum, level: Optional[LevelMap] = None) -> EnvConfig:
+    """Create EnvConfig from a curriculum for testing.
+
+    This helper allows tests to continue using curriculum-based setup
+    while the environments now use EnvConfig directly.
+    """
+    task = curriculum.get_task()
+    task_cfg = task.env_cfg()
+
+    # Extract game config
+    if hasattr(task_cfg, "game"):
+        # Already structured config
+        game_dict = OmegaConf.to_container(task_cfg.game) if hasattr(task_cfg.game, "__dict__") else task_cfg.game
+    else:
+        # Assume task_cfg is the game config
+        game_dict = OmegaConf.to_container(task_cfg) if hasattr(task_cfg, "__dict__") else task_cfg
+
+    assert isinstance(game_dict, dict), "Game config must be a dictionary"
+
+    # Create PyGameConfig from dict
+    game_config = PyGameConfig(**game_dict)
+
+    # Get level_map from task or build it
+    if level is not None:
+        # Use provided level
+        level_map = level
+    elif hasattr(game_config, "map_builder") and game_config.map_builder is not None:
+        level_map = game_config.map_builder.build()
+    else:
+        # Create a minimal level map for testing
+        import numpy as np
+
+        grid = np.array([["empty"]], dtype="<U50")
+        level_map = LevelMap(grid=grid, labels=[])
+
+    return EnvConfig(game=game_config, level_map=level_map)

--- a/mettagrid/tests/test_interactive.py
+++ b/mettagrid/tests/test_interactive.py
@@ -11,9 +11,9 @@ import time
 import numpy as np
 from omegaconf import DictConfig
 
+from metta.mettagrid import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
 from metta.mettagrid.gym_env import SingleAgentMettaGridGymEnv
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.pettingzoo_env import MettaGridPettingZooEnv
 
 
@@ -96,7 +96,7 @@ def create_game_config():
 
 
 def test_puffer_env():
-    """Test MettaGridEnv (PufferLib-based) interactively."""
+    """Test AutoResetEnv (PufferLib-based) interactively."""
     print("\n" + "=" * 50)
     print("TESTING METTAGRID ENVIRONMENT (PufferLib-based)")
     print("=" * 50)
@@ -104,7 +104,7 @@ def test_puffer_env():
     config = create_game_config()
     curriculum = SingleTaskCurriculum("mettagrid_interactive", config)
 
-    env = MettaGridEnv(
+    env = AutoResetEnv(
         curriculum=curriculum,
         render_mode="human",
         is_training=False,
@@ -144,7 +144,7 @@ def test_puffer_env():
         time.sleep(0.1)  # Brief pause for readability
 
     env.close()
-    print("MettaGridEnv (PufferLib-compatible) test completed!")
+    print("AutoResetEnv (PufferLib-compatible) test completed!")
 
 
 def test_gym_env():

--- a/mettagrid/tests/test_leaks.py
+++ b/mettagrid/tests/test_leaks.py
@@ -4,9 +4,10 @@ import os
 import psutil
 import pytest
 from hydra import compose, initialize
+from test_helpers import create_env_config_from_curriculum
 
+from metta.mettagrid import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 
 
 @pytest.fixture(scope="module")
@@ -19,16 +20,18 @@ def cfg():
 
 
 def test_mettagrid_env_init(cfg):
-    """Test that the MettaGridEnv can be initialized properly."""
+    """Test that the AutoResetEnv can be initialized properly."""
     curriculum = SingleTaskCurriculum("test", cfg)
-    env = MettaGridEnv(curriculum, render_mode=None)
-    assert env is not None, "Failed to initialize MettaGridEnv"
+    env_config = create_env_config_from_curriculum(curriculum)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
+    assert env is not None, "Failed to initialize AutoResetEnv"
 
 
 def test_mettagrid_env_reset(cfg):
-    """Test that the MettaGridEnv can be reset multiple times without memory leaks."""
+    """Test that the AutoResetEnv can be reset multiple times without memory leaks."""
     curriculum = SingleTaskCurriculum("test", cfg)
-    env = MettaGridEnv(curriculum, render_mode=None)
+    env_config = create_env_config_from_curriculum(curriculum)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
     # Reset the environment multiple times
     for _ in range(10):
         observation = env.reset()
@@ -44,7 +47,7 @@ def get_memory_usage():
 @pytest.mark.slow
 def test_mettagrid_env_no_memory_leaks(cfg):
     """
-    Test that the MettaGridEnv can be reset multiple times without memory leaks.
+    Test that the AutoResetEnv can be reset multiple times without memory leaks.
 
     This test creates and destroys an environment object after multiple resets
     to verify that no memory leaks occur during this process.
@@ -63,7 +66,8 @@ def test_mettagrid_env_no_memory_leaks(cfg):
     for i in range(num_iterations):
         # Create the environment
         curriculum = SingleTaskCurriculum("test", cfg)
-        env = MettaGridEnv(curriculum, render_mode=None)
+        env_config = create_env_config_from_curriculum(curriculum)
+        env = AutoResetEnv(env_config=env_config, render_mode=None)
 
         # Reset the environment multiple times
         for _ in range(5):

--- a/mettagrid/tests/test_mettagrid_env.py
+++ b/mettagrid/tests/test_mettagrid_env.py
@@ -1,18 +1,18 @@
 import pytest
-from omegaconf import OmegaConf
-from omegaconf.errors import ConfigAttributeError
+from pydantic import ValidationError
 
-from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
+from metta.mettagrid import AutoResetEnv
 
 
-def test_invalid_env_map_type_raises():
-    cfg = OmegaConf.create({})
-    curriculum = SingleTaskCurriculum("test", cfg)
-    with pytest.raises(ConfigAttributeError):
-        MettaGridEnv(curriculum, render_mode=None, env_map={})
+def test_invalid_env_config_type_raises():
+    """Test that invalid env_config types raise proper errors."""
+    with pytest.raises(ValidationError):
+        # Passing a dict instead of EnvConfig should raise ValidationError
+        AutoResetEnv(env_config={}, render_mode=None)
 
 
-def test_invalid_env_cfg_type_raises():
-    with pytest.raises(ValueError):
-        MettaGridEnv({}, render_mode=None)
+def test_invalid_env_config_missing_fields_raises():
+    """Test that incomplete env_config raises proper errors."""
+    with pytest.raises(ValidationError):
+        # Passing an incomplete env_config should raise ValidationError
+        AutoResetEnv(env_config={"game": {}}, render_mode=None)

--- a/mettagrid/tests/test_movement_metrics.py
+++ b/mettagrid/tests/test_movement_metrics.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import numpy as np
 from omegaconf import OmegaConf
+from test_helpers import create_env_config_from_curriculum
 
+from metta.mettagrid.auto_reset_env import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.util.hydra import get_cfg
 
 
@@ -32,7 +33,8 @@ def test_movement_metrics():
     )
     # Create curriculum and environment
     curriculum = SingleTaskCurriculum("test", cfg)
-    env = MettaGridEnv(curriculum, render_mode=None)
+    env_config = create_env_config_from_curriculum(curriculum)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
 
     obs, _ = env.reset()
 

--- a/mettagrid/tests/test_new_env_hierarchy.py
+++ b/mettagrid/tests/test_new_env_hierarchy.py
@@ -71,11 +71,11 @@ class TestNewEnvironmentHierarchy:
     def test_imports(self):
         """Test that all new classes can be imported."""
         # Test basic imports - this verifies our modules are structured correctly
+        from metta.mettagrid import AutoResetEnv
         from metta.mettagrid.gym_env import MettaGridGymEnv, SingleAgentMettaGridGymEnv
-        from metta.mettagrid.mettagrid_env import MettaGridEnv
         from metta.mettagrid.pettingzoo_env import MettaGridPettingZooEnv
 
-        assert MettaGridEnv is not None
+        assert AutoResetEnv is not None
         assert MettaGridGymEnv is not None
         assert SingleAgentMettaGridGymEnv is not None
         assert MettaGridPettingZooEnv is not None
@@ -185,7 +185,7 @@ if __name__ == "__main__":
 
     # Test imports
     try:
-        from metta.mettagrid.mettagrid_env import MettaGridEnv
+        from metta.mettagrid import AutoResetEnv
 
         print("✓ All imports successful")
     except Exception as e:
@@ -194,11 +194,11 @@ if __name__ == "__main__":
 
     # Test basic creation
     try:
-        env = MettaGridEnv(curriculum=curriculum, render_mode=None, is_training=False)
+        env = AutoResetEnv(curriculum=curriculum, render_mode=None, is_training=False)
         env.close()
-        print("✓ MettaGridEnv creation successful")
+        print("✓ AutoResetEnv creation successful")
     except Exception as e:
-        print(f"✗ MettaGridEnv creation failed: {e}")
+        print(f"✗ AutoResetEnv creation failed: {e}")
         sys.exit(1)
 
     print("✓ All manual tests passed!")

--- a/mettagrid/tests/test_pettingzoo_env.py
+++ b/mettagrid/tests/test_pettingzoo_env.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from omegaconf import DictConfig
 from pettingzoo.test import parallel_api_test
+from test_helpers import create_env_config_from_curriculum
 
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
 from metta.mettagrid.pettingzoo_env import MettaGridPettingZooEnv
@@ -67,10 +68,12 @@ def test_pettingzoo_env_creation(simple_config):
     """Test PettingZoo environment creation and properties."""
     curriculum = SingleTaskCurriculum("pettingzoo_test", simple_config)
 
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Test environment properties
@@ -86,10 +89,13 @@ def test_pettingzoo_env_creation(simple_config):
 def test_pettingzoo_env_reset(simple_config):
     """Test PettingZoo environment reset functionality."""
     curriculum = SingleTaskCurriculum("pettingzoo_reset_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Test reset
@@ -113,10 +119,13 @@ def test_pettingzoo_env_reset(simple_config):
 def test_pettingzoo_env_step(simple_config):
     """Test PettingZoo environment step functionality."""
     curriculum = SingleTaskCurriculum("pettingzoo_step_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     observations, infos = env.reset(seed=42)
@@ -157,10 +166,13 @@ def test_pettingzoo_env_step(simple_config):
 def test_pettingzoo_env_agent_removal(simple_config):
     """Test that agents are properly removed when terminated."""
     curriculum = SingleTaskCurriculum("pettingzoo_removal_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     observations, infos = env.reset(seed=42)
@@ -190,10 +202,13 @@ def test_pettingzoo_env_agent_removal(simple_config):
 def test_pettingzoo_env_spaces(simple_config):
     """Test PettingZoo environment observation and action spaces."""
     curriculum = SingleTaskCurriculum("pettingzoo_spaces_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Test space methods
@@ -214,10 +229,13 @@ def test_pettingzoo_env_spaces(simple_config):
 def test_pettingzoo_env_state(simple_config):
     """Test PettingZoo environment state functionality."""
     curriculum = SingleTaskCurriculum("pettingzoo_state_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     observations, infos = env.reset(seed=42)
@@ -237,10 +255,13 @@ def test_pettingzoo_env_state(simple_config):
 def test_pettingzoo_api_compliance(simple_config):
     """Test official PettingZoo API compliance."""
     curriculum = SingleTaskCurriculum("pettingzoo_compliance_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Run the official PettingZoo parallel API compliance test
@@ -252,10 +273,13 @@ def test_pettingzoo_api_compliance(simple_config):
 def test_pettingzoo_episode_lifecycle(simple_config):
     """Test the complete episode lifecycle with PettingZoo API."""
     curriculum = SingleTaskCurriculum("pettingzoo_lifecycle_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Reset environment
@@ -314,10 +338,13 @@ def test_pettingzoo_episode_lifecycle(simple_config):
 def test_pettingzoo_action_observation_spaces(simple_config):
     """Test that action and observation spaces are properly configured."""
     curriculum = SingleTaskCurriculum("pettingzoo_spaces_validation_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode=None,
-        is_training=False,
     )
 
     # Reset to ensure environment is initialized
@@ -348,10 +375,13 @@ def test_pettingzoo_action_observation_spaces(simple_config):
 def test_pettingzoo_render_functionality(simple_config):
     """Test that rendering works with PettingZoo interface."""
     curriculum = SingleTaskCurriculum("pettingzoo_render_test", simple_config)
+
+    # Convert to EnvConfig
+    env_config = create_env_config_from_curriculum(curriculum)
+
     env = MettaGridPettingZooEnv(
-        curriculum=curriculum,
+        env_config=env_config,
         render_mode="human",
-        is_training=False,
     )
 
     # Reset environment

--- a/mettagrid/tests/test_wandb_movement_metrics.py
+++ b/mettagrid/tests/test_wandb_movement_metrics.py
@@ -3,9 +3,10 @@
 
 import numpy as np
 from omegaconf import OmegaConf
+from test_helpers import create_env_config_from_curriculum
 
+from metta.mettagrid.auto_reset_env import AutoResetEnv
 from metta.mettagrid.curriculum.core import SingleTaskCurriculum
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.util.hydra import get_cfg
 
 
@@ -37,7 +38,8 @@ def test_wandb_movement_metrics():
 
     # Create curriculum and environment
     curriculum = SingleTaskCurriculum("test", cfg)
-    env = MettaGridEnv(curriculum, render_mode=None)
+    env_config = create_env_config_from_curriculum(curriculum)
+    env = AutoResetEnv(env_config=env_config, render_mode=None)
 
     obs, _ = env.reset()
 

--- a/tools/renderer.py
+++ b/tools/renderer.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, List, Protocol, Tuple
+from typing import Any, List, Protocol
 
 import numpy as np
 from omegaconf import DictConfig, OmegaConf
 
 from metta.mettagrid import (
-    MettaGridEnv,
+    CurriculumEnv,
     dtype_actions,
     dtype_observations,
     dtype_rewards,
@@ -35,7 +35,7 @@ class Policy(Protocol):
 class BasePolicy(ABC):
     """Base class for all policies."""
 
-    def __init__(self, env: MettaGridEnv) -> None:
+    def __init__(self, env) -> None:
         self.env = env
         self.num_agents = env.num_agents
         self.action_space = env.action_space
@@ -59,7 +59,7 @@ class RandomPolicy(BasePolicy):
 class SimplePolicy(BasePolicy):
     """A simple policy that tries to move towards objectives with valid actions."""
 
-    def __init__(self, env: MettaGridEnv) -> None:
+    def __init__(self, env) -> None:
         super().__init__(env)
 
         # Movement options
@@ -128,7 +128,7 @@ class SimplePolicy(BasePolicy):
 class TrainedPolicyWrapper(BasePolicy):
     """Wrapper for trained policies with action validation."""
 
-    def __init__(self, policy: Any, env: MettaGridEnv) -> None:
+    def __init__(self, policy: Any, env) -> None:
         super().__init__(env)
         self.policy = policy
         self._max_args: List[int] = env._c_env.max_action_args()
@@ -182,7 +182,7 @@ class TrainedPolicyWrapper(BasePolicy):
         return actions
 
 
-def get_policy(policy_type: str, env: MettaGridEnv, cfg: DictConfig) -> Policy:
+def get_policy(policy_type: str, env, cfg: DictConfig) -> Policy:
     """
     Get a policy based on the specified type.
 
@@ -205,7 +205,7 @@ def get_policy(policy_type: str, env: MettaGridEnv, cfg: DictConfig) -> Policy:
         return SimplePolicy(env)
 
 
-def _load_trained_policy(env: MettaGridEnv, cfg: DictConfig) -> Policy:
+def _load_trained_policy(env, cfg: DictConfig) -> Policy:
     """Attempt to load a trained policy, falling back to simple policy on failure."""
     try:
         policy_store = get_policy_store_from_cfg(cfg)
@@ -217,7 +217,7 @@ def _load_trained_policy(env: MettaGridEnv, cfg: DictConfig) -> Policy:
         return SimplePolicy(env)
 
 
-def setup_environment(cfg: DictConfig) -> Tuple[MettaGridEnv, str]:
+def setup_environment(cfg: DictConfig):
     """
     Set up the MettaGrid environment based on configuration.
 
@@ -250,7 +250,7 @@ def setup_environment(cfg: DictConfig) -> Tuple[MettaGridEnv, str]:
 
         curriculum = SingleTaskCurriculum("renderer", env_cfg)
 
-    env = MettaGridEnv(curriculum, render_mode=render_mode)
+    env = CurriculumEnv(curriculum=curriculum, render_mode=render_mode)
 
     return env, render_mode
 


### PR DESCRIPTION
# Refactor MettaGridEnv to AutoResetEnv and CurriculumEnv with EnvConfig

This PR adds a Pydantic object for the "MettaGridEnvConfig", which should enable us to start introducing fully pythonic configuration.

Also:
* Renames MettagridEnv --> AutoResetEnv to clarify the responsibility of that class
* Introduces a CurriculumEnv that handles updating the env config on an AutoResetEnv, which will enable us to move Curriculum out of mettagrid
* Setup a demo_config.py that can be shared by all the training demos
* Add some builder objects for easier env config configuration.

Co-written with @daveey 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211029494352239)