### PR TITLE
feat: Sort policy checkpoint files numerically in descending order

### DIFF
--- a/agent/src/metta/agent/policy_store.py
+++ b/agent/src/metta/agent/policy_store.py
@@ -13,7 +13,6 @@ import collections
 import logging
 import os
 import random
-import re
 import sys
 from typing import Any, Literal
 
@@ -331,14 +330,9 @@ class PolicyStore:
         else:
             # Get all .pt files and sort them numerically by checkpoint number
             checkpoint_files = [p for p in os.listdir(path) if p.endswith(".pt")]
-
-            # Sort by extracting the number from model_XXXX.pt filenames
-            def _get_checkpoint_number(filename):
-                match = re.search(r"_(\d+)\.pt$", filename)
-                return int(match.group(1)) if match else -1
-
             # Sort in descending order so the latest (highest number) is first
-            checkpoint_files.sort(key=_get_checkpoint_number, reverse=True)
+            # Assumes format: model_XXXXX.pt
+            checkpoint_files.sort(key=lambda f: int(f[6:-3]) if f.startswith("model_") else -1, reverse=True)
             paths.extend([os.path.join(path, p) for p in checkpoint_files])
 
         return [self._load_from_file(path, metadata_only=True) for path in paths]

--- a/agent/src/metta/agent/policy_store.py
+++ b/agent/src/metta/agent/policy_store.py
@@ -328,10 +328,7 @@ class PolicyStore:
         if path.endswith(".pt"):
             paths.append(path)
         else:
-            # Get all .pt files and sort them numerically by checkpoint number
             checkpoint_files = [p for p in os.listdir(path) if p.endswith(".pt")]
-            # Sort in descending order so the latest (highest number) is first
-            # Assumes format: model_XXXXX.pt
             checkpoint_files.sort(key=lambda f: int(f[6:-3]) if f.startswith("model_") else -1, reverse=True)
             paths.extend([os.path.join(path, p) for p in checkpoint_files])
 


### PR DESCRIPTION
### TL;DR

Sort policy checkpoint files numerically in descending order when loading from a directory.

### What changed?

Modified the `_prs_from_path` method in the `PolicyStore` class to sort checkpoint files numerically by their checkpoint number. Previously, files were loaded in directory order, but now they are sorted by extracting the numeric value from filenames matching the pattern `model_XXXX.pt`. Files are sorted in descending order so that the latest checkpoint (with the highest number) appears first in the list.

### How to test?

1. Create a directory with multiple policy checkpoint files (e.g., `model_1000.pt`, `model_2000.pt`, `model_500.pt`)
2. Use the `PolicyStore` to load policies from this directory
3. Verify that the policies are returned in descending order by checkpoint number (e.g., `model_2000.pt` first, then `model_1000.pt`, then `model_500.pt`)

### Why make this change?

This change ensures that when loading policies from a directory, they are consistently ordered by checkpoint number rather than by filesystem order. This is particularly useful when working with multiple checkpoints, as it makes it easier to identify and work with the most recent checkpoint first. The descending sort order prioritizes newer checkpoints, which is typically the desired behavior when loading policies.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211109785692161)