### PR TITLE
Fix and simplify log handler handling

### DIFF
--- a/common/src/metta/common/profiling/stopwatch.py
+++ b/common/src/metta/common/profiling/stopwatch.py
@@ -148,17 +148,8 @@ class Stopwatch:
 
         # Configure logger based on log_level
         if log_level is None:
-            self.logger.addHandler(logging.NullHandler())
+            self.logger.disabled = True
         else:
-            has_stream_handler = any(isinstance(h, logging.StreamHandler) for h in self.logger.handlers)
-            if not has_stream_handler:
-                handler = logging.StreamHandler()
-                handler.setLevel(logging.DEBUG)
-                self.logger.addHandler(handler)
-                self.logger.warning(
-                    "No handlers found on logger - added StreamHandler. This should only happen during testing."
-                )
-
             self.logger.setLevel(log_level)
 
         self.max_laps = max_laps

--- a/common/src/metta/common/profiling/system_monitor.py
+++ b/common/src/metta/common/profiling/system_monitor.py
@@ -28,15 +28,6 @@ class SystemMonitor:
         if log_level is None:
             self.logger.addHandler(logging.NullHandler())
         else:
-            has_stream_handler = any(isinstance(h, logging.StreamHandler) for h in self.logger.handlers)
-            if not has_stream_handler:
-                handler = logging.StreamHandler()
-                handler.setLevel(logging.DEBUG)
-                self.logger.addHandler(handler)
-                self.logger.warning(
-                    "No handlers found on logger - added StreamHandler. This should only happen during testing."
-                )
-
             self.logger.setLevel(log_level)
 
         self.sampling_interval_sec = sampling_interval_sec

--- a/common/src/metta/common/profiling/system_monitor.py
+++ b/common/src/metta/common/profiling/system_monitor.py
@@ -26,7 +26,7 @@ class SystemMonitor:
 
         # Configure logger based on log_level
         if log_level is None:
-            self.logger.addHandler(logging.NullHandler())
+            self.logger.disabled = True
         else:
             self.logger.setLevel(log_level)
 

--- a/common/tests/profiling/test_stopwatch.py
+++ b/common/tests/profiling/test_stopwatch.py
@@ -8,8 +8,8 @@ from metta.common.profiling.stopwatch import Checkpoint, Stopwatch, with_instanc
 
 @pytest.fixture
 def stopwatch():
-    """Stopwatch fixture with default logger."""
-    return Stopwatch()
+    """Stopwatch fixture with logging enabled."""
+    return Stopwatch(log_level=logging.INFO)
 
 
 @pytest.fixture(autouse=True)
@@ -21,43 +21,6 @@ def cleanup():
 
 class TestStopwatch:
     """Test suite for Stopwatch class."""
-
-    def test_initialization(self):
-        """Test stopwatch initialization."""
-        # Test with default log_level (None)
-        sw = Stopwatch()
-
-        # Check that logger is created with unique instance name
-        assert isinstance(sw.logger, logging.Logger)
-        assert sw.logger.name.startswith("Stopwatch.")
-        assert sw.logger.name == f"Stopwatch.{id(sw)}"
-
-        # Check that NullHandler was added
-        null_handlers = [h for h in sw.logger.handlers if isinstance(h, logging.NullHandler)]
-        assert len(null_handlers) >= 1, "Logger should have at least one NullHandler when log_level is None"
-
-        # Check global timer setup
-        assert sw.GLOBAL_TIMER_NAME == "global"
-        assert sw.GLOBAL_TIMER_NAME in sw._timers
-        assert sw.max_laps == 4  # default value
-
-        # Test with explicit log level
-        sw2 = Stopwatch(log_level=logging.INFO)
-        assert sw2.logger.name == f"Stopwatch.{id(sw2)}"
-        assert sw2.logger.level == logging.INFO
-        # Verify each instance has a unique logger
-        assert sw.logger.name != sw2.logger.name
-
-        # Test with custom max_laps
-        sw3 = Stopwatch(max_laps=10)
-        assert sw3.max_laps == 10
-        assert sw3.logger.name == f"Stopwatch.{id(sw3)}"
-
-        # Test that setting log level on one instance doesn't affect another
-        sw4 = Stopwatch(log_level=logging.DEBUG)
-        sw5 = Stopwatch(log_level=logging.ERROR)
-        assert sw4.logger.level == logging.DEBUG
-        assert sw5.logger.level == logging.ERROR
 
     def test_basic_timing(self, stopwatch):
         """Test basic start/stop timing."""
