### PR TITLE
Clean up setup module applicability/enabled checks

### DIFF
--- a/common/src/metta/common/util/collections.py
+++ b/common/src/metta/common/util/collections.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, TypeVar
+from typing import Callable, Iterable, TypeVar
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -18,3 +18,7 @@ def remove_none_values(d: dict[K, T | None]) -> dict[K, T]:
 
 def remove_none_keys(d: dict[K | None, T]) -> dict[K, T]:
     return {k: v for k, v in d.items() if k is not None}
+
+
+def find_first(collection: Iterable[T], predicate: Callable[[T], bool]) -> T | None:
+    return next((item for item in collection if predicate(item)), None)

--- a/metta/setup/README.md
+++ b/metta/setup/README.md
@@ -19,7 +19,8 @@ To add a new tool or service dependency:
 
 ## Per-Component Configuration
 
-Components can store and retrieve their own configuration settings. This allows components to remember user preferences and customize their behavior.
+Components can store and retrieve their own configuration settings. This allows components to remember user preferences
+and customize their behavior.
 
 ### For Component Developers
 
@@ -52,12 +53,15 @@ class MyComponentSetup(SetupModule):
 ```
 
 Key principles:
+
 - All settings must have defaults defined in `get_configuration_options()`
 - Only non-default values are written to disk
 - Settings are automatically namespaced under `module_settings.<component_name>`
 - Installation (`metta install`) should never prompt for configuration
-- Components can depend on other components being installed first. This should be specified in the `dependencies` class var
-- `install_once` should be used for components for which if `check_installed` is True, `metta install` only calls the component's `install` if `--force` is provided
+- Components can depend on other components being installed first. This should be specified in the `dependencies` class
+  var
+- `install_once` should be used for components for which if `check_installed` is True, `metta install` only calls the
+  component's `install` if `--force` is provided
 
 ### For Users
 
@@ -74,24 +78,32 @@ metta configure
 metta configure --profile=softmax
 ```
 
-Component settings are stored in `~/.metta/config.yaml` under the `module_settings` section. Only non-default values are saved:
+These settings are saved in `~/.metta/config.yaml` under the `module_settings` section. Only non-default values are
+saved:
 
 ```yaml
 module_settings:
   githooks:
-    commit_hook_mode: fix  # Only saved because it differs from default "check"
+    commit_hook_mode: fix # Only saved because it differs from default "check"
 ```
 
 ### Example: Git Hooks Configuration
 
 The git hooks component supports three commit hook modes:
+
 - `none`: No pre-commit linting
 - `check`: Check only, fail if issues found (default)
 - `fix`: Auto-fix issues before committing
 
 To configure:
+
 ```bash
 metta configure githooks
 ```
 
 Since `check` is the default, it won't appear in your config file unless you change it.
+
+### Enabled setup components
+
+A setup component will only be considered enabled if it is applicable (see its `_applicable` implementation) and it and
+all of its dependencies are enabled in saved settings.

--- a/metta/setup/components/aws.py
+++ b/metta/setup/components/aws.py
@@ -1,6 +1,7 @@
 from metta.setup.components.base import SetupModule
 from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info
 
 
@@ -14,13 +15,9 @@ class AWSSetup(SetupModule):
 
     @property
     def setup_script_location(self) -> str | None:
-        if self.config.user_type.is_softmax:
+        if get_saved_settings().user_type.is_softmax:
             return "devops/aws/setup_aws_profiles.sh"
         return None
-
-    def is_applicable(self) -> bool:
-        # Skypilot is a dependency of AWS
-        return any(self.config.is_component_enabled(dep) for dep in ["aws", "skypilot"])
 
     def check_installed(self) -> bool:
         try:
@@ -31,11 +28,12 @@ class AWSSetup(SetupModule):
             return False
 
     def install(self) -> None:
