### PR TITLE
Post-dehydration quenching: fix eval workers

### DIFF
--- a/app_backend/src/metta/app_backend/eval_task_worker.py
+++ b/app_backend/src/metta/app_backend/eval_task_worker.py
@@ -155,7 +155,7 @@ class SimTaskExecutor(AbstractTaskExecutor):
             "uv",
             "run",
             "tools/run.py",
-            "experiments.evals.run",
+            "experiments.evals.run.eval",
             "--args",
             f"policy_uri=wandb://run/{policy_name}",
             f"simulations_json={task.attributes.get('simulations')}",

--- a/experiments/evals/run.py
+++ b/experiments/evals/run.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 from metta.sim.simulation_config import SimulationConfig
@@ -5,10 +6,11 @@ from metta.tools.sim import SimTool
 
 
 # Used by eval_task_worker.py
-def eval(policy_uri: str, simulations_json: str) -> SimTool:
+def eval(policy_uri: str, simulations_json_base64: str) -> SimTool:
+    # Decode from base64 to avoid OmegaConf auto-parsing issues
+    simulations_json = base64.b64decode(simulations_json_base64).decode()
     simulations = [
-        SimulationConfig.model_validate_json(sim)
-        for sim in json.loads(simulations_json)
+        SimulationConfig.model_validate(sim) for sim in json.loads(simulations_json)
     ]
     return SimTool(
         simulations=simulations,


### PR DESCRIPTION
This fixes two post-dehydration issues with eval workers:
1. we were calling the wrong func
2. change our serialization of the list of simulations to dodge Omegaconf half-parsing. A possibly better path would be to write the simulations to a local temp file and point to that. We can switch to it after Slava implements that more broadly for run.py args

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211127647408336)