### PR TITLE
step1

### DIFF
--- a/experiments/recipes/arena.py
+++ b/experiments/recipes/arena.py
@@ -45,7 +45,7 @@ def make_curriculum(arena_env: Optional[EnvConfig] = None) -> CurriculumConfig:
     for obj in ["mine_red", "generator_red", "altar", "lasery", "armory"]:
         arena_tasks.add_bucket(f"game.objects.{obj}.initial_resource_count", [0, 1])
 
-    return arena_tasks.to_curriculum()
+    return CurriculumConfig(task_generator=arena_tasks)
 
 
 def make_evals(env: Optional[EnvConfig] = None) -> List[SimulationConfig]:

--- a/experiments/recipes/arena_basic_easy_shaped.py
+++ b/experiments/recipes/arena_basic_easy_shaped.py
@@ -69,7 +69,7 @@ def make_curriculum(arena_env: Optional[EnvConfig] = None) -> CurriculumConfig:
     for obj in ["mine_red", "generator_red", "altar", "lasery", "armory"]:
         arena_tasks.add_bucket(f"game.objects.{obj}.initial_resource_count", [0, 1])
 
-    return arena_tasks.to_curriculum()
+    return CurriculumConfig(task_generator=arena_tasks)
 
 
 def make_evals(env: Optional[EnvConfig] = None) -> List[SimulationConfig]:

--- a/experiments/recipes/navigation.py
+++ b/experiments/recipes/navigation.py
@@ -90,7 +90,7 @@ def make_curriculum(nav_env: Optional[EnvConfig] = None) -> CurriculumConfig:
 
     nav_tasks = cc.merge([dense_tasks, sparse_tasks])
 
-    return nav_tasks.to_curriculum()
+    return CurriculumConfig(task_generator=nav_tasks)
 
 
 def train(

--- a/metta/cogworks/curriculum/__init__.py
+++ b/metta/cogworks/curriculum/__init__.py
@@ -46,7 +46,7 @@ def single_task(env_config: EnvConfig) -> SingleTaskGeneratorConfig:
 
 def bucketed(env_config: EnvConfig) -> BucketedTaskGeneratorConfig:
     """Create a BucketedTaskGeneratorConfig from an EnvConfig."""
-    return BucketedTaskGeneratorConfig.from_env_config(env_config.model_copy(deep=True))
+    return BucketedTaskGeneratorConfig.from_env(env_config.model_copy(deep=True))
 
 
 def multi_task(env_config: EnvConfig) -> TaskGeneratorSetConfig:

--- a/metta/cogworks/curriculum/curriculum.py
+++ b/metta/cogworks/curriculum/curriculum.py
@@ -10,9 +10,7 @@ from pydantic import ConfigDict, Field, field_validator
 from metta.common.config import Config
 from metta.mettagrid.mettagrid_config import EnvConfig
 
-from .task_generator import (
-    AnyTaskGeneratorConfig,
-)
+from .task_generator import AnyTaskGeneratorConfig, SingleTaskGeneratorConfig
 
 
 class CurriculumTask:
@@ -51,6 +49,12 @@ class CurriculumConfig(Config):
         validate_assignment=True,
         populate_by_name=True,
     )
+
+    @classmethod
+    def from_env_config(cls, env_config: EnvConfig) -> CurriculumConfig:
+        return cls(
+            task_generator=SingleTaskGeneratorConfig(env=env_config),
+        )
 
     @field_validator("num_active_tasks")
     @classmethod

--- a/metta/cogworks/curriculum/curriculum.py
+++ b/metta/cogworks/curriculum/curriculum.py
@@ -51,7 +51,7 @@ class CurriculumConfig(Config):
     )
 
     @classmethod
-    def from_env_config(cls, env_config: EnvConfig) -> CurriculumConfig:
+    def from_env(cls, env_config: EnvConfig) -> CurriculumConfig:
         return cls(
             task_generator=SingleTaskGeneratorConfig(env=env_config),
         )

