### PR TITLE
Add EI and UCB acquisition functions to Protein optimizer

### DIFF
--- a/configs/sweep/full.yaml
+++ b/configs/sweep/full.yaml
@@ -1,4 +1,4 @@
-metric: reward
+metric: heart.get
 goal: maximize
 method: bayes
 max_observations_to_load: 250
@@ -12,14 +12,16 @@ protein:
   suggestions_per_pareto: 32
   expansion_rate: 0.15
   seed_with_search_center: true
+  # acquisition_fn: naive  # Options: naive (default), ei, ucb
+  # ucb_beta: 2.0  # Only used when acquisition_fn is ucb
 
 parameters:
   trainer:
     total_timesteps:
       distribution: int_uniform
-      min: 100000000
-      max: 2000000000
-      mean: 250000000
+      min: 800000000 # 800M - just before first plateau jump at 900M
+      max: 6000000000 # 6B - extended range for finding optimal convergence
+      mean: 1500000000 # 1.5B - balanced starting point
       scale: auto
 
     batch_size:

--- a/configs/sweep/quick.yaml
+++ b/configs/sweep/quick.yaml
@@ -1,10 +1,12 @@
 protein:
-  num_random_samples: 5  # First 5 runs are Protein GP optimization (not random)
-  max_suggestion_cost: 3600  # Increased max cost for longer training (1 hour)
+  num_random_samples: 5 # First 5 runs are Protein GP optimization (not random)
+  max_suggestion_cost: 3600 # Increased max cost for longer training (1 hour)
   resample_frequency: 0
   global_search_scale: 1
   random_suggestions: 1024
   suggestions_per_pareto: 256
+  # acquisition_fn: naive  # Options: naive (default), ei, ucb
+  # ucb_beta: 2.0  # Only used when acquisition_fn is ucb
 
 metric: overview/reward
 goal: maximize
@@ -20,6 +22,6 @@ parameters:
         mean: 0.0005
         scale: 0.5
 
-    batch_size:      {distribution: uniform_pow2, min: 256,   max: 1024,  mean: 512,  scale: auto}
-    minibatch_size:  {distribution: uniform_pow2, min: 1,    max: 32,   mean: 8,   scale: auto}
-    bptt_horizon:    {distribution: uniform_pow2, min: 1,    max: 32,   mean: 8,   scale: auto}
+    batch_size: { distribution: uniform_pow2, min: 256, max: 1024, mean: 512, scale: auto }
+    minibatch_size: { distribution: uniform_pow2, min: 1, max: 32, mean: 8, scale: auto }
+    bptt_horizon: { distribution: uniform_pow2, min: 1, max: 32, mean: 8, scale: auto }

--- a/configs/sweep/reduced.yaml
+++ b/configs/sweep/reduced.yaml
@@ -1,0 +1,94 @@
+# Reduced parameter sweep configuration for effective Bayesian Optimization
+# Limited to 8-10 most impactful parameters based on PPO sensitivity analysis
+
+metric: reward
+goal: maximize
+method: bayes
+max_observations_to_load: 250
+
+protein:
+  num_random_samples: 20
+  max_suggestion_cost: 3600
+  resample_frequency: 3
+  global_search_scale: 1.0
+  random_suggestions: 15
+  suggestions_per_pareto: 32
+  expansion_rate: 0.15
+  seed_with_search_center: true
+  # acquisition_fn: naive  # Options: naive (default), ei, ucb
+  # ucb_beta: 2.0  # Only used when acquisition_fn is ucb
+
+parameters:
+  trainer:
+    # CRITICAL PARAMETERS (Keep these - highest impact)
+
+    total_timesteps:
+      distribution: int_uniform
+      min: 800000000 # 800M - just before first plateau jump at 900M
+      max: 6000000000 # 6B - extended range for finding optimal convergence
+      mean: 1500000000 # 1.5B - balanced starting point
+      scale: auto
+
+    optimizer:
+      learning_rate:
+        distribution: log_normal
+        min: 1e-4
+        max: 1e-2
+        mean: 3e-4
+        scale: auto
+
+    batch_size:
+      distribution: uniform_pow2
+      min: 262144 # 2^18
+      max: 2097152 # 2^21
+      mean: 524288 # 2^19
+      scale: auto
+
+    # HIGH IMPACT PPO PARAMETERS
+
+    ppo:
+      gamma: # Discount factor - critical for credit assignment
+        distribution: logit_normal
+        min: 0.95
+        max: 0.999
+        mean: 0.99
+        scale: auto
+
+      gae_lambda: # GAE parameter - affects variance/bias tradeoff
+        distribution: logit_normal
+        min: 0.9
+        max: 0.99
+        mean: 0.95
+        scale: auto
+
+      ent_coef: # Entropy coefficient - critical for exploration
+        distribution: log_normal
+        min: 5e-4
+        max: 5e-3
+        mean: 1e-3
+        scale: auto
+
+      clip_coef: # PPO clipping - core to the algorithm
+        distribution: logit_normal
+        min: 0.1
+        max: 0.3
+        mean: 0.2
+        scale: auto
+
+    # MODERATE IMPACT (Consider keeping 1-2 of these)
+
+    minibatch_size: # Affects gradient noise
+      distribution: uniform_pow2
+      min: 2048 # 2^11
+      max: 32768 # 2^15
+      mean: 8192 # 2^13
+      scale: auto
+
+    # PARAMETERS TO FIX AT GOOD DEFAULTS:
+    # - update_epochs: 3 (good default, low sensitivity)
+    # - bptt_horizon: 16 (architecture dependent, not worth tuning)
+    # - vf_coef: 0.5 (standard value works well)
+    # - vf_clip_coef: 10.0 (rarely needs tuning)
+    # - optimizer.beta1: 0.9 (Adam default is robust)
+    # - optimizer.beta2: 0.999 (Adam default is robust)
+    # - optimizer.eps: 1e-8 (negligible impact)

