### PR TITLE
Optimize map grid memory usage

### DIFF
--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -9,8 +9,7 @@ from metta.map.scene import load_class, make_scene, scene_cfg_to_dict
 from metta.map.scenes.copy_grid import CopyGrid
 from metta.map.scenes.room_grid import RoomGrid, RoomGridParams
 from metta.map.scenes.transplant_scene import TransplantScene
-from metta.map.types import MapGrid
-from metta.mettagrid.level_builder import Level, LevelBuilder
+from metta.mettagrid.level_builder import Level, LevelBuilder, create_grid
 
 from .types import Area, AreaWhere, ChildrenAction, SceneCfg
 
@@ -149,7 +148,7 @@ class MapGen(LevelBuilder):
                         raise ValueError("width and height must be provided if the root scene has no intrinsic size")
                     self.height, self.width = intrinsic_size
 
-                instance_grid = np.full((self.height, self.width), "empty", dtype="<U50")
+                instance_grid = create_grid(self.height, self.width, fill_value="empty")
                 instance_area = Area(x=0, y=0, width=self.width, height=self.height, grid=instance_grid, tags=[])
                 instance_scene = make_scene(self.root, instance_area, rng=self.rng)
                 instance_scene.render_with_children()
@@ -226,11 +225,7 @@ class MapGen(LevelBuilder):
 
         bw = self.params.border_width
 
-        self.grid: MapGrid = np.full(
-            (self.inner_height + 2 * bw, self.inner_width + 2 * bw),
-            "empty",
-            dtype="<U50",
-        )
+        self.grid = create_grid(self.inner_height + 2 * bw, self.inner_width + 2 * bw, fill_value="empty")
 
         # draw outer walls
         # note that the inner walls when instances > 1 will be drawn by the RoomGrid scene

--- a/metta/map/mapgen.py
+++ b/metta/map/mapgen.py
@@ -148,7 +148,7 @@ class MapGen(LevelBuilder):
                         raise ValueError("width and height must be provided if the root scene has no intrinsic size")
                     self.height, self.width = intrinsic_size
 
-                instance_grid = create_grid(self.height, self.width, fill_value="empty")
+                instance_grid = create_grid(self.height, self.width)
                 instance_area = Area(x=0, y=0, width=self.width, height=self.height, grid=instance_grid, tags=[])
                 instance_scene = make_scene(self.root, instance_area, rng=self.rng)
                 instance_scene.render_with_children()
@@ -225,7 +225,7 @@ class MapGen(LevelBuilder):
 
         bw = self.params.border_width
 
-        self.grid = create_grid(self.inner_height + 2 * bw, self.inner_width + 2 * bw, fill_value="empty")
+        self.grid = create_grid(self.inner_height + 2 * bw, self.inner_width + 2 * bw)
 
         # draw outer walls
         # note that the inner walls when instances > 1 will be drawn by the RoomGrid scene

--- a/metta/map/utils/ascii_grid.py
+++ b/metta/map/utils/ascii_grid.py
@@ -1,7 +1,6 @@
-import numpy as np
-
 from metta.map.types import MapGrid
 from metta.mettagrid.char_encoder import char_to_grid_object, grid_object_to_char
+from metta.mettagrid.level_builder import create_grid
 
 
 def add_pretty_border(lines: list[str]) -> list[str]:
@@ -35,7 +34,7 @@ def print_grid(grid: MapGrid, border=True):
 
 
 def lines_to_grid(lines: list[str]) -> MapGrid:
-    grid = np.full((len(lines), len(lines[0])), "empty", dtype="<U50")
+    grid = create_grid(len(lines), len(lines[0]))
     for r, line in enumerate(lines):
         for c, char in enumerate(line):
             grid[r, c] = char_to_grid_object(char)

--- a/mettagrid/src/metta/mettagrid/level_builder.py
+++ b/mettagrid/src/metta/mettagrid/level_builder.py
@@ -1,8 +1,21 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 import numpy.typing as npt
+
+MapGrid: TypeAlias = npt.NDArray[np.str_]
+
+
+map_grid_dtype = np.dtype("<U20")
+
+
+def create_grid(height: int, width: int, fill_value: str = "empty") -> MapGrid:
+    """
+    Creates a NumPy grid with the given height and width, pre-filled with the specified fill_value.
+    """
+    return np.full((height, width), fill_value, dtype=map_grid_dtype)
 
 
 @dataclass
@@ -16,7 +29,7 @@ class Level:
     # Two-dimensional grid of strings.
     # Possible values: "wall", "empty", "agent", etc.
     # For the full list, see `mettagrid_c.cpp`.
