### PR TITLE
Simplify pushing child repo via subdirectory-filter

### DIFF
--- a/devops/git/push_child_repo.py
+++ b/devops/git/push_child_repo.py
@@ -1,77 +1,64 @@
 #!/usr/bin/env python3
 """
-Sync child repositories from monorepo with preserved git history.
+Extract the `mettagrid/` subdirectory as a standalone repo (history preserved)
+and push it to a target repository.
 
 Usage:
-    uv run devops/git/sync_package.py filter_repo_test
-    uv run devops/git/sync_package.py filter_repo_test --dry-run
-    uv run devops/git/sync_package.py filter_repo_test --yes  # Skip confirmations
+    # Dry run (no push)
+    uv run devops/git/push_child_repo.py Metta-AI/mettagrid --dry-run
 
-Add new repos to CONFIG_REGISTRY below.
+    # Force push to target (with confirmations unless -y)
+    uv run devops/git/push_child_repo.py Metta-AI/mettagrid -y
+
+Target can be either an HTTPS remote URL or an owner/repo slug.
+Only HTTPS is supported (no SSH).
 """
 
 import argparse
 import sys
 from pathlib import Path
 
-from pydantic import field_validator
-
 import gitta as git
-from metta.common.util.git_repo import GITHUB_ORGANIZATION
-from metta.mettagrid.config import Config
+
+SUBDIR = "mettagrid"
 
 
-class FilterRepoConfig(Config):
-    """Child repository configuration."""
+def build_remote_url(target: str) -> str:
+    """Build HTTPS remote URL from input target.
 
-    name: str
-    paths: list[str]
+    - If target is an HTTPS URL, return as-is
+    - If target is an owner/repo slug, return https://github.com/owner/repo.git
+    - Otherwise, exit with an error (SSH and non-HTTPS URLs are not supported)
+    """
+    # HTTPS URL provided
+    if target.startswith("https://"):
+        return target
 
-    @property
-    def remote(self) -> str:
-        """Construct remote URL from name and organization."""
-        return f"git@github.com:{GITHUB_ORGANIZATION}/{self.name}.git"
+    # Disallow SSH and non-HTTPS URLs
+    if target.startswith("git@") or target.startswith("ssh://") or target.startswith("http://"):
+        raise SystemExit("Only HTTPS remotes are supported. Provide an HTTPS URL or 'owner/repo' slug.")
 
-    @field_validator("paths")
-    @classmethod
-    def normalize_paths(cls, v: list[str]) -> list[str]:
-        """Ensure paths end with /."""
-        return [p.rstrip("/") + "/" for p in v]
+    # Expect owner/repo slug
+    if "/" not in target:
+        raise SystemExit("Target must be an HTTPS URL or an 'owner/repo' slug")
 
-
-CONFIG_REGISTRY = {
-    key: FilterRepoConfig(
-        name=key,
-        paths=paths,
-    )
-    for key, paths in {
-        # Add new child repositories here
-        "test_filter_repo": ["tests", "README.md"],
-        "mettagrid": ["mettagrid", "mettascope"],
-    }.items()
-}
+    owner_repo = target.strip("/")
+    return f"https://github.com/{owner_repo}.git"
 
 
-def sync_repo(config_name: str, dry_run: bool = False, skip_confirmation: bool = False):
-    """Filter and push repository subset to configured remote."""
+def sync_repo(target: str, dry_run: bool = False, skip_confirmation: bool = False):
+    """Filter `SUBDIR/` to repo root and push to the target remote."""
 
-    # Load config
-    if config_name not in CONFIG_REGISTRY:
-        available = ", ".join(CONFIG_REGISTRY.keys())
-        print(f"Unknown config: {config_name}")
-        print(f"Available: {available}")
-        sys.exit(1)
-
-    config = CONFIG_REGISTRY[config_name]
-
-    print(f"Syncing: {config.name}")
-    print(f"Paths: {', '.join(config.paths)}")
-    print(f"Target: {config.remote}")
+    remote_url = build_remote_url(target)
+    print(f"Syncing target: {target}")
+    print(f"Subdir: {SUBDIR}/")
+    print(f"Target: {remote_url}")
 
     # Step 1: Filter
     print("\nFiltering repository...")
     try:
