### PR TITLE
feat: fetch wandb run config by name

### DIFF
--- a/experiments/notebooks/util/__init__.py
+++ b/experiments/notebooks/util/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for experiment notebooks."""
+
+from .wandb_run_config import config_for_run
+
+__all__ = ["config_for_run"]

--- a/experiments/notebooks/util/wandb_run_config.py
+++ b/experiments/notebooks/util/wandb_run_config.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import wandb
+
+from metta.common.util.constants import METTA_WANDB_ENTITY, METTA_WANDB_PROJECT
+
+
+def config_for_run(
+    *,
+    run_name: str | None = None,
+    policy_name: str | None = None,
+    entity: str = METTA_WANDB_ENTITY,
+    project: str = METTA_WANDB_PROJECT,
+) -> dict[str, Any]:
+    """Fetch a W&B run configuration by run or policy name.
+
+    Exactly one of ``run_name`` or ``policy_name`` must be provided. The function
+    searches the given W&B project for a run matching the provided identifier and
+    returns its configuration dictionary.
+
+    Args:
+        run_name: Display name of the W&B run to fetch.
+        policy_name: Policy name stored in the run configuration under the
+            ``policy_name`` key.
+        entity: W&B entity (user or team) to search within.
+        project: W&B project name.
+
+    Returns:
+        The configuration dictionary for the matching run.
+
+    Raises:
+        ValueError: If neither or both ``run_name`` and ``policy_name`` are given.
+        LookupError: If no run matching the criteria is found.
+    """
+    if (run_name is None) == (policy_name is None):
+        msg = "Provide exactly one of run_name or policy_name"
+        raise ValueError(msg)
+
+    api = wandb.Api()
+    filters: dict[str, Any]
+    if run_name is not None:
+        filters = {"displayName": run_name}
+    else:
+        filters = {"config.policy_name": policy_name}
+
+    runs = api.runs(f"{entity}/{project}", filters=filters)
+    for run in runs:
+        config = dict(run.config)
+        if run_name is not None and run.name == run_name:
+            return config
+        if policy_name is not None and config.get("policy_name") == policy_name:
+            return config
+
+    identifier = run_name if run_name is not None else policy_name
+    raise LookupError(f"No W&B run found for '{identifier}'")

--- a/tests/test_wandb_run_config.py
+++ b/tests/test_wandb_run_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pytest
+
+from experiments.notebooks.util import config_for_run
+
+
+class _FakeRun:
+    def __init__(self, name: str, config: dict[str, Any]) -> None:
+        self.name = name
+        self.config = config
+
+
+class _FakeApi:
+    def __init__(self, runs: Iterable[_FakeRun]) -> None:
+        self._runs = list(runs)
+
+    def runs(self, _path: str, *, filters: dict[str, Any] | None = None) -> list[_FakeRun]:
+        if not filters:
+            return self._runs
+        if "displayName" in filters:
+            return [r for r in self._runs if r.name == filters["displayName"]]
+        if "config.policy_name" in filters:
+            key = filters["config.policy_name"]
+            return [r for r in self._runs if r.config.get("policy_name") == key]
+        return []
+
+
+def test_config_for_run_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    run = _FakeRun("train-run", {"lr": 0.1})
+    monkeypatch.setattr("wandb.Api", lambda: _FakeApi([run]))
+    cfg = config_for_run(run_name="train-run")
+    assert cfg == {"lr": 0.1}
+
+
+def test_config_for_run_by_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    run = _FakeRun("other-run", {"policy_name": "my-policy", "gamma": 0.99})
+    monkeypatch.setattr("wandb.Api", lambda: _FakeApi([run]))
+    cfg = config_for_run(policy_name="my-policy")
+    assert cfg == {"policy_name": "my-policy", "gamma": 0.99}
+
+
+def test_config_for_run_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("wandb.Api", lambda: _FakeApi([]))
+    with pytest.raises(LookupError):
+        config_for_run(run_name="missing")


### PR DESCRIPTION
## Summary
- add helper to retrieve a Weights & Biases run config by run or policy name
- expose the helper for experiment notebooks
- cover run config lookup with unit tests

## Testing
- `uv run ruff format experiments/notebooks/util/__init__.py experiments/notebooks/util/wandb_run_config.py tests/test_wandb_run_config.py`
- `uv run ruff check experiments/notebooks/util/__init__.py experiments/notebooks/util/wandb_run_config.py tests/test_wandb_run_config.py`
- `pipx run mypy --ignore-missing-imports --explicit-package-bases experiments/notebooks/util/wandb_run_config.py tests/test_wandb_run_config.py`
- `uv run pytest tests/test_wandb_run_config.py tests/test_action_compatibility.py -q -n0`
- `uv run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68a00c09ff348324bc65e71e24467973

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211070182417064)