### PR TITLE
simulation batch dimension preserving fix (200 agents instead of 1 agent simulated)

### DIFF
--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -253,7 +253,16 @@ class Simulation:
         # ---------------- forward passes ------------------------- #
         with torch.no_grad():
             # Candidate-policy agents
-            my_obs = self._obs[self._policy_idxs.cpu()]
+            # Use advanced indexing to preserve batch dimensions
+            policy_idxs_cpu = self._policy_idxs.cpu()
+            my_obs = self._obs[policy_idxs_cpu]
+
+            # Ensure we maintain batch dimension even for single agent selection
+            if my_obs.ndim == 2 and len(policy_idxs_cpu) == 1:
+                # If indexing a single agent from (1, tokens, features) resulted in (tokens, features),
+                # restore the batch dimension to (1, tokens, features)
+                my_obs = my_obs[None, ...]  # Add batch dimension back
+
             td = obs_to_td(my_obs, self._device)  # One-liner conversion
             policy = self._policy_pr.policy
             policy(td)
@@ -262,6 +271,11 @@ class Simulation:
             # NPC agents (if any)
             if self._npc_pr is not None and len(self._npc_idxs):
                 npc_obs = self._obs[self._npc_idxs]
+
+                # Ensure we maintain batch dimension for NPC agents too
+                if npc_obs.ndim == 2 and len(self._npc_idxs) == 1:
+                    npc_obs = npc_obs[None, ...]  # Add batch dimension back
+
                 td = obs_to_td(npc_obs, self._device)  # One-liner conversion
                 npc_policy = self._npc_pr.policy
                 try:


### PR DESCRIPTION
bugfix for simulating environments with single agents. without this fix, the system simulates for 200 agents instead of 1 agent.

  🎯 The Real Problem:

  File: ./metta/sim/simulation.py:256
  my_obs = self._obs[self._policy_idxs.cpu()]  # BUG: Indexing drops batch dimension

  What happened:
  - self._obs shape: (1, 200, 3) (1 agent, 200 tokens, 3 features)
  - self._policy_idxs.cpu() is [0] (select agent 0)
  - my_obs = self._obs[0] → (200, 3) ← Batch dimension lost!
  - obs_to_td() sets batch_size=obs.shape[0] → batch_size=200
  - System thinks: 200 agents instead of 1 agent with 200 tokens

  🛠️ The Fix:

  Added proper batch dimension preservation in simulation.py:261-264:
```python
# Ensure we maintain batch dimension even for single agent selection
if my_obs.ndim == 2 and len(policy_idxs_cpu) == 1:
    # If indexing a single agent from (1, tokens, features) resulted in (tokens, features),
    # restore the batch dimension to (1, tokens, features)
    my_obs = my_obs[None, ...]  # Add batch dimension back
```