### PR TITLE
hotfix: fix request_eval

### DIFF
--- a/common/src/metta/common/wandb/wandb_context.py
+++ b/common/src/metta/common/wandb/wandb_context.py
@@ -104,10 +104,11 @@ class WandbContext:
                 settings=wandb.Settings(quiet=True, init_timeout=self.timeout),
             )
 
-            # Save config and set up file syncing only if wandb init succeeded
-            wandb.save(os.path.join(self.cfg.data_dir, "*.log"), base_path=self.cfg.data_dir, policy="live")
-            wandb.save(os.path.join(self.cfg.data_dir, "*.yaml"), base_path=self.cfg.data_dir, policy="live")
-            wandb.save(os.path.join(self.cfg.data_dir, "*.json"), base_path=self.cfg.data_dir, policy="live")
+            # Save config and set up file syncing only if wandb init succeeded and data_dir is set
+            if self.cfg.data_dir:
+                wandb.save(os.path.join(self.cfg.data_dir, "*.log"), base_path=self.cfg.data_dir, policy="live")
+                wandb.save(os.path.join(self.cfg.data_dir, "*.yaml"), base_path=self.cfg.data_dir, policy="live")
+                wandb.save(os.path.join(self.cfg.data_dir, "*.json"), base_path=self.cfg.data_dir, policy="live")
             logger.info(f"Successfully initialized W&B run: {self.run.name} ({self.run.id})")
 
             # --- File-based IPC: Write to the same directory as HEARTBEAT_FILE ---

--- a/metta/sim/simulation.py
+++ b/metta/sim/simulation.py
@@ -388,30 +388,22 @@ class Simulation:
 
             if self._policy_uri:  # Only add if we have a URI
                 policy_details.append((self._policy_uri, None))
-                # Extract policy name for later use
-                metadata = CheckpointManager.get_policy_metadata(self._policy_uri)
-                policy_name = metadata["run_name"]
-            else:
-                policy_name = None
 
             # Add NPC policy if it exists
-            npc_name = None
             if self._npc_policy_uri:
                 policy_details.append((self._npc_policy_uri, "NPC policy"))
-                # Extract NPC name for later use
-                metadata = CheckpointManager.get_policy_metadata(self._npc_policy_uri)
-                npc_name = f"npc_{metadata['run_name']}"
 
             policy_ids = get_or_create_policy_ids(self._stats_client, policy_details, self._stats_epoch_id)
 
             agent_map: Dict[int, uuid.UUID] = {}
-            if policy_name:
+            # Use URIs as keys since that's what get_or_create_policy_ids returns
+            if self._policy_uri:
                 for idx in self._policy_idxs:
-                    agent_map[int(idx.item())] = policy_ids[policy_name]
+                    agent_map[int(idx.item())] = policy_ids[self._policy_uri]
 
-            if npc_name:
+            if self._npc_policy_uri:
                 for idx in self._npc_idxs:
-                    agent_map[int(idx.item())] = policy_ids[npc_name]
+                    agent_map[int(idx.item())] = policy_ids[self._npc_policy_uri]
 
             # Get all episodes from the database
             episodes_df = stats_db.query("SELECT * FROM episodes")
@@ -445,10 +437,12 @@ class Simulation:
                 # Record the episode remotely
                 episode_tags = self._episode_tags or None
                 try:
