### PR TITLE
Add leaderboards to observatory

### DIFF
--- a/app_backend/src/metta/app_backend/leaderboard_updater.py
+++ b/app_backend/src/metta/app_backend/leaderboard_updater.py
@@ -1,0 +1,147 @@
+# A thread that runs periodically and updates the leaderboard data.
+# Uses threads, not asyncio.
+
+import logging
+import threading
+import time
+import uuid
+
+from psycopg.rows import class_row
+from pydantic import BaseModel
+
+from metta.app_backend.metta_repo import LeaderboardRow, MettaRepo
+
+
+class EvalScore(BaseModel):
+    eval_name: str
+    total_score: float
+    num_agents: int
+
+    @property
+    def score(self) -> float:
+        return self.total_score / self.num_agents
+
+
+logger = logging.getLogger("leaderboard_updater")
+
+
+class LeaderboardUpdater:
+    def __init__(self, repo: MettaRepo):
+        self.repo = repo
+
+    def start(self):
+        self.running = True
+        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread.name = "LeaderboardUpdater"
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        self.thread.join()
+
+    async def _get_policy_score(
+        self, policy_id: uuid.UUID, eval_names: list[str], metric: str, latest_episode_id: int
+    ) -> float:
+        """Get the score for a policy.
+
+        The score is computed as the average of the scores of each eval, unweighted by the number of episodes.
+        """
+
+        query = """
+                  SELECT e.eval_name, SUM(eam.value) as total_score, COUNT(*) as num_agents
+                  FROM episodes e
+                  JOIN episode_agent_metrics eam ON e.internal_id = eam.episode_internal_id
+                  WHERE e.primary_policy_id = %s
+                  AND eam.metric = %s
+                  AND e.internal_id <= %s
+                  AND e.eval_name = ANY(%s)
+                  GROUP BY e.eval_name
+                  """
+
+        async with self.repo.connect() as con:
+            async with con.cursor(row_factory=class_row(EvalScore)) as cursor:
+                await cursor.execute(query, (policy_id, metric, latest_episode_id, eval_names))
+
+                rows = await cursor.fetchall()
+                if len(rows) == 0:
+                    return 0
+                else:
+                    return sum(row.score for row in rows) / len(eval_names)
+
+    async def _get_updated_policies(self, leaderboard: LeaderboardRow, latest_episode_id: int) -> list[uuid.UUID]:
+        """Get the policies that have had new relevant episodes."""
+
+        async with self.repo.connect() as con:
+            async with con.cursor() as cursor:
+                res = await cursor.execute(
+                    """
+                            SELECT DISTINCT p.id
+                            FROM policies p
+                            JOIN episodes e ON e.primary_policy_id = p.id
+                            WHERE e.internal_id > %s
+                            AND e.internal_id <= %s
+                            AND p.created_at >= %s
+                            AND e.eval_name = ANY(%s)
+                          """,
+                    (leaderboard.latest_episode, latest_episode_id, leaderboard.start_date, leaderboard.evals),
+                )
+                rows = await res.fetchall()
+                return [row[0] for row in rows]
+
+    async def _get_latest_episode_id(self) -> int:
+        async with self.repo.connect() as con:
+            async with con.cursor() as cursor:
+                await cursor.execute("SELECT MAX(internal_id) FROM episodes", ())
+                latest_episode_id_row = await cursor.fetchone()
+                if latest_episode_id_row is None:
+                    return 0
+                return latest_episode_id_row[0]
+
+    async def _update_leaderboard(self, leaderboard: LeaderboardRow):
+        """This function maintains the (leaderboard_id, policy_id) -> score mapping in the leaderboard_policy_scores
+        table.
+
+        It does this by:
+        - Getting the latest episode ID
+        - Getting the policies that have had new relevant episodes
+        - Re-computing the score for each policy and updating the leaderboard_policy_scores table
+        - Updating the leaderboard latest_episode_id column
+        """
+
+        latest_episode_id = await self._get_latest_episode_id()
+        if latest_episode_id == leaderboard.latest_episode:
+            return
+        if latest_episode_id < leaderboard.latest_episode:
+            raise ValueError(
+                f"Latest episode ID {latest_episode_id} < leaderboard latest episode {leaderboard.latest_episode}"
+            )
+
+        updated_policies = await self._get_updated_policies(leaderboard, latest_episode_id)
+        if len(updated_policies) == 0:
+            return
+
+        logger.info(f"Updating leaderboard {leaderboard.id} with {len(updated_policies)} updated policies")
+
+        for policy_id in updated_policies:
+            policy_score = await self._get_policy_score(
+                policy_id, leaderboard.evals, leaderboard.metric, latest_episode_id
+            )
+            await self.repo.upsert_leaderboard_policy_score(leaderboard.id, policy_id, policy_score)
+
+        await self.repo.update_leaderboard_latest_episode(leaderboard.id, latest_episode_id)
+
+    async def _run_once(self):
+        leaderboards = await self.repo.list_leaderboards()
+        for leaderboard in leaderboards:
+            await self._update_leaderboard(leaderboard)
+
+    def run(self):
+        while self.running:
+            try:
+                import asyncio
+
+                asyncio.run(self._run_once())
+            except Exception as e:
+                logger.error(f"Error updating leaderboards: {e}")
+
+            time.sleep(30)

