### PR TITLE
Remove the remaining non-mettagrid imports

### DIFF
--- a/metta/sim/map_preview.py
+++ b/metta/sim/map_preview.py
@@ -9,6 +9,7 @@ import wandb
 from wandb.sdk import wandb_run
 
 from metta.common.util.constants import METTASCOPE_REPLAY_URL
+from metta.common.util.fs import get_repo_root
 from metta.mettagrid.mettagrid_config import MettaGridConfig
 from metta.mettagrid.mettagrid_env import MettaGridEnv
 from metta.mettagrid.util.file import write_file
@@ -40,7 +41,8 @@ def write_map_preview_file(preview_path: str, env: MettaGridEnv, gzipped: bool):
 
 
 def write_local_map_preview(env: MettaGridEnv):
-    maps_dir = "./outputs/maps"
+    repo_root = get_repo_root()
+    maps_dir = repo_root / "outputs" / "maps"
     os.makedirs(maps_dir, exist_ok=True)
 
     with tempfile.NamedTemporaryFile(delete=False, dir=maps_dir, suffix=".json") as temp_file:

--- a/mettagrid/src/metta/mettagrid/mapgen/tools/gen.py
+++ b/mettagrid/src/metta/mettagrid/mapgen/tools/gen.py
@@ -30,7 +30,7 @@ class GenTool(Tool):
         show_mode = self.show_mode
         if not show_mode and not self.output_uri:
             # if not asked to save, show the map
-            show_mode = "mettascope"
+            show_mode = "ascii_border"
 
         output_uri = self.output_uri
         count = self.count

--- a/mettagrid/src/metta/mettagrid/mapgen/utils/show.py
+++ b/mettagrid/src/metta/mettagrid/mapgen/utils/show.py
@@ -1,44 +1,15 @@
 from typing import Literal
 
-import numpy as np
-
-from metta.mettagrid.config.envs import make_arena
 from metta.mettagrid.mapgen.utils.storable_map import StorableMap, grid_to_lines
-from metta.mettagrid.mettagrid_env import MettaGridEnv
 
-ShowMode = Literal["mettascope", "ascii", "ascii_border", "none"]
+ShowMode = Literal["ascii", "ascii_border", "none"]
 
 
 def show_map(storable_map: StorableMap, mode: ShowMode | None):
     if not mode or mode == "none":
         return
 
-    if mode == "mettascope":
-        try:
-            import mettascope.server
-            from metta.sim.map_preview import write_local_map_preview
-            from metta.sim.simulation_config import SimulationConfig
-            from metta.tools.play import PlayTool
-        except ImportError:
-            raise ImportError("Mettascope mode is not available outside of metta monorepo.") from None
-
-        num_agents = np.count_nonzero(np.char.startswith(storable_map.grid, "agent"))
-        env_cfg = make_arena(num_agents=num_agents)
-        env_cfg = env_cfg.with_ascii_map(map_data=[list(line) for line in grid_to_lines(storable_map.grid)])
-        env = MettaGridEnv(env_cfg, render_mode="rgb_array")
-
-        file_path = write_local_map_preview(env)
-
-        play = PlayTool(
-            sim=SimulationConfig(
-                env=env_cfg,
-                name="map.utils.show",
-            ),
-            open_browser_on_start=True,
-        )
-        mettascope.server.run(play, open_url=f"?replayUrl=local/{file_path}")
-
-    elif mode == "ascii":
+    if mode == "ascii":
         ascii_lines = grid_to_lines(storable_map.grid)
         print("\n".join(ascii_lines))
 

--- a/mettagrid/src/metta/mettagrid/mapgen/utils/show.py
+++ b/mettagrid/src/metta/mettagrid/mapgen/utils/show.py
@@ -2,13 +2,9 @@ from typing import Literal
 
 import numpy as np
 
-import mettascope.server
 from metta.mettagrid.config.envs import make_arena
 from metta.mettagrid.mapgen.utils.storable_map import StorableMap, grid_to_lines
 from metta.mettagrid.mettagrid_env import MettaGridEnv
