### PR TITLE
fix bazel cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -380,15 +380,30 @@ jobs:
         with:
           install-mode: "testing"
 
+      - name: Setup Bazel caching
+        run: |
+          # Configure Bazel to use specific cache directories
+          echo "build --disk_cache=$HOME/.bazel-disk-cache" >> .bazelrc
+          echo "build --repository_cache=$HOME/.bazel-repo-cache" >> .bazelrc
+
+          # Ensure directories exist
+          mkdir -p $HOME/.bazel-disk-cache
+          mkdir -p $HOME/.bazel-repo-cache
+
       - name: Cache Bazel build artifacts
         uses: actions/cache@v4
+        id: bazel-cache
         with:
           path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
+            ~/.bazel-disk-cache
+            ~/.bazel-repo-cache
           key: bazel-${{ runner.os }}-${{ hashFiles('mettagrid/MODULE.bazel', 'mettagrid/.bazelrc', '.bazelversion') }}
           restore-keys: |
             bazel-${{ runner.os }}-
+
+      - name: Clean Bazel output if no cache hit
+        if: steps.bazel-cache.outputs.cache-hit != 'true'
+        run: bazel clean --expunge
 
       - name: Build MettaGrid C++ (with coverage)
         id: mettagrid_build_check
@@ -460,15 +475,30 @@ jobs:
         with:
           install-mode: "testing"
 
+      - name: Setup Bazel caching
+        run: |
+          # Configure Bazel to use specific cache directories
+          echo "build --disk_cache=$HOME/.bazel-disk-cache" >> .bazelrc
+          echo "build --repository_cache=$HOME/.bazel-repo-cache" >> .bazelrc
+
+          # Ensure directories exist
+          mkdir -p $HOME/.bazel-disk-cache
+          mkdir -p $HOME/.bazel-repo-cache
+
       - name: Cache Bazel build artifacts
         uses: actions/cache@v4
+        id: bazel-cache
         with:
           path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
+            ~/.bazel-disk-cache
+            ~/.bazel-repo-cache
           key: bazel-${{ runner.os }}-${{ hashFiles('mettagrid/MODULE.bazel', 'mettagrid/.bazelrc', '.bazelversion') }}
           restore-keys: |
             bazel-${{ runner.os }}-
+
+      - name: Clean Bazel output if no cache hit
+        if: steps.bazel-cache.outputs.cache-hit != 'true'
+        run: bazel clean --expunge
 
       - name: Build C++ benchmarks
         id: benchmark_build_check


### PR DESCRIPTION

The CI was failing to restore Bazel cache with errors:
- "Cannot open: File exists" when extracting cached files
- Future timestamp warnings (files dated 2035)

### Solution
- Configure Bazel to use dedicated cache directories (`~/.bazel-disk-cache` and `~/.bazel-repo-cache`) instead of the default `~/.cache/bazel`
- Add these paths to `.bazelrc` to ensure Bazel uses them consistently
- Clean Bazel state when there's no cache hit to avoid conflicts

### Changes
- Added "Setup Bazel caching" step to configure cache directories
- Updated cache paths in `actions/cache@v4` to use the new locations
- Added `bazel clean --expunge` when cache miss occurs

This prevents conflicts with Bazel's internal directory structure and resolves the extraction errors.