### PR TITLE
load_symbol cleanups

### DIFF
--- a/common/src/metta/common/util/module.py
+++ b/common/src/metta/common/util/module.py
@@ -2,6 +2,16 @@ import importlib
 
 
 def load_symbol(full_name: str):
+    """
+    Load a symbol from a full name, for example:
+    "metta.common.config.tool.Tool" -> Tool
+
+    Args:
+        full_name: The full name of the symbol to load.
+
+    Returns:
+        The loaded symbol.
+    """
     parts = full_name.rsplit(".", 1)
     if len(parts) != 2:
         raise ValueError(f"Invalid symbol name: {full_name}")

--- a/common/tests/util/test_module.py
+++ b/common/tests/util/test_module.py
@@ -1,0 +1,37 @@
+import importlib
+
+import pytest
+
+from metta.common.util.module import load_symbol
+
+
+def test_load_symbol_with_builtin() -> None:
+    result = load_symbol("builtins.str")
+    assert result is str
+
+
+def test_load_symbol_with_stdlib_function() -> None:
+    result = load_symbol("importlib.import_module")
+    assert result is importlib.import_module
+
+
+def test_load_symbol_invalid_format_raises_value_error() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        load_symbol("NotFullyQualifiedName")
+    assert "Invalid symbol name" in str(excinfo.value)
+
+
+def test_load_symbol_missing_module_raises_module_not_found_error() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        load_symbol("this_module_does_not_exist__abcdef.Symbol")
+
+
+def test_load_self() -> None:
+    result = load_symbol("metta.common.util.module.load_symbol")
+    assert callable(result)
+
+
+def test_load_config() -> None:
+    result = load_symbol("metta.common.config.config.Config")
+    assert isinstance(result, type)
+    assert result.__name__ == "Config"