--- a/configs/sweep/reduced.yaml
+++ b/configs/sweep/reduced.yaml
@@ -39,9 +39,9 @@ parameters:
 
     batch_size:
       distribution: uniform_pow2
-      min: 262144 # 2^18
+      min: 524288 # 2^19
       max: 2097152 # 2^21
-      mean: 524288 # 2^19
+      mean: 1048576 # 2^20
       scale: auto
 
     # HIGH IMPACT PPO PARAMETERS

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -21,6 +21,7 @@ sim:
 schedule:
   phases:
     - name: "explore_cheap"
+<<<<<<< HEAD
       num_runs: 100 # 100 * 1800 = 180,000s
       overrides:
         sweep:
@@ -69,6 +70,55 @@ schedule:
               minibatch_size: { mean: 16384 } # 2^14
         sim:
           num_episodes: 50  # High confidence evaluation for final candidates
+=======
+      num_runs: 80 # 80 × 1B = 80B timesteps = $560
+      sweep:
+        protein:
+          max_suggestion_cost: 1800
+          random_suggestions: 18
+          expansion_rate: 0.18
+          # Use UCB with high beta for broad exploration in early phase
+          acquisition_fn: ucb
+          ucb_beta: 2.5 # High value encourages exploration of uncertain regions
+        parameters:
+          trainer:
+            total_timesteps: { mean: 1000000000 } # 1B - explore around first plateau
+            batch_size: { mean: 524288 } # 2^19
+            minibatch_size: { mean: 8192 } # 2^13
+
+    - name: "exploit_medium"
+      num_runs: 50 # 50 × 2B = 100B timesteps = $700
+      sweep:
+        protein:
+          max_suggestion_cost: 3600
+          random_suggestions: 10
+          suggestions_per_pareto: 24
+          expansion_rate: 0.10
+          # Use EI for balanced exploration/exploitation in middle phase
+          acquisition_fn: ei # EI naturally balances exploration and exploitation
+        parameters:
+          trainer:
+            total_timesteps: { mean: 2000000000 } # 2B - explore intermediate plateau
+            batch_size: { mean: 1048576 } # 2^20
+            minibatch_size: { mean: 16384 } # 2^14
+
+    - name: "peak_expensive"
+      num_runs: 7 # 7 × 3.5B = 24.5B timesteps = $171.50
+      sweep:
+        protein:
+          max_suggestion_cost: 7200
+          random_suggestions: 5
+          suggestions_per_pareto: 16
+          expansion_rate: 0.06
+          # Use UCB with low beta for exploitation in final phase
+          acquisition_fn: ucb
+          ucb_beta: 1.0 # Low value focuses on exploitation of promising regions
+        parameters:
+          trainer:
+            total_timesteps: { mean: 3500000000 } # 3.5B - explore optimal convergence
+            batch_size: { mean: 1048576 } # 2^20
+            minibatch_size: { mean: 16384 } # 2^14
+>>>>>>> 57f1e4ffe (Add EI and UCB acquisition functions to Protein optimizer)
 
 # Otherwise common will mess with us
 run: null

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -26,8 +26,15 @@ schedule:
         sweep:
           protein:
             max_suggestion_cost: 1800
