### PR TITLE
Fix: `metta` binary correctly uses enclosing uv project

### DIFF
--- a/metta/setup/installer/bin/metta
+++ b/metta/setup/installer/bin/metta
@@ -2,12 +2,13 @@
 # Wrapper script for metta command
 # This allows users to run 'metta' directly without prefixing with 'uv run'
 
-# Function to find the metta repository root
-find_metta_root() {
-    local dir="$PWD"
+# Function to find the metta repository root starting from a given directory
+find_metta_root_from() {
+    local dir="$1"
     while [ "$dir" != "/" ]; do
         # Check if this is a metta repository
-        if [ -f "$dir/metta/setup/metta_cli.py" ] && [ -d "$dir/.git" ]; then
+        # Note: .git can be either a directory (regular repo) or a file (worktree)
+        if [ -f "$dir/metta/setup/metta_cli.py" ] && [ -e "$dir/.git" ]; then
             echo "$dir"
             return 0
         fi
@@ -16,16 +17,19 @@ find_metta_root() {
     return 1
 }
 
-# First, try to find if we're in a metta repository
-if metta_root=$(find_metta_root); then
-    # We're in a metta repository (could be main repo or worktree)
-    PROJECT_DIR="$metta_root"
+# First, resolve the symlink to find the default metta repository
+# This ensures we use the repository where the symlink points (e.g., m3)
+SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+DEFAULT_PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Now check if we're currently in a different metta repository
+if current_metta_root=$(find_metta_root_from "$PWD"); then
+    # We're in a metta repository - use it instead of the default
+    PROJECT_DIR="$current_metta_root"
 else
-    # Fall back to the original install location
-    # Get the real path of this script (following symlinks)
-    SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
-    PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    # Not in a metta repository - use the default (where symlink points)
+    PROJECT_DIR="$DEFAULT_PROJECT_DIR"
 fi
 
 # Run metta using uv with the project directory

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
+import gitta
+
 # Minimal imports needed for all commands (or safe minimal imports tested for non-slowness)
 from metta.common.util.fs import get_repo_root
 from metta.setup.profiles import PROFILE_DEFINITIONS, UserType
@@ -532,6 +534,10 @@ class MettaCLI:
     def cmd_report_env_details(self, args, unknown_args=None) -> None:
         print(f"UV Project Directory: {self.repo_root}")
         print(f"Metta CLI Working Directory: {Path.cwd()}")
+        if branch := gitta.get_current_branch():
+            print(f"Git Branch: {branch}")
+        if commit := gitta.get_current_commit():
+            print(f"Git Commit: {commit}")
 
     def cmd_local(self, args, unknown_args=None) -> None:
         self.local_commands.main(unknown_args)


### PR DESCRIPTION
`./install.sh` sets up a symlink to ~/.local/bin such that `metta` can be used in lieu of `uv run metta`. to support multiple checkouts, the symlnik points to a binary that tries to identify the appropriate checkout and use its uv environment

Our logic for finding the appropriate checkout was previously broken, which made running `metta` always refer to the `metta_cli.py` in the checkout from which the symlink was established even if you were currently within another checkout. this fixes that

