### PR TITLE
Evaluate remotely by default

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -84,9 +84,6 @@ def handle_train(cfg: DictConfig, wandb_run: WandbRun | None, logger: Logger):
         if not stats_client:
             cfg.trainer.simulation.evaluate_remote = False
             logger.info("Not connected to stats server, disabling remote evaluations")
-        elif not cfg.trainer.simulation.evaluate_interval:
-            cfg.trainer.simulation.evaluate_remote = False
-            logger.info("Evaluate interval set to 0, disabling remote evaluations")
         elif not cfg.trainer.simulation.git_hash:
             cfg.trainer.simulation.git_hash = get_git_hash_for_remote_task(
                 skip_git_check=cfg.trainer.simulation.skip_git_check,


### PR DESCRIPTION
evaluate_interval is now null by default

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211097401042938)