### PR TITLE
maybe speed up skypilot job startup

### DIFF
--- a/devops/skypilot/config/skypilot_run.yaml
+++ b/devops/skypilot/config/skypilot_run.yaml
@@ -29,6 +29,7 @@ resources:
 
 config:
   docker:
+    pull_before_run: false
     run_options:
       - --cap-add=IPC_LOCK
       - --ulimit memlock=-1:-1


### PR DESCRIPTION
I see we're spending >5m in skypilot job startup [here](https://github.com/skypilot-org/skypilot/blob/master/sky/provision/instance_setup.py#L174), and I'm guessing most of that is in pulling the image [here](https://github.com/skypilot-org/skypilot/blob/master/sky/provision/docker_utils.py#L251), which we can potentially disable. I would think our image is already loaded into the cluster so i'm not totally sure if pulling it does any good

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211104506484583)