-        filtered_path = git.filter_repo(Path.cwd(), config.paths)
+        # Make the configured subdirectory the repository root in the filtered repo
+        filtered_path = git.filter_repo(Path.cwd(), [SUBDIR], root_subdir=SUBDIR)
     except Exception as e:
         print(f"Filter failed: {e}")
         sys.exit(1)
@@ -84,7 +71,7 @@ def sync_repo(config_name: str, dry_run: bool = False, skip_confirmation: bool =
     # Step 3: Safety checks before push
     try:
         current_origin = git.run_git("remote", "get-url", "origin").strip()
-        if current_origin and config.remote.rstrip("/").rstrip(".git") == current_origin.rstrip("/").rstrip(".git"):
+        if current_origin and remote_url.rstrip("/").rstrip(".git") == current_origin.rstrip("/").rstrip(".git"):
             print("\n*** SAFETY STOP ***")
             print("Target remote matches current origin!")
             print("This would destroy the main repository.")
@@ -93,12 +80,12 @@ def sync_repo(config_name: str, dry_run: bool = False, skip_confirmation: bool =
         pass  # No origin is fine
 
     # Step 4: Push (with confirmations)
-    print(f"\n{'DRY RUN: ' if dry_run else ''}Push to {config.remote}")
+    print(f"\n{'DRY RUN: ' if dry_run else ''}Push to {remote_url}")
 
     if not dry_run and not skip_confirmation:
         print("\nThis will FORCE PUSH and replace the target repository!")
         print("Type the target URL to confirm:")
-        if input("> ").strip() != config.remote:
+        if input("> ").strip() != remote_url:
             print("Aborted - URLs don't match")
             sys.exit(1)
 
@@ -108,7 +95,7 @@ def sync_repo(config_name: str, dry_run: bool = False, skip_confirmation: bool =
 
     # Do the push
     try:
-        git.add_remote("production", config.remote, filtered_path)
+        git.add_remote("production", remote_url, filtered_path)
 
         push_cmd = ["push", "--force", "production", "HEAD:main"]
         if dry_run:
@@ -128,14 +115,14 @@ def sync_repo(config_name: str, dry_run: bool = False, skip_confirmation: bool =
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("config", help="Repository config name")
+    parser.add_argument("target", help="Target GitHub repository (owner/repo) or full remote URL")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be pushed")
     parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
 
     args = parser.parse_args()
 
     try:
-        sync_repo(args.config, args.dry_run, args.yes)
+        sync_repo(args.target, args.dry_run, args.yes)
     except KeyboardInterrupt:
         print("\nAborted")
         sys.exit(1)

--- a/gitta/src/gitta/__init__.py
+++ b/gitta/src/gitta/__init__.py
@@ -688,7 +688,7 @@ def post_commit_status(
 # ============================================================================
 
 
-def filter_repo(source_path: Path, paths: list[str]) -> Path:
+def filter_repo(source_path: Path, paths: list[str], root_subdir: str | None = None) -> Path:
     """Filter repository to only include specified paths.
 
     Args:
@@ -731,10 +731,14 @@ def filter_repo(source_path: Path, paths: list[str]) -> Path:
 
     # Filter repository
     filter_cmd = ["git", "filter-repo", "--force"]
-    for path in paths:
-        filter_cmd.extend(["--path", path])
-
-    print(f"Filtering to: {', '.join(paths)}")
+    if root_subdir:
+        # Make specified subdirectory become repository root
+        filter_cmd.extend(["--subdirectory-filter", root_subdir])
+        print(f"Filtering to subdirectory root: {root_subdir}")
+    else:
+        for path in paths:
+            filter_cmd.extend(["--path", path])
+        print(f"Filtering to: {', '.join(paths)}")
 
     result = subprocess.run(filter_cmd, cwd=filtered_path, capture_output=True, text=True)
     if result.returncode != 0:


### PR DESCRIPTION
Makes the mettagrid folder the new root in a child-repo. 

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211252817267396)