### PR TITLE
# feat: Auto-Config Fixes, Cloud CLI Support, and Environment Variable Consolidation

### DIFF
--- a/metta/setup/saved_settings.py
+++ b/metta/setup/saved_settings.py
@@ -111,6 +111,23 @@ class SavedSettings:
             for key, value in settings.items():
                 self.set(f"components.{component}.{key}", value)
 
+    def get_cloud_config(self, key: str | None = None) -> dict | str | None:
+        """Get cloud-specific configuration."""
+        if key:
+            return self.get(f"cloud_config.{key}", None)
+        return self.get("cloud_config", {})
+
+    def set_cloud_config(self, key: str, value: str | None) -> None:
+        """Set cloud-specific configuration."""
+        if value is None:
+            # Remove the key if value is None
+            cloud_config = self.get("cloud_config", {})
+            if key in cloud_config:
+                del cloud_config[key]
+                self.set("cloud_config", cloud_config)
+        else:
+            self.set(f"cloud_config.{key}", value)
+
 
 @functools.cache
 def get_saved_settings(config_path: Path | None = None) -> SavedSettings:

--- a/metta/tools/play.py
+++ b/metta/tools/play.py
@@ -9,7 +9,7 @@ from metta.common.util.constants import DEV_METTASCOPE_FRONTEND_URL
 from metta.common.wandb.wandb_context import WandbConfig
 from metta.sim.simulation import Simulation
 from metta.sim.simulation_config import SimulationConfig
-from metta.tools.utils.auto_config import auto_wandb_config
+from metta.tools.utils.auto_config import auto_replay_dir, auto_wandb_config
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +25,8 @@ class PlayTool(Tool):
 
     @property
     def effective_replay_dir(self) -> str:
-        """Get the replay directory, defaulting to system.data_dir/replays if not specified."""
-        return self.replay_dir if self.replay_dir is not None else f"{self.system.data_dir}/replays"
+        """Get the replay directory, using auto_replay_dir if not specified."""
+        return self.replay_dir if self.replay_dir is not None else auto_replay_dir()
 
     @property
     def effective_stats_dir(self) -> str:

--- a/metta/tools/replay.py
+++ b/metta/tools/replay.py
@@ -11,7 +11,7 @@ from metta.common.util.constants import DEV_METTASCOPE_FRONTEND_URL
 from metta.common.wandb.wandb_context import WandbConfig
 from metta.sim.simulation import Simulation
 from metta.sim.simulation_config import SimulationConfig
-from metta.tools.utils.auto_config import auto_wandb_config
+from metta.tools.utils.auto_config import auto_replay_dir, auto_wandb_config
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +22,14 @@ class ReplayTool(Tool):
     sim: SimulationConfig
     policy_uri: str | None = None
     selector_type: str = "latest"
-    replay_dir: str = "./train_dir/replays"
+    replay_dir: str | None = None
     stats_dir: str = "./train_dir/stats"
     open_browser_on_start: bool = True
 
     def invoke(self, args: dict[str, str], overrides: list[str]) -> int | None:
+        # Use auto_replay_dir if not specified
+        effective_replay_dir = self.replay_dir if self.replay_dir is not None else auto_replay_dir()
+
         # Create policy store directly without WandbContext
         policy_store = PolicyStore.create(
             device=self.system.device,
@@ -42,7 +45,7 @@ class ReplayTool(Tool):
             device=self.system.device,
             vectorization=self.system.vectorization,
             stats_dir=self.stats_dir,
-            replay_dir=self.replay_dir,
+            replay_dir=effective_replay_dir,
             policy_uri=self.policy_uri,
             run_name="replay_run",
         )

--- a/metta/tools/sim.py
+++ b/metta/tools/sim.py
@@ -22,12 +22,11 @@ from metta.agent.policy_record import PolicyRecord
 from metta.agent.policy_store import PolicySelectorType, PolicyStore
 from metta.app_backend.clients.stats_client import StatsClient
 from metta.common.config.tool import Tool
