### PR TITLE
Fix vscode-runnable training/eval/etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,8 @@ sweep_id
 # Notebooks
 experiments/notebooks/.ipynb_checkpoints
 experiments/notebooks/utils/scorecard_widget/scorecard_widget/static/index.js
-experiments/user/*.py
-!experiments/user/example.py
+experiments/recipes/scratchpad/*.py
+!experiments/recipes/scratchpad/README.md
+!experiments/recipes/scratchpad/example.py
 
 resources

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "tools.run",
-      "args": ["experiments.user.${env:USER}.train"],
+      "args": ["experiments.recipes.scratchpad.${env:USER}.train"],
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
@@ -67,7 +67,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "tools.run",
-      "args": ["experiments.user.${env:USER}.evaluate"],
+      "args": ["experiments.recipes.scratchpad.${env:USER}.evaluate"],
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
@@ -95,7 +95,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "tools.run",
-      "args": ["experiments.user.${env:USER}.analyze"],
+      "args": ["experiments.recipes.scratchpad.${env:USER}.analyze"],
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
@@ -109,7 +109,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "tools.run",
-      "args": ["experiments.user.${env:USER}.replay"],
+      "args": ["experiments.recipes.scratchpad.${env:USER}.replay"],
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",
@@ -123,7 +123,7 @@
       "type": "debugpy",
       "request": "launch",
       "module": "tools.run",
-      "args": ["experiments.user.${env:USER}.play"],
+      "args": ["experiments.recipes.scratchpad.${env:USER}.play"],
       "cwd": "${workspaceFolder}",
       "env": {
         "PYTHONPATH": "${workspaceFolder}",

--- a/experiments/recipes/scratchpad/README.md
+++ b/experiments/recipes/scratchpad/README.md
@@ -1,0 +1,1 @@
+For experimentation that you do not intend to commit

--- a/experiments/recipes/scratchpad/example.py
+++ b/experiments/recipes/scratchpad/example.py
@@ -1,0 +1,42 @@
+from experiments.recipes import arena
+from metta.tools.play import PlayTool
+from metta.tools.replay import ReplayTool
+from metta.tools.sim import SimTool
+from metta.tools.train import TrainTool
+
+# This file is for local experimentation only. It is not checked in, and therefore won't be usable on skypilot
+
+# You can run these functions locally with e.g. `./tools/run.py experiments.recipes.scratchpad.{{ USER }}.train`
+# The VSCode "Run and Debug" section supports options to run these functions.
+
+
+def train() -> TrainTool:
+    env = arena.make_env()
+    env.game.max_steps = 100
+    cfg = arena.train(
+        curriculum=arena.make_curriculum(env),
+    )
+    return cfg
+
+
+def play() -> PlayTool:
+    env = arena.make_evals()[0].env
+    env.game.max_steps = 100
+    cfg = arena.play(env)
+    return cfg
+
+
+def replay() -> ReplayTool:
+    env = arena.make_env()
+    env.game.max_steps = 100
+    cfg = arena.replay(env)
+    # cfg.policy_uri = "wandb://run/daveey.combat.lpsm.8x4"
+    return cfg
+
+
+def evaluate(run: str = "local.{{ USER }}.1") -> SimTool:
+    cfg = arena.evaluate(policy_uri=f"wandb://run/{run}")
+
+    # If your run doesn't exist, try this:
+    # cfg = arena.evaluate(policy_uri="wandb://run/daveey.combat.lpsm.8x4")
+    return cfg

--- a/metta/setup/components/experiments.py
+++ b/metta/setup/components/experiments.py
@@ -14,7 +14,7 @@ class ExperimentsSetup(SetupModule):
 
     @property
     def user_experiments_dir(self) -> Path:
-        return self.repo_root / "experiments" / "user"
+        return self.repo_root / "experiments" / "recipes" / "scratchpad"
 
     @property
     def _personal_experiments_path(self) -> Path:


### PR DESCRIPTION
We removed the experiments/user folder, which broke vscode "Train"/etc actions

This re-introduces similar functionality in what is hopefully the right place: experiments/recipes. there's now a scratchpad folder that is not checked in in which `metta install experiments` will create a file specific to that user from a template, and vscode actions target that file