### PR TITLE
feat: add heartbeat monitoring to evaluation pipeline

### DIFF
--- a/metta/eval/eval_service.py
+++ b/metta/eval/eval_service.py
@@ -6,6 +6,7 @@ import torch
 from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.common.util.heartbeat import record_heartbeat
 from metta.eval.eval_request_config import EvalResults, EvalRewardSummary
 from metta.eval.eval_stats_db import EvalStatsDB
 from metta.mettagrid.curriculum.core import Curriculum
@@ -42,6 +43,10 @@ def evaluate_policy(
 
     # For each checkpoint of the policy, simulate
     logger.info(f"Evaluating policy {pr.uri}")
+
+    # Record heartbeat at start of evaluation
+    record_heartbeat()
+
     if training_curriculum:
         logger.info(f"Adding training task to simulation suite: {training_curriculum}")
         task_cfg = training_curriculum.get_task().env_cfg()
@@ -70,6 +75,9 @@ def evaluate_policy(
 
     eval_stats_db = EvalStatsDB.from_sim_stats_db(result.stats_db)
     logger.info("Evaluation complete for policy %s", pr.uri)
+
+    # Record heartbeat after evaluation completes
+    record_heartbeat()
     scores = extract_scores(policy_record, simulation_suite, eval_stats_db, logger)
 
     if export_stats_db_uri is not None:

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -26,6 +26,7 @@ from tensordict import TensorDict
 from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.common.util.heartbeat import record_heartbeat
 from metta.mettagrid import MettaGridEnv, dtype_actions
 from metta.mettagrid.curriculum.core import Curriculum, SingleTrialTask, Task
 from metta.mettagrid.curriculum.util import curriculum_from_config_path
@@ -396,9 +397,18 @@ class Simulation:
         if self._npc_pr is not None:
             self._npc_pr.policy.reset_memory()
 
+        # Track iterations for heartbeat
+        iteration_count = 0
+        heartbeat_interval = 100  # Record heartbeat every 100 iterations
+
         while (self._episode_counters < self._min_episodes).any() and (time.time() - self._t0) < self._max_time_s:
             actions_np = self.generate_actions()
             self.step_simulation(actions_np)
+
+            # Record heartbeat periodically
+            iteration_count += 1
+            if iteration_count % heartbeat_interval == 0:
+                record_heartbeat()
 
         return self.end_simulation()
 

--- a/metta/sim/simulation_suite.py
+++ b/metta/sim/simulation_suite.py
@@ -7,6 +7,7 @@ import torch
 from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.common.util.heartbeat import record_heartbeat
 from metta.sim.simulation import Simulation, SimulationCompatibilityError, SimulationResults
 from metta.sim.simulation_config import SimulationSuiteConfig
 from metta.sim.simulation_stats_db import SimulationStatsDB
@@ -56,6 +57,9 @@ class SimulationSuite:
 
         for name, sim_config in self._config.simulations.items():
             try:
+                # Record heartbeat before starting each simulation
+                record_heartbeat()
+
                 # merge global simulation suite overrides with simulation-specific overrides
                 sim_config.env_overrides = {**self._config.env_overrides, **sim_config.env_overrides}
                 sim = Simulation(
@@ -77,6 +81,9 @@ class SimulationSuite:
                 logger.info("=== Simulation '%s' ===", name)
                 sim_result = sim.simulate()
                 merged_db.merge_in(sim_result.stats_db)
+
+                # Record heartbeat after completing each simulation
+                record_heartbeat()
 
                 # Collect replay URLs if available
                 if self._replay_dir is not None:


### PR DESCRIPTION
## Summary
Add heartbeat recording during evaluations to prevent timeout issues in long-running evaluations and sweeps.

## Changes
- Record heartbeat at start/end of overall evaluation in `eval_service.py`
- Record heartbeat every 100 iterations in simulation loop in `simulation.py`
- Record heartbeat before/after each simulation in suite in `simulation_suite.py`

## Motivation
This ensures long-running evaluations and sweeps won't timeout when HEARTBEAT_FILE is configured, which is critical for cloud-based training runs on SkyPilot.

## Testing
The heartbeat monitoring has been tested as part of the sweep improvements and works correctly with the existing heartbeat infrastructure.

Cherry-picked from commit f2ede73e8 on the axel-sweep-massive-improvements branch to isolate this feature for independent merging.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211097055925987)