+                    # Use the primary policy URI if available
+                    primary_policy_id = policy_ids[self._policy_uri] if self._policy_uri else None
                     self._stats_client.record_episode(
                         agent_policies=agent_map,
                         agent_metrics=agent_metrics,
-                        primary_policy_id=policy_ids[policy_name],
+                        primary_policy_id=primary_policy_id,
                         stats_epoch=self._stats_epoch_id,
                         sim_name=self._name,
                         env_label=self._config.env.label,

--- a/tools/request_eval.py
+++ b/tools/request_eval.py
@@ -108,7 +108,7 @@ async def _create_remote_eval_tasks(
 
     # Register policies with stats server
     policy_ids: bidict[str, uuid.UUID] = get_or_create_policy_ids(
-        stats_client, [(p["run_name"], p["uri"], None) for p in valid_policies]
+        stats_client, [(p["uri"], None) for p in valid_policies]
     )
 
     if not policy_ids:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/axel/Documents/Softmax/metta-repo/./tools/run.py", line 5, in <module>
    run_tool.main()
  File "/Users/axel/Documents/Softmax/metta-repo/common/src/metta/common/config/run_tool.py", line 99, in main
    result = tool_cfg.invoke(args_conf, overrides)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/axel/Documents/Softmax/metta-repo/metta/tools/sim.py", line 97, in invoke
    eval_results = evaluate_policy(
                   ^^^^^^^^^^^^^^^^
  File "/Users/axel/Documents/Softmax/metta-repo/metta/eval/eval_service.py", line 66, in evaluate_policy
    sim_result = sim.simulate()
                 ^^^^^^^^^^^^^^
  File "/Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py", line 355, in simulate
    return self.end_simulation()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py", line 324, in end_simulation
    self._write_remote_stats(db, thumbnail_url=thumbnail_url)
  File "/Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py", line 410, in _write_remote_stats
    agent_map[int(idx.item())] = policy_ids[policy_name]
                                 ~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/axel/Documents/Softmax/metta-repo/.venv/lib/python3.11/site-packages/bidict/_base.py", line 524, in __getitem__
    return self._fwdm[key]
           ~~~~~~~~~~^^^^^
KeyError: 'test_arena_basic_1431_trial_0001'
╭───────────────────── Traceback (most recent call last) ─────────────────────╮
│ /Users/axel/Documents/Softmax/metta-repo/./tools/run.py:5 in <module>       │
│                                                                             │
│   2 import metta.common.config.run_tool as run_tool                         │
│   3                                                                         │
│   4 if __name__ == "__main__":                                              │
│ ❱ 5 │   run_tool.main()                                                     │
│   6                                                                         │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/common/src/metta/common/config/run │
│ _tool.py:99 in main                                                         │
│                                                                             │
│    96 │   │   print(tool_cfg.model_dump_json(indent=2))                     │
│    97 │   │   sys.exit(0)                                                   │
│    98 │                                                                     │
│ ❱  99 │   result = tool_cfg.invoke(args_conf, overrides)                    │
│   100 │                                                                     │
│   101 │   if result is not None:                                            │
│   102 │   │   sys.exit(result)                                              │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/metta/tools/sim.py:97 in invoke    │
│                                                                             │
│    94 │   │   │   eval_run_name = _determine_run_name(policy_uri)           │
│    95 │   │   │   results = {"policy_uri": policy_uri, "checkpoints": []}   │
│    96 │   │   │                                                             │
│ ❱  97 │   │   │   eval_results = evaluate_policy(                           │
│    98 │   │   │   │   checkpoint_uri=normalized_uri,                        │
│    99 │   │   │   │   simulations=list(self.simulations),                   │
│   100 │   │   │   │   stats_dir=self.stats_dir,                             │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/metta/eval/eval_service.py:66 in   │
│ evaluate_policy                                                             │
│                                                                             │
│    63 │   │   try:                                                          │
│    64 │   │   │   record_heartbeat()                                        │
│    65 │   │   │   logger.info("=== Simulation '%s' ===", sim.name)          │
│ ❱  66 │   │   │   sim_result = sim.simulate()                               │
│    67 │   │   │   merged_db.merge_in(sim_result.stats_db)                   │
│    68 │   │   │   record_heartbeat()                                        │
│    69 │   │   │   if replay_dir is not None:                                │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py:355 in     │
│ simulate                                                                    │
│                                                                             │
│   352 │   │   │   if iteration_count % heartbeat_interval == 0:             │
│   353 │   │   │   │   record_heartbeat()                                    │
│   354 │   │                                                                 │
│ ❱ 355 │   │   return self.end_simulation()                                  │
│   356 │                                                                     │
│   357 │   def _from_shards_and_context(self) -> SimulationStatsDB:          │
│   358 │   │   """Merge all *.duckdb* shards for this simulation → one `Stat │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py:324 in     │
│ end_simulation                                                              │
│                                                                             │
│   321 │   │                                                                 │
│   322 │   │   # Generate thumbnail before writing to database so we can inc │
│   323 │   │   thumbnail_url = self._maybe_generate_thumbnail()              │
│ ❱ 324 │   │   self._write_remote_stats(db, thumbnail_url=thumbnail_url)     │
│   325 │   │                                                                 │
│   326 │   │   logger.info(                                                  │
│   327 │   │   │   "Sim '%s' finished: %d episodes in %.1fs",                │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/metta/sim/simulation.py:410 in     │
│ _write_remote_stats                                                         │
│                                                                             │
│   407 │   │   │   agent_map: Dict[int, uuid.UUID] = {}                      │
│   408 │   │   │   if policy_name:                                           │
│   409 │   │   │   │   for idx in self._policy_idxs:                         │
│ ❱ 410 │   │   │   │   │   agent_map[int(idx.item())] = policy_ids[policy_na │
│   411 │   │   │                                                             │
│   412 │   │   │   if npc_name:                                              │
│   413 │   │   │   │   for idx in self._npc_idxs:                            │
│                                                                             │
│ /Users/axel/Documents/Softmax/metta-repo/.venv/lib/python3.11/site-packages │
│ /bidict/_base.py:524 in __getitem__                                         │
│                                                                             │
│   521 │                                                                     │
│   522 │   def __getitem__(self, key: KT) -> VT:                             │
│   523 │   │   """*x.__getitem__(key) ⟺ x[key]*"""                           │
│ ❱ 524 │   │   return self._fwdm[key]                                        │
│   525 │                                                                     │
│   526 │   def __reduce__(self) -> tuple[t.Any, ...]:                        │
│   527 │   │   """Return state information for pickling."""                  │
╰─────────────────────────────────────────────────────────────────────────────╯
KeyError: 'test_arena_basic_1431_trial_0001'
wandb:
wandb: 🚀 View run test_arena_basic_1431_trial_0001 at: https://wandb.ai/metta-research/metta/runs/test_arena_basic_1431_trial_0001
wandb: Find logs at: wandb/run-20250903_144533-test_arena_basic_1431_trial_0001/logs
```

and wandb seems confused: 

wandb: WARNING Ignoring ID a1d2u4b3 loaded due to resume='auto' because the run ID is set to test_arena_basic_1431_trial_0001.
wandb: Resuming run test_arena_basic_1431_trial_0001
wandb: 🚀 View run at https://wandb.ai/metta-research/metta/runs/test_arena_basic_1431_trial_0001
ERROR:metta.common.wandb.wandb_context:Unexpected error during W&B initialization: expected str, bytes or os.PathLike object, not NoneType
INFO:metta.common.wandb.wandb_context:Continuing without W&B logging
INFO:metta.tools.sim:Initialized wandb run: None
INFO:metta.rl.wandb:Loading policy from wandb URI: wandb://metta/test_arena_basic_1431_trial_0001:latest
Full command I'm using to run eval: 

uv run ./tools/run.py experiments.recipes.arena_basic_easy_shaped.evaluate --args policy_uri=wandb://metta/test_arena_basic_1431_trial_0001:latest --overrides push_metrics_to_wandb=True stats_server_uri=https://api.observatory.softmax-research.net wandb.name=test_arena_basic_1431_trial_0001 wandb.run_id=test_arena_basic_1431_trial_0001 wandb.group=test_arena_basic_1431

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211230172364995)