### PR TITLE
feat: clean atlas lib implementation

### DIFF
--- a/mettascope/.prettierignore
+++ b/mettascope/.prettierignore
@@ -1,2 +1,3 @@
 index.html
+index.css
 dist

--- a/mettascope/src/actions.ts
+++ b/mettascope/src/actions.ts
@@ -5,7 +5,7 @@ import { sendAction } from './replay.js'
 
 // Small timing window to combine two directional key presses (e.g., W+A -> Northwest).
 const COMBO_WINDOW_MS = 100
-let comboKeys: Set<'w' | 'a' | 's' | 'd'> = new Set()
+const comboKeys: Set<'w' | 'a' | 's' | 'd'> = new Set()
 let comboTimer: number | null = null
 
 // Queue up a key press for a directional combo.

--- a/mettascope/src/atlas.ts
+++ b/mettascope/src/atlas.ts
@@ -1,0 +1,229 @@
+import { Vec2f } from './vector_math.js'
+
+/**
+ * Type definition for atlas data loaded from JSON.
+ *
+ * @example
+ * {
+ *   "player.png": [0, 0, 32, 32],
+ *   "enemy.png": [32, 0, 32, 32],
+ *   "metadata": { "version": "1.0" }
+ * }
+ *
+ * The optional metadata field can contain additional data like font information.
+ */
+export type SpriteBounds = [x: number, y: number, width: number, height: number]
+
+function isSpriteBounds(val: unknown): val is SpriteBounds {
+  return Array.isArray(val) && val.length === 4 && val.every((n) => typeof n === 'number')
+}
+
+export interface AtlasSpriteMap {
+  [key: string]: SpriteBounds
+}
+
+export interface AtlasMetadata {
+  [key: string]: unknown
+}
+
+/* Complete atlas bundle containing both the texture and sprite data. */
+export interface Atlas {
+  data: AtlasSpriteMap // The atlas JSON data with sprite definitions
+  metadata: AtlasMetadata // Atlas metadata
+  texture: WebGLTexture // The WebGL texture containing all sprites
+  size: Vec2f // Dimensions of the texture in pixels
+  margin: number // Pixel margin added around sprites to prevent texture bleeding
+}
+
+/* Validates that an atlas object has the correct structure and types. */
+export function validateAtlas(atlas: Atlas): boolean {
+  return (
+    typeof atlas.margin === 'number' &&
+    atlas.size instanceof Vec2f &&
+    atlas.texture !== null &&
+    Object.values(atlas.data).every(
+      (bounds) => Array.isArray(bounds) && bounds.length === 4 && bounds.every((n) => typeof n === 'number')
+    )
+  )
+}
+
+/* Loads and parses atlas JSON data from a URL, returning sprite map and metadata. */
+export async function loadAtlasJson(url: string): Promise<[AtlasSpriteMap, AtlasMetadata] | null> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      throw new Error(`Failed to fetch atlas: ${res.statusText}`)
+    }
+
+    const raw = await res.json()
+    const metadata = (raw.metadata ?? {}) as AtlasMetadata
+    const spriteEntries = Object.entries(raw).filter(([k, v]) => k !== 'metadata' && isSpriteBounds(v))
+    const sprites = Object.fromEntries(spriteEntries) as AtlasSpriteMap
+
+    return [sprites as AtlasSpriteMap, metadata as AtlasMetadata]
+  } catch (err) {
+    console.error(`Error loading atlas ${url}:`, err)
+    return null
+  }
+}
+
+/* Loads an image from a URL and creates a premultiplied alpha ImageBitmap. */
+export async function loadAtlasImage(url: string): Promise<ImageBitmap | null> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      throw new Error(`Failed to fetch image: ${res.statusText}`)
+    }
+    const blob = await res.blob()
+    // Use premultiplied alpha to fix border issues
+    return await createImageBitmap(blob, {
+      colorSpaceConversion: 'none',
+      premultiplyAlpha: 'premultiply',
+    })
+  } catch (err) {
+    console.error(`Error loading image ${url}:`, err)
+    return null
+  }
+}
+
+type TextureWrapMode =
+  | WebGLRenderingContext['REPEAT']
+  | WebGLRenderingContext['CLAMP_TO_EDGE']
+  | WebGLRenderingContext['MIRRORED_REPEAT']
+
+type TextureFilterMode =
+  | WebGLRenderingContext['NEAREST']
+  | WebGLRenderingContext['LINEAR']
+  | WebGLRenderingContext['NEAREST_MIPMAP_NEAREST']
+  | WebGLRenderingContext['LINEAR_MIPMAP_NEAREST']
+  | WebGLRenderingContext['NEAREST_MIPMAP_LINEAR']
+  | WebGLRenderingContext['LINEAR_MIPMAP_LINEAR']
+
+type TextureMinFilterMode = TextureFilterMode
+type TextureMagFilterMode = WebGLRenderingContext['NEAREST'] | WebGLRenderingContext['LINEAR']
+
+/* Checks if a minification filter requires mipmaps. */
+function requiresMipmaps(gl: WebGLRenderingContext, minFilter: TextureMinFilterMode): boolean {
+  return (
+    minFilter === gl.NEAREST_MIPMAP_NEAREST ||
+    minFilter === gl.LINEAR_MIPMAP_NEAREST ||
+    minFilter === gl.NEAREST_MIPMAP_LINEAR ||
+    minFilter === gl.LINEAR_MIPMAP_LINEAR
+  )
+}
+
+/* Creates a WebGL texture from an image with specified wrap and filter modes. */
+export function createTexture(
+  gl: WebGLRenderingContext,
+  image: ImageBitmap,
+  wrapS: TextureWrapMode,
+  wrapT: TextureWrapMode,
+  minFilter: TextureMinFilterMode,
+  magFilter: TextureMagFilterMode,
+  generateMipmap: boolean
+): WebGLTexture {
+  // Validate mipmap requirements
+  if (!generateMipmap && requiresMipmaps(gl, minFilter)) {
+    throw new Error(
+      `Minification filter requires mipmaps but generateMipmap is false. ` +
+        `Use NEAREST or LINEAR for minFilter when not generating mipmaps.`
+    )
+  }
+
+  const texture = gl.createTexture()!
+  gl.bindTexture(gl.TEXTURE_2D, texture)
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
+
+  if (generateMipmap) {
+    gl.generateMipmap(gl.TEXTURE_2D)
+  }
+
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter)
+
+  return texture
+}
+
+/* Loads a complete texture atlas from JSON and image URLs. Texture settings are selected for pixel art. */
+export async function loadAtlas(gl: WebGLRenderingContext, jsonUrl: string, imageUrl: string): Promise<Atlas> {
+  const [json, image] = await Promise.all([loadAtlasJson(jsonUrl), loadAtlasImage(imageUrl)])
+
+  const [data, metadata] = json!
+
+  const texture = createTexture(
+    gl,
+    image!,
+    gl.CLAMP_TO_EDGE, // wrapS
+    gl.CLAMP_TO_EDGE, // wrapT
+    gl.NEAREST, // minFilter
+    gl.NEAREST, // magFilter
+    false // generateMipmap
+  )
+
+  return {
+    data,
+    metadata,
+    texture,
+    size: new Vec2f(image!.width, image!.height),
+    margin: 4, // Default margin
+  }
+}
+
+/* Retrieves sprite bounds and UV coordinates for a named sprite in the atlas. */
+export function getSpriteBounds(
+  atlas: Atlas,
+  spriteName: string
+): {
+  x: number // X position with margin applied
+  y: number // Y position with margin applied
+  width: number // Width including margin on both sides
+  height: number // Height including margin on both sides
+  u0: number // Left texture coordinate (0-1)
+  v0: number // Top texture coordinate (0-1)
+  u1: number // Right texture coordinate (0-1)
+  v1: number // Bottom texture coordinate (0-1)
+} | null {
+  const spriteData = atlas.data[spriteName]
+
+  // Check if it's actually sprite data (array of 4 numbers)
+  if (!Array.isArray(spriteData) || spriteData.length !== 4) {
+    return null
+  }
+
+  const [x, y, width, height] = spriteData
+  const m = atlas.margin
+
+  return {
+    x: x - m,
+    y: y - m,
+    width: width + 2 * m,
+    height: height + 2 * m,
+    u0: (x - m) / atlas.size.x(),
+    v0: (y - m) / atlas.size.y(),
+    u1: (x + width + m) / atlas.size.x(),
+    v1: (y + height + m) / atlas.size.y(),
+  }
+}
+
+/* Checks whether a sprite with the given name exists in the atlas. */
+export function hasSprite(atlas: Atlas, spriteName: string): boolean {
+  const data = atlas.data[spriteName]
+  return Array.isArray(data) && data.length === 4
+}
+
+/* Gets the UV coordinates for a solid white color pixel. */
+export function getWhiteUV(atlas: Atlas): { u: number; v: number } {
+  const whiteSprite = atlas.data['white.png']
+
+  if (!Array.isArray(whiteSprite) || whiteSprite.length !== 4) {
+    throw new Error(`White pixel (u,v) coordinates are not available in the atlas!`)
+  }
+
+  const [x, y, width, height] = whiteSprite
+  return {
+    u: (x + width / 2) / atlas.size.x(),
+    v: (y + height / 2) / atlas.size.y(),
+  }
+}

