### PR TITLE
fix: match all three tokens in wall observation test

### DIFF
--- a/mettagrid/tests/test_observations.py
+++ b/mettagrid/tests/test_observations.py
@@ -91,7 +91,11 @@ class TestObservations:
         # Check no walls at empty positions
         for x, y in no_wall_positions_agent0:
             location = PackedCoordinate.pack(y, x)
-            wall_tokens = (agent0_obs[:, 0] == location) & (agent0_obs[:, 2] == TokenTypes.WALL_TYPE_ID)
+            wall_tokens = (
+                (agent0_obs[:, 0] == location)
+                & (agent0_obs[:, 1] == TokenTypes.TYPE_ID_FEATURE)
+                & (agent0_obs[:, 2] == TokenTypes.WALL_TYPE_ID)
+            )
             assert not wall_tokens.any(), f"Agent 0: Expected no wall at ({x}, {y})"
 
         # Verify wall count
@@ -122,7 +126,11 @@ class TestObservations:
         # Check no walls at empty positions
         for x, y in no_wall_positions_agent1:
             location = PackedCoordinate.pack(y, x)
-            wall_tokens = (agent1_obs[:, 0] == location) & (agent1_obs[:, 2] == TokenTypes.WALL_TYPE_ID)
+            wall_tokens = (
+                (agent1_obs[:, 0] == location)
+                & (agent1_obs[:, 1] == TokenTypes.TYPE_ID_FEATURE)
+                & (agent1_obs[:, 2] == TokenTypes.WALL_TYPE_ID)
+            )
             assert not wall_tokens.any(), f"Agent 1: Expected no wall at ({x}, {y})"
 
         # Verify wall count


### PR DESCRIPTION

This PR fixes a bug in the wall observation test where global tokens were incorrectly being identified as walls due to incomplete token matching.

## The Problem
The test `test_detailed_wall_observations` was failing intermittently because it was only checking two out of three token components when identifying walls:
- ✅ Location (first column)
- ❌ Token type (second column) - **missing!**
- ✅ Value (third column)

This meant that any token at a given location whose value happened to equal `WALL_TYPE_ID` would be incorrectly identified as a wall.

## Why This Happened
In the MettaGrid observation system, global tokens (episode completion percentage, last action, last action arg, last reward) are placed at the center of the observation window. For a 3x3 window, this is position (1,1) - the same position where the agent sees itself.

When these global tokens had values that coincidentally matched `WALL_TYPE_ID`, the test would fail with:
```
AssertionError: Agent 0: Expected no wall at (1, 1)
```

## The Fix
Added the missing token type check to ensure we only identify tokens as walls when:
1. They're at the specified location
2. They're `TYPE_ID_FEATURE` tokens (not global tokens or other types)
3. Their value is `WALL_TYPE_ID`

This change makes the wall detection logic consistent with the `_check_token_exists` helper method, which already correctly checks all three token components.

fixes https://app.asana.com/1/1209016784099267/project/1209805539287945/task/1211059290660307?focus=true

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211061982210802)