-        if self.config.user_type == UserType.SOFTMAX_DOCKER:
+        saved_settings = get_saved_settings()
+        if saved_settings.user_type == UserType.SOFTMAX_DOCKER:
             info("AWS access for this profile should be provided via IAM roles or environment variables.")
             info("Skipping AWS profile setup.")
             return
-        if self.config.user_type == UserType.SOFTMAX:
+        if saved_settings.user_type == UserType.SOFTMAX:
             info("""
                 Your AWS access should have been provisioned.
                 If you don't have access, contact your team lead.

--- a/metta/setup/components/base.py
+++ b/metta/setup/components/base.py
@@ -191,7 +191,7 @@ class SetupModule(ABC):
         Returns:
             Dictionary with status information or None if not applicable
         """
-        if not self.is_applicable():
+        if not self.is_enabled():
             return None
 
         installed = self.check_installed()

--- a/metta/setup/components/base.py
+++ b/metta/setup/components/base.py
@@ -28,13 +28,17 @@ class SetupModule(ABC):
     def setup_script_location(self) -> str | None:
         return None
 
-    @abstractmethod
-    def is_applicable(self) -> bool:
-        pass
+    def _is_applicable(self) -> bool:
+        return True
 
     @abstractmethod
     def check_installed(self) -> bool:
         pass
+
+    def is_enabled(self) -> bool:
+        return self._is_applicable() and all(
+            get_saved_settings().is_component_enabled(dep) for dep in ([self.name] + self.dependencies())
+        )
 
     def dependencies(self) -> list[str]:
         # Other components that must be installed before this one

--- a/metta/setup/components/codeclip.py
+++ b/metta/setup/components/codeclip.py
@@ -3,6 +3,7 @@ import subprocess
 from metta.setup.components.base import SetupModule
 from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info, success, warning
 
 
@@ -14,9 +15,9 @@ class CodeclipSetup(SetupModule):
     def description(self) -> str:
         return "Developer tools copying code for LLM contexts"
 
-    def is_applicable(self) -> bool:
+    def _is_applicable(self) -> bool:
         # Only applicable for developer profiles, not docker profiles
-        return self.config.user_type in [UserType.SOFTMAX, UserType.EXTERNAL, UserType.CLOUD]
+        return get_saved_settings().user_type in [UserType.SOFTMAX, UserType.EXTERNAL, UserType.CLOUD]
 
     def check_installed(self) -> bool:
         """Check if codeclip is installed."""

--- a/metta/setup/components/core.py
+++ b/metta/setup/components/core.py
@@ -12,9 +12,6 @@ class CoreSetup(SetupModule):
     def description(self) -> str:
         return "Core Python dependencies and virtual environment"
 
-    def is_applicable(self) -> bool:
-        return True
-
     def check_installed(self) -> bool:
         try:
             subprocess.run(["uv", "--version"], check=True, capture_output=True)

--- a/metta/setup/components/filter_repo.py
+++ b/metta/setup/components/filter_repo.py
@@ -19,9 +19,6 @@ class FilterRepoSetup(SetupModule):
     def description(self) -> str:
         return "git-filter-repo tool for extracting repository subsets"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("filter-repo")
-
     def check_installed(self) -> bool:
         """Check if git-filter-repo is installed."""
         try:

--- a/metta/setup/components/githooks.py
+++ b/metta/setup/components/githooks.py
@@ -43,8 +43,8 @@ class GitHooksSetup(SetupModule):
     def description(self) -> str:
         return "Git hooks"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("githooks") and not self._is_in_worktree()
+    def _is_applicable(self) -> bool:
+        return not self._is_in_worktree()
 
     def _is_in_worktree(self) -> bool:
         try:

--- a/metta/setup/components/mettascope.py
+++ b/metta/setup/components/mettascope.py
@@ -15,9 +15,6 @@ class MettaScopeSetup(SetupModule):
     def setup_script_location(self) -> str:
         return "mettascope/install.sh"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("mettascope")
-
     def check_installed(self) -> bool:
         mettascope_dir = self.repo_root / "mettascope"
         node_modules = mettascope_dir / "node_modules"

--- a/metta/setup/components/nodejs.py
+++ b/metta/setup/components/nodejs.py
@@ -14,9 +14,6 @@ class NodejsSetup(SetupModule):
     def description(self) -> str:
         return "Node.js infrastructure - pnpm and turborepo"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("nodejs")
-
     def _script_exists(self, script: str) -> bool:
         try:
             self.run_command(["which", script], capture_output=True)

--- a/metta/setup/components/notebookwidgets.py
+++ b/metta/setup/components/notebookwidgets.py
@@ -2,7 +2,6 @@ import subprocess
 
 from metta.setup.components.base import SetupModule
 from metta.setup.registry import register_module
-from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info, warning
 
 
@@ -26,9 +25,6 @@ class NotebookWidgetsSetup(SetupModule):
     def __init__(self):
         super().__init__()
         self.widget_root = self.repo_root / "experiments/notebooks/utils"
-
-    def is_applicable(self) -> bool:
-        return get_saved_settings().is_component_enabled("notebookwidgets")
 
     def should_install_widget(self, widget: str) -> bool:
         widget_path = self.widget_root / widget

--- a/metta/setup/components/notebookwidgets.py
+++ b/metta/setup/components/notebookwidgets.py
@@ -1,8 +1,8 @@
 import subprocess
 
 from metta.setup.components.base import SetupModule
-from metta.setup.config import SetupConfig
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info, warning
 
 
@@ -23,12 +23,12 @@ class NotebookWidgetsSetup(SetupModule):
     def description(self) -> str:
         return "The python notebook widgets we create"
 
-    def __init__(self, config: SetupConfig):
-        super().__init__(config)
+    def __init__(self):
+        super().__init__()
         self.widget_root = self.repo_root / "experiments/notebooks/utils"
 
     def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("notebookwidgets")
+        return get_saved_settings().is_component_enabled("notebookwidgets")
 
     def should_install_widget(self, widget: str) -> bool:
         widget_path = self.widget_root / widget

--- a/metta/setup/components/observatory_key.py
+++ b/metta/setup/components/observatory_key.py
@@ -22,9 +22,6 @@ class ObservatoryKeySetup(SetupModule):
     def description(self) -> str:
         return "Observatory auth key"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("observatory-key")
-
     def get_token(self, server_url: str | None = None) -> str | None:
         """Get token for specific server using the shared implementation"""
         return get_machine_token(server_url)
@@ -79,6 +76,3 @@ class ObservatoryKeyLocalSetup(ObservatoryKeySetup):
     @property
     def description(self) -> str:
         return "Observatory auth key (local development)"
-
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("observatory-key-local")

--- a/metta/setup/components/skypilot.py
+++ b/metta/setup/components/skypilot.py
@@ -5,6 +5,7 @@ import subprocess
 from metta.common.util.constants import METTA_SKYPILOT_URL
 from metta.setup.components.base import SetupModule
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info, success
 
 
@@ -69,7 +70,7 @@ class SkypilotSetup(SetupModule):
             info("SkyPilot is already configured for external use. Skipping authentication.")
         else:
             # Need to authenticate skypilot.
-            if self.config.user_type.is_softmax:
+            if get_saved_settings().user_type.is_softmax:
                 try:
                     # Temporarily block Ctrl+C for parent process during script execution
                     # This is necessary because `sky api login` flow requires ctrl+c before the token can be pasted.
@@ -93,7 +94,7 @@ class SkypilotSetup(SetupModule):
         if not self.check_installed():
             return None
 
-        if self.config.user_type.is_softmax:
+        if get_saved_settings().user_type.is_softmax:
             try:
                 result = subprocess.run(["uv", "run", "sky", "api", "info"], capture_output=True, text=True)
 

--- a/metta/setup/components/skypilot.py
+++ b/metta/setup/components/skypilot.py
@@ -21,9 +21,6 @@ class SkypilotSetup(SetupModule):
     def description(self) -> str:
         return "SkyPilot cloud compute orchestration"
 
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("skypilot") and self.config.is_component_enabled("aws")
-
     def check_installed(self) -> bool:
         try:
             result = subprocess.run(["sky", "--version"], capture_output=True, text=True)

--- a/metta/setup/components/system.py
+++ b/metta/setup/components/system.py
@@ -19,10 +19,6 @@ class SystemSetup(SetupModule):
     def description(self) -> str:
         return "System dependencies (Homebrew packages, etc.)"
 
-    @override
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("system")
-
     @property
     def supported_for_platform(self) -> bool:
         return platform.system() == "Darwin" or self._find_brew_path() is not None

--- a/metta/setup/components/tailscale.py
+++ b/metta/setup/components/tailscale.py
@@ -16,13 +16,9 @@ class TailscaleSetup(SetupModule):
     def description(self) -> str:
         return "Tailscale VPN for internal network access"
 
-    def is_applicable(self) -> bool:
+    def _is_applicable(self) -> bool:
         saved_settings = get_saved_settings()
-        return (
-            platform.system() == "Darwin"
-            and saved_settings.user_type == UserType.SOFTMAX
-            and saved_settings.is_component_enabled("tailscale")
-        )
+        return platform.system() == "Darwin" and saved_settings.user_type == UserType.SOFTMAX
 
     def check_installed(self) -> bool:
         try:

--- a/metta/setup/components/tailscale.py
+++ b/metta/setup/components/tailscale.py
@@ -3,8 +3,8 @@ import platform
 import subprocess
 
 from metta.setup.components.base import SetupModule
-from metta.setup.config import UserType
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import UserType, get_saved_settings
 from metta.setup.utils import info, success, warning
 
 
@@ -17,10 +17,11 @@ class TailscaleSetup(SetupModule):
         return "Tailscale VPN for internal network access"
 
     def is_applicable(self) -> bool:
+        saved_settings = get_saved_settings()
         return (
             platform.system() == "Darwin"
-            and self.config.user_type == UserType.SOFTMAX
-            and self.config.is_component_enabled("tailscale")
+            and saved_settings.user_type == UserType.SOFTMAX
+            and saved_settings.is_component_enabled("tailscale")
         )
 
     def check_installed(self) -> bool:

--- a/metta/setup/components/wandb.py
+++ b/metta/setup/components/wandb.py
@@ -4,6 +4,7 @@ import subprocess
 from metta.setup.components.base import SetupModule
 from metta.setup.profiles import UserType
 from metta.setup.registry import register_module
+from metta.setup.saved_settings import get_saved_settings
 from metta.setup.utils import info, success, warning
 
 
@@ -14,9 +15,6 @@ class WandbSetup(SetupModule):
     @property
     def description(self) -> str:
         return "Weights & Biases experiment tracking"
-
-    def is_applicable(self) -> bool:
-        return self.config.is_component_enabled("wandb")
 
     def check_installed(self) -> bool:
         if os.environ.get("WANDB_API_KEY"):
@@ -36,14 +34,15 @@ class WandbSetup(SetupModule):
             success("W&B already configured")
             return
 
-        if self.config.user_type == UserType.SOFTMAX:
+        saved_settings = get_saved_settings()
+        if saved_settings.user_type == UserType.SOFTMAX:
             info("""
                 Your Weights & Biases access should have been provisioned.
                 If you don't have access, contact your team lead.
 
                 Visit https://wandb.ai/authorize to get your API key.
             """)
-        elif self.config.user_type == UserType.SOFTMAX_DOCKER:
+        elif saved_settings.user_type == UserType.SOFTMAX_DOCKER:
             info("Weights & Biases access should be provided via environment variables.")
             info("Skipping W&B setup.")
         else:

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -367,11 +367,10 @@ class MettaCLI:
         module.run(args.args)
 
     def cmd_install(self, args, unknown_args=None) -> None:
-        from metta.setup.registry import get_all_modules, get_applicable_modules
+        from metta.setup.registry import get_all_modules, get_enabled_setup_modules
         from metta.setup.utils import error, info, success, warning
 
-        saved_settings = get_saved_settings()
-        if not saved_settings.config_path.exists():
+        if not self.saved_settings.config_path.exists():
             warning("No configuration found. Running setup wizard first...")
             self.setup_wizard()
 
@@ -384,7 +383,7 @@ class MettaCLI:
         if args.components:
             modules = get_all_modules()
         else:
-            modules = get_applicable_modules()
+            modules = get_enabled_setup_modules()
 
         if args.components:
             only_names = args.components
@@ -635,7 +634,7 @@ class MettaCLI:
             return
 
         # Check if any modules are applicable
-        applicable_modules = [m for m in modules if m.is_applicable()]
+        applicable_modules = [m for m in modules if m.is_enabled()]
         if not applicable_modules:
             warning("No applicable modules found.")
             return

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -247,7 +247,7 @@ class MettaCLI:
         info("Note: You can run 'metta configure <component>' to change component-level settings later.\n")
 
         saved_settings = get_saved_settings()
-        if saved_settings.config_path.exists():
+        if saved_settings.exists():
             info("Current configuration:")
             info(f"Profile: {saved_settings.user_type.value}")
             info(f"Mode: {'custom' if saved_settings.is_custom_config else 'profile'}")
@@ -262,7 +262,7 @@ class MettaCLI:
         choices = [(ut, ut.get_description()) for ut in UserType]
 
         # Current configuration
-        current_user_type = saved_settings.user_type if saved_settings.config_path.exists() else None
+        current_user_type = saved_settings.user_type if saved_settings.exists() else None
 
         result = prompt_choice(
             "Select configuration:",
@@ -370,7 +370,7 @@ class MettaCLI:
         from metta.setup.registry import get_all_modules, get_enabled_setup_modules
         from metta.setup.utils import error, info, success, warning
 
-        if not self.saved_settings.config_path.exists():
+        if not get_saved_settings().exists():
             warning("No configuration found. Running setup wizard first...")
             self.setup_wizard()
 
@@ -843,7 +843,7 @@ Examples:
         saved_settings = get_saved_settings()
         # Handle no command
         if not args.command:
-            if not saved_settings.config_path.exists():
+            if not saved_settings.exists():
                 print("No configuration found. Running setup wizard...\n")
                 self.setup_wizard()
                 return
@@ -855,7 +855,7 @@ Examples:
         if args.command in COMMAND_REGISTRY:
             cmd_config = COMMAND_REGISTRY[args.command]
             if cmd_config.needs_config and args.command not in ["configure", "symlink-setup"]:
-                if not saved_settings.config_path.exists():
+                if not saved_settings.exists():
                     print("Error: No configuration found. Please run 'metta configure' first.", file=sys.stderr)
                     sys.exit(1)
                 else:

--- a/metta/setup/registry.py
+++ b/metta/setup/registry.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Type
 
+from metta.common.util.collections import find_first
+
 if TYPE_CHECKING:
     from metta.setup.components.base import SetupModule
 
@@ -11,8 +13,8 @@ def register_module(cls: Type["SetupModule"]) -> Type["SetupModule"]:
     return cls
 
 
-def get_all_modules(config) -> list["SetupModule"]:
-    all_modules = [cls(config) for cls in _REGISTRY]
+def get_all_modules() -> list["SetupModule"]:
+    all_modules = [cls() for cls in _REGISTRY]
 
     # Create a mapping from name to module for easy lookup
     name_to_module = {m.name: m for m in all_modules}
@@ -47,5 +49,9 @@ def get_all_modules(config) -> list["SetupModule"]:
     return result
 
 
-def get_applicable_modules(config) -> list["SetupModule"]:
-    return [m for m in get_all_modules(config) if m.is_applicable()]
+def get_applicable_modules() -> list["SetupModule"]:
+    return [m for m in get_all_modules() if m.is_applicable()]
+
+
+def get_available_module_by_name(name: str) -> "SetupModule | None":
+    return find_first(get_applicable_modules(), lambda m: m.name == name)

--- a/metta/setup/registry.py
+++ b/metta/setup/registry.py
@@ -49,9 +49,9 @@ def get_all_modules() -> list["SetupModule"]:
     return result
 
 
-def get_applicable_modules() -> list["SetupModule"]:
-    return [m for m in get_all_modules() if m.is_applicable()]
+def get_enabled_setup_modules() -> list["SetupModule"]:
+    return [m for m in get_all_modules() if m.is_enabled()]
 
 
-def get_available_module_by_name(name: str) -> "SetupModule | None":
-    return find_first(get_applicable_modules(), lambda m: m.name == name)
+def get_enabled_setup_module_by_name(name: str) -> "SetupModule | None":
+    return find_first(get_enabled_setup_modules(), lambda m: m.name == name)

--- a/metta/setup/saved_settings.py
+++ b/metta/setup/saved_settings.py
@@ -17,6 +17,9 @@ class SavedSettings:
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
         self._config: dict = self._load_config()
 
+    def exists(self) -> bool:
+        return self.config_path.exists()
+
     def _load_config(self) -> dict:
         if self.config_path.exists():
             with open(self.config_path, "r") as f:

--- a/tests/setup/test_integration_install.py
+++ b/tests/setup/test_integration_install.py
@@ -10,7 +10,7 @@ import unittest
 
 import pytest
 
-from metta.setup.config import SetupConfig, UserType
+from metta.setup.saved_settings import SavedSettings, UserType
 from tests.setup.test_base import BaseMettaSetupTest
 
 
@@ -55,7 +55,7 @@ class TestInstallSoftmax(BaseMettaSetupTest):
         assert r_symlink.returncode == 0
 
         # Verify config written
-        config = SetupConfig(self.test_config_dir / "config.yaml")
+        config = SavedSettings(self.test_config_dir / "config.yaml")
         assert config.user_type == UserType.SOFTMAX
 
     def test_install_without_config_fails(self):
@@ -88,7 +88,7 @@ class TestInstallCloud(BaseMettaSetupTest):
         self._create_test_config(UserType.CLOUD)
         result = self._run_metta_command(["install"])
         assert result.returncode == 0, f"Install failed: {result.stderr}"
-        config = SetupConfig(self.test_config_dir / "config.yaml")
+        config = SavedSettings(self.test_config_dir / "config.yaml")
         assert config.user_type == UserType.CLOUD
         assert config.is_component_enabled("aws")
 
@@ -100,7 +100,7 @@ class TestInstallCustom(BaseMettaSetupTest):
         self._create_test_config(UserType.EXTERNAL, custom_config=True)
         result = self._run_metta_command(["install"])
         assert result.returncode == 0, f"Install failed: {result.stderr}"
-        config = SetupConfig(self.test_config_dir / "config.yaml")
+        config = SavedSettings(self.test_config_dir / "config.yaml")
         assert config.user_type == UserType.EXTERNAL
         assert config.is_custom_config
 

--- a/uv.lock
+++ b/uv.lock
@@ -2749,6 +2749,7 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.26.1"
+
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },


### PR DESCRIPTION
This is service of setting up a slightly cleaner interface for getting user settings (e.g. seeing if they have wandb enabled)

- MettaCli's `config` is now renamed to a more descriptive `SavedSettings`
- saved settings are now a singleton object, not as a thing that has to get instantiated several times and passed to setup modules
- Remove per-module repeated logic around checking if both it and all its dependencies are enabled. Put that in the base class
- Setup modules now enforce that they are only enabled if they are applicable (default true but with optionally specifiable logic) and both they and all their dependencies are enabled in saved settings
- Update uv.lock because somewhere downstack someone updated a dep; this is just `uv sync`
[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211093000700500)