### PR TITLE
Make converter obs tests less fragile

### DIFF
--- a/mettagrid/tests/test_converter.py
+++ b/mettagrid/tests/test_converter.py
@@ -95,17 +95,15 @@ class TestConverterObservations:
         # Check generator at position (3, 1) - appears at (4, 2) in observation window
         generator_tokens = self.get_converter_tokens_at_location(agent_obs, 4, 2)
 
+        input_output_feature_ids = {
+            v["id"] for k, v in env.feature_spec().items() if k.startswith("input:") or k.startswith("output:")
+        }
+
         # Extract feature IDs from tokens
         feature_ids = generator_tokens[:, 1]
 
-        # Inventory features are IDs 14-17
-        inventory_feature_start = 14
-        inventory_feature_end = inventory_feature_start + 4  # 4 inventory items
-
         # No inventory features should be present (since converter has no actual inventory)
-        inventory_features = feature_ids[
-            (feature_ids >= inventory_feature_start) & (feature_ids < inventory_feature_end)
-        ]
+        inventory_features = [id for id in feature_ids if id in input_output_feature_ids]
 
         assert len(inventory_features) == 0, (
             "No inventory/recipe features should be present when recipe_details_obs=False"
@@ -120,26 +118,12 @@ class TestConverterObservations:
         # Check generator at position (3, 1) - appears at (4, 2) in observation window
         generator_tokens = self.get_converter_tokens_at_location(agent_obs, 4, 2)
 
-        # Converters should emit TypeId, Color, ConvertingOrCoolingDown, and recipe inputs
-        assert len(generator_tokens) >= 3, f"Converter should emit at least 3 tokens, got {len(generator_tokens)}"
-
-        # Extract feature IDs and values from tokens
-        feature_ids = generator_tokens[:, 1]
-        feature_values = generator_tokens[:, 2]
+        ore_red_input_id = env.feature_spec()["input:ore_red"]["id"]
+        ore_blue_input_id = env.feature_spec()["input:ore_blue"]["id"]
+        battery_red_output_id = env.feature_spec()["output:battery_red"]["id"]
 
         # Create a mapping of feature ID to value
-        feature_map = {fid: val for fid, val in zip(feature_ids, feature_values, strict=False)}
-
-        # Calculate dynamic offsets based on inventory item count
-        resource_count = 4  # ore_red, ore_blue, battery_red, heart
-        input_recipe_offset = 15 + resource_count  # 19
-        output_recipe_offset = input_recipe_offset + resource_count  # 23
-
-        # Recipe inputs are shown at dynamic offsets
-        # ore_red=input_recipe_offset+0, ore_blue=input_recipe_offset+1, etc.
-        ore_red_input_id = input_recipe_offset + 0  # 18
-        ore_blue_input_id = input_recipe_offset + 1  # 19
-        battery_red_output_id = output_recipe_offset + 2  # 24
+        feature_map = {token[1]: token[2] for token in generator_tokens}
 
         assert ore_red_input_id in feature_map, f"Should have ore_red recipe input at offset {ore_red_input_id}"
         assert ore_blue_input_id in feature_map, f"Should have ore_blue recipe input at offset {ore_blue_input_id}"
@@ -155,45 +139,6 @@ class TestConverterObservations:
         assert feature_map[battery_red_output_id] == 1, (
             f"battery_red output should be 1, got {feature_map[battery_red_output_id]}"
         )
-
-    def test_altar_obs_with_recipe_details(self):
-        """Test altar observations with recipe details enabled."""
-        env = self.create_converter_env(recipe_details_obs=True)
-        obs, _ = env.reset()
-        agent_obs = obs[0]
-
-        # Check altar at position (1, 3) - appears at (2, 4) in observation window
-        altar_tokens = self.get_converter_tokens_at_location(agent_obs, 2, 4)
-
-        # Altar should emit at least TypeId, Color, and ConvertingOrCoolingDown
-        assert len(altar_tokens) >= 3, f"Altar should emit at least 3 tokens, got {len(altar_tokens)}"
-
-        # Extract feature IDs and values
-        feature_ids = altar_tokens[:, 1]
-        feature_values = altar_tokens[:, 2]
-
-        # Create a mapping of feature ID to value
-        feature_map = {fid: val for fid, val in zip(feature_ids, feature_values, strict=False)}
-
-        # Calculate dynamic offsets based on inventory item count
-        resource_count = 4  # ore_red, ore_blue, battery_red, heart
-        input_recipe_offset = 15 + resource_count
-        output_recipe_offset = input_recipe_offset + resource_count
-
-        # Altar expects: battery_red=3 (feature ID is input_recipe_offset + 2)
-        battery_red_input_id = input_recipe_offset + 2
-        heart_output_id = output_recipe_offset + 3
-
-        assert battery_red_input_id in feature_map, (
-            f"Should have battery_red recipe input at offset {battery_red_input_id}"
-        )
-        assert feature_map[battery_red_input_id] == 3, (
-            f"battery_red input should be 3, got {feature_map[battery_red_input_id]}"
-        )
-
-        # Altar produces: heart=1
-        assert heart_output_id in feature_map, f"Should have heart recipe output at offset {heart_output_id}"
-        assert feature_map[heart_output_id] == 1, f"heart output should be 1, got {feature_map[heart_output_id]}"
 
     def test_multiple_converters_different_recipes(self):
         """Test that different converters show their own recipe details correctly."""
@@ -215,15 +160,9 @@ class TestConverterObservations:
         # Extract recipe features for altar
         altar_feature_map = {token[1]: token[2] for token in altar_tokens}
 
-        # Calculate dynamic offsets
-        resource_count = 4  # ore_red, ore_blue, battery_red, heart
-        input_recipe_offset = 15 + resource_count
-
-        # Verify they have different recipe requirements
-        # Generator has ore_red and ore_blue inputs
-        ore_red_input_id = input_recipe_offset + 0  # 18
-        ore_blue_input_id = input_recipe_offset + 1  # 19
-        battery_red_input_id = input_recipe_offset + 2  # 20
+        ore_red_input_id = env.feature_spec()["input:ore_red"]["id"]
+        ore_blue_input_id = env.feature_spec()["input:ore_blue"]["id"]
+        battery_red_input_id = env.feature_spec()["input:battery_red"]["id"]
 
         assert ore_red_input_id in gen_feature_map and ore_blue_input_id in gen_feature_map, (
             f"Generator should have ore inputs at offsets {ore_red_input_id}, {ore_blue_input_id}"
@@ -234,42 +173,5 @@ class TestConverterObservations:
 
         # Verify the recipe differences
         assert battery_red_input_id not in gen_feature_map, "Generator should not have battery_red input"
-        assert ore_red_input_id not in altar_feature_map and ore_blue_input_id not in altar_feature_map, (
-            "Altar should not have ore inputs"
-        )
-
-    def test_converter_with_no_inputs(self):
-        """Test converter that produces output without requiring inputs."""
-        game_config = self.get_base_game_config()
-        game_config["recipe_details_obs"] = True
-        game_config["resource_names"] = ["ore_red"]  # Only one inventory item
-
-        # Add mine object
-        game_config["objects"]["mine"] = {
-            "type_id": 2,
-            "input_resources": {},  # No inputs required
-            "output_resources": {"ore_red": 1},
-            "max_output": -1,
-            "conversion_ticks": 1,
-            "cooldown": 0,
-            "initial_resource_count": 0,
-            "color": 1,
-        }
-
-        game_map = [
-            ["wall", "wall", "wall"],
-            ["wall", "agent.agent", "mine"],
-            ["wall", "wall", "wall"],
-        ]
-
-        env = MettaGrid(from_mettagrid_config(game_config), game_map, 42)
-        obs, _ = env.reset()
-        agent_obs = obs[0]
-
-        # Check mine at position (2, 1) - appears at (3, 2) in observation window
-        mine_tokens = self.get_converter_tokens_at_location(agent_obs, 3, 2)
-        feature_ids = mine_tokens[:, 1]
-
-        # Mine has no input requirements, so should only have base features
-        inventory_features = feature_ids[(feature_ids >= 14) & (feature_ids < 15)]
-        assert len(inventory_features) == 0, "Mine with no inputs should have no recipe features"
+        assert ore_red_input_id not in altar_feature_map, "Altar should not have ore_red input"
+        assert ore_blue_input_id not in altar_feature_map, "Altar should not have ore_blue input"


### PR DESCRIPTION
This removes some hard coding of feature ids / feature id space from tests. This now only relies on the string names of the features remaining consistent.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211230708254653)