--- a/metta/cogworks/curriculum/task_generator.py
+++ b/metta/cogworks/curriculum/task_generator.py
@@ -16,8 +16,8 @@ from pydantic import (
 from typing_extensions import Generic
 
 from metta.common.config import Config
+from metta.common.util.module import load_symbol
 from metta.mettagrid.mettagrid_config import EnvConfig
-from metta.utils.module import load_symbol
 
 if TYPE_CHECKING:
     from metta.cogworks.curriculum.curriculum import CurriculumConfig

--- a/metta/cogworks/curriculum/task_generator.py
+++ b/metta/cogworks/curriculum/task_generator.py
@@ -17,7 +17,7 @@ from typing_extensions import Generic
 
 from metta.common.config import Config
 from metta.mettagrid.mettagrid_config import EnvConfig
-from metta.utils.module import load_class
+from metta.utils.module import load_symbol
 
 if TYPE_CHECKING:
     from metta.cogworks.curriculum.curriculum import CurriculumConfig
@@ -309,7 +309,7 @@ def _validate_open_task_generator(v: Any, handler):
             return handler(v)
 
         # Import the symbol named in 'type'
-        target = load_class(t) if isinstance(t, str) else t
+        target = load_symbol(t) if isinstance(t, str) else t
 
         # If it's a Generator, use its nested Config
         if isinstance(target, type) and issubclass(target, TaskGenerator):

--- a/metta/map/scene.py
+++ b/metta/map/scene.py
@@ -10,16 +10,16 @@ from metta.common.config import Config
 from metta.map.config import scenes_root
 from metta.map.random.int import MaybeSeed
 from metta.map.types import Area, AreaQuery, MapGrid
-from metta.utils.module import load_class
+from metta.utils.module import load_symbol
 
 ParamsT = TypeVar("ParamsT", bound=Config)
 
 SceneT = TypeVar("SceneT", bound="Scene")
 
 
-def _ensure_scene_cls(v: Any) -> type["Scene"]:
+def _ensure_scene_cls(v: Any) -> type[Scene]:
     if isinstance(v, str):
-        return load_scene_class(v)
+        v = load_symbol(v)
     if not issubclass(v, Scene):
         raise ValueError(f"Class {v} does not inherit from Scene")
     return v
@@ -331,13 +331,6 @@ class Scene(Generic[ParamsT]):
         # recurse into children scenes
         for child_scene in self.children:
             child_scene.transplant_to_grid(grid, shift_x, shift_y, is_root=False)
-
-
-def load_scene_class(full_class_name: str, check_is_scene=True) -> type[Scene]:
-    cls = load_class(full_class_name)
-    if check_is_scene and not issubclass(cls, Scene):
-        raise ValueError(f"Class {cls} does not inherit from Scene")
-    return cls
 
 
 def resolve_scene_config(cfg: SceneConfigOrFile) -> SceneConfig:

--- a/metta/map/scene.py
+++ b/metta/map/scene.py
@@ -7,10 +7,10 @@ from omegaconf import DictConfig, OmegaConf
 from pydantic import FieldSerializationInfo, ValidationInfo, field_serializer, field_validator
 
 from metta.common.config import Config
+from metta.common.util.module import load_symbol
 from metta.map.config import scenes_root
 from metta.map.random.int import MaybeSeed
 from metta.map.types import Area, AreaQuery, MapGrid
-from metta.utils.module import load_symbol
 
 ParamsT = TypeVar("ParamsT", bound=Config)
 

--- a/metta/map/tools/gen.py
+++ b/metta/map/tools/gen.py
@@ -7,7 +7,7 @@ from metta.common.config.tool import Tool
 from metta.map.utils.show import ShowMode, show_map
 from metta.map.utils.storable_map import StorableMap
 from metta.mettagrid.mettagrid_config import EnvConfig
-from metta.utils.module import load_function
+from metta.utils.module import load_symbol
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,10 @@ class GenTool(Tool):
         count = self.count
         env_fn_name = self.env_fn
 
-        env_fn = load_function(env_fn_name)
+        env_fn = load_symbol(env_fn_name)
+
+        if not callable(env_fn):
+            raise ValueError(f"Env {env_fn_name} is not callable")
 
         # TODO - support env_fn args?
         env_config = env_fn()

--- a/metta/map/tools/gen.py
+++ b/metta/map/tools/gen.py
@@ -4,10 +4,10 @@ import random
 import string
 
 from metta.common.config.tool import Tool
+from metta.common.util.module import load_symbol
 from metta.map.utils.show import ShowMode, show_map
 from metta.map.utils.storable_map import StorableMap
 from metta.mettagrid.mettagrid_config import EnvConfig
-from metta.utils.module import load_symbol
 
 logger = logging.getLogger(__name__)
 

--- a/metta/utils/module.py
+++ b/metta/utils/module.py
@@ -1,21 +1,11 @@
 import importlib
 
 
-def load_class(full_class_name: str):
-    parts = full_class_name.rsplit(".", 1)
+def load_symbol(full_name: str):
+    parts = full_name.rsplit(".", 1)
     if len(parts) != 2:
-        raise ValueError(f"Invalid class name: {full_class_name}")
-    module_name, class_name = parts
+        raise ValueError(f"Invalid symbol name: {full_name}")
+    module_name, symbol_name = parts
     module = importlib.import_module(module_name)
-    cls = getattr(module, class_name)
-    return cls
-
-
-def load_function(full_function_name: str):
-    parts = full_function_name.rsplit(".", 1)
-    if len(parts) != 2:
-        raise ValueError(f"Invalid function name: {full_function_name}")
-    module_name, function_name = parts
-    module = importlib.import_module(module_name)
-    func = getattr(module, function_name)
-    return func
+    value = getattr(module, symbol_name)
+    return value

--- a/mettagrid/src/metta/mettagrid/map_builder/map_builder.py
+++ b/mettagrid/src/metta/mettagrid/map_builder/map_builder.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 from pydantic import SerializeAsAny, WrapValidator, model_serializer, model_validator
 
 from metta.common.config import Config
-from metta.utils.module import load_function
+from metta.utils.module import load_symbol
 
 # We store maps as 2D arrays of object names.
 # "empty" means an empty cell; "wall" means a wall, etc. See `metta.mettagrid.char_encoder` for the full list.
@@ -121,7 +121,7 @@ def _validate_open_map_builder(v: Any, handler):
             return handler(v)
 
         # Import the symbol named in 'type'
-        target = load_function(t) if isinstance(t, str) else t
+        target = load_symbol(t) if isinstance(t, str) else t
 
         # If it's a Builder, use its nested Config
         if isinstance(target, type) and issubclass(target, MapBuilder):

--- a/mettagrid/src/metta/mettagrid/map_builder/map_builder.py
+++ b/mettagrid/src/metta/mettagrid/map_builder/map_builder.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 from pydantic import SerializeAsAny, WrapValidator, model_serializer, model_validator
 
 from metta.common.config import Config
-from metta.utils.module import load_symbol
+from metta.common.util.module import load_symbol
 
 # We store maps as 2D arrays of object names.
 # "empty" means an empty cell; "wall" means a wall, etc. See `metta.mettagrid.char_encoder` for the full list.

--- a/tools/run.py
+++ b/tools/run.py
@@ -15,7 +15,7 @@ from metta.common.config.config import Config
 from metta.common.config.tool import Tool
 from metta.common.util.logging_helpers import init_logging
 from metta.rl.system_config import seed_everything
-from metta.utils.module import load_function
+from metta.utils.module import load_symbol
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def main():
     args_conf = cast(dict[str, Any], args_conf)
 
     # Create the tool config object
-    make_tool_cfg = load_function(args.make_tool_cfg_path)
+    make_tool_cfg = load_symbol(args.make_tool_cfg_path)
 
     if issubclass(make_tool_cfg, Tool):
         # tool config constructor

--- a/tools/run.py
+++ b/tools/run.py
@@ -14,8 +14,8 @@ from typing_extensions import TypeVar
 from metta.common.config.config import Config
 from metta.common.config.tool import Tool
 from metta.common.util.logging_helpers import init_logging
+from metta.common.util.module import load_symbol
 from metta.rl.system_config import seed_everything
-from metta.utils.module import load_symbol
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- consolidate `load_function` and `load_class` under `load_symbol`
- move it to `metta.common.util.module` since it's used by mettagrid
- tests

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211126285472952)