### PR TITLE
fix: nodejs component installation fails on fresh laptops with PATH configuration

### DIFF
--- a/metta/setup/components/nodejs.py
+++ b/metta/setup/components/nodejs.py
@@ -1,11 +1,10 @@
 import os
-import platform
 import re
 import subprocess
 
 from metta.setup.components.base import SetupModule
 from metta.setup.registry import register_module
-from metta.setup.utils import info, warning
+from metta.setup.utils import info, success, warning
 
 
 @register_module
@@ -13,6 +12,9 @@ class NodejsSetup(SetupModule):
     @property
     def description(self) -> str:
         return "Node.js infrastructure - pnpm and turborepo"
+
+    def dependencies(self) -> list[str]:
+        return ["system"]  # Ensure Node.js/corepack is installed before running pnpm setup
 
     def _script_exists(self, script: str) -> bool:
         try:
@@ -47,6 +49,192 @@ class NodejsSetup(SetupModule):
             return result.returncode == 0
         except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
             return False
+
+    def _get_shell_config_paths(self) -> list[tuple[str, str]]:
+        """Get paths to shell configuration files.
+
+        Returns:
+            List of (shell_name, config_path) tuples
+        """
+        paths = []
+
+        # zsh config - respect ZDOTDIR
+        zdotdir = os.environ.get("ZDOTDIR")
+        if zdotdir:
+            zshrc_path = os.path.join(zdotdir, ".zshrc")
+        else:
+            zshrc_path = os.path.expanduser("~/.zshrc")
+        paths.append(("zsh", zshrc_path))
+
+        # bash config
+        bashrc_path = os.path.expanduser("~/.bashrc")
+        paths.append(("bash", bashrc_path))
+
+        return paths
+
+    def _check_pnpm_config_in_file(self, file_path: str, expected_pnpm_home: str) -> bool:
+        """Check if a shell config file has the correct PNPM configuration.
+
+        Args:
+            file_path: Path to shell config file
+            expected_pnpm_home: Expected PNPM_HOME value
+
+        Returns:
+            True if file has correct PNPM config, False otherwise
+        """
+        if not os.path.exists(file_path):
+            return False
+
+        try:
+            with open(file_path, "r") as f:
+                content = f.read()
+        except (IOError, OSError):
+            return False
+
+        # Check if pnpm section exists
+        if "# pnpm" not in content or "# pnpm end" not in content:
+            return False
+
+        # Check if the correct PNPM_HOME is set (handle both expanded and $HOME formats)
+        expected_export_full = f'export PNPM_HOME="{expected_pnpm_home}"'
+        expected_export_home = 'export PNPM_HOME="$HOME/.local/share/pnpm"'
+        if expected_export_full not in content and expected_export_home not in content:
+            return False
+
+        # Check if PATH logic exists
+        if 'export PATH="$PNPM_HOME:$PATH"' not in content and '*":$PNPM_HOME:"*' not in content:
+            return False
+
+        return True
+
+    def _print_shell_reload_instructions(self, modified_files: list[tuple[str, str]]) -> None:
+        """Print instructions for reloading shell after profile modifications.
+
+        Args:
+            modified_files: List of (shell_name, config_path) tuples for modified files
+        """
+
+        if not modified_files:
+            return
+
+        success("Shell profiles have been updated with PNPM_HOME configuration!")
+        info("")
+        info("To apply the changes immediately, reload your shell:")
+
+        for shell_name, _config_path in modified_files:
+            if shell_name == "zsh":
+                info("  For zsh: exec zsh")
+            elif shell_name == "bash":
+                info("  For bash: exec bash")
+            else:
+                info(f"  For {shell_name}: exec {shell_name}")
+
+        info("")
+        info("Or simply restart your terminal.")
+        info("After reloading, global packages like 'turbo' will be available in your PATH.")
+
+    def _update_shell_profiles_for_pnpm(self, pnpm_home: str) -> None:
+        """Update shell profiles with PNPM_HOME configuration.
+
+        Args:
+            pnpm_home: Path to pnpm home directory
+        """
+        pnpm_config_lines = [
+            "# pnpm",
+            f'export PNPM_HOME="{pnpm_home}"',
+            'case ":$PATH:" in',
+            '  *":$PNPM_HOME:"*) ;;',
+            '  *) export PATH="$PNPM_HOME:$PATH" ;;',
+            "esac",
+            "# pnpm end",
+        ]
+
+        modified_files = []
+
+        for shell_name, config_path in self._get_shell_config_paths():
+            # Check if file already has correct configuration
+            if self._check_pnpm_config_in_file(config_path, pnpm_home):
+                info(f"PNPM_HOME correctly configured in {config_path}")
+                continue
+
+            # Check if the file exists, if not, create it
+            if not os.path.exists(config_path):
+                # Create parent directory if needed
+                os.makedirs(os.path.dirname(config_path), exist_ok=True)
+                with open(config_path, "w") as f:
+                    f.write(f"# {shell_name} configuration\n")
+                info(f"Created {config_path}")
+
+            # Read existing content
+            try:
+                with open(config_path, "r") as f:
+                    content = f.read()
+            except (IOError, OSError):
+                warning(f"Could not read {config_path}, skipping")
+                continue
+
+            # Check if there's an existing pnpm section that needs updating
+            if "# pnpm" in content and "# pnpm end" in content:
+                # Remove old pnpm section and add new one
+                lines = content.split("\n")
+                new_lines = []
+                in_pnpm_section = False
+
+                for line in lines:
+                    if line.strip() == "# pnpm":
+                        in_pnpm_section = True
+                        continue
+                    elif line.strip() == "# pnpm end":
+                        in_pnpm_section = False
+                        continue
+                    elif not in_pnpm_section:
+                        new_lines.append(line)
+
+                # Add the new pnpm configuration
+                new_content = "\n".join(new_lines)
+                if not new_content.endswith("\n"):
+                    new_content += "\n"
+                new_content += "\n" + "\n".join(pnpm_config_lines) + "\n"
+
+                try:
+                    with open(config_path, "w") as f:
+                        f.write(new_content)
+                    info(f"Updated PNPM_HOME configuration in {config_path}")
+                    modified_files.append((shell_name, config_path))
+                except (IOError, OSError):
+                    warning(f"Could not write to {config_path}")
+            else:
+                # No existing pnpm section, just append
+                try:
+                    with open(config_path, "a") as f:
+                        f.write("\n" + "\n".join(pnpm_config_lines) + "\n")
+                    info(f"Added PNPM_HOME configuration to {config_path}")
+                    modified_files.append((shell_name, config_path))
+                except (IOError, OSError):
+                    warning(f"Could not write to {config_path}")
+
+        # Provide shell reload instructions if any files were modified
+        if modified_files:
+            self._print_shell_reload_instructions(modified_files)
+
+    def _setup_pnpm_environment(self, pnpm_home: str) -> None:
+        """Set up PNPM_HOME and PATH in current process and shell profiles.
+
+        Args:
+            pnpm_home: Path to pnpm home directory
+        """
+        # Ensure directory exists
+        os.makedirs(pnpm_home, exist_ok=True)
+
+        # Set environment variables for current process
+        os.environ["PNPM_HOME"] = pnpm_home
+        if pnpm_home not in os.environ.get("PATH", ""):
+            os.environ["PATH"] = f"{pnpm_home}:{os.environ['PATH']}"
+
+        # Update shell profiles
+        self._update_shell_profiles_for_pnpm(pnpm_home)
+
+        info(f"PNPM_HOME set to: {pnpm_home}")
 
     def _enable_corepack_with_cleanup(self):
         """Enable corepack, removing dead symlinks as needed."""
