### PR TITLE
Evaluate remote by default again now that policy evaluator is working

### DIFF
--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -63,7 +63,7 @@ class EvaluationConfig(Config):
 
     # Interval at which to evaluate and generate replays: Type 2 arbitrary default
     evaluate_interval: int = Field(default=50, ge=0)  # 0 to disable
-    evaluate_remote: bool = Field(default=False)
+    evaluate_remote: bool = Field(default=True)
     evaluate_local: bool = Field(default=True)
     skip_git_check: bool = Field(default=False)
     git_hash: str | None = Field(default=None)


### PR DESCRIPTION
`_configure_evaluation_settings` makes sure that this gets turned off for remote users if they dont have access

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211127582917746)