--- a/app_backend/src/metta/app_backend/routes/leaderboard_routes.py
+++ b/app_backend/src/metta/app_backend/routes/leaderboard_routes.py
@@ -1,0 +1,113 @@
+import logging
+import uuid
+from typing import Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from metta.app_backend.auth import create_user_or_token_dependency
+from metta.app_backend.metta_repo import LeaderboardRow, MettaRepo
+from metta.app_backend.route_logger import timed_route
+
+# Set up logging for leaderboard routes
+logger = logging.getLogger("leaderboard_routes")
+logger.setLevel(logging.INFO)
+
+
+class LeaderboardCreate(BaseModel):
+    name: str
+    evals: List[str]
+    metric: str
+    start_date: str
+
+
+class LeaderboardResponse(BaseModel):
+    id: str
+    name: str
+    user_id: str
+    evals: List[str]
+    metric: str
+    start_date: str
+    latest_episode: int
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_db(cls, leaderboard: LeaderboardRow) -> "LeaderboardResponse":
+        return cls(
+            id=str(leaderboard.id),
+            name=leaderboard.name,
+            user_id=leaderboard.user_id,
+            evals=leaderboard.evals,
+            metric=leaderboard.metric,
+            start_date=leaderboard.start_date.isoformat(),
+            latest_episode=leaderboard.latest_episode,
+            created_at=leaderboard.created_at.isoformat(),
+            updated_at=leaderboard.updated_at.isoformat(),
+        )
+
+
+class LeaderboardListResponse(BaseModel):
+    leaderboards: List[LeaderboardResponse]
+
+
+def create_leaderboard_router(metta_repo: MettaRepo) -> APIRouter:
+    """Create a leaderboard router with the given MettaRepo instance."""
+    router = APIRouter(prefix="/leaderboards", tags=["leaderboards"])
+
+    # Create the user-or-token authentication dependency
+    user_or_token = Depends(dependency=create_user_or_token_dependency(metta_repo))
+
+    @router.get("")
+    @timed_route("list_leaderboards")
+    async def list_leaderboards(user_id: str = user_or_token) -> LeaderboardListResponse:  # type: ignore[reportUnusedFunction]
+        """List all leaderboards for the current user."""
+        leaderboards = await metta_repo.list_leaderboards()
+        return LeaderboardListResponse(
+            leaderboards=[LeaderboardResponse.from_db(leaderboard) for leaderboard in leaderboards]
+        )
+
+    @router.get("/{leaderboard_id}")
+    @timed_route("get_leaderboard")
+    async def get_leaderboard(leaderboard_id: str, user_id: str = user_or_token) -> LeaderboardResponse:  # type: ignore[reportUnusedFunction]
+        """Get a specific leaderboard by ID."""
+        leaderboard = await metta_repo.get_leaderboard(uuid.UUID(leaderboard_id))
+        if not leaderboard:
+            raise HTTPException(status_code=404, detail="Leaderboard not found")
+
+        return LeaderboardResponse.from_db(leaderboard)
+
+    @router.post("")
+    @timed_route("create_leaderboard")
+    async def create_leaderboard(  # type: ignore[reportUnusedFunction]
+        leaderboard_data: LeaderboardCreate,
+        user_id: str = user_or_token,
+    ) -> LeaderboardResponse:
+        """Create a new leaderboard."""
+        leaderboard_id = await metta_repo.create_leaderboard(
+            name=leaderboard_data.name,
+            user_id=user_id,
+            evals=leaderboard_data.evals,
+            metric=leaderboard_data.metric,
+            start_date=leaderboard_data.start_date,
+        )
+
+        # Fetch the created leaderboard to return
+        leaderboard = await metta_repo.get_leaderboard(leaderboard_id)
+        if not leaderboard:
+            raise HTTPException(status_code=500, detail="Failed to create leaderboard")
+
+        return LeaderboardResponse.from_db(leaderboard)
+
+    @router.delete("/{leaderboard_id}")
+    @timed_route("delete_leaderboard")
+    async def delete_leaderboard(  # type: ignore[reportUnusedFunction]
+        leaderboard_id: str, user_id: str = user_or_token
+    ) -> Dict[str, str]:
+        """Delete a leaderboard."""
+        success = await metta_repo.delete_leaderboard(leaderboard_id, user_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Leaderboard not found")
+        return {"message": "Leaderboard deleted successfully"}
+
+    return router

--- a/app_backend/src/metta/app_backend/routes/scorecard_routes.py
+++ b/app_backend/src/metta/app_backend/routes/scorecard_routes.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -94,11 +95,19 @@ class ScorecardData(BaseModel):
     evalMaxScores: Dict[str, float]
 
 
+class LeaderboardScorecardRequest(BaseModel):
+    """Request body for generating leaderboard scorecard."""
+
+    leaderboard_id: uuid.UUID
+    selector: Literal["latest", "best"]
+    num_policies: int
+
+
 @dataclass
 class PolicyEvaluationResult:
     """Represents a single policy evaluation result for the new system."""
 
-    policy_id: str
+    policy_id: uuid.UUID
     policy_name: str
     eval_category: str
     env_name: str
@@ -106,7 +115,7 @@ class PolicyEvaluationResult:
     total_score: float
     num_agents: int
     episode_id: int
-    run_id: Optional[str] = None
+    run_id: Optional[uuid.UUID] = None
     epoch: Optional[int] = None
 
     @property
@@ -119,31 +128,19 @@ class PolicyEvaluationResult:
         """Combined evaluation name for display."""
         return f"{self.eval_category}/{self.env_name}"
 
+    @property
+    def unified_id(self) -> uuid.UUID:
+        """Unified ID."""
+        if self.run_id:
+            return self.run_id
+        return self.policy_id
+
 
 # ============================================================================
 # SQL Queries
 # ============================================================================
 
-UNIFIED_POLICIES_QUERY = """
-    WITH good_policies AS (select distinct primary_policy_id FROM episodes),
-    my_training_runs AS (
-      SELECT t.id AS id, 'training_run' AS type, t.name, t.user_id, t.created_at, t.tags
-      FROM training_runs t JOIN epochs e ON t.id = e.run_id
-      JOIN policies p ON p.epoch_id = e.id
-      JOIN good_policies g ON p.id = g.primary_policy_id
-    ),
-    my_run_free_policies AS (
-      SELECT p.id AS id, 'policy' AS type, p.name, NULL as user_id, p.created_at, NULL::text[] as tags
-      FROM policies p
-      JOIN good_policies g ON p.id = g.primary_policy_id
-      WHERE p.epoch_id IS NULL
-    )
-
-    SELECT * FROM my_training_runs
-    UNION
-    SELECT * FROM my_run_free_policies
-    ORDER BY created_at DESC
-"""
+UNIFIED_POLICIES_QUERY = """SELECT * FROM unified_training_runs ORDER BY created_at DESC"""
 
 GET_EVALS_QUERY = """
     SELECT DISTINCT eval_name
@@ -189,7 +186,7 @@ POLICY_SCORECARD_DATA_QUERY = """
     JOIN episode_agent_metrics eam ON we.internal_id = eam.episode_internal_id
     WHERE (
         we.training_run_id = ANY(%s) OR  -- Policies from selected training runs
-        (we.training_run_id IS NULL AND we.primary_policy_id = ANY(%s))  -- Selected run-free policies
+        (we.primary_policy_id = ANY(%s))  -- Selected policies
     )
     AND eam.metric = %s
     AND we.eval_name = ANY(%s)
@@ -249,8 +246,8 @@ async def get_available_metrics_for_selection(
 
 async def fetch_policy_scorecard_data(
     con: AsyncConnection,
-    training_run_ids: List[str],
-    run_free_policy_ids: List[str],
+    training_run_ids: List[str] | List[uuid.UUID],
+    run_free_policy_ids: List[str] | List[uuid.UUID],
     eval_names: List[str],
     metric: str,
 ) -> List[PolicyEvaluationResult]:
@@ -394,6 +391,74 @@ def build_policy_scorecard(
     )
 
 
+@dataclass
+class LeaderboardTrainingRunScore:
+    """Represents a training run score for a leaderboard."""
+
+    policy_id: uuid.UUID
+    score: float
+    selector_score: float
+
+
+async def get_leaderboard_training_run_scores(
+    con: AsyncConnection, leaderboard_id: uuid.UUID, selector: Literal["latest", "best"]
+) -> dict[uuid.UUID, LeaderboardTrainingRunScore]:
+    """Get the training run scores for a leaderboard."""
+
+    query = """
+      SELECT lps.policy_id, lps.score, e.run_id as training_run_id, e.end_training_epoch
+      FROM leaderboard_policy_scores lps
+      JOIN policies p ON p.id = lps.policy_id
+      JOIN epochs e ON p.epoch_id = e.id
+      WHERE lps.leaderboard_id = %s
+    """
+
+    @dataclass
+    class LeaderboardPolicyTrainingRunScore:
+        """Represents a policy score and its associated training run info"""
+
+        policy_id: uuid.UUID
+        score: float
+        training_run_id: uuid.UUID
+        end_training_epoch: int
+
+    async with con.cursor(row_factory=class_row(LeaderboardPolicyTrainingRunScore)) as cursor:
+        await cursor.execute(query, (leaderboard_id,))
+        rows = await cursor.fetchall()
+        rows_by_training_run_id: dict[uuid.UUID, LeaderboardTrainingRunScore] = {}
+        for row in rows:
+            selector_score = row.score if selector == "best" else row.end_training_epoch
+            cur_training_run_best = rows_by_training_run_id.get(row.training_run_id)
+            best_selector_score = cur_training_run_best.selector_score if cur_training_run_best else -1
+            if selector_score > best_selector_score:
+                rows_by_training_run_id[row.training_run_id] = LeaderboardTrainingRunScore(
+                    policy_id=row.policy_id, score=row.score, selector_score=selector_score
+                )
+
+        return rows_by_training_run_id
+
+
+async def get_leaderboard_free_policy_scores(con: AsyncConnection, leaderboard_id: uuid.UUID) -> dict[uuid.UUID, float]:
+    """Get the free policy scores for a leaderboard."""
+
+    query = """
+      SELECT lps.policy_id, lps.score
+      FROM leaderboard_policy_scores lps
+      JOIN policies p ON p.id = lps.policy_id
+      WHERE lps.leaderboard_id = %s AND p.epoch_id IS NULL
+    """
+
+    @dataclass
+    class QueryRow:
+        policy_id: uuid.UUID
+        score: float
+
+    async with con.cursor(row_factory=class_row(QueryRow)) as cursor:
+        await cursor.execute(query, (leaderboard_id,))
+        rows = await cursor.fetchall()
+        return {row.policy_id: row.score for row in rows}
+
+
 # ============================================================================
 # API Routes
 # ============================================================================
@@ -492,5 +557,57 @@ def create_policy_scorecard_router(metta_repo: MettaRepo) -> APIRouter:
                     evalAverageScores={},
                     evalMaxScores={},
                 )
+
+    @router.post("/leaderboard")
+    @timed_route("generate_leaderboard_scorecard")
+    async def generate_leaderboard_scorecard_route(request: LeaderboardScorecardRequest) -> ScorecardData:
+        """Generate scorecard data for a leaderboard in the following way:
+
+        1. Use the leaderboard_policy_scores table to get either the 'latest' or 'best' policy_id for each training run
+        2. Use the leaderboard_policy_scores table to get the score for each policy that doesn't have a training run
+        3. Combine the lists from 1 and 2 and take the top {leaderboard.num_policies} policies by score
+        4. Now that we have top N policies, get the eval scores and replay urls and build the scorecard
+
+        """
+        async with metta_repo.connect() as con:
+            # Get leaderboard configuration
+            leaderboard = await metta_repo.get_leaderboard(request.leaderboard_id)
+            if not leaderboard:
+                raise HTTPException(status_code=404, detail="Leaderboard not found")
+
+            training_run_scores = await get_leaderboard_training_run_scores(
+                con, request.leaderboard_id, request.selector
+            )
+            free_policy_scores = await get_leaderboard_free_policy_scores(con, request.leaderboard_id)
+
+            @dataclass
+            class UnifiedScore:
+                id: uuid.UUID
+                score: float
+                type: Literal["training_run", "policy"]
+                policy_id: uuid.UUID
+
+            unified_scores: list[UnifiedScore] = []
+            for training_run_id, training_run_score in training_run_scores.items():
+                unified_scores.append(
+                    UnifiedScore(
+                        id=training_run_id,
+                        score=training_run_score.score,
+                        type="training_run",
+                        policy_id=training_run_score.policy_id,
+                    )
+                )
+            for policy_id, score in free_policy_scores.items():
+                unified_scores.append(UnifiedScore(id=policy_id, score=score, type="policy", policy_id=policy_id))
+            unified_scores.sort(key=lambda x: x.score, reverse=True)
+            top_n_scores = unified_scores[: request.num_policies]
+            top_n_policy_ids = [score.policy_id for score in top_n_scores]
+
+            # Fetch evaluation data for top policies
+            evaluations = await fetch_policy_scorecard_data(
+                con, [], top_n_policy_ids, leaderboard.evals, leaderboard.metric
+            )
+
+            return build_policy_scorecard(evaluations, leaderboard.evals)
 
     return router

--- a/app_backend/src/metta/app_backend/server.py
+++ b/app_backend/src/metta/app_backend/server.py
@@ -9,11 +9,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic.main import BaseModel
 
 from metta.app_backend.auth import user_from_header_or_token
+from metta.app_backend.leaderboard_updater import LeaderboardUpdater
 from metta.app_backend.metta_repo import MettaRepo
 from metta.app_backend.routes import (
     dashboard_routes,
     entity_routes,
     eval_task_routes,
+    leaderboard_routes,
     scorecard_routes,
     sql_routes,
     stats_routes,
@@ -70,6 +72,10 @@ def setup_logging():
     scorecard_routes_logger = logging.getLogger("policy_scorecard_routes")
     scorecard_routes_logger.setLevel(logging.INFO)
 
+    # Configure leaderboard updater logger
+    leaderboard_updater_logger = logging.getLogger("leaderboard_updater")
+    leaderboard_updater_logger.setLevel(logging.INFO)
+
     # Ensure the loggers don't duplicate messages from root logger
     scorecard_logger.propagate = True
     db_logger.propagate = True
@@ -105,6 +111,7 @@ def create_app(stats_repo: MettaRepo) -> fastapi.FastAPI:
     # Create routers with the provided StatsRepo
     dashboard_router = dashboard_routes.create_dashboard_router(stats_repo)
     eval_task_router = eval_task_routes.create_eval_task_router(stats_repo)
+    leaderboard_router = leaderboard_routes.create_leaderboard_router(stats_repo)
     sql_router = sql_routes.create_sql_router(stats_repo)
     stats_router = stats_routes.create_stats_router(stats_repo)
     token_router = token_routes.create_token_router(stats_repo)
@@ -114,6 +121,7 @@ def create_app(stats_repo: MettaRepo) -> fastapi.FastAPI:
 
     app.include_router(dashboard_router)
     app.include_router(eval_task_router)
+    app.include_router(leaderboard_router)
     app.include_router(sql_router)
     app.include_router(stats_router)
     app.include_router(token_router)
@@ -139,5 +147,7 @@ if __name__ == "__main__":
 
     stats_repo = MettaRepo(stats_db_uri)
     app = create_app(stats_repo)
+    leaderboard_updater = LeaderboardUpdater(stats_repo)
+    leaderboard_updater.start()
 
     uvicorn.run(app, host=host, port=port)

--- a/app_backend/tests/conftest.py
+++ b/app_backend/tests/conftest.py
@@ -10,7 +10,7 @@ from metta.app_backend.clients.stats_client import StatsClient
 from metta.app_backend.metta_repo import MettaRepo
 from metta.app_backend.server import create_app
 from metta.app_backend.test_support import create_test_stats_client
-from metta.common.test_support import docker_client_fixture
+from metta.common.test_support import docker_client_fixture, isolated_test_schema_uri
 
 # Register the docker_client fixture
 docker_client = docker_client_fixture()
@@ -91,3 +91,45 @@ def stats_client(test_client: TestClient) -> StatsClient:
 
     # Create stats client that works with TestClient
     return create_test_stats_client(test_client, machine_token=token)
+
+
+# Isolated fixtures for function-scoped testing
+@pytest.fixture(scope="function")
+def isolated_db_context(db_uri: str) -> str:
+    """Create an isolated schema context for a single test."""
+    schema_uri = isolated_test_schema_uri(db_uri)
+    return schema_uri
+
+
+@pytest.fixture(scope="function")
+def isolated_stats_repo(isolated_db_context: str) -> MettaRepo:
+    """Create a MettaRepo instance with an isolated schema."""
+    return MettaRepo(isolated_db_context)
+
+
+@pytest.fixture(scope="function")
+def isolated_test_app(isolated_stats_repo: MettaRepo) -> FastAPI:
+    """Create a test FastAPI app with isolated database."""
+    return create_app(isolated_stats_repo)
+
+
+@pytest.fixture(scope="function")
+def isolated_test_client(isolated_test_app: FastAPI) -> TestClient:
+    """Create a test client with isolated database."""
+    return TestClient(isolated_test_app)
+
+
+@pytest.fixture(scope="function")
+def isolated_stats_client(isolated_test_client: TestClient) -> StatsClient:
+    """Create a stats client with isolated database for testing."""
+    # First create a machine token
+    token_response = isolated_test_client.post(
+        "/tokens",
+        json={"name": "test_token", "permissions": ["read", "write"]},
+        headers={"X-Auth-Request-Email": "test_user@example.com"},
+    )
+    assert token_response.status_code == 200, f"Failed to create token: {token_response.text}"
+    token = token_response.json()["token"]
+
+    # Create stats client that works with TestClient
+    return create_test_stats_client(isolated_test_client, machine_token=token)

--- a/app_backend/tests/generate_test_data.py
+++ b/app_backend/tests/generate_test_data.py
@@ -256,7 +256,7 @@ def generate_test_data():
         )
 
         # Update description and tags
-        run_id = uuid.UUID(training_run.id)
+        run_id = training_run.id
         update_training_run_metadata(
             base_url, run_config["token"], run_id, run_config["description"], run_config["tags"]
         )
@@ -267,7 +267,7 @@ def generate_test_data():
         policies: List[PolicyData] = []
         for _i, epoch_config in enumerate(run_config["epochs"]):
             epoch = stats_client.create_epoch(
-                run_id=uuid.UUID(training_run.id),
+                run_id=training_run.id,
                 start_training_epoch=epoch_config["start"],
                 end_training_epoch=epoch_config["end"],
                 attributes={"learning_rate": epoch_config["lr"], "performance_stage": epoch_config["performance"]},
@@ -279,7 +279,7 @@ def generate_test_data():
                 name=policy_name,
                 description=f"Policy after {epoch_config['end']} epochs - {epoch_config['performance']} stage",
                 url=f"https://storage.example.com/policies/{policy_name}.pt",
-                epoch_id=uuid.UUID(epoch.id),
+                epoch_id=epoch.id,
             )
             policies.append({"policy": policy, "epoch": epoch, "config": epoch_config, "name": policy_name})
 
@@ -351,7 +351,7 @@ def generate_test_data():
                                 # Add some noise
                                 import random
 
-                                policy_id = uuid.UUID(policy.id)
+                                policy_id = policy.id
                                 random.seed(hash((policy_id, task, metric, agent_id)) % (2**32))
                                 noise = random.uniform(0.8, 1.2)
                                 metrics[metric] = final_reward * noise
@@ -360,7 +360,7 @@ def generate_test_data():
                                 base_rate = base_performance * difficulty_factor
                                 import random
 
-                                policy_id = uuid.UUID(policy.id)
+                                policy_id = policy.id
                                 random.seed(hash((policy_id, task, metric, agent_id)) % (2**32))
                                 noise = random.uniform(0.9, 1.1)
                                 metrics[metric] = min(1.0, base_rate * noise)
@@ -372,7 +372,7 @@ def generate_test_data():
                                 performance_factor = 2.0 - base_performance
                                 import random
 
-                                policy_id = uuid.UUID(policy.id)
+                                policy_id = policy.id
                                 random.seed(hash((policy_id, task, metric, agent_id)) % (2**32))
                                 noise = random.uniform(0.8, 1.2)
                                 metrics[metric] = base_value * performance_factor * noise
@@ -382,7 +382,7 @@ def generate_test_data():
                                 base_value = 0.8
                                 import random
 
-                                policy_id = uuid.UUID(policy.id)
+                                policy_id = policy.id
                                 random.seed(hash((policy_id, task, metric, agent_id)) % (2**32))
                                 noise = random.uniform(0.9, 1.1)
                                 metrics[metric] = base_value * base_performance * noise
@@ -390,8 +390,8 @@ def generate_test_data():
                         agent_metrics[agent_id] = metrics
 
                     # Create episode
-                    policy_id = uuid.UUID(policy.id)
-                    epoch_id = uuid.UUID(epoch.id)
+                    policy_id = policy.id
+                    epoch_id = epoch.id
                     stats_client.record_episode(
                         agent_policies={aid: policy_id for aid in range(num_agents)},
                         agent_metrics=agent_metrics,

--- a/app_backend/tests/test_scorecard_routes.py
+++ b/app_backend/tests/test_scorecard_routes.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.app_backend.metta_repo import MettaRepo
 
 
 @pytest.mark.slow
@@ -2164,6 +2165,226 @@ class TestPolicyScorecardRoutes:
         # The average should be dominated by the large value, so should be quite large
         assert actual_avg > 200000.0  # Much larger than the other values
         assert actual_avg < 1000000.0  # But less than the max value
+
+    @pytest.mark.asyncio
+    async def test_leaderboard_scorecard_integration(
+        self, isolated_test_client: TestClient, isolated_stats_client: StatsClient, isolated_stats_repo: MettaRepo
+    ) -> None:
+        """Integration test for leaderboard scorecard functionality.
+
+        This test:
+        1. Sets up test data with multiple training runs and run-free policies
+        2. Creates a leaderboard
+        3. Runs the leaderboard updater to populate scores
+        4. Gets the leaderboard scorecard
+        5. Compares it with individually selected policies to validate consistency
+        """
+        import datetime
+
+        stats_client = isolated_stats_client
+        test_client = isolated_test_client
+        stats_repo = isolated_stats_repo
+
+        # Create test data with multiple training runs and run-free policies
+        test_data1 = self._create_test_data(stats_client, "leaderboard_integration_run1", num_policies=3)
+        test_data2 = self._create_test_data(stats_client, "leaderboard_integration_run2", num_policies=2)
+        run_free_data = self._create_test_data(
+            stats_client, "leaderboard_integration_runfree", num_policies=0, create_run_free_policies=2
+        )
+
+        # Record episodes with varied performance across different categories
+        categories_and_envs = [
+            ("navigation", ["maze1", "maze2"]),
+            ("combat", ["arena1", "arena2"]),
+            ("cooperation", ["team1"]),
+        ]
+
+        # Training run 1: policy 2 is best (highest average)
+        run1_metrics = {
+            "policy_0_maze1": 60.0,
+            "policy_0_maze2": 65.0,  # avg: 62.5
+            "policy_0_arena1": 55.0,
+            "policy_0_arena2": 60.0,  # avg: 57.5
+            "policy_0_team1": 50.0,  # Overall avg: 56.67
+            "policy_1_maze1": 70.0,
+            "policy_1_maze2": 75.0,  # avg: 72.5
+            "policy_1_arena1": 65.0,
+            "policy_1_arena2": 70.0,  # avg: 67.5
+            "policy_1_team1": 60.0,  # Overall avg: 66.67
+            "policy_2_maze1": 85.0,
+            "policy_2_maze2": 90.0,  # avg: 87.5
+            "policy_2_arena1": 80.0,
+            "policy_2_arena2": 85.0,  # avg: 82.5
+            "policy_2_team1": 75.0,  # Overall avg: 81.67 (best)
+        }
+        self._record_episodes(stats_client, test_data1, "navigation", ["maze1", "maze2"], run1_metrics)
+        self._record_episodes(stats_client, test_data1, "combat", ["arena1", "arena2"], run1_metrics)
+        self._record_episodes(stats_client, test_data1, "cooperation", ["team1"], run1_metrics)
+
+        # Training run 2: policy 1 is best
+        run2_metrics = {
+            "policy_0_maze1": 50.0,
+            "policy_0_maze2": 55.0,  # avg: 52.5
+            "policy_0_arena1": 45.0,
+            "policy_0_arena2": 50.0,  # avg: 47.5
+            "policy_0_team1": 40.0,  # Overall avg: 46.67
+            "policy_1_maze1": 90.0,
+            "policy_1_maze2": 95.0,  # avg: 92.5
+            "policy_1_arena1": 85.0,
+            "policy_1_arena2": 90.0,  # avg: 87.5
+            "policy_1_team1": 80.0,  # Overall avg: 86.67 (best)
+        }
+        self._record_episodes(stats_client, test_data2, "navigation", ["maze1", "maze2"], run2_metrics)
+        self._record_episodes(stats_client, test_data2, "combat", ["arena1", "arena2"], run2_metrics)
+        self._record_episodes(stats_client, test_data2, "cooperation", ["team1"], run2_metrics)
+
+        # Run-free policies: high performance
+        runfree_metrics = {
+            "policy_0_maze1": 95.0,
+            "policy_0_maze2": 98.0,  # avg: 96.5
+            "policy_0_arena1": 92.0,
+            "policy_0_arena2": 95.0,  # avg: 93.5
+            "policy_0_team1": 90.0,  # Overall avg: 93.33
+            "policy_1_maze1": 88.0,
+            "policy_1_maze2": 92.0,  # avg: 90.0
+            "policy_1_arena1": 85.0,
+            "policy_1_arena2": 88.0,  # avg: 86.5
+            "policy_1_team1": 82.0,  # Overall avg: 86.17
+        }
+        self._record_episodes(stats_client, run_free_data, "navigation", ["maze1", "maze2"], runfree_metrics)
+        self._record_episodes(stats_client, run_free_data, "combat", ["arena1", "arena2"], runfree_metrics)
+        self._record_episodes(stats_client, run_free_data, "cooperation", ["team1"], runfree_metrics)
+
+        # Create leaderboard
+        eval_names = [f"{cat}/{env}" for cat, envs in categories_and_envs for env in envs]
+        start_date = datetime.datetime.now() - datetime.timedelta(days=1)
+
+        leaderboard_response = test_client.post(
+            "/leaderboards",
+            json={
+                "name": "Integration Test Leaderboard",
+                "evals": eval_names,
+                "metric": "reward",
+                "start_date": start_date.isoformat(),
+            },
+            headers={"X-Auth-Request-Email": "test_user@example.com"},
+        )
+        assert leaderboard_response.status_code == 200, f"Failed to create leaderboard: {leaderboard_response.text}"
+        leaderboard = leaderboard_response.json()
+        leaderboard_id = leaderboard["id"]
+
+        # Now we need to manually trigger the leaderboard update process
+        # to populate the leaderboard_policy_scores table. We'll do this by
+        # manually running the update logic using the stats_repo fixture.
+
+        # Import the necessary components for manual leaderboard update
+        import uuid
+
+        from metta.app_backend.leaderboard_updater import LeaderboardUpdater
+
+        # Create a leaderboard updater instance
+        updater = LeaderboardUpdater(stats_repo)
+
+        # Get the leaderboard from the database
+        leaderboard_uuid = uuid.UUID(leaderboard_id)
+        leaderboard_row = await stats_repo.get_leaderboard(leaderboard_uuid)
+
+        # Manually trigger the update for this specific leaderboard
+        await updater._update_leaderboard(leaderboard_row)
+
+        # Get the leaderboard scorecard
+        leaderboard_scorecard_response = test_client.post(
+            "/scorecard/leaderboard",
+            json={
+                "leaderboard_id": leaderboard_id,
+                "selector": "best",
+                "num_policies": 4,
+            },
+        )
+        assert leaderboard_scorecard_response.status_code == 200, (
+            f"Failed to get leaderboard scorecard: {leaderboard_scorecard_response.text}"
+        )
+        leaderboard_scorecard = leaderboard_scorecard_response.json()
+
+        # The leaderboard scorecard endpoint is working correctly!
+        # After running the leaderboard updater, it should now return populated data.
+
+        # Now get the same data by individually selecting the policies
+        # Based on our test data, the top 4 policies should be:
+        # 1. Run-free policy 0 (avg: 93.33)
+        # 2. Run-free policy 1 (avg: 86.17)
+        # 3. Training run 1 policy 2 (avg: 81.67)
+        # 4. Training run 2 policy 1 (avg: 86.67)
+
+        # Get training run IDs
+        training_run_ids = [
+            str(test_data1["training_run"].id),
+            str(test_data2["training_run"].id),
+        ]
+
+        # Get run-free policy IDs
+        run_free_policy_ids = [str(p.id) for p in run_free_data["policies"]]
+
+        # Get individual scorecard with best selector
+        individual_scorecard_response = test_client.post(
+            "/scorecard/scorecard",
+            json={
+                "training_run_ids": training_run_ids,
+                "run_free_policy_ids": run_free_policy_ids,
+                "eval_names": eval_names,
+                "training_run_policy_selector": "best",
+                "metric": "reward",
+            },
+        )
+        assert individual_scorecard_response.status_code == 200, (
+            f"Failed to get individual scorecard: {individual_scorecard_response.text}"
+        )
+        individual_scorecard = individual_scorecard_response.json()
+
+        # Now compare the leaderboard scorecard with the individual scorecard
+        # to validate that they return exactly the same data
+
+        # Both should have the same evaluation names
+        assert leaderboard_scorecard["evalNames"] == individual_scorecard["evalNames"]
+
+        # Both scorecards should now return exactly the same policies and data
+        # since the leaderboard scorecard now correctly applies the num_policies limit
+        # and policy selection logic
+        leaderboard_policies = set(leaderboard_scorecard["policyNames"])
+        individual_policies = set(individual_scorecard["policyNames"])
+
+        # Both should have exactly 4 policies (as configured with num_policies: 4)
+        assert len(leaderboard_policies) == 4, (
+            f"Leaderboard should have exactly 4 policies, got {len(leaderboard_policies)}"
+        )
+        assert len(individual_policies) == 4, (
+            f"Individual scorecard should have exactly 4 policies, got {len(individual_policies)}"
+        )
+
+        # Both should have the same policies
+        assert leaderboard_policies == individual_policies, (
+            f"Leaderboard and individual scorecards should have identical policies. "
+            f"Leaderboard: {leaderboard_policies}, Individual: {individual_policies}"
+        )
+
+        # Verify that all data is identical between both scorecards
+        for policy_name in leaderboard_policies:
+            # Check that all evaluation values match exactly
+            for eval_name in eval_names:
+                leaderboard_cell = leaderboard_scorecard["cells"][policy_name][eval_name]
+                individual_cell = individual_scorecard["cells"][policy_name][eval_name]
+
+                assert leaderboard_cell["value"] == individual_cell["value"], (
+                    f"Value mismatch for {policy_name}/{eval_name}"
+                )
+                assert leaderboard_cell["replayUrl"] == individual_cell["replayUrl"], (
+                    f"Replay URL mismatch for {policy_name}/{eval_name}"
+                )
+
+        # Verify that average scores and other metadata are also identical
+        assert leaderboard_scorecard["policyAverageScores"] == individual_scorecard["policyAverageScores"]
+        assert leaderboard_scorecard["evalAverageScores"] == individual_scorecard["evalAverageScores"]
+        assert leaderboard_scorecard["evalMaxScores"] == individual_scorecard["evalMaxScores"]
 
 
 if __name__ == "__main__":

--- a/metta/common/test_support/__init__.py
+++ b/metta/common/test_support/__init__.py
@@ -1,4 +1,5 @@
 from .fixtures import docker_client_fixture
 from .pytest_shard import pytest_collection_modifyitems
+from .schema_isolation_functions import isolated_test_schema_uri
 
-__all__ = [docker_client_fixture, pytest_collection_modifyitems]
+__all__ = [docker_client_fixture, pytest_collection_modifyitems, isolated_test_schema_uri]

--- a/metta/common/test_support/schema_isolation_functions.py
+++ b/metta/common/test_support/schema_isolation_functions.py
@@ -1,0 +1,47 @@
+import uuid
+from urllib.parse import quote, urlparse, urlunparse
+
+import psycopg
+
+
+def create_isolated_schema_uri(base_uri: str, schema_name: str) -> str:
+    """Create a database URI with a specific schema in the search path."""
+    parsed = urlparse(base_uri)
+
+    # Extract existing query parameters
+    query_params = dict(param.split("=", 1) for param in parsed.query.split("&") if param)
+
+    # Add or update the search_path option - URL encode the value
+    # Include public schema so UUID functions are available
+    query_params["options"] = quote(f"-csearch_path={schema_name},public")
+
+    # Reconstruct the query string
+    query = "&".join(f"{k}={v}" for k, v in query_params.items())
+
+    # Build the new URI with the schema option
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, parsed.fragment))
+
+
+def isolated_test_schema_uri(base_uri: str) -> str:
+    """Create an isolated schema for testing.
+
+    Returns the database URI configured to use the isolated schema.
+    """
+    # Generate a unique schema name for this test
+    schema_name = f"test_schema_{uuid.uuid4().hex[:8]}"
+
+    # Create connection to create the schema
+    with psycopg.connect(base_uri) as conn:
+        with conn.cursor() as cursor:
+            # Create the isolated schema
+            cursor.execute(f"CREATE SCHEMA {schema_name}")
+            # Ensure UUID extension is available (create it in public schema if not exists)
+            cursor.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+            # Set search path to use our schema
+            cursor.execute(f"SET search_path TO {schema_name}, public")
+        conn.commit()
+
+    # Create URI that uses the isolated schema
+    schema_uri = create_isolated_schema_uri(base_uri, schema_name)
+
+    return schema_uri

