### PR TITLE
8way move restricted agents

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/move_8way.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/move_8way.hpp
@@ -10,7 +10,9 @@
 
 class Move8Way : public ActionHandler {
 public:
-  explicit Move8Way(const ActionConfig& cfg) : ActionHandler(cfg, "move_8way") {}
+  bool _no_agent_interference;
+  explicit Move8Way(const ActionConfig& cfg, bool no_agent_interference = false)
+  : ActionHandler(cfg, "move_8way"), _no_agent_interference(no_agent_interference) {}
 
   unsigned char max_arg() const override {
     return 7;  // 8 directions
@@ -32,11 +34,11 @@ protected:
         target_location.r -= 1;
         target_location.c += 1;
         new_orientation = Orientation::Up;
-        if (!_is_valid_square(target_location)) {
+        if (!_is_valid_square(target_location, _no_agent_interference)) {
             // Tries clockwise adj cardinal dir
             target_location.r += 1;
             new_orientation = Orientation::Up;
-            if (!_is_valid_square(target_location)) {
+            if (!_is_valid_square(target_location, _no_agent_interference)) {
                 // Tries counter-clockwise adj cardinal dir
                 target_location.r -= 1;
                 target_location.c -= 1;
@@ -54,11 +56,11 @@ protected:
         target_location.r += 1;
         target_location.c += 1;
         new_orientation = Orientation::Down;
-        if (!_is_valid_square(target_location)) {
+        if (!_is_valid_square(target_location, _no_agent_interference)) {
             // Tries clockwise adj cardinal dir
             target_location.c -= 1;
             new_orientation = Orientation::Right;
-            if (!_is_valid_square(target_location)) {
+            if (!_is_valid_square(target_location, _no_agent_interference)) {
                 // Tries counter-clockwise adj cardinal dir
                 target_location.r -= 1;
                 target_location.c += 1;
@@ -76,11 +78,11 @@ protected:
         target_location.r += 1;
         target_location.c -= 1;
         new_orientation = Orientation::Down;
-        if (!_is_valid_square(target_location)) {
+        if (!_is_valid_square(target_location, _no_agent_interference)) {
             // Tries clockwise adj cardinal dir
             target_location.r -= 1;
             new_orientation = Orientation::Down;
-            if (!_is_valid_square(target_location)) {
+            if (!_is_valid_square(target_location, _no_agent_interference)) {
                 // Tries counter-clockwise adj cardinal dir
                 target_location.r += 1;
                 target_location.c += 1;
@@ -98,11 +100,11 @@ protected:
         target_location.r -= 1;
         target_location.c -= 1;
         new_orientation = Orientation::Up;
-        if (!_is_valid_square(target_location)) {
+        if (!_is_valid_square(target_location, _no_agent_interference)) {
             // Tries clockwise adj cardinal dir
             target_location.c += 1;
             new_orientation = Orientation::Left;
-            if (!_is_valid_square(target_location)) {
+            if (!_is_valid_square(target_location, _no_agent_interference)) {
                 // Tries counter-clockwise adj cardinal dir
                 target_location.r += 1;
                 target_location.c -= 1;
@@ -116,23 +118,33 @@ protected:
         return false;
     }
 
-    // Check if only/remaining target location is valid and empty
-    if (!_is_valid_square(target_location)) {
-      return false;
-    }
-
     // Update orientation before moving
     actor->orientation = new_orientation;
 
+    // Check if only/remaining target location is valid and empty
+    if (!_is_valid_square(target_location, _no_agent_interference)) {
+      return false;
+    }
+
     // Move the agent with new orientation
-    return _grid->move_object(actor->id, target_location);
+    if(_no_agent_interference) {
+      return _grid->ghost_move_object(actor->id, target_location);
+    } else {
+      return _grid->move_object(actor->id, target_location);
+    }
   }
-  bool _is_valid_square(GridLocation target_location) {
+  bool _is_valid_square(GridLocation target_location, bool no_agent_interference) {
     if (!_grid->is_valid_location(target_location)) {
       return false;
     }
-    if (!_grid->is_empty(target_location.r, target_location.c)) {
-      return false;
+    if(no_agent_interference) {
+      if (!_grid->is_empty_at_layer(target_location.r, target_location.c, GridLayer::ObjectLayer)) {
+        return false;
+      }
+    } else {
+      if (!_grid->is_empty(target_location.r, target_location.c)) {
+        return false;
+      }
     }
     return true;
   }

--- a/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
+++ b/mettagrid/src/metta/mettagrid/mettagrid_c.cpp
@@ -102,7 +102,7 @@ MettaGrid::MettaGrid(const GameConfig& cfg, const py::list map, unsigned int see
     } else if (action_name_str == "move") {
       _action_handlers.push_back(std::make_unique<Move>(*action_config, _track_movement_metrics, _no_agent_interference));
     } else if (action_name_str == "move_8way") {
-      _action_handlers.push_back(std::make_unique<Move8Way>(*action_config));
+      _action_handlers.push_back(std::make_unique<Move8Way>(*action_config, _no_agent_interference));
     } else if (action_name_str == "move_cardinal") {
       _action_handlers.push_back(std::make_unique<MoveCardinal>(*action_config));
     } else if (action_name_str == "rotate") {


### PR DESCRIPTION
Two things:
- agent orientation was being updated after rejecting a movement for the target location having an object, making the movement not be able to allow for rotations. Now moving into an occupied target location updates your orientation in that direction. 
- adding agent_interference flag to move_8way