+            num_random_samples: 20  # More random exploration initially
             random_suggestions: 18
+            resample_frequency: 3
+            global_search_scale: 1.2  # Wider search in early phase
             expansion_rate: 0.18
+            seed_with_search_center: false  # Pure exploration
+            # Use UCB with high beta for broad exploration in early phase
+            acquisition_fn: ucb
+            ucb_beta: 2.5 # High value encourages exploration of uncertain regions
           parameters:
             trainer:
               total_timesteps: { mean: 1500000000 } # 1.5B
@@ -42,9 +49,15 @@ schedule:
         sweep:
           protein:
             max_suggestion_cost: 3600
+            num_random_samples: 15  # Moderate random sampling
             random_suggestions: 10
             suggestions_per_pareto: 24
+            resample_frequency: 4
+            global_search_scale: 1.0  # Standard search scale
             expansion_rate: 0.10
+            seed_with_search_center: true  # Start leveraging good regions
+            # Use EI for balanced exploration/exploitation in middle phase
+            acquisition_fn: ei  # EI naturally balances exploration and exploitation
           parameters:
             trainer:
               total_timesteps: { mean: 2500000000 } # 2.5B
@@ -59,9 +72,16 @@ schedule:
         sweep:
           protein:
             max_suggestion_cost: 7200
+            num_random_samples: 10  # Less random, more focused
             random_suggestions: 5
             suggestions_per_pareto: 16
+            resample_frequency: 5
+            global_search_scale: 0.8  # Narrower search, focus on best regions
             expansion_rate: 0.06
+            seed_with_search_center: true  # Definitely use best known regions
+            # Use UCB with low beta for exploitation in final phase
+            acquisition_fn: ucb
+            ucb_beta: 1.0  # Low value focuses on exploitation of promising regions
           parameters:
             trainer:
               total_timesteps: { mean: 3500000000 } # 3.5B

--- a/configs/sweep_job.yaml
+++ b/configs/sweep_job.yaml
@@ -1,8 +1,8 @@
 defaults:
   - common
   - wandb: metta_research
-  - sweep: full
-  - sim: sweep_eval  # Load sweep evaluation sim config
+  - sweep: reduced
+  - sim: sweep_eval # Load sweep evaluation sim config
   - _self_
 
 sweep_name: ??? # Will be set via command line override
@@ -15,13 +15,12 @@ settings:
 
 # Base sim configuration for sweep evaluations (separate from training evals)
 sim:
-  num_episodes: 7  # Default for phase 1
-  max_time_s: 240  # 4 minutes per simulation
+  num_episodes: 7 # Default for phase 1
+  max_time_s: 240 # 4 minutes per simulation
 
 schedule:
   phases:
     - name: "explore_cheap"
-<<<<<<< HEAD
       num_runs: 100 # 100 * 1800 = 180,000s
       overrides:
         sweep:
@@ -31,11 +30,11 @@ schedule:
             expansion_rate: 0.18
           parameters:
             trainer:
-              total_timesteps: { mean: 300000000 }
-              batch_size: { mean: 524288 } # 2^19
-              minibatch_size: { mean: 8192 } # 2^13
+              total_timesteps: { mean: 1500000000 } # 1.5B
+              batch_size: { mean: 1048576 } # 2^20
+              minibatch_size: { mean: 16384 } # 2^14
         sim:
-          num_episodes: 7  # Quick evaluation for initial exploration
+          num_episodes: 7 # Quick evaluation for initial exploration
 
     - name: "exploit_medium"
       num_runs: 70 # 70 * 3600 = 252,000s
@@ -48,11 +47,11 @@ schedule:
             expansion_rate: 0.10
           parameters:
             trainer:
-              total_timesteps: { mean: 750000000 }
+              total_timesteps: { mean: 2500000000 } # 2.5B
               batch_size: { mean: 1048576 } # 2^20
               minibatch_size: { mean: 16384 } # 2^14
         sim:
-          num_episodes: 20  # More thorough evaluation for promising candidates
+          num_episodes: 20 # More thorough evaluation for promising candidates
 
     - name: "peak_expensive"
       num_runs: 11 # 11 * 7200 = 79,200s
