### PR TITLE
Rename some env_cfg to cfg

### DIFF
--- a/mettagrid/tests/test_env_config_serialization.py
+++ b/mettagrid/tests/test_env_config_serialization.py
@@ -12,10 +12,10 @@ def test_env_config_map_builder_serialization():
     """Test that map_builder polymorphic serialization includes all fields."""
 
     # Create config with specific map_builder parameters
-    env_config = MettaGridConfig.EmptyRoom(num_agents=24, border_width=0)
+    config = MettaGridConfig.EmptyRoom(num_agents=24, border_width=0)
 
     # Serialize to JSON and parse back
-    config_json = env_config.model_dump_json(indent=2)
+    config_json = config.model_dump_json(indent=2)
     config_dict = json.loads(config_json)
 
     # Verify that map_builder contains all expected fields
@@ -48,12 +48,12 @@ def test_env_config_custom_map_builder():
     )
 
     # Create env config with custom map builder
-    env_config = MettaGridConfig()
-    env_config.game.map_builder = custom_map_builder
-    env_config.game.num_agents = 12
+    config = MettaGridConfig()
+    config.game.map_builder = custom_map_builder
+    config.game.num_agents = 12
 
     # Serialize and verify
-    config_dict = env_config.model_dump()
+    config_dict = config.model_dump()
     map_builder = config_dict["game"]["map_builder"]
 
     assert map_builder["type"] == "metta.mettagrid.map_builder.random.RandomMapBuilder"

--- a/mettagrid/tests/test_env_map.py
+++ b/mettagrid/tests/test_env_map.py
@@ -3,8 +3,8 @@ from metta.mettagrid.mettagrid_config import MettaGridConfig
 
 
 def test_env_map():
-    env_config = MettaGridConfig.EmptyRoom(width=3, height=4, num_agents=1, border_width=1)
-    env = MettaGridGymEnv(env_config=env_config, render_mode="human")
+    config = MettaGridConfig.EmptyRoom(width=3, height=4, num_agents=1, border_width=1)
+    env = MettaGridGymEnv(env_config=config, render_mode="human")
 
     # The map dimensions should match the specified width/height
     assert env.map_width == 3

--- a/mettagrid/tests/test_interactive.py
+++ b/mettagrid/tests/test_interactive.py
@@ -80,7 +80,7 @@ def test_gym_env():
     print("=" * 50)
 
     # Create environment with a simple map
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -101,7 +101,7 @@ def test_gym_env():
         )
     )
 
-    env = MettaGridGymEnv(env_cfg, render_mode="human")
+    env = MettaGridGymEnv(cfg, render_mode="human")
 
     print("Environment created!")
     print(f"- Agents: {env.num_agents}")
@@ -140,7 +140,7 @@ def test_pettingzoo_env():
     print("=" * 50)
 
     # Create environment with a simple map for 3 agents
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=3,
             actions=ActionsConfig(
@@ -167,7 +167,7 @@ def test_pettingzoo_env():
         )
     )
 
-    env = MettaGridPettingZooEnv(env_cfg, render_mode="human")
+    env = MettaGridPettingZooEnv(cfg, render_mode="human")
 
     print("Environment created!")
     print(f"- Max agents: {env.max_num_agents}")

--- a/mettagrid/tests/test_mettagrid.py
+++ b/mettagrid/tests/test_mettagrid.py
@@ -13,7 +13,7 @@ NUM_OBS_TOKENS = 50
 @pytest.fixture
 def basic_env() -> MettaGrid:
     """Create a basic test environment with 8x4 grid and 2 agents."""
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=2,
             obs_width=3,
@@ -32,7 +32,7 @@ def basic_env() -> MettaGrid:
             ),
         )
     )
-    return MettaGridCore(env_cfg)
+    return MettaGridCore(cfg)
 
 
 class TestBasicFunctionality:

--- a/mettagrid/tests/test_move.py
+++ b/mettagrid/tests/test_move.py
@@ -122,7 +122,7 @@ def configured_env(base_config):
 # Tests for MettaGridCore (low-level API)
 def test_8way_movement_all_directions():
     """Test 8-way movement in all eight directions using MettaGridCore."""
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -142,7 +142,7 @@ def test_8way_movement_all_directions():
             allow_diagonals=True,
         )
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects
@@ -186,7 +186,7 @@ def test_8way_movement_all_directions():
 
 def test_8way_movement_obstacles():
     """Test that 8-way movement respects obstacles."""
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -206,7 +206,7 @@ def test_8way_movement_obstacles():
             ),
         )
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects
@@ -239,7 +239,7 @@ def test_8way_movement_obstacles():
 
 def test_orientation_changes_with_8way():
     """Test that orientation changes to match movement direction with 8-way movement."""
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -256,7 +256,7 @@ def test_orientation_changes_with_8way():
             ),
         ),
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects
@@ -325,7 +325,7 @@ def test_orientation_changes_with_8way():
 def test_8way_movement_with_simple_environment():
     """Test 8-way movement using the simple environment builder."""
     # Create a larger environment to test diagonal movements
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -348,7 +348,7 @@ def test_8way_movement_with_simple_environment():
             allow_diagonals=True,
         ),
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects
@@ -391,7 +391,7 @@ def test_8way_movement_with_simple_environment():
 def test_8way_movement_boundary_check():
     """Test 8-way movement respects environment boundaries."""
     # Small environment to easily test boundaries
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             actions=ActionsConfig(
@@ -409,7 +409,7 @@ def test_8way_movement_boundary_check():
             allow_diagonals=True,
         )
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects
@@ -452,7 +452,7 @@ def test_8way_movement_boundary_check():
 
 def test_orientation_changes_on_failed_8way_movement():
     """Test that orientation DOES change when 8-way movement fails due to obstacles (new behavior)."""
-    env_cfg = MettaGridConfig(
+    cfg = MettaGridConfig(
         game=GameConfig(
             num_agents=1,
             allow_diagonals=True,  # Enable diagonal movements for this test
@@ -470,7 +470,7 @@ def test_orientation_changes_on_failed_8way_movement():
             ),
         )
     )
-    env = MettaGridCore(env_cfg)
+    env = MettaGridCore(cfg)
     env.reset()
 
     objects = env.grid_objects

--- a/mettagrid/tests/test_resource_loss.py
+++ b/mettagrid/tests/test_resource_loss.py
@@ -11,17 +11,17 @@ class TestResourceLoss:
     def test_resource_loss_prob_1_0_causes_complete_loss(self):
         """Test that resource_loss_prob=1.0 causes all items to be lost in the next timestep."""
         # Create a simple environment with resource_loss_prob=1.0
-        env_cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
             [
                 ["#", "#", "#"],
                 ["#", "@", "#"],
                 ["#", "#", "#"],
             ]
         )
-        env_cfg.game.resource_loss_prob = 1.0
-        env_cfg.game.agent.initial_inventory = {"heart": 5, "battery_blue": 3}
-        env_cfg.game.actions.noop.enabled = True
-        env = MettaGridCore(env_cfg)
+        cfg.game.resource_loss_prob = 1.0
+        cfg.game.agent.initial_inventory = {"heart": 5, "battery_blue": 3}
+        cfg.game.actions.noop.enabled = True
+        env = MettaGridCore(cfg)
 
         # Reset environment
         obs, info = env.reset()
@@ -70,17 +70,17 @@ class TestResourceLoss:
     def test_resource_loss_prob_0_0_causes_no_loss(self):
         """Test that resource_loss_prob=0.0 causes no items to be lost."""
         # Create a simple environment with resource_loss_prob=0.0
-        env_cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
             [
                 ["#", "#", "#"],
                 ["#", "@", "#"],
                 ["#", "#", "#"],
             ]
         )
