### PR TITLE
Enforce that if a stats_server_uri is provided, we can connect to it

### DIFF
--- a/app_backend/src/metta/app_backend/clients/stats_client.py
+++ b/app_backend/src/metta/app_backend/clients/stats_client.py
@@ -1,13 +1,11 @@
 import logging
 import uuid
-from pathlib import Path
 from typing import Any, Optional, Type, TypeVar
 
 import httpx
-import yaml
 from pydantic import BaseModel
 
-from metta.app_backend.clients.base_client import BaseAppBackendClient
+from metta.app_backend.clients.base_client import BaseAppBackendClient, NotAuthenticatedError, get_machine_token
 from metta.app_backend.routes.eval_task_routes import TaskCreateRequest, TaskFilterParams, TaskResponse, TasksResponse
 from metta.app_backend.routes.score_routes import (
     PolicyScoresData,
@@ -158,12 +156,12 @@ class StatsClient:
         response.raise_for_status()
         return response_type.model_validate(response.json())
 
-    def validate_authenticated(self) -> str:
+    def _validate_authenticated(self) -> str:
         from metta.app_backend.server import WhoAmIResponse
 
         auth_user = self._make_sync_request(WhoAmIResponse, "GET", "/whoami")
         if auth_user.user_email in ["unknown", None]:
-            raise ConnectionError(f"Not authenticated. User: {auth_user.user_email}")
+            raise NotAuthenticatedError(f"Not authenticated. User: {auth_user.user_email}")
         return auth_user.user_email
 
     def get_policy_ids(self, policy_names: list[str]) -> PolicyIdResponse:
@@ -273,47 +271,7 @@ class StatsClient:
     def create(cls, stats_server_uri: str) -> Optional["StatsClient"]:
         machine_token = get_machine_token(stats_server_uri)
         if machine_token is None:
-            logger.warning(f"No machine token found for {stats_server_uri}, stats logging disabled")
-            return None
+            raise NotAuthenticatedError(f"No machine token found for {stats_server_uri}")
         stats_client = cls(backend_url=stats_server_uri, machine_token=machine_token)
-        stats_client.validate_authenticated()
+        stats_client._validate_authenticated()
         return stats_client
-
-
-def get_machine_token(stats_server_uri: str | None = None) -> str | None:
-    """Get machine token for the given stats server.
-
-    Args:
-        stats_server_uri: The stats server URI to get token for.
-                         If None, returns token from env var or legacy location.
-
-    Returns:
-        The machine token or None if not found.
-    """
-    yaml_file = Path.home() / ".metta" / "observatory_tokens.yaml"
-    if yaml_file.exists():
-        with open(yaml_file) as f:
-            tokens = yaml.safe_load(f) or {}
-        if isinstance(tokens, dict) and stats_server_uri in tokens:
-            token = tokens[stats_server_uri].strip()
-        else:
-            return None
-    elif stats_server_uri is None or stats_server_uri in (
-        "https://observatory.softmax-research.net/api",
-        PROD_STATS_SERVER_URI,
-    ):
-        # Fall back to legacy token file, which is assumed to contain production
-        # server tokens if it exists
-        legacy_file = Path.home() / ".metta" / "observatory_token"
-        if legacy_file.exists():
-            with open(legacy_file) as f:
-                token = f.read().strip()
-        else:
-            return None
-    else:
-        return None
-
-    if not token or token.lower() == "none":
-        return None
-
-    return token

--- a/cogweb/cogweb_client.py
+++ b/cogweb/cogweb_client.py
@@ -2,8 +2,8 @@
 
 from typing import Optional
 
+from metta.app_backend.clients.base_client import get_machine_token
 from metta.app_backend.sweep_client import SweepClient
-from metta.common.util.stats_client_cfg import get_machine_token
 
 
 class CogwebClient:

--- a/metta/setup/components/observatory_key.py
+++ b/metta/setup/components/observatory_key.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
 
+from metta.app_backend.clients.base_client import get_machine_token
 from metta.common.util.constants import DEV_STATS_SERVER_URI, PROD_STATS_SERVER_URI
-from metta.common.util.stats_client_cfg import get_machine_token
 from metta.setup.components.base import SetupModule
 from metta.setup.registry import register_module
 from metta.setup.utils import info, success, warning

--- a/metta/setup/local_commands.py
+++ b/metta/setup/local_commands.py
@@ -198,7 +198,6 @@ class LocalCommands:
         if not stats_client:
             print("No stats client")
             return
-        stats_client.validate_authenticated()
         runs = find_training_runs(
             entity=entity,
             project=project,

--- a/metta/setup/tools/local/kind.py
+++ b/metta/setup/tools/local/kind.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Callable
 
 from devops.docker.push_image import push_image
+from metta.app_backend.clients.base_client import get_machine_token
 from metta.common.util.constants import DEV_STATS_SERVER_URI, METTA_AWS_ACCOUNT_ID, METTA_AWS_REGION
 from metta.common.util.fs import get_repo_root
-from metta.common.util.stats_client_cfg import get_machine_token
 from metta.setup.utils import error, info, success
 
 repo_root = get_repo_root()

--- a/metta/tools/train.py
+++ b/metta/tools/train.py
@@ -30,7 +30,7 @@ class TrainTool(Tool):
     run: str
     run_dir: Optional[str] = None
 
-    # Stats server configuration
+    # Stats server configuration. If null, stats logging is disabled. If set, authentication with the server is verified
     stats_server_uri: Optional[str] = "https://api.observatory.softmax-research.net"
 
     # Policy configuration

--- a/observatory/launch.py
+++ b/observatory/launch.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from metta.app_backend.clients.base_client import get_machine_token
 from metta.common.util.constants import DEV_STATS_SERVER_URI, PROD_STATS_SERVER_URI
-from metta.common.util.stats_client_cfg import get_machine_token
 from metta.setup.utils import error, info
 
 

--- a/tools/request_eval.py
+++ b/tools/request_eval.py
@@ -111,7 +111,6 @@ async def _create_remote_eval_tasks(
     if stats_client is None:
         warning("No stats client found")
         return
-    stats_client.validate_authenticated()
 
     policy_store = PolicyStore(
         wandb_entity=request.wandb_entity,


### PR DESCRIPTION
Enforce authenticated within `StatsClient.create` to address prevent silent failures. Disable this by submitting stats_server_uri=null

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211086647374641)