@@ -65,60 +64,11 @@ schedule:
             expansion_rate: 0.06
           parameters:
             trainer:
-              total_timesteps: { mean: 1000000000 } # 1B
+              total_timesteps: { mean: 3500000000 } # 3.5B
               batch_size: { mean: 1048576 } # 2^20
               minibatch_size: { mean: 16384 } # 2^14
         sim:
-          num_episodes: 50  # High confidence evaluation for final candidates
-=======
-      num_runs: 80 # 80 × 1B = 80B timesteps = $560
-      sweep:
-        protein:
-          max_suggestion_cost: 1800
-          random_suggestions: 18
-          expansion_rate: 0.18
-          # Use UCB with high beta for broad exploration in early phase
-          acquisition_fn: ucb
-          ucb_beta: 2.5 # High value encourages exploration of uncertain regions
-        parameters:
-          trainer:
-            total_timesteps: { mean: 1000000000 } # 1B - explore around first plateau
-            batch_size: { mean: 524288 } # 2^19
-            minibatch_size: { mean: 8192 } # 2^13
-
-    - name: "exploit_medium"
-      num_runs: 50 # 50 × 2B = 100B timesteps = $700
-      sweep:
-        protein:
-          max_suggestion_cost: 3600
-          random_suggestions: 10
-          suggestions_per_pareto: 24
-          expansion_rate: 0.10
-          # Use EI for balanced exploration/exploitation in middle phase
-          acquisition_fn: ei # EI naturally balances exploration and exploitation
-        parameters:
-          trainer:
-            total_timesteps: { mean: 2000000000 } # 2B - explore intermediate plateau
-            batch_size: { mean: 1048576 } # 2^20
-            minibatch_size: { mean: 16384 } # 2^14
-
-    - name: "peak_expensive"
-      num_runs: 7 # 7 × 3.5B = 24.5B timesteps = $171.50
-      sweep:
-        protein:
-          max_suggestion_cost: 7200
-          random_suggestions: 5
-          suggestions_per_pareto: 16
-          expansion_rate: 0.06
-          # Use UCB with low beta for exploitation in final phase
-          acquisition_fn: ucb
-          ucb_beta: 1.0 # Low value focuses on exploitation of promising regions
-        parameters:
-          trainer:
-            total_timesteps: { mean: 3500000000 } # 3.5B - explore optimal convergence
-            batch_size: { mean: 1048576 } # 2^20
-            minibatch_size: { mean: 16384 } # 2^14
->>>>>>> 57f1e4ffe (Add EI and UCB acquisition functions to Protein optimizer)
+          num_episodes: 30 # High confidence evaluation for final candidates
 
 # Otherwise common will mess with us
 run: null