@@ -84,36 +272,41 @@ class NodejsSetup(SetupModule):
     def install(self) -> None:
         info("Setting up pnpm...")
 
+        # First, determine the correct PNPM_HOME path
+        pnpm_home = None
+
+        # If PNPM_HOME already exists and is working, use it
+        if os.environ.get("PNPM_HOME") and self._check_pnpm():
+            pnpm_home = os.environ["PNPM_HOME"]
+            info(f"Using existing PNPM_HOME: {pnpm_home}")
+        else:
+            # Set up PNPM_HOME BEFORE running any pnpm commands
+            # Use the standard location that pnpm creates
+            pnpm_home = os.path.expanduser("~/.local/share/pnpm")
+            info(f"Setting up PNPM_HOME at: {pnpm_home}")
+
+            # Set up environment and shell profiles
+            self._setup_pnpm_environment(pnpm_home)
+
+        # Now enable corepack if pnpm is not working
         if not self._check_pnpm():
-            # Try to enable corepack with automatic cleanup
             if not self._enable_corepack_with_cleanup():
                 raise RuntimeError("Failed to set up pnpm via corepack")
 
-        def _set_pnpm_home_now(value: str) -> None:
-            os.environ["PNPM_HOME"] = value
-            os.environ["PATH"] = f"{value}:{os.environ['PATH']}"  # pnpm complains if PNPM_HOME is not in PATH
-            info("PNPM_HOME configured. Restart your shell to apply.")
-
-        if not os.environ.get("PNPM_HOME"):
-            # We need to setup pnpm before we can install turbo globally
-            # This command will update the user's `~/.bashrc` or `~/.zshrc`.
+        # Run pnpm setup to ensure shell profiles are configured correctly
+        # This is safe to run multiple times and will update configs if needed
+        info("Running pnpm setup to ensure shell configuration...")
+        try:
             self.run_command(["pnpm", "setup"], capture_output=False)