@@ -605,7 +568,7 @@ class TestStopwatchIntegration:
 
     def test_logging_scenarios(self, caplog):
         """Test various logging scenarios in integration."""
-        sw = Stopwatch()
+        sw = Stopwatch(log_level=logging.INFO)
 
         with caplog.at_level(logging.INFO):
             # Test multiple operations with logging
@@ -646,8 +609,8 @@ class TestStopwatchIntegration:
 
         class TestClass:
             def __init__(self):
-                self.timer = Stopwatch()  # Default timer attribute
-                self.instance_timer = Stopwatch()  # Custom timer attribute
+                self.timer = Stopwatch(log_level=logging.INFO)  # Default timer attribute with logging
+                self.instance_timer = Stopwatch(log_level=logging.INFO)  # Custom timer attribute with logging
                 self.call_count = 0
 
             @with_timer(sw, "external_timer")

--- a/common/tests/profiling/test_system_monitor.py
+++ b/common/tests/profiling/test_system_monitor.py
@@ -10,29 +10,13 @@ from metta.common.profiling.system_monitor import SystemMonitor
 @pytest.fixture
 def monitor() -> Generator[SystemMonitor, None, None]:
     """Create a SystemMonitor instance with auto_start=False"""
-    monitor = SystemMonitor(sampling_interval_sec=0.1, history_size=10, auto_start=False)
+    monitor = SystemMonitor(sampling_interval_sec=0.1, history_size=10, auto_start=False, log_level=logging.INFO)
     yield monitor
     # Cleanup
     monitor.stop()
 
 
 class TestInitialization:
-    def test_init_default_params(self):
-        """Test initialization with default parameters"""
-        monitor = SystemMonitor(auto_start=False)
-
-        assert monitor.sampling_interval_sec == 1.0
-        assert monitor.history_size == 100
-        assert not monitor._thread or not monitor._thread.is_alive()
-
-        # Check logger is created with unique instance name
-        assert isinstance(monitor.logger, logging.Logger)
-        assert monitor.logger.name == f"SystemMonitor.{id(monitor)}"
-
-        # Check that NullHandler was added (default log_level is None)
-        null_handlers = [h for h in monitor.logger.handlers if isinstance(h, logging.NullHandler)]
-        assert len(null_handlers) >= 1, "Logger should have at least one NullHandler when log_level is None"
-
     def test_init_custom_params(self):
         """Test initialization with custom parameters"""
         monitor = SystemMonitor(sampling_interval_sec=2.0, history_size=50, log_level=logging.DEBUG, auto_start=False)
@@ -40,27 +24,6 @@ class TestInitialization:
         assert monitor.sampling_interval_sec == 2.0
         assert monitor.history_size == 50
         assert monitor.logger.level == logging.DEBUG
-
-    def test_log_levels(self):
-        """Test initialization with different log levels"""
-        # Test with None (should add NullHandler)
-        monitor1 = SystemMonitor(log_level=None, auto_start=False)
-        null_handlers = [h for h in monitor1.logger.handlers if isinstance(h, logging.NullHandler)]
-        assert len(null_handlers) >= 1
-
-        # Test with explicit log level
-        monitor2 = SystemMonitor(log_level=logging.INFO, auto_start=False)
-        assert monitor2.logger.level == logging.INFO
-
-        # Verify each instance has unique logger
-        assert monitor1.logger.name != monitor2.logger.name
-        assert monitor1.logger.name == f"SystemMonitor.{id(monitor1)}"
-        assert monitor2.logger.name == f"SystemMonitor.{id(monitor2)}"
-
-        # Test that log levels are isolated
-        monitor3 = SystemMonitor(log_level=logging.ERROR, auto_start=False)
-        assert monitor2.logger.level == logging.INFO  # Unchanged
-        assert monitor3.logger.level == logging.ERROR
 
     def test_auto_start(self):
         """Test auto_start functionality"""


### PR DESCRIPTION
For classes with optional log levels
- support disabling by setting logger.disabled=True
- setting log level on a logger prevents logs sent at lower levels from being sent to handlers or propagating to the root logger, so it's sufficient to just set the level on the logger and not its handlers (or root handlers)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211230404822390)