--- a/observatory/src/App.tsx
+++ b/observatory/src/App.tsx
@@ -8,6 +8,9 @@ import { SQLQuery } from './SQLQuery'
 import { TrainingRuns } from './TrainingRuns'
 import { TrainingRunDetail } from './TrainingRunDetail'
 import { EvalTasks } from './EvalTasks'
+import { Leaderboards } from './Leaderboards'
+import { LeaderboardConfig } from './LeaderboardConfig'
+import { LeaderboardView } from './LeaderboardView'
 import { config } from './config'
 
 // CSS for navigation
@@ -205,6 +208,12 @@ function App() {
               >
                 Evaluate Policies
               </Link>
+              <Link
+                to="/leaderboards"
+                className={`nav-tab ${location.pathname.startsWith('/leaderboard') ? 'active' : ''}`}
+              >
+                Leaderboards
+              </Link>
               <Link to="/saved" className={`nav-tab ${location.pathname === '/saved' ? 'active' : ''}`}>
                 Saved Dashboards
               </Link>
@@ -224,6 +233,9 @@ function App() {
             <Route path="/training-runs" element={<TrainingRuns repo={state.repo} />} />
             <Route path="/training-run/:runId" element={<TrainingRunDetail repo={state.repo} />} />
             <Route path="/eval-tasks" element={<EvalTasks repo={state.repo} />} />
+            <Route path="/leaderboards" element={<Leaderboards repo={state.repo} currentUser={state.currentUser} />} />
+            <Route path="/leaderboards/create" element={<LeaderboardConfig repo={state.repo} />} />
+            <Route path="/leaderboards/:leaderboardId" element={<LeaderboardView repo={state.repo} />} />
             <Route path="/saved" element={<SavedDashboards repo={state.repo} currentUser={state.currentUser} />} />
             <Route path="/tokens" element={<TokenManager repo={state.repo} />} />
             <Route path="/sql-query" element={<SQLQuery repo={state.repo} />} />

--- a/observatory/src/LeaderboardConfig.tsx
+++ b/observatory/src/LeaderboardConfig.tsx
@@ -1,0 +1,435 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Repo, LeaderboardCreate, UnifiedPolicyInfo } from './repo'
+import { EvalSelector } from './components/EvalSelector'
+import { MetricSelector } from './components/MetricSelector'
+import { DateSelector } from './components/DateSelector'
+
+// CSS for leaderboard config
+const LEADERBOARD_CONFIG_CSS = `
+.config-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+}
+
+.config-header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.config-title {
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.config-subtitle {
+  color: #666;
+  font-size: 14px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0,123,255,.25);
+}
+
+.form-textarea {
+  min-height: 60px;
+  resize: vertical;
+}
+
+.form-checkbox-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.form-checkbox {
+  width: auto;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #0056b3;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: #fff;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: #5a6268;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.widget {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.widget-title {
+  color: #333;
+  margin: 0 0 16px 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+.error {
+  text-align: center;
+  padding: 40px;
+  color: #dc3545;
+}
+
+.small-input {
+  max-width: 120px;
+}
+`
+
+interface LeaderboardConfigProps {
+  repo: Repo
+}
+
+export function LeaderboardConfig({ repo }: LeaderboardConfigProps) {
+  const navigate = useNavigate()
+
+  // Form state
+  const [name, setName] = useState('')
+  const [startDate, setStartDate] = useState(() => {
+    const date = new Date()
+    date.setMonth(date.getMonth() - 1) // Default to 1 month ago
+    return date.toISOString().split('T')[0]
+  })
+  const [selectedEvalNames, setSelectedEvalNames] = useState<Set<string>>(new Set())
+  const [selectedMetric, setSelectedMetric] = useState<string>('reward')
+
+  // Data state
+  const [policies, setPolicies] = useState<UnifiedPolicyInfo[]>([])
+  const [evalNames, setEvalNames] = useState<Set<string>>(new Set())
+  const [availableMetrics, setAvailableMetrics] = useState<string[]>([])
+
+  // UI state
+  const [loading, setLoading] = useState({
+    page: false,
+    policies: false,
+    evalCategories: false,
+    metrics: false,
+    saving: false,
+  })
+  const [error, setError] = useState<string | null>(null)
+
+  // Get filtered policies based on start date
+  const filteredPolicies = policies.filter(policy => {
+    const policyDate = new Date(policy.created_at).toISOString().split('T')[0]
+    return policyDate >= startDate
+  })
+
+  const trainingRunIds = filteredPolicies
+    .filter(p => p.type === 'training_run')
+    .map(p => p.id)
+
+  const runFreePolicyIds = filteredPolicies
+    .filter(p => p.type === 'policy')
+    .map(p => p.id)
+
+  // Load policies on mount
+  useEffect(() => {
+    loadPolicies()
+  }, [])
+
+  // Load eval names when policies/start date changes
+  useEffect(() => {
+    if (filteredPolicies.length > 0) {
+      loadEvalNames()
+    } else {
+      setEvalNames(new Set())
+      setSelectedEvalNames(new Set())
+    }
+  }, [startDate, policies])
+
+  // Load metrics when policies and evals are selected
+  useEffect(() => {
+    if (filteredPolicies.length > 0 && selectedEvalNames.size > 0) {
+      loadMetrics()
+    } else {
+      setAvailableMetrics([])
+      setSelectedMetric('reward')
+    }
+  }, [startDate, policies, selectedEvalNames])
+
+  const loadPolicies = async () => {
+    try {
+      setLoading(prev => ({ ...prev, policies: true }))
+      setError(null)
+      const response = await repo.getPolicies()
+      setPolicies(response.policies)
+    } catch (err: any) {
+      setError(`Failed to load policies: ${err.message}`)
+    } finally {
+      setLoading(prev => ({ ...prev, policies: false }))
+    }
+  }
+
+  const loadEvalNames = async () => {
+    try {
+      setLoading(prev => ({ ...prev, evalCategories: true }))
+      setError(null)
+      const evalNamesData = await repo.getEvalNames({
+        training_run_ids: trainingRunIds,
+        run_free_policy_ids: runFreePolicyIds,
+      })
+      setEvalNames(evalNamesData)
+      setSelectedEvalNames(prev => new Set([...prev].filter(evalName => evalNamesData.has(evalName))))
+    } catch (err: any) {
+      setError(`Failed to load eval names: ${err.message}`)
+      setEvalNames(new Set())
+      setSelectedEvalNames(new Set())
+    } finally {
+      setLoading(prev => ({ ...prev, evalCategories: false }))
+    }
+  }
+
+  const loadMetrics = async () => {
+    try {
+      setLoading(prev => ({ ...prev, metrics: true }))
+      setError(null)
+      const metricsData = await repo.getAvailableMetrics({
+        training_run_ids: trainingRunIds,
+        run_free_policy_ids: runFreePolicyIds,
+        eval_names: Array.from(selectedEvalNames),
+      })
+      setAvailableMetrics(metricsData)
+
+      if (selectedMetric && !metricsData.includes(selectedMetric)) {
+        if (metricsData.includes('reward')) {
+          setSelectedMetric('reward')
+        } else if (metricsData.length > 0) {
+          setSelectedMetric(metricsData[0])
+        } else {
+          setSelectedMetric('')
+        }
+      }
+    } catch (err: any) {
+      setError(`Failed to load metrics: ${err.message}`)
+      setAvailableMetrics([])
+      setSelectedMetric('')
+    } finally {
+      setLoading(prev => ({ ...prev, metrics: false }))
+    }
+  }
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      alert('Please enter a name for the leaderboard')
+      return
+    }
+
+    if (selectedEvalNames.size === 0) {
+      alert('Please select at least one evaluation')
+      return
+    }
+
+    if (!selectedMetric) {
+      alert('Please select a metric')
+      return
+    }
+
+    try {
+      setLoading(prev => ({ ...prev, saving: true }))
+
+      // Only creation is supported - editing is removed
+      const createData: LeaderboardCreate = {
+        name: name.trim(),
+        evals: Array.from(selectedEvalNames),
+        metric: selectedMetric,
+        start_date: startDate,
+      }
+      await repo.createLeaderboard(createData)
+
+      navigate('/leaderboards')
+    } catch (err: any) {
+      alert(`Failed to create leaderboard: ${err.message}`)
+    } finally {
+      setLoading(prev => ({ ...prev, saving: false }))
+    }
+  }
+
+  const handleCancel = () => {
+    navigate('/leaderboards')
+  }
+
+  if (loading.page) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_CONFIG_CSS}</style>
+        <div className="loading">
+          <h3>Loading leaderboard...</h3>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_CONFIG_CSS}</style>
+        <div className="error">
+          <h3>Error</h3>
+          <p>{error}</p>
+          <button className="btn btn-primary" onClick={() => window.location.reload()}>
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+      <style>{LEADERBOARD_CONFIG_CSS}</style>
+
+      <div className="config-container">
+        <div className="config-header">
+          <h1 className="config-title">
+            Create New Leaderboard
+          </h1>
+          <p className="config-subtitle">
+            Configure leaderboard settings to track and compare policy performance across evaluations.
+          </p>
+        </div>
+
+        {/* Basic Information */}
+        <div className="form-group">
+          <label className="form-label" htmlFor="name">Leaderboard Name</label>
+          <input
+            id="name"
+            type="text"
+            className="form-input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Enter a descriptive name for your leaderboard"
+          />
+        </div>
+
+        {/* Start Date Filter */}
+        <div className="widget">
+          <h3 className="widget-title">Policy Filter</h3>
+          <DateSelector
+            value={startDate}
+            onChange={setStartDate}
+            label="Training Start Date"
+          />
+          <p style={{ color: '#666', fontSize: '14px', marginTop: '8px' }}>
+            Only policies created after this date will be included.
+            Currently showing {filteredPolicies.length} policies.
+          </p>
+        </div>
+
+        {/* Evaluation Selection */}
+        <div className="widget">
+          <h3 className="widget-title">Evaluation Selection</h3>
+          <EvalSelector
+            evalNames={evalNames}
+            selectedEvalNames={selectedEvalNames}
+            onSelectionChange={setSelectedEvalNames}
+            loading={loading.evalCategories}
+          />
+        </div>
+
+        {/* Training Run Policy Selector - Removed from leaderboard creation */}
+
+        {/* Metric Selection */}
+        <div className="widget">
+          <h3 className="widget-title">Metric Selection</h3>
+          <MetricSelector
+            metrics={availableMetrics}
+            selectedMetric={selectedMetric}
+            onSelectionChange={setSelectedMetric}
+            loading={loading.metrics}
+            disabled={filteredPolicies.length === 0 || selectedEvalNames.size === 0}
+          />
+        </div>
+
+        {/* Advanced Options - Removed from leaderboard creation */}
+
+        {/* Form Actions */}
+        <div className="form-actions">
+          <button
+            className="btn btn-secondary"
+            onClick={handleCancel}
+            disabled={loading.saving}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={loading.saving || !name.trim() || selectedEvalNames.size === 0 || !selectedMetric}
+          >
+            {loading.saving ? 'Creating...' : 'Create Leaderboard'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/observatory/src/LeaderboardView.tsx
+++ b/observatory/src/LeaderboardView.tsx
@@ -164,6 +164,19 @@ export function LeaderboardView({ repo }: LeaderboardViewProps) {
     }
   }, [leaderboard, policySelector, numPolicies])
 
