### PR TITLE
Make monitor/gpu_available wandb log a float, not a bool

### DIFF
--- a/common/src/metta/common/util/system_monitor.py
+++ b/common/src/metta/common/util/system_monitor.py
@@ -150,7 +150,7 @@ class SystemMonitor:
             self._metric_collectors.update(
                 {
                     "gpu_count": lambda: 1,  # MPS presents as single device
-                    "gpu_available": lambda: torch.backends.mps.is_available(),
+                    "gpu_available": lambda: float(torch.backends.mps.is_available()),
                 }
             )
             self.logger.info("GPU monitoring enabled via MPS (Apple Silicon)")


### PR DESCRIPTION
so it shows up in wandb charts nicely


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211178392483015)