--- a/metta/cogworks/curriculum/demo.py
+++ b/metta/cogworks/curriculum/demo.py
@@ -23,7 +23,7 @@ for item in arena.game.inventory_item_names:
 # to maintain action space consistency.
 arena_tasks.add_bucket("game.actions.attack.consumed_resources.laser", [1, 100])
 
-curriculum_cfg = arena_tasks.to_curriculum(num_tasks=4)
+curriculum_cfg = CurriculumConfig(task_generator=arena_tasks)
 
 print(curriculum_cfg.model_dump_json(indent=2))
 print(curriculum_cfg.task_generator.model_dump_json(indent=2))

--- a/metta/cogworks/curriculum/task_generator.py
+++ b/metta/cogworks/curriculum/task_generator.py
@@ -67,14 +67,6 @@ class TaskGeneratorConfig(Config, Generic[TTaskGenerator]):
             )
         return cls._generator_cls
 
-    def to_curriculum(self, num_tasks: Optional[int] = None) -> "CurriculumConfig":
-        """Create a CurriculumConfig from this configuration."""
-        from metta.cogworks.curriculum.curriculum import CurriculumConfig
-
-        cc = CurriculumConfig(task_generator=self)
-        cc.num_active_tasks = num_tasks or cast(int, cc.num_active_tasks)
-        return cc
-
     @model_serializer(mode="wrap")
     def _serialize_with_type(self, handler):
         """Ensure YAML/JSON dumps always include a 'type' with a nice FQCN."""
@@ -256,7 +248,7 @@ class BucketedTaskGenerator(TaskGenerator):
             return self
 
         @classmethod
-        def from_env_config(cls, env_config: EnvConfig) -> "BucketedTaskGenerator.Config":
+        def from_env(cls, env_config: EnvConfig) -> "BucketedTaskGenerator.Config":
             """Create a BucketedTaskGenerator.Config from an EnvConfig."""
             return cls(child_generator_config=SingleTaskGenerator.Config(env=env_config))
 

--- a/metta/rl/trainer.py
+++ b/metta/rl/trainer.py
@@ -57,6 +57,7 @@ from metta.rl.wandb import (
     log_model_parameters,
     setup_wandb_metrics,
 )
+from metta.sim.simulation_config import SimulationConfig
 from metta.utils.batch import calculate_batch_sizes, calculate_prioritized_sampling_params
 
 try:
@@ -519,7 +520,10 @@ def train(
                         ).id
 
                     sims = [
-                        curriculum.get_task().get_env_cfg().to_sim(f"train_task_{i}")
+                        SimulationConfig(
+                            name=f"train_task_{i}",
+                            env=curriculum.get_task().get_env_cfg(),
+                        )
                         for i in range(trainer_cfg.evaluation.num_training_tasks)
                     ]
                     sims.extend(trainer_cfg.evaluation.simulations)

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -23,6 +23,7 @@ from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicyStore
 from metta.agent.utils import obs_to_td
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.cogworks.curriculum.curriculum import CurriculumConfig
 from metta.common.util.heartbeat import record_heartbeat
 from metta.mettagrid import MettaGridEnv, dtype_actions
 from metta.mettagrid.replay_writer import ReplayWriter