-        env_cfg.game.resource_loss_prob = 0.0
-        env_cfg.game.agent.initial_inventory = {"heart": 5, "battery_blue": 3}
-        env_cfg.game.actions.noop.enabled = True
-        env = MettaGridCore(env_cfg)
+        cfg.game.resource_loss_prob = 0.0
+        cfg.game.agent.initial_inventory = {"heart": 5, "battery_blue": 3}
+        cfg.game.actions.noop.enabled = True
+        env = MettaGridCore(cfg)
 
         # Reset environment
         obs, info = env.reset()
@@ -130,19 +130,19 @@ class TestResourceLoss:
     def test_resource_loss_prob_0_5_causes_partial_loss(self):
         """Test that resource_loss_prob=0.5 causes some items to be lost over multiple steps."""
         # Create a simple environment with resource_loss_prob=0.5
-        env_cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
             [
                 ["#", "#", "#"],
                 ["#", "@", "#"],
                 ["#", "#", "#"],
             ]
         )
-        env_cfg.game.actions.noop.enabled = True
-        env_cfg.game.resource_loss_prob = 0.5
-        env_cfg.game.agent.initial_inventory = {"heart": 100}
+        cfg.game.actions.noop.enabled = True
+        cfg.game.resource_loss_prob = 0.5
+        cfg.game.agent.initial_inventory = {"heart": 100}
 
         # Create environment with resource_loss_prob=0.5 and initial inventory
-        env = MettaGridCore(env_cfg)
+        env = MettaGridCore(cfg)
 
         # Reset environment
         obs, info = env.reset()

--- a/tests/cogworks/curriculum/test_curriculum.py
+++ b/tests/cogworks/curriculum/test_curriculum.py
@@ -19,12 +19,12 @@ class TestCurriculumTask:
     def test_curriculum_task_creation(self):
         """Test creating a CurriculumTask with required parameters."""
         task_id = 123
-        env_cfg = MettaGridConfig()
+        cfg = MettaGridConfig()
 
-        task = CurriculumTask(task_id, env_cfg)
+        task = CurriculumTask(task_id, cfg)
 
         assert task._task_id == task_id
-        assert task._env_cfg == env_cfg
+        assert task._env_cfg == cfg
         assert task._num_completions == 0
         assert task._total_score == 0.0
         assert task._mean_score == 0.0
@@ -32,10 +32,10 @@ class TestCurriculumTask:
 
     def test_curriculum_task_get_env_cfg(self):
         """Test that get_env_cfg returns the correct env config."""
-        env_cfg = MettaGridConfig()
-        task = CurriculumTask(123, env_cfg)
+        cfg = MettaGridConfig()
+        task = CurriculumTask(123, cfg)
 
-        assert task.get_env_cfg() is env_cfg
+        assert task.get_env_cfg() is cfg
 
     def test_curriculum_task_complete(self):
         """Test task completion updates statistics."""

--- a/tests/cogworks/curriculum/test_task.py
+++ b/tests/cogworks/curriculum/test_task.py
@@ -9,49 +9,49 @@ class TestTask:
 
     def test_task_creation(self):
         """Test creating a Task with required parameters."""
-        env_cfg = MettaGridConfig()
+        cfg = MettaGridConfig()
         task_id = "test_task"
-        task = Task(task_id=task_id, env_cfg=env_cfg)
+        task = Task(task_id=task_id, env_cfg=cfg)
 
-        assert task.env_cfg == env_cfg
-        assert task.get_env_config() == env_cfg
+        assert task.env_cfg == cfg
+        assert task.get_env_config() == cfg
         assert task.get_id() == task_id
 
     def test_task_with_custom_id(self):
         """Test creating a Task with different IDs."""
-        env_cfg = MettaGridConfig()
+        cfg = MettaGridConfig()
         custom_id = "my_custom_task_42"
-        task = Task(task_id=custom_id, env_cfg=env_cfg)
+        task = Task(task_id=custom_id, env_cfg=cfg)
 
-        assert task.env_cfg == env_cfg
-        assert task.get_env_config() == env_cfg
+        assert task.env_cfg == cfg
+        assert task.get_env_config() == cfg
         assert task.get_id() == custom_id
 
     def test_task_with_different_env_configs(self):
         """Test tasks with different env configs."""
         # Create env configs with different values
