### PR TITLE
minor refactor: activate_observations not _initialize

### DIFF
--- a/agent/src/metta/agent/metta_agent.py
+++ b/agent/src/metta/agent/metta_agent.py
@@ -226,10 +226,10 @@ class MettaAgent(nn.Module):
             device: Device to place tensors on
         """
         # Use PyTorch's built-in training mode detection
-        self._initialize_observations(features, device)
+        self.activate_observations(features, device)
         self.activate_actions(action_names, action_max_params, device)
 
-    def _initialize_observations(self, features: dict[str, dict], device):
+    def activate_observations(self, features: dict[str, dict], device):
         """Initialize observation features by storing the feature mapping."""
         self.active_features = features
         self.device = device

--- a/agent/src/metta/agent/mocks/mock_agent.py
+++ b/agent/src/metta/agent/mocks/mock_agent.py
@@ -86,7 +86,7 @@ class MockAgent(MettaAgent):
         self.activate_actions(action_names, action_max_params, device)
 
         # Initialize observations to support feature remapping
-        self._initialize_observations(features, device)
+        self.activate_observations(features, device)
 
     def reset_memory(self):
         """Mock implementation - no memory to reset."""

--- a/agent/src/metta/agent/pytorch/fast.py
+++ b/agent/src/metta/agent/pytorch/fast.py
@@ -45,10 +45,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
             device: Device to place tensors on
             is_training: Deprecated. Training mode is now automatically detected.
         """
-        self._initialize_observations(features, device, is_training)
+        self.activate_observations(features, device, is_training)
         self.activate_actions(action_names, action_max_params, device)
 
-    def _initialize_observations(self, features: dict[str, dict], device, is_training: bool):
+    def activate_observations(self, features: dict[str, dict], device, is_training: bool):
         """Initialize observation features by storing the feature mapping."""
         self.active_features = features
         self.device = device

--- a/agent/src/metta/agent/pytorch/latent_attn_med.py
+++ b/agent/src/metta/agent/pytorch/latent_attn_med.py
@@ -48,10 +48,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
             device: Device to place tensors on
             is_training: Deprecated. Training mode is now automatically detected.
         """
-        self._initialize_observations(features, device, is_training)
+        self.activate_observations(features, device, is_training)
         self.activate_actions(action_names, action_max_params, device)
 
-    def _initialize_observations(self, features: dict[str, dict], device, is_training: bool):
+    def activate_observations(self, features: dict[str, dict], device, is_training: bool):
         """Initialize observation features by storing the feature mapping."""
         self.active_features = features
         self.device = device

--- a/agent/src/metta/agent/pytorch/latent_attn_small.py
+++ b/agent/src/metta/agent/pytorch/latent_attn_small.py
@@ -48,10 +48,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
             device: Device to place tensors on
             is_training: Deprecated. Training mode is now automatically detected.
         """
-        self._initialize_observations(features, device, is_training)
+        self.activate_observations(features, device, is_training)
         self.activate_actions(action_names, action_max_params, device)
 
-    def _initialize_observations(self, features: dict[str, dict], device, is_training: bool):
+    def activate_observations(self, features: dict[str, dict], device, is_training: bool):
         """Initialize observation features by storing the feature mapping."""
         self.active_features = features
         self.device = device

--- a/agent/src/metta/agent/pytorch/latent_attn_tiny.py
+++ b/agent/src/metta/agent/pytorch/latent_attn_tiny.py
@@ -48,10 +48,10 @@ class Recurrent(pufferlib.models.LSTMWrapper):
             device: Device to place tensors on
             is_training: Deprecated. Training mode is now automatically detected.
         """
-        self._initialize_observations(features, device, is_training)
+        self.activate_observations(features, device, is_training)
         self.activate_actions(action_names, action_max_params, device)
 
-    def _initialize_observations(self, features: dict[str, dict], device, is_training: bool):
+    def activate_observations(self, features: dict[str, dict], device, is_training: bool):
         """Initialize observation features by storing the feature mapping."""
         self.active_features = features
         self.device = device

--- a/agent/tests/test_feature_remapping.py
+++ b/agent/tests/test_feature_remapping.py
@@ -93,7 +93,7 @@ def test_feature_remapping_in_agent():
     """Test that feature remapping is correctly set up in MettaAgent."""
     agent = MockAgent()
 
-    # Test _initialize_observations with original features
+    # Test activate_observations with original features
     original_features = {
         "type_id": {"id": 0, "type": "categorical"},
         "hp": {"id": 2, "type": "scalar", "normalization": 30.0},
@@ -102,7 +102,7 @@ def test_feature_remapping_in_agent():
 
     # Set training mode for first initialization
     agent.train()
-    agent._initialize_observations(original_features, "cpu")
+    agent.activate_observations(original_features, "cpu")
 
     # Verify original mapping stored
     assert agent.original_feature_mapping == {
@@ -122,7 +122,7 @@ def test_feature_remapping_in_agent():
     mock_obs = MockObsComponent()
     agent.components["_obs_"] = mock_obs
 
-    agent._initialize_observations(new_features, "cpu")
+    agent.activate_observations(new_features, "cpu")
 
     # Verify all remappings in a clear block
     assert agent.feature_id_remap[5] == 2  # hp: 5->2
@@ -147,7 +147,7 @@ def test_unknown_feature_handling():
 
     # Set training mode for first initialization
     agent.train()
-    agent._initialize_observations(original_features, "cpu")
+    agent.activate_observations(original_features, "cpu")
 
     # Add mock observation component
     mock_obs = MockObsComponent()
@@ -162,7 +162,7 @@ def test_unknown_feature_handling():
 
     # Initialize in evaluation mode
     agent.eval()
-    agent._initialize_observations(new_features_with_unknown, "cpu")
+    agent.activate_observations(new_features_with_unknown, "cpu")
 
     # Verify all remappings in a clear block
     # Known features should be remapped to their original IDs
@@ -194,7 +194,7 @@ def test_feature_mapping_persistence_via_metadata():
 
     # Initialize the agent
     agent.train()
-    agent._initialize_observations(original_features, "cpu")
+    agent.activate_observations(original_features, "cpu")
 
     # Get the original feature mapping
     original_mapping = agent.get_original_feature_mapping()
@@ -225,7 +225,7 @@ def test_feature_mapping_persistence_via_metadata():
 
     # Initialize in training mode - new features should be learned
     new_agent.train()
-    new_agent._initialize_observations(new_features, "cpu")
+    new_agent.activate_observations(new_features, "cpu")
 
     # Verify all remappings in a clear block
     assert new_agent.feature_id_remap[5] == 0  # type_id: 5->0
@@ -246,7 +246,7 @@ def test_feature_mapping_persistence_via_metadata():
 
     # Initialize in eval mode - new features should map to 255
     eval_agent.eval()
-    eval_agent._initialize_observations(new_features, "cpu")
+    eval_agent.activate_observations(new_features, "cpu")
 
     # Check the observation component's remap table
     obs_component = eval_agent.components["_obs_"]


### PR DESCRIPTION
function name change to match activate_actions

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211049171239992)