@@ -104,7 +105,7 @@ class Simulation:
         )
 
         self._vecenv = make_vecenv(
-            cfg.env.to_curriculum(),
+            CurriculumConfig.from_env(cfg.env),
             vectorization,
             num_envs=num_envs,
             stats_writer=self._stats_writer,

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -6,8 +6,6 @@ from metta.common.config import Config
 from metta.mettagrid.map_builder.ascii import AsciiMapBuilder
 from metta.mettagrid.map_builder.random import RandomMapBuilder
 
-if TYPE_CHECKING:
-    from metta.sim.simulation_config import SimulationConfig
 from metta.mettagrid.map_builder.map_builder import AnyMapBuilderConfig
 
 # ===== Python Configuration Models =====
@@ -231,14 +229,6 @@ class EnvConfig(Config):
     @model_validator(mode="after")
     def validate_fields(self) -> "EnvConfig":
         return self
-
-    def to_sim(self, name: str) -> "SimulationConfig":
-        from metta.sim.simulation_config import SimulationConfig
-
-        return SimulationConfig(
-            name=name,
-            env=self,
-        )
 
     def with_ascii_map(self, map_data: list[list[str]]) -> "EnvConfig":
         self.game.map_builder = AsciiMapBuilder.Config(map_data=map_data)

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -232,11 +232,6 @@ class EnvConfig(Config):
     def validate_fields(self) -> "EnvConfig":
         return self
 
-    def to_curriculum(self):
-        from metta.cogworks.curriculum.curriculum import Curriculum
-
-        return Curriculum(self.to_curriculum_cfg())
-
     def to_sim(self, name: str) -> "SimulationConfig":
         from metta.sim.simulation_config import SimulationConfig
 

--- a/mettagrid/src/metta/mettagrid/mettagrid_config.py
+++ b/mettagrid/src/metta/mettagrid/mettagrid_config.py
@@ -7,7 +7,6 @@ from metta.mettagrid.map_builder.ascii import AsciiMapBuilder
 from metta.mettagrid.map_builder.random import RandomMapBuilder
 
 if TYPE_CHECKING:
-    from metta.cogworks.curriculum.curriculum import CurriculumConfig
     from metta.sim.simulation_config import SimulationConfig
 from metta.mettagrid.map_builder.map_builder import AnyMapBuilderConfig
 
@@ -232,14 +231,6 @@ class EnvConfig(Config):
     @model_validator(mode="after")
     def validate_fields(self) -> "EnvConfig":
         return self
-
-    def to_curriculum_cfg(self) -> "CurriculumConfig":
-        from metta.cogworks.curriculum.curriculum import CurriculumConfig
-        from metta.cogworks.curriculum.task_generator import SingleTaskGeneratorConfig
-
-        return CurriculumConfig(
-            task_generator=SingleTaskGeneratorConfig(env=self),
-        )
 
     def to_curriculum(self):
         from metta.cogworks.curriculum.curriculum import Curriculum

--- a/tests/cogworks/curriculum/test_serialization.py
+++ b/tests/cogworks/curriculum/test_serialization.py
@@ -44,8 +44,7 @@ class TestCurriculumConfigSerialization(unittest.TestCase):
         arena_tasks.add_bucket("game.level_map.height", [10, 20, 30])
         arena_tasks.add_bucket("game.agent.rewards.inventory.ore_red", [0, vr.vr(0, 1.0)])
 
-        original = arena_tasks.to_curriculum(num_tasks=5)
-
+        original = CurriculumConfig(task_generator=arena_tasks)
         # Serialize and deserialize
         json_str = original.model_dump_json()
         restored = CurriculumConfig.model_validate_json(json_str)

--- a/tests/cogworks/curriculum/test_serialization.py
+++ b/tests/cogworks/curriculum/test_serialization.py
@@ -100,7 +100,7 @@ class TestCurriculumConfigSerialization(unittest.TestCase):
         # Add bucket with ValueRange
         arena_tasks.add_bucket("test.param", [0, vr.vr(0.5, 1.5), 2])
 
-        original = arena_tasks.to_curriculum()
+        original = CurriculumConfig(task_generator=arena_tasks)
 
         # Serialize and deserialize
         json_str = original.model_dump_json()


### PR DESCRIPTION
step1

refactor: remove to_curriculum methods in favor of direct construction

- Remove to_curriculum() from TaskGeneratorConfig and EnvConfig
- Rename from_env_config() to from_env() for consistency
- Update recipes to use CurriculumConfig(task_generator=...) directly
- Clean up imports and method signatures

remove dependencies on metta from mettagrid