### PR TITLE
fix: avoid possible underflow in move action

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/move.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/move.hpp
@@ -39,8 +39,16 @@ protected:
     getOrientationDelta(move_direction, dc, dr);
 
     // Calculate target location
-    target_location.r += dr;
-    target_location.c += dc;
+    int new_r = static_cast<int>(target_location.r) + dr;
+    int new_c = static_cast<int>(target_location.c) + dc;
+
+    if (new_r < 0 || new_r > std::numeric_limits<GridCoord>::max() || new_c < 0 ||
+        new_c > std::numeric_limits<GridCoord>::max()) {
+      return false;
+    }
+
+    target_location.r = static_cast<GridCoord>(new_r);
+    target_location.c = static_cast<GridCoord>(new_c);
 
     // Update orientation to face the movement direction (even if movement fails)
     actor->orientation = move_direction;


### PR DESCRIPTION
### Problem
The `GridCoord` type is `uint16_t` (unsigned), which can cause underflow when agents attempt to move beyond map boundaries. For example, if an agent at position (0, 0) tries to move up (dr = -1), the direct arithmetic `target_location.r += dr` would underflow, wrapping around to 65535 instead of -1.

### Solution
This PR adds proper bounds checking by:
1. Performing position calculations using signed integers
2. Validating that the resulting coordinates are non-negative and within `uint16_t` range
3. Returning early if the movement would result in invalid coordinates

### Changes
- Calculate new position using signed integer arithmetic
- Add bounds check before casting back to `GridCoord`
- Return `false` if movement would cause underflow or exceed valid range

This prevents edge-case bugs where agents could teleport to the opposite side of the map due to unsigned integer wraparound.