### PR TITLE
fix: only inc restart counter from master node

### DIFF
--- a/devops/skypilot/config/configure_environment.sh
+++ b/devops/skypilot/config/configure_environment.sh
@@ -32,7 +32,12 @@ if [ -f "$RESTART_COUNT_FILE" ]; then
 else
     RESTART_COUNT=0
 fi
-echo "$RESTART_COUNT" > "$RESTART_COUNT_FILE"
+
+if [[ "$IS_MASTER" == "true" ]]; then
+    echo "$RESTART_COUNT" > "$RESTART_COUNT_FILE"
+else
+    echo "[INFO] Skipping RESTART_COUNT update on non-master node"
+fi
 
 # Read accumulated runtime
 if [ -f "$ACCUMULATED_RUNTIME_FILE" ]; then

--- a/devops/skypilot/config/sk_train_run.sh
+++ b/devops/skypilot/config/sk_train_run.sh
@@ -12,7 +12,7 @@ fi
 
 # Determine node role using SkyPilot environment variables
 RANK=${SKYPILOT_NODE_RANK:-0}
-IS_MASTER=$([[ "$RANK" == "0" ]] && echo "true" || echo "false")
+export IS_MASTER=$([[ "$RANK" == "0" ]] && echo "true" || echo "false")
 TOTAL_NODES=${SKYPILOT_NUM_NODES:-1}
 
 # Master-only: Collect SkyPilot latency
@@ -150,6 +150,13 @@ maybe_send_discord_notification() {
 maybe_set_github_status() {
   if [[ "$IS_MASTER" != "true" ]] || [ "$ENABLE_GITHUB_STATUS" != "true" ]; then
     return 0
+  fi
+
+  # Read SkyPilot job ID from file and export it
+  if [ -f /tmp/.sky_tmp/sky_job_id ]; then
+    export SKYPILOT_JOB_ID=$(cat /tmp/.sky_tmp/sky_job_id)
+  else
+    export SKYPILOT_JOB_ID=""
   fi
 
   echo "[RUN] Setting GitHub status: ${GITHUB_STATUS_STATE:-} - ${GITHUB_STATUS_DESCRIPTION:-}"

--- a/devops/skypilot/set_github_status.py
+++ b/devops/skypilot/set_github_status.py
@@ -69,9 +69,12 @@ def main() -> int:
         "Training completed successfully" if state == "success" else failure_message,
     )
 
-    task_id = os.getenv("SKYPILOT_TASK_ID", "").strip()
-    if task_id:
-        desc += f" - [ jl {task_id} ]"
+    job_id = os.getenv("SKYPILOT_JOB_ID", "").strip()
+    if job_id:
+        print(f"[INFO] Setting GitHub status for job {job_id}")
+        desc += f" - [ jl {job_id} ]"
+    else:
+        print("[INFO] No SkyPilot job ID found")
 
     # The target_url is a URL that GitHub will associate with the commit status. When users view the commit status
     # on GitHub (for example, in pull requests or on the commit page), they can click on the status check and be


### PR DESCRIPTION
This PR ensures that the RESTART_COUNT is only incremented by the master node during SkyPilot job execution, preventing redundant or conflicting updates across multiple nodes.

Changes

Conditionally update RESTART_COUNT_FILE only if IS_MASTER=true.

Fix export of IS_MASTER in sk_train_run.sh.

Inject SKYPILOT_JOB_ID from remote metadata file (/tmp/.sky_tmp/sky_job_id) for use in GitHub status reporting.

Update set_github_status.py to append job_id (if present) to commit status description.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211069714234180)