### PR TITLE
remove the ability to run "rm" from claude code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,6 @@
       "Bash(cat:*)",
       "Bash(pytest:*)",
       "Bash(./devops/test_uv_setup.sh:*)",
-      "Bash(rm:*)",
       "WebFetch(domain:docs.astral.sh)",
       "Bash(ruff check:*)",
       "Bash(metta configure:*)",


### PR DESCRIPTION
claude can currently run the rm command in our repo. not good practice. he is deleting files without permission. you can put that in ./.claude/settings.local.json if you want claude to be able to rm without permission