-from metta.sim.map_preview import write_local_map_preview
-from metta.sim.simulation_config import SimulationConfig
-from metta.tools.play import PlayTool
 
 ShowMode = Literal["mettascope", "ascii", "ascii_border", "none"]
 
@@ -18,6 +14,14 @@ def show_map(storable_map: StorableMap, mode: ShowMode | None):
         return
 
     if mode == "mettascope":
+        try:
+            import mettascope.server
+            from metta.sim.map_preview import write_local_map_preview
+            from metta.sim.simulation_config import SimulationConfig
+            from metta.tools.play import PlayTool
+        except ImportError:
+            raise ImportError("Mettascope mode is not available outside of metta monorepo.") from None
+
         num_agents = np.count_nonzero(np.char.startswith(storable_map.grid, "agent"))
         env_cfg = make_arena(num_agents=num_agents)
         env_cfg = env_cfg.with_ascii_map(map_data=[list(line) for line in grid_to_lines(storable_map.grid)])

--- a/mettagrid/tests/test_forbidden_imports.py
+++ b/mettagrid/tests/test_forbidden_imports.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterable
+
+ALLOWED_METTA_PACKAGES = ["metta.mettagrid", "metta.common"]
+
+EXCLUDE_FILES = set(
+    [
+        "metta/mettagrid/mapgen/utils/show.py",  # uses conditional imports of mettascope, for now
+    ]
+)
+
+
+def find_forbidden_imports(file_path: Path) -> list[ast.stmt]:
+    """Return list of AST nodes with forbidden imports in a file.
+
+    Flags both:
+    - import metta.rl[.x]
+    - from metta.rl[.x] import ...
+    """
+    source = file_path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        # Skip files with syntax errors
+        return []
+
+    bad_nodes: list[ast.stmt] = []
+    for node in ast.walk(tree):
+        modules: list[str] = []
+
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # Only care about absolute imports (level == 0)
+            if node.level == 0 and node.module is not None:
+                modules.append(node.module)
+        else:
+            continue
+
+        for module in modules:
+            if module.startswith("metta.") and not any(
+                module.startswith(allowed) for allowed in ALLOWED_METTA_PACKAGES
+            ):
+                bad_nodes.append(node)
+
+    return bad_nodes
+
+
+def iter_python_files(root: Path) -> Iterable[Path]:
+    yield from root.rglob("*.py")
+
+
+def test_no_forbidden_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+    assert src_dir.is_dir(), f"Expected source directory not found: {src_dir}"
+
+    failures: list[str] = []
+    for py_file in iter_python_files(src_dir):
+        if str(py_file.relative_to(src_dir)) in EXCLUDE_FILES:
+            continue
+        for node in find_forbidden_imports(py_file):
+            rel = py_file.relative_to(src_dir)
+            failures.append(f"{rel}:{node.lineno}: {ast.unparse(node)}")
+
+    if failures:
+        details = "\n".join(sorted(failures))
+        raise AssertionError("Forbidden imports detected:\n" + details)

--- a/mettagrid/tests/test_forbidden_imports.py
+++ b/mettagrid/tests/test_forbidden_imports.py
@@ -6,11 +6,7 @@ from typing import Iterable
 
 ALLOWED_METTA_PACKAGES = ["metta.mettagrid", "metta.common"]
 
-EXCLUDE_FILES = set(
-    [
-        "metta/mettagrid/mapgen/utils/show.py",  # uses conditional imports of mettascope, for now
-    ]
-)
+EXCLUDE_FILES = set()
 
 
 def find_forbidden_imports(file_path: Path) -> list[ast.stmt]:


### PR DESCRIPTION
I had to keep the conditional PlayTool/mettascope import in mapgen show_map, for now (unsure if it'll be useful post-dehydration, will revisit later).

This PR also includes the test that'll catch all future violations.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211213067779041)