+        except subprocess.CalledProcessError as e:
+            warning(f"pnpm setup failed: {e}. Continuing with manual configuration.")
 
-            # PNPM_HOME configuration is in the user's shell profile, but we need to set it now.
-            # Apply some heuristics to detect the correct directory.
-            #
-            # Note: we could run a new temporary shell script, print env from it and capture, but that might be more
-            # error prone.
-            if platform.system() == "Darwin":
-                _set_pnpm_home_now(os.path.expanduser("~/Library/pnpm"))
-            elif os.path.exists(os.path.expanduser("~/.pnpm")):
-                _set_pnpm_home_now(os.path.expanduser("~/.pnpm"))
-
-        if os.environ.get("PNPM_HOME"):
+        # Verify pnpm is working with correct PNPM_HOME
+        if self._check_pnpm() and os.environ.get("PNPM_HOME"):
             info("Installing turbo...")
             self.run_command(["pnpm", "install", "--global", "turbo"], capture_output=False)
         else:
-            warning("Failed to detect PNPM_HOME dir, skipping global turbo install")
+            warning("PNPM_HOME not properly configured, skipping global turbo install")
 
         info("Installing dependencies...")
         # pnpm install with frozen lockfile to avoid prompts

--- a/tests/setup/test_nodejs_component.py
+++ b/tests/setup/test_nodejs_component.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Tests for nodejs component setup functionality.
+
+These tests verify:
+- Correct dependencies are declared (system component)
+- PNPM_HOME and PATH configuration works properly
+- Shell profile updates work correctly
+- Fresh installation scenarios work as expected
+"""
+
+import os
+import tempfile
+import unittest
+
+import pytest
+
+from metta.setup.components.nodejs import NodejsSetup
+from metta.setup.saved_settings import UserType
+from tests.setup.test_base import BaseMettaSetupTest
+
+
+@pytest.mark.setup
+@pytest.mark.profile("external")
+class TestNodejsComponentDependencies(BaseMettaSetupTest):
+    """Test nodejs component has correct dependencies."""
+
+    def test_nodejs_requires_system_dependency(self):
+        """Test that nodejs component declares system as dependency."""
+        nodejs_setup = NodejsSetup()
+        dependencies = nodejs_setup.dependencies()
+
+        self.assertIn(
+            "system",
+            dependencies,
+            "nodejs component must depend on system component to ensure Node.js/corepack is available",
+        )
+
+    def test_nodejs_component_name(self):
+        """Test nodejs component has correct name."""
+        nodejs_setup = NodejsSetup()
+        self.assertEqual(nodejs_setup.name, "nodejs")
+
+
+@pytest.mark.setup
+@pytest.mark.profile("external")
+class TestPnpmPathConfiguration(BaseMettaSetupTest):
+    """Test PNPM_HOME and PATH configuration logic."""
+
+    def setUp(self):
+        super().setUp()
+        self.nodejs_setup = NodejsSetup()
+
+    def test_shell_config_paths_respect_zdotdir(self):
+        """Test that shell config paths respect ZDOTDIR environment variable."""
+        # Test without ZDOTDIR
+        os.environ.pop("ZDOTDIR", None)
+        paths = self.nodejs_setup._get_shell_config_paths()
+
+        zsh_path = None
+        bash_path = None
+        for shell_name, config_path in paths:
+            if shell_name == "zsh":
+                zsh_path = config_path
+            elif shell_name == "bash":
+                bash_path = config_path
+
+        self.assertIsNotNone(zsh_path)
+        self.assertIsNotNone(bash_path)
+        self.assertTrue(zsh_path.endswith("/.zshrc"))
+        self.assertTrue(bash_path.endswith("/.bashrc"))
+
+        # Test with custom ZDOTDIR
+        with tempfile.TemporaryDirectory() as temp_dir:
+            custom_zdotdir = os.path.join(temp_dir, "custom_zsh")
+            os.environ["ZDOTDIR"] = custom_zdotdir
+
+            paths = self.nodejs_setup._get_shell_config_paths()
+            zsh_path = None
+            for shell_name, config_path in paths:
+                if shell_name == "zsh":
+                    zsh_path = config_path
+                    break
+
+            self.assertIsNotNone(zsh_path)
+            self.assertEqual(zsh_path, os.path.join(custom_zdotdir, ".zshrc"))
+
+    def test_pnpm_config_detection_various_formats(self):
+        """Test that PNPM configuration detection handles different formats."""
+        pnpm_home = "/Users/testuser/.local/share/pnpm"
+
+        # Test with expanded path format
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write(f"""# pnpm
+export PNPM_HOME="{pnpm_home}"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end
+""")
+            f.flush()
+
+            result = self.nodejs_setup._check_pnpm_config_in_file(f.name, pnpm_home)
+            self.assertTrue(result, "Should detect correctly configured pnpm with expanded path")
+
+            os.unlink(f.name)
+
+        # Test with $HOME format
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write("""# pnpm
+export PNPM_HOME="$HOME/.local/share/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end
+""")
+            f.flush()
+
+            result = self.nodejs_setup._check_pnpm_config_in_file(f.name, pnpm_home)
+            self.assertTrue(result, "Should detect correctly configured pnpm with $HOME format")
+
+            os.unlink(f.name)
+
+        # Test with missing pnpm section
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write('# shell config without pnpm\nexport PATH="/some/path:$PATH"\n')
+            f.flush()
+
+            result = self.nodejs_setup._check_pnpm_config_in_file(f.name, pnpm_home)
+            self.assertFalse(result, "Should not detect pnpm config when missing")
+
+            os.unlink(f.name)
+
+    def test_pnpm_environment_setup(self):
+        """Test that PNPM environment setup works correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pnpm_home = os.path.join(temp_dir, "pnpm")
+
+            # Save original environment
+            original_pnpm_home = os.environ.get("PNPM_HOME")
+            original_path = os.environ.get("PATH", "")
+
+            try:
+                # Test setup
+                self.nodejs_setup._setup_pnpm_environment(pnpm_home)
+
+                # Verify directory was created
+                self.assertTrue(os.path.exists(pnpm_home), "PNPM_HOME directory should be created")
+
+                # Verify environment variables
+                self.assertEqual(os.environ.get("PNPM_HOME"), pnpm_home, "PNPM_HOME should be set")
+                self.assertIn(pnpm_home, os.environ.get("PATH", ""), "PNPM_HOME should be in PATH")
+
+            finally:
+                # Restore original environment
+                if original_pnpm_home is not None:
+                    os.environ["PNPM_HOME"] = original_pnpm_home
+                else:
+                    os.environ.pop("PNPM_HOME", None)
+                os.environ["PATH"] = original_path
+
+
+@pytest.mark.setup
+@pytest.mark.profile("external")
+class TestNodejsInstallationFlow(BaseMettaSetupTest):
+    """Test the complete nodejs installation flow."""
+
+    def test_nodejs_component_enabled_in_external_profile(self):
+        """Test that nodejs component is enabled in external profile."""
+        self._create_test_config(UserType.EXTERNAL)
+
+        nodejs_setup = NodejsSetup()
+        self.assertTrue(nodejs_setup.is_enabled(), "nodejs should be enabled for external profile")
+
+    def test_nodejs_binaries_installation_flow(self):
+        """Test that nodejs installation provides all required binaries."""
+        import shutil
+        import subprocess
+
+        # Skip if running in CI without proper Node.js setup
+        if os.environ.get("CI") and not shutil.which("node"):
+            self.skipTest("Skipping nodejs binary test in CI without Node.js")
+
+        self._create_test_config(UserType.EXTERNAL)
+
+        def check_binary_available(binary_name):
+            """Check if a binary is available in PATH."""
+            return shutil.which(binary_name) is not None
+
+        def safely_remove_global_package(package_name):
+            """Remove a global pnpm package if it exists."""
+            try:
+                # Check if pnpm is available first
+                if not check_binary_available("pnpm"):
+                    return
+
+                # Try to uninstall the global package
+                subprocess.run(
+                    ["pnpm", "remove", "--global", package_name],
+                    capture_output=True,
+                    check=False,  # Don't fail if package wasn't installed
+                )
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass  # Ignore errors - package might not have been installed
+
+        # Step 1: Remove turbo if it exists (pnpm and corepack come with Node.js)
+        safely_remove_global_package("turbo")
+        # Step 2: Verify turbo is not available initially (we expect it might still be there)
+        self.assertFalse(check_binary_available("turbo"), "turbo should not be available initially")
+
+        # Step 3: Run nodejs installation
+        nodejs_setup = NodejsSetup()
+
+        # First ensure system dependency is met (Node.js should be installed)
+        node_available = check_binary_available("node")
+        self.assertTrue(node_available, "Node.js should be installed by system component dependency")
+
+        # Corepack should be available (comes with Node.js)
+        corepack_available = check_binary_available("corepack")
+        self.assertTrue(corepack_available, "corepack should be available with Node.js installation")
+
+        # Run the nodejs setup
+        try:
+            nodejs_setup.install()
+        except Exception as e:
+            self.fail(f"nodejs installation failed: {e}")
+
+        # Step 4: Verify all binaries are now available
+        pnpm_available_after = check_binary_available("pnpm")
+        self.assertTrue(pnpm_available_after, "pnpm should be available after nodejs installation")
+
+        turbo_available_after = check_binary_available("turbo")
+        self.assertTrue(turbo_available_after, "turbo should be installed globally by nodejs setup")
+
+        # Step 5: Verify pnpm works
+        try:
+            result = subprocess.run(["pnpm", "--version"], capture_output=True, text=True, check=True)
+            self.assertIsNotNone(result.stdout.strip(), "pnpm should return version")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"pnpm --version failed: {e}")
+
+        # Step 6: Verify turbo works
+        try:
+            result = subprocess.run(["turbo", "--version"], capture_output=True, text=True, check=True)
+            self.assertIsNotNone(result.stdout.strip(), "turbo should return version")
+        except subprocess.CalledProcessError as e:
+            self.fail(f"turbo --version failed: {e}")
+
+        # Step 7: Verify PNPM_HOME is set correctly
+        pnpm_home = os.environ.get("PNPM_HOME")
+        self.assertIsNotNone(pnpm_home, "PNPM_HOME should be set after installation")
+        if pnpm_home:
+            self.assertTrue(os.path.exists(pnpm_home), "PNPM_HOME directory should exist")
+
+        # Step 8: Verify PNPM_HOME is in PATH
+        path_env = os.environ.get("PATH", "")
+        self.assertIn(pnpm_home, path_env, "PNPM_HOME should be in PATH")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes critical bug where `metta install nodejs` would fail on fresh laptop setups with error:
> "The configured global bin directory '/Users/user/Library/pnpm' is not in PATH"

