### PR TITLE
Change get_agent_position to not return None

### DIFF
--- a/mettagrid/src/metta/mettagrid/test_support/actions.py
+++ b/mettagrid/src/metta/mettagrid/test_support/actions.py
@@ -410,25 +410,17 @@ def get_current_observation(env: MettaGrid, agent_idx: int):
         return obs.copy()
 
 
-def get_agent_position(env: MettaGrid, agent_idx: int = 0) -> Optional[tuple]:
-    """Get agent's current position (r, c)."""
-    try:
-        grid_objects = env.grid_objects()
-        for _obj_id, obj_data in grid_objects.items():
-            if "agent_id" in obj_data and obj_data.get("agent_id") == agent_idx:
-                return (obj_data["r"], obj_data["c"])
-        return None
-    except Exception:
-        return None
+def get_agent_position(env: MettaGrid, agent_idx: int = 0) -> tuple[int, int]:
+    grid_objects = env.grid_objects()
+    for _obj_id, obj_data in grid_objects.items():
+        if "agent_id" in obj_data and obj_data.get("agent_id") == agent_idx:
+            return (obj_data["r"], obj_data["c"])
+    raise ValueError(f"Agent {agent_idx} not found in grid objects")
 
 
-def get_agent_orientation(env: MettaGrid, agent_idx: int = 0) -> Optional[int]:
-    """Get agent's current orientation."""
-    try:
-        grid_objects = env.grid_objects()
-        for _obj_id, obj_data in grid_objects.items():
-            if "agent_id" in obj_data and obj_data.get("agent_id") == agent_idx:
-                return obj_data.get("agent:orientation", None)
-        return None
-    except Exception:
-        return None
+def get_agent_orientation(env: MettaGrid, agent_idx: int = 0) -> int:
+    grid_objects = env.grid_objects()
+    for _obj_id, obj_data in grid_objects.items():
+        if "agent_id" in obj_data and obj_data.get("agent_id") == agent_idx:
+            return obj_data["agent:orientation"]
+    raise ValueError(f"Agent {agent_idx} not found in grid objects")

--- a/mettagrid/tests/test_move.py
+++ b/mettagrid/tests/test_move.py
@@ -642,7 +642,6 @@ def test_move_returns_to_center(configured_env, movement_game_map):
     env = configured_env(movement_game_map)
 
     initial_pos = get_agent_position(env)
-    assert initial_pos is not None, "Agent should have a valid initial position"
 
     # Move in a square: north, east, south, west
     moves = [

--- a/mettagrid/tests/test_no_agent_interference.py
+++ b/mettagrid/tests/test_no_agent_interference.py
@@ -74,7 +74,6 @@ class TestNoAgentInterference:
             initial_positions = []
             for agent_idx in range(2):
                 agent_pos = get_agent_position(env.__c_env_instance, agent_idx)
-                assert agent_pos is not None, f"Agent {agent_idx} should have a valid position"
                 initial_positions.append(agent_pos)
 
             # Check if agents are adjacent
@@ -286,11 +285,8 @@ def _test_ghost_movement_with_interference_flag(no_agent_interference: bool):
     initial_positions = []
     for agent_idx in range(2):
         agent_pos = get_agent_position(env.__c_env_instance, agent_idx)
-        if agent_pos:
-            initial_positions.append(agent_pos)
-            print(f"  Agent {agent_idx} initial position: {agent_pos}")
-        else:
-            print(f"  Agent {agent_idx} initial position: unknown")
+        initial_positions.append(agent_pos)
+        print(f"  Agent {agent_idx} initial position: {agent_pos}")
 
     # Check if agents are adjacent
     if len(initial_positions) == 2:
@@ -321,11 +317,8 @@ def _test_ghost_movement_with_interference_flag(no_agent_interference: bool):
     final_positions = []
     for agent_idx in range(2):
         agent_pos = get_agent_position(env.__c_env_instance, agent_idx)
-        if agent_pos:
-            final_positions.append(agent_pos)
-            print(f"  Agent {agent_idx} final position: {agent_pos}")
-        else:
-            print(f"  Agent {agent_idx} final position: unknown")
+        final_positions.append(agent_pos)
+        print(f"  Agent {agent_idx} final position: {agent_pos}")
 
     # Analyze results
     if no_agent_interference:

--- a/mettagrid/tests/test_visitation_counts.py
+++ b/mettagrid/tests/test_visitation_counts.py
@@ -2,7 +2,6 @@
 
 import copy
 import time
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -170,13 +169,13 @@ def count_visitation_features_at_center(obs: np.ndarray) -> int:
     return count
 
 
-def get_agent_position(env: MettaGridCore) -> Optional[tuple[int, int]]:
+def get_agent_position(env: MettaGridCore) -> tuple[int, int]:
     """Get the current agent position."""
     grid_objects = env.grid_objects
     for obj in grid_objects.values():
         if "agent_id" in obj:
             return (obj["r"], obj["c"])
-    return None
+    raise ValueError("Agent not found in grid objects")
 
 
 @pytest.mark.skip(reason="Visitation counts not incrementing - needs investigation")


### PR DESCRIPTION
If we can't figure out the agents positions, that should be an error. If there's a reason someone wants to write a test where they're checking the position of an agent that doesn't exist, they can catch that error. But for all the upstanding citizens that only ask about agents that do exist, you now don't need to guard against this returning None.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211164822971260)