### PR TITLE
cooling: reduce comments and imports found in richard-policy-cull

### DIFF
--- a/agent/tests/test_metta_agent.py
+++ b/agent/tests/test_metta_agent.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 import torch
 from tensordict import TensorDict
+from torchrl.data import Composite
 
 # Import the actual class
 from metta.agent.agent_config import AgentConfig
@@ -250,8 +251,6 @@ def test_agent_experience_spec(create_metta_agent):
     spec = agent.get_agent_experience_spec()
 
     # Check it's a Composite spec
-    from torchrl.data import Composite
-
     assert isinstance(spec, Composite)
 
     # Check it has expected keys

--- a/app_backend/src/metta/app_backend/clients/scorecard_client.py
+++ b/app_backend/src/metta/app_backend/clients/scorecard_client.py
@@ -1,5 +1,6 @@
 from typing import Generic, Literal, TypeVar
 
+import requests
 from pydantic import RootModel
 
 from metta.app_backend.clients.base_client import BaseAppBackendClient
@@ -87,8 +88,6 @@ class ScorecardClient(BaseAppBackendClient):
         Returns:
             PoliciesResponse containing matching policies
         """
-        import requests
-
         # Create the request payload
         payload = PoliciesSearchRequest(
             search=search,

--- a/app_backend/tests/test_eval_task_orchestrator_integration.py
+++ b/app_backend/tests/test_eval_task_orchestrator_integration.py
@@ -1,6 +1,7 @@
 import asyncio
 import uuid
 from datetime import datetime
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -326,7 +327,6 @@ class TestEvalTaskOrchestratorIntegration:
         self, eval_task_client: EvalTaskClient, test_policy_id: uuid.UUID
     ):
         """Test that orchestrator works with custom worker managers."""
-        from unittest.mock import AsyncMock, Mock
 
         # Create mock worker manager
         mock_worker_manager = Mock(spec=AbstractWorkerManager)

--- a/app_backend/tests/test_scorecard_routes.py
+++ b/app_backend/tests/test_scorecard_routes.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from metta.app_backend.clients.stats_client import StatsClient
+from metta.app_backend.leaderboard_updater import LeaderboardUpdater
 from metta.app_backend.metta_repo import MettaRepo
 
 
@@ -2234,10 +2235,6 @@ class TestPolicyScorecardRoutes:
         # Now we need to manually trigger the leaderboard update process
         # to populate the leaderboard_policy_scores table. We'll do this by
         # manually running the update logic using the stats_repo fixture.
-
-        # Import the necessary components for manual leaderboard update
-
-        from metta.app_backend.leaderboard_updater import LeaderboardUpdater
 
         # Create a leaderboard updater instance
         updater = LeaderboardUpdater(stats_repo)

--- a/app_backend/tests/test_training_runs_routes.py
+++ b/app_backend/tests/test_training_runs_routes.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict
 
 import pytest
@@ -337,7 +338,6 @@ class TestTrainingRunsRoutes:
         assert "Invalid UUID format" in response.json()["detail"]
 
         # Test non-existent training run (the exact error message may vary)
-        import uuid
 
         fake_id = str(uuid.uuid4())  # Generate a random UUID that definitely won't exist
         response = test_client.patch(
@@ -350,7 +350,6 @@ class TestTrainingRunsRoutes:
         self, test_client: TestClient, auth_headers: Dict[str, str]
     ) -> None:
         """Test that non-existent training run returns proper 'not found' error, not 'Invalid UUID format'."""
-        import uuid
 
         fake_id = str(uuid.uuid4())  # Valid UUID format but non-existent
         response = test_client.patch(

--- a/cogweb/cogweb_client.py
+++ b/cogweb/cogweb_client.py
@@ -1,5 +1,3 @@
-"""Unified client for all Cogweb backend services."""
-
 from typing import Optional
 
 from metta.app_backend.clients.base_client import get_machine_token
@@ -52,6 +50,6 @@ class CogwebClient:
     #     """Get the stats client for metrics and logging operations."""
     #     return self._stats_client
     #
-    # def policy_store(self) -> PolicyStore:
-    #     """Get the policy store for model management."""
-    #     return self._policy_store
+    # def checkpoint_manager(self) -> CheckpointManager:
+    #     """Get the checkpoint manager for model management."""
+    #     return self._checkpoint_manager

--- a/mettagrid/tests/mapgen/test_validate_all_ascii_maps.py
+++ b/mettagrid/tests/mapgen/test_validate_all_ascii_maps.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from metta.mettagrid.char_encoder import CHAR_TO_NAME
+from metta.mettagrid.map_builder.random import RandomMapBuilder
 
 
 def find_map_files(root_dir="configs") -> list[str]:
@@ -39,7 +40,6 @@ def map_files():
 
 def test_programmatic_map_generation():
     """Test that maps can be generated programmatically without config files."""
-    from metta.mettagrid.map_builder.random import RandomMapBuilder
 
     # Create a simple map builder configuration
     map_builder = RandomMapBuilder.Config(

--- a/tests/cogworks/curriculum/test_curriculum.py
+++ b/tests/cogworks/curriculum/test_curriculum.py
@@ -14,10 +14,7 @@ from metta.mettagrid.mettagrid_config import MettaGridConfig
 
 
 class TestCurriculumTask:
-    """Test cases for CurriculumTask class."""
-
     def test_curriculum_task_creation(self):
-        """Test creating a CurriculumTask with required parameters."""
         task_id = 123
         cfg = MettaGridConfig()
 
@@ -31,14 +28,12 @@ class TestCurriculumTask:
         assert task._num_scheduled == 0
 
     def test_curriculum_task_get_env_cfg(self):
-        """Test that get_env_cfg returns the correct env config."""
         cfg = MettaGridConfig()
         task = CurriculumTask(123, cfg)
 
         assert task.get_env_cfg() is cfg
 
     def test_curriculum_task_complete(self):
-        """Test task completion updates statistics."""
         task = CurriculumTask(123, MettaGridConfig())
 
         # Complete with score 0.8
@@ -55,8 +50,6 @@ class TestCurriculumTask:
 
 
 class TestCurriculumConfig:
-    """Test cases for CurriculumConfig."""
-
     def test_curriculum_config_creation(self):
         """Test creating a CurriculumConfig with valid parameters."""
         task_gen_config = SingleTaskGeneratorConfig(env=MettaGridConfig())

--- a/tests/setup/test_base.py
+++ b/tests/setup/test_base.py
@@ -1,13 +1,14 @@
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 import yaml
 
-from metta.setup.profiles import UserType
+from metta.setup.profiles import PROFILE_DEFINITIONS, UserType
 
 
 class BaseMettaSetupTest(unittest.TestCase):
@@ -104,8 +105,6 @@ class BaseMettaSetupTest(unittest.TestCase):
         # Clear AWS config if it exists
         aws_dir = self.test_home / ".aws"
         if aws_dir.exists():
-            import shutil
-
             shutil.rmtree(aws_dir, ignore_errors=True)
 
     def _create_test_config(self, user_type: UserType, custom_config: bool = False) -> None:
@@ -123,8 +122,6 @@ class BaseMettaSetupTest(unittest.TestCase):
 
         if custom_config:
             # Add component configurations
-            from metta.setup.profiles import PROFILE_DEFINITIONS
-
             profile_config = PROFILE_DEFINITIONS.get(user_type, {})
             config_data["components"] = profile_config.get("components", {})
 
@@ -149,9 +146,6 @@ class BaseMettaSetupTest(unittest.TestCase):
         Returns:
             CompletedProcess with stdout, stderr, and returncode
         """
-        import subprocess
-        import sys
-
         cmd = [sys.executable, "-m", "metta.setup.metta_cli"] + args
         return subprocess.run(
             cmd,


### PR DESCRIPTION
from richard-policy-cull

These files only contain comment removals and import reorganizations, no functional code changes. Extracted from the richard-policy-cull branch to create a separate, focused PR for style improvements.

Files updated:
- agent/tests/test_metta_agent.py
- app_backend/src/metta/app_backend/clients/scorecard_client.py
- app_backend/tests/test_eval_task_orchestrator_integration.py
- app_backend/tests/test_scorecard_routes.py
- app_backend/tests/test_training_runs_routes.py
- cogweb/cogweb_client.py
- mettagrid/tests/mapgen/test_validate_all_ascii_maps.py
- tests/cogworks/curriculum/test_curriculum.py
- tests/setup/test_base.py