-from metta.common.util.constants import SOFTMAX_S3_BASE
 from metta.common.wandb.wandb_context import WandbConfig
 from metta.eval.eval_service import evaluate_policy
 from metta.rl.stats import process_policy_evaluator_stats
 from metta.sim.simulation_config import SimulationConfig
-from metta.tools.utils.auto_config import auto_wandb_config
+from metta.tools.utils.auto_config import auto_replay_dir, auto_wandb_config
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ class SimTool(Tool):
     # required params:
     simulations: Sequence[SimulationConfig]  # list of simulations to run
     policy_uris: str | Sequence[str] | None = None  # list of policy uris to evaluate
-    replay_dir: str = Field(default=f"{SOFTMAX_S3_BASE}/replays/{str(uuid.uuid4())}")
+    replay_dir: str = Field(default_factory=lambda: f"{auto_replay_dir()}/{str(uuid.uuid4())}")
 
     wandb: WandbConfig = auto_wandb_config()
 

--- a/metta/tools/train.py
+++ b/metta/tools/train.py
@@ -19,7 +19,12 @@ from metta.common.wandb.wandb_context import WandbConfig, WandbContext, WandbRun
 from metta.core.distributed import TorchDistributedConfig, setup_torch_distributed
 from metta.rl.trainer import train
 from metta.rl.trainer_config import TrainerConfig