-    grid: npt.NDArray[np.str_]
+    grid: MapGrid
 
     # List of labels. These will be used for `rewards/map:...` episode stats.
     labels: list[str]

--- a/mettagrid/src/metta/mettagrid/room/maze.py
+++ b/mettagrid/src/metta/mettagrid/room/maze.py
@@ -1,7 +1,8 @@
 import random
 
+from metta.mettagrid.level_builder import create_grid
 from metta.mettagrid.room.room import Room
-from metta.mettagrid.room.utils import create_grid, set_position
+from metta.mettagrid.room.utils import set_position
 
 
 # Maze generation using Prim's algorithm

--- a/mettagrid/src/metta/mettagrid/room/room.py
+++ b/mettagrid/src/metta/mettagrid/room/room.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 import numpy.typing as npt
 
-from metta.mettagrid.level_builder import Level, LevelBuilder
+from metta.mettagrid.level_builder import Level, LevelBuilder, create_grid
 
 
 class Room(LevelBuilder):
@@ -29,7 +29,7 @@ class Room(LevelBuilder):
     def _add_border(self, room):
         b = self._border_width
         h, w = room.shape
-        final_level = np.full((h + b * 2, w + b * 2), self._border_object, dtype="<U50")
+        final_level = create_grid(h + b * 2, w + b * 2, fill_value=self._border_object)
         final_level[b : b + h, b : b + w] = room
         return final_level
 

--- a/mettagrid/src/metta/mettagrid/room/room_list.py
+++ b/mettagrid/src/metta/mettagrid/room/room_list.py
@@ -2,6 +2,7 @@ from typing import List
 
 import numpy as np
 
+from metta.mettagrid.level_builder import create_grid
 from metta.mettagrid.room.room import Room
 
 
@@ -47,7 +48,7 @@ class RoomList(Room):
             grid_cols = n_rooms
 
         # Create empty grid to hold all rooms
-        level = np.full((grid_rows * max_height, grid_cols * max_width), "empty", dtype="<U50")
+        level = create_grid(grid_rows * max_height, grid_cols * max_width)
 
         # Place rooms into grid
         for i in range(n_rooms):

--- a/mettagrid/src/metta/mettagrid/room/utils.py
+++ b/mettagrid/src/metta/mettagrid/room/utils.py
@@ -4,15 +4,10 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import numpy as np
 
-
-def create_grid(height: int, width: int, fill_value: str = "empty", dtype: str = "<U50") -> np.ndarray:
-    """
-    Creates a NumPy grid with the given height and width, pre-filled with the specified fill_value.
-    """
-    return np.full((height, width), fill_value, dtype=dtype)
+from metta.map.types import MapGrid
 
 
-def draw_border(grid: np.ndarray, border_width: int, border_object: str) -> None:
+def draw_border(grid: MapGrid, border_width: int, border_object: str) -> None:
     """
     Draws a border on the given grid in-place. The border (of thickness border_width) is set to border_object.
     """

--- a/mettagrid/src/metta/mettagrid/test_support/environment_builder.py
+++ b/mettagrid/src/metta/mettagrid/test_support/environment_builder.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional, Tuple
 
 import numpy as np
 
+from metta.mettagrid.level_builder import create_grid
 from metta.mettagrid.mettagrid_c import MettaGrid, PackedCoordinate, dtype_actions  # noqa: F401
 from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 
@@ -28,7 +29,7 @@ class TestEnvironmentBuilder:
     @staticmethod
     def create_basic_grid(width: int = 8, height: int = 4) -> np.ndarray:
         """Create a basic grid with walls around perimeter."""
-        game_map = np.full((height, width), "empty", dtype="<U50")
+        game_map = create_grid(height, width)
         game_map[0, :] = "wall"
         game_map[-1, :] = "wall"
         game_map[:, 0] = "wall"

