### PR TITLE
Skip flaky memory and performance tests

### DIFF
--- a/common/tests/util/test_system_monitor.py
+++ b/common/tests/util/test_system_monitor.py
@@ -617,6 +617,7 @@ class TestRealSystemMonitoring:
     """Tests that use the real system (not mocked)"""
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="Flaky test - memory release behavior is platform-dependent")
     def test_real_monitoring_memory_pattern(self):
         """Test monitoring memory allocation and deallocation patterns"""
         monitor = SystemMonitor(

--- a/mettagrid/tests/test_visitation_counts.py
+++ b/mettagrid/tests/test_visitation_counts.py
@@ -202,6 +202,7 @@ def _median_runtime(env, move_action, warmup_steps=10, test_steps=200, reps=15):
     return times[len(times) // 2]
 
 
+@pytest.mark.skip(reason="Flaky performance test - timing variations on different systems")
 def test_visitation_performance_impact(performance_config, simple_map):
     """Disabled visitation should not be materially slower."""
     move_action = np.array([[0, 0]], dtype=np.int32)


### PR DESCRIPTION
### TL;DR

Skip flaky tests that produce inconsistent results across different platforms.

### What changed?

- Added `@pytest.mark.skip` to two tests that exhibit flaky behavior:
  - `test_real_monitoring_memory_pattern` in `common/tests/util/test_system_monitor.py` due to platform-dependent memory release behavior
  - `test_visitation_performance_impact` in `mettagrid/tests/test_visitation_counts.py` due to timing variations on different systems

### How to test?

1. Run the test suite to verify that these tests are now skipped
2. Confirm that CI builds complete successfully without the flaky test failures

### Why make this change?

These tests were causing intermittent failures in CI pipelines due to their dependency on system-specific behaviors. Memory release patterns vary across platforms, and performance timing tests are sensitive to system load and hardware differences. Skipping these tests improves CI reliability while preserving the tests for potential local debugging when needed.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211039588731891)