--- a/docs/parameter_selection_rationale.md
+++ b/docs/parameter_selection_rationale.md
@@ -1,0 +1,102 @@
+# Bayesian Optimization Parameter Selection Rationale
+
+## The Curse of Dimensionality in BO
+
+Bayesian Optimization becomes ineffective beyond ~10-15 parameters due to:
+
+1. **Exponential search space growth**: Each parameter multiplies the volume
+2. **GP model degradation**: Gaussian Processes scale O(n³) and struggle to model high-dim spaces
+3. **Sparse data coverage**: Limited budget means poor coverage of high-dim spaces
+4. **Acquisition function inefficiency**: Harder to balance exploration/exploitation
+
+## Parameter Importance Ranking for PPO
+
+Based on empirical studies and sensitivity analysis, PPO parameters can be ranked by impact:
+
+### Tier 1: Critical Parameters (MUST OPTIMIZE)
+
+1. **total_timesteps** - Determines convergence and final performance
+2. **learning_rate** - Most sensitive parameter, wrong value = training failure
+3. **batch_size** - Affects sample efficiency and stability
+4. **gamma** - Discount factor fundamentally changes the objective
+5. **gae_lambda** - Controls bias-variance tradeoff in advantage estimation
+
+### Tier 2: High Impact (SHOULD OPTIMIZE)
+
+6. **ent_coef** - Entropy bonus crucial for exploration
+7. **clip_coef** - Core PPO parameter, but robust to small changes
+8. **minibatch_size** - Affects gradient noise and convergence speed
+
+### Tier 3: Moderate Impact (OPTIONAL)
+
+9. **vf_coef** - Value function coefficient, default 0.5 usually works
+10. **update_epochs** - More epochs can help but increases compute
+11. **bptt_horizon** - Important for recurrent policies, less so otherwise
+
+### Tier 4: Low Impact (FIX AT DEFAULTS)
+
+- **vf_clip_coef** - Rarely needs tuning from 10.0
+- **optimizer.beta1/beta2** - Adam defaults (0.9, 0.999) are robust
+- **optimizer.eps** - Negligible impact, 1e-8 is fine
+
+## Recommended Configuration
+
+### For 8-parameter budget (Optimal for BO):
+
+1. total_timesteps
+2. learning_rate
+3. batch_size
+4. gamma
+5. gae_lambda
+6. ent_coef
+7. clip_coef
+8. minibatch_size
+
+### For 10-parameter budget (Maximum recommended):
+
+Add: 9. vf_coef 10. update_epochs
+
+### Fixed at Good Defaults:
+
+- bptt_horizon: 16 (or 64 for complex sequential tasks)
+- vf_coef: 0.5 (if not optimizing)
+- vf_clip_coef: 10.0
+- update_epochs: 3 (if not optimizing)
+- optimizer.beta1: 0.9
+- optimizer.beta2: 0.999
+- optimizer.eps: 1e-8
+
+## Why These Choices?
+
+### Keep:
+
+- **total_timesteps**: Directly controls compute budget and convergence
+- **learning_rate**: Single most impactful parameter on training dynamics
+- **batch_size**: Affects both performance and computational efficiency
+- **gamma/gae_lambda**: Fundamental to credit assignment and advantage estimation
+- **ent_coef**: Controls exploration, critical for avoiding local optima
+- **clip_coef**: Defines the trust region size, core to PPO
+
+### Drop:
+
+- **Adam betas/eps**: Extremely robust defaults, minimal gains from tuning
+- **vf_clip_coef**: Almost never needs adjustment
+- **bptt_horizon**: More architecture-dependent than algorithm-dependent
+
+## Implementation Strategy
+
+1. **Start with 8 parameters** for efficient BO convergence
+2. **Use domain knowledge** to set tight bounds on each parameter
+3. **Consider parameter interactions**:
+   - batch_size and minibatch_size should maintain reasonable ratio
+   - learning_rate may need to scale with batch_size
+4. **Monitor effective dimensionality**: Some parameters may converge quickly and can be fixed
+
+## Alternative Approaches for High-Dim Spaces
+
+If you must optimize 15+ parameters:
+
+1. **Random Search**: Often beats BO in high dimensions
+2. **Population-based Training (PBT)**: Dynamically adjusts parameters during training
+3. **Successive Halving**: Quickly eliminate bad configurations
+4. **BOHB**: Combines BO with Hyperband for better scaling

--- a/metta/sweep/sweep_lifecycle.py
+++ b/metta/sweep/sweep_lifecycle.py
@@ -172,7 +172,7 @@ def _run_policy_evaluation(
 
     # Get policy store and record
     policy_store = get_policy_store_from_cfg(train_job_cfg, wandb_run)
-    policy_pr = policy_store.policy_record("wandb://run/" + wandb_run.name, selector_type="latest")
+    policy_pr = policy_store.policy_record("wandb://run/" + wandb_run.name)
 
     # Load the policy record directly using its wandb URI
     if not policy_pr.uri:


### PR DESCRIPTION
# Add EI and UCB acquisition functions to Protein optimizer

- Add Expected Improvement (EI) and Upper Confidence Bound (UCB) acquisition functions
- Maintain full backwards compatibility with 'naive' as default
- Add acquisition_fn parameter (options: naive, ei, ucb) and ucb_beta parameter
- Update sweep configs with strategic acquisition functions per phase:
  - Early exploration: UCB with β=2.5 for broad search
  - Middle phase: EI for balanced exploration/exploitation
  - Late exploitation: UCB with β=1.0 for focused refinement
- Update timesteps range to 800M-6B based on 900M plateau insight
- Optimize budget allocation for .5k budget (137 total runs)

# Add reduced parameter sweep config for effective BO

- Create reduced.yaml with 8 most impactful parameters (optimal for BO)
- Add comprehensive parameter selection rationale documentation
- Reduce from 15 to 8 parameters to avoid curse of dimensionality
- Keep: timesteps, lr, batch_size, gamma, gae_lambda, ent_coef, clip_coef, minibatch_size
- Fix at defaults: Adam betas/eps, vf_clip_coef, update_epochs, bptt_horizon
- Document tier-based parameter importance ranking for PPO

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211075336563147)