-        env_cfg1 = MettaGridConfig(game=GameConfig(num_agents=1))
-        env_cfg2 = MettaGridConfig(game=GameConfig(num_agents=2))
+        cfg1 = MettaGridConfig(game=GameConfig(num_agents=1))
+        cfg2 = MettaGridConfig(game=GameConfig(num_agents=2))
 
-        task1 = Task(task_id="task1", env_cfg=env_cfg1)
-        task2 = Task(task_id="task2", env_cfg=env_cfg2)
+        task1 = Task(task_id="task1", env_cfg=cfg1)
+        task2 = Task(task_id="task2", env_cfg=cfg2)
 
         assert task1.get_env_config() != task2.get_env_config()
         assert task1.get_id() != task2.get_id()
 
     def test_task_immutability_assumption(self):
         """Test that Task preserves env_config reference."""
-        env_cfg = MettaGridConfig()
-        task = Task(task_id="test", env_cfg=env_cfg)
+        cfg = MettaGridConfig()
+        task = Task(task_id="test", env_cfg=cfg)
 
         # Task should maintain reference to the same env_config object
-        assert task.get_env_config() is env_cfg
-        assert task.env_cfg is env_cfg
+        assert task.get_env_config() is cfg
+        assert task.env_cfg is cfg
 
     def test_task_str_representation(self):
         """Test that task has reasonable string representation."""
-        env_cfg = MettaGridConfig()
-        task = Task(task_id="test_task", env_cfg=env_cfg)
+        cfg = MettaGridConfig()
+        task = Task(task_id="test_task", env_cfg=cfg)
 
         # Should be able to convert to string without error
         str_repr = str(task)
@@ -59,11 +59,11 @@ class TestTask:
 
     def test_task_instances_are_unique(self):
         """Test that each Task instance is unique."""
-        env_cfg = MettaGridConfig()
+        cfg = MettaGridConfig()
 
-        task1 = Task(task_id="task1", env_cfg=env_cfg)
-        task2 = Task(task_id="task1", env_cfg=env_cfg)  # Same ID and config
-        task3 = Task(task_id="task2", env_cfg=env_cfg)
+        task1 = Task(task_id="task1", env_cfg=cfg)
+        task2 = Task(task_id="task1", env_cfg=cfg)  # Same ID and config
+        task3 = Task(task_id="task2", env_cfg=cfg)
 
         # Each instance should be unique (no __eq__ override)
         assert task1 is not task2

--- a/tests/test_programmatic_env_creation.py
+++ b/tests/test_programmatic_env_creation.py
@@ -25,7 +25,7 @@ class TestProgrammaticEnvironments:
 
     def test_create_simple_environment(self):
         """Test creating a simple environment with basic components."""