--- a/mettascope/src/common.ts
+++ b/mettascope/src/common.ts
@@ -1,10 +1,10 @@
 import { Context3d } from './context3d.js'
+import { Heatmap } from './heatmap.js'
 import type { HoverBubble } from './hoverbubbles.js'
 import { find, localStorageGetNumber, parseHtmlColor, toggleOpacity } from './htmlutils.js'
 import { PanelInfo } from './panels.js'
-import { Vec2f } from './vector_math.js'
 import { Entity, Replay } from './replay.js'
-import { Heatmap } from './heatmap.js'
+import { Vec2f } from './vector_math.js'
 
 // The 3D context, used for nearly everything.
 export const ctx = new Context3d(find('#global-canvas') as HTMLCanvasElement)
@@ -176,7 +176,7 @@ export const html = {
 }
 
 /** Generates a color from an agent ID. */
-export function colorFromId(agentId: number) {
+export function colorFromId(agentId: number): [number, number, number, number] {
   const n = agentId + Math.PI + Math.E + Math.SQRT2
   return [(n * Math.PI) % 1.0, (n * Math.E) % 1.0, (n * Math.SQRT2) % 1.0, 1.0]
 }

--- a/mettascope/src/replay.ts
+++ b/mettascope/src/replay.ts
@@ -2,8 +2,8 @@ import { updateAgentTable } from './agentpanel.js'
 import * as Common from './common.js'
 import { ctx, html, state, ui } from './common.js'
 import { onResize, requestFrame, updateStep } from './main.js'
-import { focusFullMap } from './worldmap.js'
 import { validateReplayData, validateReplayStep } from './validation.js'
+import { focusFullMap } from './worldmap.js'
 
 /** This represents a sequence of values sort of like a movie timeline. */
 export class Sequence<T> {
@@ -256,7 +256,7 @@ function fixReplay() {
   // Create action image mappings for faster access.
   state.replay.actionImages = []
   for (const actionName of state.replay.actionNames) {
-    let imagePath = `trace/${actionName}.png`
+    const imagePath = `trace/${actionName}.png`
 
     if (ctx.hasImage(imagePath)) {
       state.replay.actionImages.push(imagePath)

--- a/mettascope/src/worldmap.ts
+++ b/mettascope/src/worldmap.ts
@@ -1,5 +1,5 @@
 import * as Common from './common.js'
-import { ctx, setFollowSelection, state, ui, HEATMAP_MIN_OPACITY, HEATMAP_MAX_OPACITY } from './common.js'
+import { ctx, setFollowSelection, state, ui } from './common.js'
 import { Grid } from './grid.js'
 import { renderHeatmapTiles } from './heatmap.js'
 import { type HoverBubble, updateHoverBubble, updateReadout } from './hoverbubbles.js'
@@ -544,7 +544,13 @@ function drawThoughtBubbles() {
         continue
       }
       const actionName = state.replay.actionNames[actionId]
-      if (actionName === 'noop' || actionName === 'rotate' || actionName === 'move' || actionName === 'move_cardinal' || actionName === 'move_8way') {
+      if (
+        actionName === 'noop' ||
+        actionName === 'rotate' ||
+        actionName === 'move' ||
+        actionName === 'move_cardinal' ||
+        actionName === 'move_8way'
+      ) {
         continue
       }
       keyAction = [actionId, actionParam]
@@ -640,7 +646,7 @@ function drawVisibility() {
       }
     }
 
-    let color = [0, 0, 0, 0.25]
+    let color: [number, number, number, number] = [0, 0, 0, 0.25]
     if (state.showFogOfWar) {
       color = [0, 0, 0, 1]
     }


### PR DESCRIPTION

This PR refactors the texture atlas handling code into a dedicated, well-typed library with improved error handling and cleaner APIs.

### Key Changes

1. **New `atlas.ts` module** - Extracted all atlas-related functionality into a standalone module with:
   - Proper TypeScript types for all atlas data structures
   - Runtime validation for texture parameters (mipmap requirements)
   - Consistent error handling using exceptions for fatal errors
   - Clean separation between loading (JSON/image) and texture creation

2. **Improved texture handling**:
   - Fixed premultiplied alpha handling - images are now correctly loaded with premultiplied alpha and the fragment shader no longer double-premultiplies
   - Pixel-art friendly defaults with `NEAREST` filtering and `CLAMP_TO_EDGE` wrap mode
   - Proper mipmap validation to prevent WebGL errors

3. **Simplified `Context3d`**:
   - Removed ~170 lines of atlas management code
   - Cleaner initialization using the new atlas API
   - More consistent sprite drawing methods

4. **Bug fixes**:
   - Fixed double premultiplication issue in fragment shader
   - Added proper null assertions for WebGL texture creation
   - Fixed color type annotations throughout
