### PR TITLE
fix: correct Scene configuration in envs.make_arena()

### DIFF
--- a/mettagrid/src/metta/mettagrid/config/envs.py
+++ b/mettagrid/src/metta/mettagrid/config/envs.py
@@ -1,5 +1,4 @@
 from metta.map.mapgen import MapGenConfig
-from metta.map.types import SceneCfg
 from metta.mettagrid.config import building
 from metta.mettagrid.map_builder.random import RandomMapBuilderConfig
 from metta.mettagrid.mettagrid_config import (
@@ -73,28 +72,26 @@ def make_arena(
                 ),
             },
             map_builder=MapGenConfig(
-                agents=num_agents,
+                num_agents=num_agents,
                 width=25,
                 height=25,
-                instances=num_agents // 6,
+                instances=max(1, num_agents // 6),
                 border_width=6,
                 instance_border_width=0,
-                root=SceneCfg(
-                    {
-                        "type": "metta.map.scenes.random.Random",
-                        "params": {
-                            "agents": 6,
-                            "objects": {
-                                "wall": 20,
-                                "altar": 5,
-                                "mine_red": 10,
-                                "generator_red": 5,
-                                "lasery": 1,
-                                "armory": 1,
-                            },
+                root={
+                    "type": "metta.map.scenes.random.Random",
+                    "params": {
+                        "agents": min(6, num_agents),
+                        "objects": {
+                            "wall": 20,
+                            "altar": 5,
+                            "mine_red": 10,
+                            "generator_red": 5,
+                            "lasery": 1,
+                            "armory": 1,
                         },
-                    }
-                ),
+                    },
+                },
             ),
         )
     )


### PR DESCRIPTION
- Remove incorrect SceneCfg() wrapper around scene dict
- Change agents= to num_agents= in MapGenConfig
- Use max(1, num_agents // 6) to prevent zero instances
- Use min(6, num_agents) for scene agents to scale properly
- Remove unused SceneCfg import