## Problem Analysis

This error occurred on fresh laptop installations because:

1. **PNPM_HOME not set in current process**: The nodejs component would run `pnpm` commands before setting up the PNPM_HOME environment variable in the current process
2. **Shell profiles not updated**: The component wasn't properly updating shell profiles (.zshrc/.bashrc) with PNPM_HOME configuration
3. **Missing system dependency**: No explicit dependency on the system component, so nodejs could run before Node.js/corepack was available

## Technical Details

On a fresh laptop, the installation flow should be:
1. System component installs Node.js via Homebrew (`node@24` includes corepack)  
2. Nodejs component enables corepack to provide pnpm
3. PNPM_HOME gets configured and added to PATH
4. Shell profiles get updated for future sessions

The bug broke this flow because PNPM_HOME wasn't set in the current process environment before running pnpm commands.

## Solution

### Core Fixes

- **Added explicit system dependency**: Ensures Node.js/corepack installed first
- **Fixed PNPM_HOME timing**: Set PNPM_HOME and PATH in current process BEFORE running any pnpm commands
- **Used correct pnpm location**: Use standard `~/.local/share/pnpm` path instead of wrong hardcoded paths
- **Comprehensive shell profile management**: Added proper ZDOTDIR support and intelligent profile updating
- **User-friendly notifications**: Provide shell reload instructions when profiles are modified
- **Conditional updates**: Only update shell profiles when configuration is missing/incorrect

