### PR TITLE
Fix: simple config override function

### DIFF
--- a/common/src/metta/common/config/config.py
+++ b/common/src/metta/common/config/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, NoReturn, Self, Union
+from typing import Any, NoReturn, Self, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
@@ -18,7 +18,6 @@ class Config(BaseModel):
         self, parent_obj: "Config", field_name: str, traversed_path: list[str], fail
     ) -> "Config | None":
         """Auto-initialize a None field if possible."""
-        from typing import get_args, get_origin
 
         cls = type(parent_obj)
         field = cls.model_fields.get(field_name)

--- a/metta/tools/train.py
+++ b/metta/tools/train.py
@@ -66,6 +66,10 @@ class TrainTool(Tool):
         if not self.trainer.checkpoint.checkpoint_dir:
             self.trainer.checkpoint.checkpoint_dir = f"{self.run_dir}/checkpoints/"
 
+        # Initialize policy_architecture if not provided
+        if self.policy_architecture is None:
+            self.policy_architecture = AgentConfig()
+
         if self.wandb == WandbConfig.Unconfigured():
             self.wandb = auto_wandb_config(self.run)
 

--- a/metta/tools/train.py
+++ b/metta/tools/train.py
@@ -66,10 +66,6 @@ class TrainTool(Tool):
         if not self.trainer.checkpoint.checkpoint_dir:
             self.trainer.checkpoint.checkpoint_dir = f"{self.run_dir}/checkpoints/"
 
-        # Initialize policy_architecture if not provided
-        if self.policy_architecture is None:
-            self.policy_architecture = AgentConfig()
-
         if self.wandb == WandbConfig.Unconfigured():
             self.wandb = auto_wandb_config(self.run)
 


### PR DESCRIPTION
This PR solves the issue arising when using the `--overrides policy_architecture.name=` to specify available policies.  
initially the policy_architecture is None and doesn't have `name` attribute. This handles the issue to first initializes the default config and then overrides the name.

```
policy_architecture = None
↓ (auto-initialize)
policy_architecture = AgentConfig()
↓ (apply override)
policy_architecture = AgentConfig(name="pytorch/fast", ...)
```