-        env_config = MettaGridConfig(
+        config = MettaGridConfig(
             label="test_simple",
             game=GameConfig(
                 num_agents=4,
@@ -55,11 +55,11 @@ class TestProgrammaticEnvironments:
             ),
         )
 
-        assert env_config.label == "test_simple"
-        assert env_config.game.num_agents == 4
-        assert env_config.game.max_steps == 100
-        assert "wall" in env_config.game.objects
-        assert env_config.game.actions.move is not None
+        assert config.label == "test_simple"
+        assert config.game.num_agents == 4
+        assert config.game.max_steps == 100
+        assert "wall" in config.game.objects
+        assert config.game.actions.move is not None
 
     def test_create_arena_like_environment(self):
         """Test creating an arena-style environment similar to experiments/arena.py."""
@@ -91,7 +91,7 @@ class TestProgrammaticEnvironments:
 
     def test_environment_with_custom_rewards(self):
         """Test creating an environment with custom reward configuration."""
-        env_config = MettaGridConfig(
+        config = MettaGridConfig(
             label="custom_rewards",
             game=GameConfig(
                 num_agents=2,
@@ -128,20 +128,20 @@ class TestProgrammaticEnvironments:
         )
 
         # Verify custom rewards are set
-        rewards = env_config.game.agent.rewards.inventory
+        rewards = config.game.agent.rewards.inventory
         assert rewards["heart"] == 1.0
         assert rewards["ore_red"] == 0.5
         assert rewards["battery_red"] == 0.8
 
         # Verify resource limits
-        limits = env_config.game.agent.resource_limits
+        limits = config.game.agent.resource_limits
         assert limits["heart"] == 255
         assert limits["ore_red"] == 10
         assert limits["battery_red"] == 5
 
     def test_environment_with_groups(self):
         """Test creating an environment with agent groups."""
-        env_config = MettaGridConfig(
+        config = MettaGridConfig(
             label="groups_test",
             game=GameConfig(
                 num_agents=6,
@@ -186,14 +186,14 @@ class TestProgrammaticEnvironments:
             ),
         )
 
-        assert len(env_config.game.groups) == 2
-        assert "team_a" in env_config.game.groups
-        assert "team_b" in env_config.game.groups
-        assert env_config.game.groups["team_a"].id == 0
-        assert env_config.game.groups["team_b"].id == 1
+        assert len(config.game.groups) == 2
+        assert "team_a" in config.game.groups
+        assert "team_b" in config.game.groups
+        assert config.game.groups["team_a"].id == 0
+        assert config.game.groups["team_b"].id == 1
 
         # This would be a good addition to the test, but we don't currently expose cpp_config.objects.
-        # cpp_config = convert_to_cpp_game_config(env_config.game)
+        # cpp_config = convert_to_cpp_game_config(config.game)
         # # The keys will be ints, but the values should be easy to check. Did we merge correctly?
         # assert set(cpp_config.objects["agent.team_a"]["resource_rewards"].values()) == {0.5, 0.8, 2}
         # assert set(cpp_config.objects["agent.team_b"]["resource_rewards"].values()) == {0.5, 0.8, 1}
@@ -203,10 +203,10 @@ class TestProgrammaticEnvironments:
         """Test that programmatic environments work with MettaGridEnv."""
 
         # Create environment config
-        env_config = eb.make_navigation(num_agents=2)
+        config = eb.make_navigation(num_agents=2)
 
         # Initialize the actual environment
-        env = MettaGridEnv(env_config)
+        env = MettaGridEnv(config)
 
         try:
             # Reset and verify

--- a/tests/tools/test_opportunistic_policy.py
+++ b/tests/tools/test_opportunistic_policy.py
@@ -8,8 +8,8 @@
 # TODO: (richard) #dehydration
 # @pytest.fixture
 # def env_with_agent_and_resource():
-#     env_cfg = MettaGridConfig.EmptyRoom(num_agents=1)
-#     env = MettaGridEnv(env_cfg, render_mode="human")
+#     cfg = MettaGridConfig.EmptyRoom(num_agents=1)
+#     env = MettaGridEnv(cfg, render_mode="human")
 #     obs, _ = env.reset()
 #     assert obs.dtype == dtype_observations
 #     try:

--- a/tests/tools/test_policy_selection.py
+++ b/tests/tools/test_policy_selection.py
@@ -8,8 +8,8 @@
 # TODO: (richard) #dehydration
 # @pytest.fixture
 # def tiny_env():
-#     env_cfg = MettaGridConfig.EmptyRoom(num_agents=1)
-#     env = MettaGridEnv(env_cfg, render_mode="human")
+#     cfg = MettaGridConfig.EmptyRoom(num_agents=1)
+#     env = MettaGridEnv(cfg, render_mode="human")
 #     obs, _ = env.reset()
 #     assert obs.dtype == dtype_observations
 #     try:


### PR DESCRIPTION
We want to rename `EnvConfig → MettaGridConfig`, which means all `env_cfg` variables should also be renamed. Since our tests are currently split between calling `EnvConfig`s `env_cfg` vs `cfg`, it seems like we can just rename them all to `cfg` to sidestep the [near] future issue of `EnvConfig` being renamed.

I.e., let's rename to make things generic now, to make a future rename a little easier to review.

https://app.asana.com/1/1209016784099267/project/1209096222434381/task/1211112167711541?focus=true

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211167017685732)