### Test Coverage

Added comprehensive test suite in `tests/setup/test_nodejs_component.py`:

- **Component dependencies**: Verify nodejs declares system dependency 
- **PNPM configuration detection**: Test shell profile parsing in various formats
- **Full installation flow**: Uninstall/reinstall binaries and verify PATH availability
- **Environment verification**: Check PNPM_HOME and PATH configuration

### Key Code Changes

**metta/setup/components/nodejs.py:**
- Added `def dependencies(self) -> list[str]: return ["system"]` 
- Fixed PNPM_HOME setup timing in `_setup_pnpm_environment()`
- Added comprehensive shell profile management with ZDOTDIR support
- Added shell reload instruction notifications

## Testing

The comprehensive test `test_nodejs_binaries_installation_flow()`:
1. Safely removes turbo global package 
2. Verifies Node.js and corepack are available (system dependency check)
3. Runs nodejs installation via `nodejs_setup.install()`
4. Verifies pnpm and turbo are available and working with version checks
5. Verifies PNPM_HOME environment variable is set and in PATH

## Verification

This fix ensures fresh laptop setups work correctly:
1. `./install.sh` installs system dependencies (Node.js/corepack via Homebrew)
2. `metta install nodejs` properly sets up pnpm with correct PATH configuration  
3. Shell profiles get updated with reload instructions
4. Global packages like turbo become available in PATH

Closes [related issue if any]