### PR TITLE
fix wandb run name

### DIFF
--- a/metta/rl/stats.py
+++ b/metta/rl/stats.py
@@ -404,9 +404,13 @@ def process_policy_evaluator_stats(
     if epoch is None or agent_step is None or not run_name:
         logger.warning("No epoch or agent_step found in policy record - using defaults")
 
+    # Sanitize run_name for wandb - remove version suffix and invalid characters
+    # WandB run IDs cannot contain: :;,#?/'
+    sanitized_run_name = run_name.split(":")[0] if run_name else None
+
     # TODO: improve this parsing to be more general
     run = wandb.init(
-        id=run_name,
+        id=sanitized_run_name,
         project=METTA_WANDB_PROJECT,
         entity=METTA_WANDB_ENTITY,
         resume="must",


### PR DESCRIPTION
# Fix WandB Run ID Validation Error During Policy Evaluation

## Problem
Policy evaluation was failing with error:
```
Run ID cannot contain the characters: :;,#?/'
```

## Root Cause
The `get_wandb_checkpoint_metadata()` function appends version suffixes (`:v7`) to run names, but `process_policy_evaluator_stats()` uses these unsanitized run names directly as WandB run IDs. WandB rejects run IDs containing `:` characters.

## Solution
Sanitize run names before passing to `wandb.init()` by:
- Removing version suffix (`:v7` → empty)  
- Ensuring compatibility with WandB run ID constraints

## Testing
- Confirmed fix resolves evaluation error during policy evaluation
- No impact on existing functionality

## Files Changed
- `metta/rl/stats.py`: Added run name sanitization in `process_policy_evaluator_stats()`

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211243086732274)