-from metta.tools.utils.auto_config import auto_replay_dir, auto_stats_server_uri, auto_wandb_config
+from metta.tools.utils.auto_config import (
+    auto_replay_dir,
+    auto_stats_server_uri,
+    auto_torch_profile_dir,
+    auto_wandb_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +177,11 @@ def _configure_evaluation_settings(cfg: TrainTool) -> StatsClient | None:
     if cfg.trainer.evaluation.replay_dir is None:
         cfg.trainer.evaluation.replay_dir = auto_replay_dir()
         log_on_master(f"Setting replay_dir to {cfg.trainer.evaluation.replay_dir}")
+
+    # Auto-configure torch profiler directory if not set
+    if cfg.trainer.profiler.profile_dir is None:
+        cfg.trainer.profiler.profile_dir = auto_torch_profile_dir()
+        log_on_master(f"Setting torch profile_dir to {cfg.trainer.profiler.profile_dir}")
 
     stats_client: StatsClient | None = None
     if cfg.stats_server_uri is not None:

--- a/tests/tools/test_auto_config.py
+++ b/tests/tools/test_auto_config.py
@@ -1,0 +1,41 @@
+"""Tests for auto_config functions."""
+
+from unittest.mock import Mock, patch
+
+from metta.tools.utils.auto_config import auto_replay_dir, auto_torch_profile_dir
+
+
+class TestAutoConfig:
+    """Test auto configuration functions."""
+
+    def test_auto_replay_dir_external_user(self):
+        """External users should get local replay directory."""
+        with patch("metta.tools.utils.auto_config.AWSSetup") as mock_aws_setup:
+            mock_setup = Mock()
+            mock_setup.to_config_settings.return_value = {"replay_dir": "./train_dir/replays/"}
+            mock_aws_setup.return_value = mock_setup
+
+            result = auto_replay_dir()
+            assert result == "./train_dir/replays/"
+
+
+    def test_auto_torch_profile_dir_external_user(self):
+        """External users should get local torch profile directory."""
+        with patch("metta.setup.saved_settings.get_saved_settings") as mock_settings:
+            mock_saved = Mock()
+            mock_saved.user_type.is_softmax = False
+            mock_settings.return_value = mock_saved
+
+            result = auto_torch_profile_dir()
+            assert result == "./train_dir/torch_traces/"
+
+    def test_auto_torch_profile_dir_softmax_user(self):
+        """Softmax users should get S3 torch profile directory."""
+        with patch("metta.setup.saved_settings.get_saved_settings") as mock_settings:
+            mock_saved = Mock()
+            mock_saved.user_type.is_softmax = True
+            mock_settings.return_value = mock_saved
+
+            result = auto_torch_profile_dir()
+            assert result == "s3://softmax-public/torch_traces/"
+

--- a/tests/tools/test_auto_config.py
+++ b/tests/tools/test_auto_config.py
@@ -18,7 +18,6 @@ class TestAutoConfig:
             result = auto_replay_dir()
             assert result == "./train_dir/replays/"
 
-
     def test_auto_torch_profile_dir_external_user(self):
         """External users should get local torch profile directory."""
         with patch("metta.setup.saved_settings.get_saved_settings") as mock_settings:
@@ -39,3 +38,25 @@ class TestAutoConfig:
             result = auto_torch_profile_dir()
             assert result == "s3://softmax-public/torch_traces/"
 
+    def test_auto_config_cloud_user_with_s3_bucket(self):
+        """Cloud users with S3 bucket configured should get custom S3 paths."""
+        from metta.setup.profiles import UserType
+
+        with patch("metta.setup.saved_settings.get_saved_settings") as mock_settings:
+            mock_saved = Mock()
+            mock_saved.user_type = UserType.CLOUD
+            mock_saved.get_cloud_config.return_value = {"s3_bucket": "my-company-bucket"}
+            mock_settings.return_value = mock_saved
+
+            # Test replay_dir uses cloud config
+            with patch("metta.tools.utils.auto_config.AWSSetup") as mock_aws_setup:
+                mock_setup = Mock()
+                mock_setup.to_config_settings.return_value = {"replay_dir": "./train_dir/replays/"}
+                mock_aws_setup.return_value = mock_setup
+
+                result = auto_replay_dir()
+                assert result == "s3://my-company-bucket/replays/"
+
+            # Test torch_profile_dir uses cloud config
+            result = auto_torch_profile_dir()
+            assert result == "s3://my-company-bucket/torch_traces/"


### PR DESCRIPTION
# feat: Auto-Config Fixes, Cloud CLI Support, and Environment Variable Consolidation

## Summary

This PR implements three major configuration system improvements:

1. **Fixed critical auto-config bugs** - External users were getting S3 paths instead of local paths
2. **Added cloud user CLI support** - `metta configure cloud` with persistent settings
3. **Consolidated environment variables** - Reduced 3 pydantic classes to 1 unified class

## What Changed

### 1. Critical Bug Fixes
- **Fixed `sim.py` S3 hardcoding** - All users were getting S3 paths (now profile-appropriate)
- **Added missing functions** - `auto_torch_profile_dir()` and `auto_checkpoint_dir()` were missing
- **Updated 4 tool files** - Consistent auto-config usage across codebase

### 2. Cloud User CLI Support
- **New commands:** `metta configure cloud --s3-bucket=X --wandb-project=Y`
- **Persistent config:** Settings saved in `~/.metta/config.yaml`
- **Priority chain:** CLI → Env Vars → **Cloud Config** → Profile Defaults

### 3. Environment Variable Consolidation
- **Before:** 3 separate classes 
- **After:** 1 unified `EnvOverrides` class 
- **All 8 env vars** now in one organized location:
  ```
  WANDB_*, STATS_SERVER_*, REPLAY_DIR, TORCH_PROFILE_DIR, CHECKPOINT_DIR
  ```

## Files Modified
- `metta/tools/sim.py` - Fixed critical S3 bug
- `metta/tools/train.py`, `play.py`, `replay.py` - Auto-config consistency  
- `metta/setup/saved_settings.py` - Cloud configuration methods
- `metta/setup/metta_cli.py` - Cloud CLI commands
- `metta/tools/utils/auto_config.py` - Unified env var handling
- `tests/tools/test_auto_config.py` - Comprehensive test file


