### PR TITLE
fix: remove references to deleted script outputs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,13 +49,18 @@ jobs:
       github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.graphite_ci.outputs.skip }}
+      should_skip: ${{ steps.graphite_ci.outputs.skip || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect PR context
+        id: detect-pr
+        uses: ./.github/actions/detect-external-pr
+
       - name: Graphite CI Optimizer
         id: graphite_ci
+        if: steps.detect-pr.outputs.is_external != 'true'
         uses: withgraphite/graphite-ci-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -317,7 +317,7 @@ jobs:
           make coverage VERBOSE=1
 
       - name: Upload MettaGrid C++ coverage to Codecov
-        if: needs.setup-checks.outputs.is_external != 'true' && steps.mettagrid_build_check.outputs.build_success == 'true'
+        if: needs.setup-checks.outputs.is_external != 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -381,7 +381,6 @@ jobs:
           make benchmark VERBOSE=1
 
       - name: Collect benchmarks
-        if: steps.benchmark_build_check.outputs.build_success == 'true'
         working-directory: ./mettagrid
         run: |
           mkdir -p benchmark_output


### PR DESCRIPTION
We recently removed a mettagrid build script from CI but did not correctly update workflows that depended on its output.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211186766621840)