+  // Auto-refresh when leaderboard is building (latest_episode is 0)
+  useEffect(() => {
+    if (!leaderboard || leaderboard.latest_episode > 0) {
+      return
+    }
+
+    const interval = setInterval(() => {
+      loadLeaderboard()
+    }, 5000) // Refresh every 5 seconds
+
+    return () => clearInterval(interval)
+  }, [leaderboard, leaderboardId])
+
   const loadLeaderboard = async () => {
     if (!leaderboardId) return
 
@@ -260,6 +273,19 @@ export function LeaderboardView({ repo }: LeaderboardViewProps) {
           <button className="btn btn-primary" onClick={handleBack}>
             Back to Leaderboards
           </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Check if leaderboard is still building
+  if (leaderboard.latest_episode === 0) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_VIEW_CSS}</style>
+        <div className="loading">
+          <h3>Leaderboard building</h3>
+          <p>This may take a few minutes. The page will automatically refresh...</p>
         </div>
       </div>
     )

--- a/observatory/src/LeaderboardView.tsx
+++ b/observatory/src/LeaderboardView.tsx
@@ -1,0 +1,350 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { Repo, Leaderboard, ScorecardData, LeaderboardScorecardRequest } from './repo'
+import { Scorecard } from './Scorecard'
+import { MapViewer } from './MapViewer'
+import { METTASCOPE_REPLAY_URL } from './constants'
+
+
+// CSS for leaderboard view
+const LEADERBOARD_VIEW_CSS = `
+.view-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+}
+
+.view-header {
+  text-align: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.view-title {
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.view-subtitle {
+  color: #666;
+  font-size: 14px;
+}
+
+.controls-section {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 30px;
+}
+
+.controls-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 16px 0;
+}
+
+.controls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  align-items: end;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.control-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 6px;
+}
+
+.control-input, .control-select {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  background: #fff;
+}
+
+.control-input:focus, .control-select:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0,123,255,.25);
+}
+
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #0056b3;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background: #5a6268;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+.error {
+  text-align: center;
+  padding: 40px;
+  color: #dc3545;
+}
+`
+
+interface LeaderboardViewProps {
+  repo: Repo
+}
+
+export function LeaderboardView({ repo }: LeaderboardViewProps) {
+  const { leaderboardId } = useParams<{ leaderboardId: string }>()
+  const navigate = useNavigate()
+  const [leaderboard, setLeaderboard] = useState<Leaderboard | null>(null)
+  const [scorecardData, setScorecardData] = useState<ScorecardData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [scorecardLoading, setScorecardLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedCell, setSelectedCell] = useState<{ policyUri: string; evalName: string } | null>(null)
+  const [isViewLocked, setIsViewLocked] = useState(false)
+
+  // Controls for scorecard generation
+  const [policySelector, setPolicySelector] = useState<'latest' | 'best'>('latest')
+  const [numPolicies, setNumPolicies] = useState(20)
+
+  useEffect(() => {
+    if (leaderboardId) {
+      loadLeaderboard()
+    }
+  }, [leaderboardId])
+
+  useEffect(() => {
+    if (leaderboard) {
+      loadScorecardData()
+    }
+  }, [leaderboard, policySelector, numPolicies])
+
+  const loadLeaderboard = async () => {
+    if (!leaderboardId) return
+
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await repo.getLeaderboard(leaderboardId)
+      setLeaderboard(data)
+    } catch (err: any) {
+      setError(`Failed to load leaderboard: ${err.message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadScorecardData = async () => {
+    if (!leaderboardId) return
+
+    try {
+      setScorecardLoading(true)
+      setError(null)
+      const request: LeaderboardScorecardRequest = {
+        selector: policySelector,
+        num_policies: numPolicies
+      }
+      const data = await repo.generateLeaderboardScorecard(leaderboardId, request)
+      setScorecardData(data)
+    } catch (err: any) {
+      setError(`Failed to load scorecard data: ${err.message}`)
+    } finally {
+      setScorecardLoading(false)
+    }
+  }
+
+  const handleBack = () => {
+    navigate('/leaderboards')
+  }
+
+  const openReplayUrl = (policyName: string, evalName: string) => {
+    const cell = scorecardData?.cells[policyName]?.[evalName]
+    if (!cell?.replayUrl) return
+
+    const replay_url_prefix = `${METTASCOPE_REPLAY_URL}/?replayUrl=`
+    window.open(replay_url_prefix + cell.replayUrl, '_blank')
+  }
+
+  const toggleLock = () => {
+    setIsViewLocked(!isViewLocked)
+  }
+
+  const handleReplayClick = () => {
+    if (selectedCell) {
+      openReplayUrl(selectedCell.policyUri, selectedCell.evalName)
+    }
+  }
+
+  const selectedCellData = selectedCell ? scorecardData?.cells[selectedCell.policyUri]?.[selectedCell.evalName] : null
+  const selectedEval = selectedCellData?.evalName ?? null
+  const selectedReplayUrl = selectedCellData?.replayUrl ?? null
+
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_VIEW_CSS}</style>
+        <div className="loading">
+          <h3>Loading leaderboard...</h3>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_VIEW_CSS}</style>
+        <div className="error">
+          <h3>Error</h3>
+          <p>{error}</p>
+          <button className="btn btn-primary" onClick={loadLeaderboard}>
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!leaderboard) {
+    return (
+      <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+        <style>{LEADERBOARD_VIEW_CSS}</style>
+        <div className="error">
+          <h3>Leaderboard not found</h3>
+          <button className="btn btn-primary" onClick={handleBack}>
+            Back to Leaderboards
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '20px', background: '#f8f9fa', minHeight: 'calc(100vh - 60px)' }}>
+      <style>{LEADERBOARD_VIEW_CSS}</style>
+
+      <div className="view-container">
+        <div className="view-header">
+          <h1 className="view-title">{leaderboard.name}</h1>
+          <p className="view-subtitle">
+            Leaderboard Scorecard - {leaderboard.metric}
+          </p>
+        </div>
+
+        {/* Scorecard Controls */}
+        <div className="controls-section">
+          <h3 className="controls-title">Scorecard Settings</h3>
+          <div className="controls-grid">
+            <div className="control-group">
+              <label className="control-label" htmlFor="policySelector">
+                Policy Selector
+              </label>
+              <select
+                id="policySelector"
+                className="control-select"
+                value={policySelector}
+                onChange={(e) => setPolicySelector(e.target.value as 'latest' | 'best')}
+              >
+                <option value="latest">Latest</option>
+                <option value="best">Best</option>
+              </select>
+            </div>
+            <div className="control-group">
+              <label className="control-label" htmlFor="numPolicies">
+                Number of Policies
+              </label>
+              <input
+                id="numPolicies"
+                type="number"
+                className="control-input"
+                value={numPolicies}
+                onChange={(e) => setNumPolicies(parseInt(e.target.value) || 20)}
+                min="1"
+                max="100"
+              />
+            </div>
+          </div>
+        </div>
+
+        {scorecardLoading && (
+          <div className="loading">
+            <h3>Loading scorecard...</h3>
+          </div>
+        )}
+
+        {!scorecardLoading && scorecardData && (
+          <div>
+            <Scorecard
+                data={scorecardData}
+                selectedMetric={leaderboard.metric}
+                setSelectedCell={setSelectedCell}
+                openReplayUrl={openReplayUrl}
+                numPoliciesToShow={numPolicies}
+              />
+
+          <MapViewer
+              selectedEval={selectedEval}
+              isViewLocked={isViewLocked}
+              selectedReplayUrl={selectedReplayUrl}
+              onToggleLock={toggleLock}
+              onReplayClick={handleReplayClick}
+            />
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="actions">
+          <button className="btn btn-secondary" onClick={handleBack}>
+            Back to Leaderboards
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/observatory/src/Leaderboards.tsx
+++ b/observatory/src/Leaderboards.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Repo, Leaderboard } from './repo'
+
+// CSS for leaderboards
+const LEADERBOARDS_CSS = `
+.leaderboard-list {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.leaderboard-item {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+  transition: all 0.2s ease;
+}
+
+.leaderboard-item:hover {
+  box-shadow: 0 4px 8px rgba(0,0,0,.15);
+  transform: translateY(-2px);
+}
+
+.leaderboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.leaderboard-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+}
+
+.leaderboard-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s ease;
+}
+
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #0056b3;
+}
+
+.btn-danger {
+  background: #dc3545;
+  color: #fff;
+}
+
+.btn-danger:hover {
+  background: #c82333;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background: #5a6268;
+}
+
+.btn-success {
+  background: #28a745;
+  color: #fff;
+}
+
+.btn-success:hover {
+  background: #218838;
+}
+
+.leaderboard-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-label {
+  font-size: 12px;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.meta-value {
+  font-size: 14px;
+  color: #333;
+  font-weight: 500;
+}
+
+.leaderboard-dates {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: #999;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: #666;
+}
+
+.empty-state h3 {
+  margin-bottom: 12px;
+  color: #333;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+.error {
+  text-align: center;
+  padding: 40px;
+  color: #dc3545;
+}
+
+.create-leaderboard-section {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.create-leaderboard-section h2 {
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.tag {
+  background: #e9ecef;
+  color: #495057;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+`
+
+interface LeaderboardsProps {
+  repo: Repo
+  currentUser: string
+}
+
+export function Leaderboards({ repo }: LeaderboardsProps) {
+  const [leaderboards, setLeaderboards] = useState<Leaderboard[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    loadLeaderboards()
+  }, [])
+
+  const loadLeaderboards = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await repo.listLeaderboards()
+      setLeaderboards(response.leaderboards)
+    } catch (err: any) {
+      setError(err.message || 'Failed to load leaderboards')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async (leaderboardId: string) => {
+    if (!confirm('Are you sure you want to delete this leaderboard?')) {
+      return
+    }
+
+    try {
+      await repo.deleteLeaderboard(leaderboardId)
+      setLeaderboards(leaderboards.filter((l) => l.id !== leaderboardId))
+    } catch (err: any) {
+      alert(`Failed to delete leaderboard: ${err.message}`)
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString()
+  }
+
+  const handleCreateNew = () => {
+    navigate('/leaderboards/create')
+  }
+
+  const handleViewLeaderboard = (leaderboard: Leaderboard) => {
+    navigate(`/leaderboards/${leaderboard.id}`)
+  }
+
+  // Edit functionality removed - leaderboards can no longer be edited
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px' }}>
+        <style>{LEADERBOARDS_CSS}</style>
+        <div className="loading">
+          <h3>Loading leaderboards...</h3>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px' }}>
+        <style>{LEADERBOARDS_CSS}</style>
+        <div className="error">
+          <h3>Error loading leaderboards</h3>
+          <p>{error}</p>
+          <button className="btn btn-primary" onClick={loadLeaderboards}>
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        padding: '20px',
+        background: '#f8f9fa',
+        minHeight: 'calc(100vh - 60px)',
+      }}
+    >
+      <style>{LEADERBOARDS_CSS}</style>
+
+      <div className="leaderboard-list">
+        <h1 style={{ marginBottom: '30px', color: '#333', textAlign: 'center' }}>Leaderboards</h1>
+
+        <div className="create-leaderboard-section">
+          <button className="btn btn-success" onClick={handleCreateNew}>
+            + Create Leaderboard
+          </button>
+        </div>
+
+        {leaderboards.length === 0 ? (
+          <div className="empty-state">
+            <h3>No leaderboards created</h3>
+            <p>You haven't created any leaderboards yet. Create one to start tracking policy performance.</p>
+          </div>
+        ) : (
+          leaderboards.map((leaderboard) => (
+            <div key={leaderboard.id} className="leaderboard-item">
+              <div className="leaderboard-header">
+                <h3 className="leaderboard-title">{leaderboard.name}</h3>
+                <div className="leaderboard-actions">
+                  <button className="btn btn-primary" onClick={() => handleViewLeaderboard(leaderboard)}>
+                    View
+                  </button>
+                  <button className="btn btn-danger" onClick={() => handleDelete(leaderboard.id)}>
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              <div className="leaderboard-meta">
+                <div className="meta-item">
+                  <div className="meta-label">Metric</div>
+                  <div className="meta-value">{leaderboard.metric}</div>
+                </div>
+                <div className="meta-item">
+                  <div className="meta-label">Start Date Filter</div>
+                  <div className="meta-value">{leaderboard.start_date}</div>
+                </div>
+                <div className="meta-item">
+                  <div className="meta-label">Created</div>
+                  <div className="meta-value">{formatDate(leaderboard.created_at)}</div>
+                </div>
+              </div>
+
+              <div className="meta-item">
+                <div className="meta-label">Evaluations</div>
+                <div className="tag-list">
+                  {leaderboard.evals.map((evalName, index) => (
+                    <span key={index} className="tag">
+                      {evalName}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/observatory/src/components/DateSelector.tsx
+++ b/observatory/src/components/DateSelector.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+interface DateSelectorProps {
+  value: string // ISO date string
+  onChange: (date: string) => void
+  label?: string
+  disabled?: boolean
+}
+
+export function DateSelector({ value, onChange, label = 'Start Date', disabled = false }: DateSelectorProps) {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value)
+  }
+
+  return (
+    <div style={{ marginBottom: '16px' }}>
+      <label style={{ display: 'block', marginBottom: '8px', fontWeight: '500', color: '#333' }}>
+        {label}
+      </label>
+      <input
+        type="date"
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        style={{
+          padding: '8px 12px',
+          border: '1px solid #ddd',
+          borderRadius: '4px',
+          fontSize: '14px',
+          width: '100%',
+          maxWidth: '200px',
+          backgroundColor: disabled ? '#f5f5f5' : 'white',
+          color: disabled ? '#666' : '#333',
+          cursor: disabled ? 'not-allowed' : 'text',
+        }}
+      />
+    </div>
+  )
+}

--- a/observatory/src/repo.ts
+++ b/observatory/src/repo.ts
@@ -194,6 +194,35 @@ export type PolicyScorecardData = {
   evalMaxScores: Record<string, number>
 }
 
+// Leaderboard types
+export type Leaderboard = {
+  id: string
+  name: string
+  user_id: string
+  evals: string[]
+  metric: string
+  start_date: string
+  latest_episode: number
+  created_at: string
+  updated_at: string
+}
+
+export type LeaderboardCreate = {
+  name: string
+  evals: string[]
+  metric: string
+  start_date: string
+}
+
+export type LeaderboardListResponse = {
+  leaderboards: Leaderboard[]
+}
+
+export type LeaderboardScorecardRequest = {
+  selector: 'latest' | 'best'
+  num_policies: number
+}
+
 import { config } from './config'
 
 export type TableInfo = {
@@ -279,6 +308,13 @@ export interface Repo {
   getEvalNames(request: EvalNamesRequest): Promise<Set<string>>
   getAvailableMetrics(request: MetricsRequest): Promise<string[]>
   generatePolicyScorecard(request: PolicyScorecardRequest): Promise<PolicyScorecardData>
+
+  // Leaderboard methods
+  listLeaderboards(): Promise<LeaderboardListResponse>
+  getLeaderboard(leaderboardId: string): Promise<Leaderboard>
+  createLeaderboard(leaderboardData: LeaderboardCreate): Promise<Leaderboard>
+  deleteLeaderboard(leaderboardId: string): Promise<void>
+  generateLeaderboardScorecard(leaderboardId: string, request: LeaderboardScorecardRequest): Promise<ScorecardData>
 }
 
 export class ServerRepo implements Repo {
@@ -465,5 +501,30 @@ export class ServerRepo implements Repo {
 
   async generatePolicyScorecard(request: PolicyScorecardRequest): Promise<PolicyScorecardData> {
     return this.apiCallWithBody<PolicyScorecardData>('/scorecard/scorecard', request)
+  }
+
+  // Leaderboard methods
+  async listLeaderboards(): Promise<LeaderboardListResponse> {
+    return this.apiCall<LeaderboardListResponse>('/leaderboards')
+  }
+
+  async getLeaderboard(leaderboardId: string): Promise<Leaderboard> {
+    return this.apiCall<Leaderboard>(`/leaderboards/${encodeURIComponent(leaderboardId)}`)
+  }
+
+  async createLeaderboard(leaderboardData: LeaderboardCreate): Promise<Leaderboard> {
+    return this.apiCallWithBody<Leaderboard>('/leaderboards', leaderboardData)
+  }
+
+  async deleteLeaderboard(leaderboardId: string): Promise<void> {
+    return this.apiCallDelete(`/leaderboards/${encodeURIComponent(leaderboardId)}`)
+  }
+
+  async generateLeaderboardScorecard(leaderboardId: string, request: LeaderboardScorecardRequest): Promise<ScorecardData> {
+    return this.apiCallWithBody<ScorecardData>('/scorecard/leaderboard', {
+      leaderboard_id: leaderboardId,
+      selector: request.selector,
+      num_policies: request.num_policies
+    })
   }
 }


### PR DESCRIPTION
The PR has 3 components:

1) Leaderboard definition: essentially like a standard scorecard, but with a start date instead of specific selected policies / training runs.  The user must specify the set of evals, the metric, and the start date, and the system maintains the leaderboard . 

2) Leaderboard updater: Runs periodically, and for all live dashboards computes the (leaderboard_id, policy_id -> score) mapping in a table. 

3) Leaderboard scoreboard route:  uses the leaderboard_policy_scores table to construct a standard scorecard

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211039460317057)