--- a/mettagrid/tests/test_buffers.py
+++ b/mettagrid/tests/test_buffers.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from metta.mettagrid.level_builder import create_grid
 from metta.mettagrid.mettagrid_c import (
     MettaGrid,
     dtype_actions,
@@ -28,7 +29,7 @@ def create_minimal_mettagrid_c_env(max_steps=10, width=5, height=5, config_overr
         config_override: Dictionary to override/merge with default config
     """
     # Define a simple map: empty with walls around perimeter
-    game_map = np.full((height, width), "empty", dtype="<U50")
+    game_map = create_grid(height, width)
     game_map[0, :] = "wall"
     game_map[-1, :] = "wall"
     game_map[:, 0] = "wall"

--- a/mettagrid/tests/test_observations.py
+++ b/mettagrid/tests/test_observations.py
@@ -3,6 +3,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from metta.mettagrid.level_builder import create_grid
 from metta.mettagrid.mettagrid_c import MettaGrid, PackedCoordinate, dtype_actions
 from metta.mettagrid.test_support import ObservationHelper, TestEnvironmentBuilder, TokenTypes
 
@@ -727,7 +728,7 @@ class TestEdgeObservations:
         """Test observation window behavior when agent walks to corner of large map."""
         # Create a 15x10 grid (width=15, height=10) with 7x7 observation window
         builder = TestEnvironmentBuilder()
-        game_map = np.full((10, 15), "empty", dtype="<U50")
+        game_map = create_grid(10, 15)
 
         # Add walls around perimeter
         game_map[0, :] = "wall"

--- a/mettagrid/tests/test_swap.py
+++ b/mettagrid/tests/test_swap.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from metta.mettagrid.level_builder import map_grid_dtype
 from metta.mettagrid.mettagrid_c import MettaGrid, dtype_actions
 from metta.mettagrid.mettagrid_c_config import from_mettagrid_config
 
@@ -13,7 +14,7 @@ def test_swap():
     #   W A B    W=wall, A=agent, B=block (swappable)
     #   W W W
     game_map = np.array(
-        [["wall", "wall", "wall"], ["wall", "agent.red", "block"], ["wall", "wall", "wall"]], dtype="<U50"
+        [["wall", "wall", "wall"], ["wall", "agent.red", "block"], ["wall", "wall", "wall"]], dtype=map_grid_dtype
     )
 
     game_config = {
@@ -152,7 +153,7 @@ def test_swap_frozen_agent_preserves_layers():
             ["wall", "empty", "empty", "agent.blue", "wall"],
             ["wall", "wall", "wall", "wall", "wall"],
         ],
-        dtype="<U50",
+        dtype=map_grid_dtype,
     )
 
     game_config = {

--- a/tests/map/scenes/test_random.py
+++ b/tests/map/scenes/test_random.py
@@ -1,11 +1,5 @@
-import numpy as np
-
 from metta.map.scenes.random import Random
 from tests.map.scenes.utils import render_scene
-
-
-def make_grid(height: int, width: int) -> np.ndarray:
-    return np.full((height, width), "empty", dtype="<U50")
 
 
 def test_objects():

--- a/tests/map/scenes/utils.py
+++ b/tests/map/scenes/utils.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from metta.map.random.int import MaybeSeed
@@ -6,6 +5,7 @@ from metta.map.scene import Scene
 from metta.map.types import Area, ChildrenAction, MapGrid
 from metta.map.utils.ascii_grid import add_pretty_border, char_grid_to_lines
 from metta.map.utils.storable_map import grid_to_lines
+from metta.mettagrid.level_builder import create_grid
 
 
 def render_scene(
@@ -15,7 +15,7 @@ def render_scene(
     children: list[ChildrenAction] | None = None,
     seed: MaybeSeed = None,
 ):
-    grid = np.full(shape, "empty", dtype="<U50")
+    grid = create_grid(shape[0], shape[1])
     area = Area.root_area_from_grid(grid)
     scene = cls(area=area, params=params, children_actions=children or [], seed=seed)
     scene.render_with_children()

--- a/tests/map/utils/test_storable_map_io.py
+++ b/tests/map/utils/test_storable_map_io.py
@@ -2,11 +2,12 @@ import numpy as np
 from omegaconf import DictConfig
 
 from metta.map.utils.storable_map import StorableMap
+from metta.mettagrid.level_builder import map_grid_dtype
 from metta.mettagrid.util import file as file_utils
 
 
 def simple_map():
-    grid = np.array([["empty", "wall"], ["wall", "empty"]], dtype="<U50")
+    grid = np.array([["empty", "wall"], ["wall", "empty"]], dtype=map_grid_dtype)
     return StorableMap(grid, metadata={}, config=DictConfig({}))
 
 


### PR DESCRIPTION
See https://app.asana.com/1/1209016784099267/project/1209805539287945/task/1211015230313270?focus=true for context - we now store `self._level` in `MettaGridCore`, and `U50` dtype used 175 bytes (maybe even 200? I'm pretty sure it's 4-byte unicode strings) per cell, which is a lot.

This PR switches us to `U20`. The longest object name we currently use, `generator_green`, is 15 chars long.

Longer-term, I want to switch map grids to int-based arrays; we can do this by parameterizing map builder with env config, and using `type_id`s to write strings in scene classes. But that's a bigger refactoring (in particular, it requires figuring out what to do with agents, which don't type `type_id`s, only group ids).

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211030531657496)