### PR TITLE
fix passing of observatory tokens to create_job_secrets in skypilot jobs

### DIFF
--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -990,7 +990,7 @@ class MettaRepo:
     async def create_machine_token(self, user_id: str, name: str, expiration_days: int = 365) -> str:
         """Create a new machine token for a user."""
         # Generate a secure random token
-        token = f"obs-{secrets.token_urlsafe(32)}"
+        token = secrets.token_urlsafe(32)
         token_hash = self._hash_token(token)
 
         # Set expiration time

--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -990,7 +990,7 @@ class MettaRepo:
     async def create_machine_token(self, user_id: str, name: str, expiration_days: int = 365) -> str:
         """Create a new machine token for a user."""
         # Generate a secure random token
-        token = secrets.token_urlsafe(32)
+        token = "obs-" + secrets.token_urlsafe(32)
         token_hash = self._hash_token(token)
 
         # Set expiration time

--- a/app_backend/src/metta/app_backend/metta_repo.py
+++ b/app_backend/src/metta/app_backend/metta_repo.py
@@ -990,7 +990,7 @@ class MettaRepo:
     async def create_machine_token(self, user_id: str, name: str, expiration_days: int = 365) -> str:
         """Create a new machine token for a user."""
         # Generate a secure random token
-        token = "obs-" + secrets.token_urlsafe(32)
+        token = f"obs-{secrets.token_urlsafe(32)}"
         token_hash = self._hash_token(token)
 
         # Set expiration time

--- a/devops/skypilot/config/lifecycle/configure_environment.sh
+++ b/devops/skypilot/config/lifecycle/configure_environment.sh
@@ -123,7 +123,7 @@ CMD="uv run ./devops/skypilot/config/lifecycle/create_job_secrets.py --profile s
 
 # Add observatory-token only if it's set
 if [ -n "$OBSERVATORY_TOKEN" ]; then
-  CMD="$CMD --observatory-token \"$OBSERVATORY_TOKEN\""
+  CMD="$CMD --observatory-token=\"$OBSERVATORY_TOKEN\""
 fi
 
 # Execute the command


### PR DESCRIPTION
Daphne ran into a very confusing issue where her observatory token existed locally, `metta status` said it was fine, and she kept getting issues in skypilot jobs indicating the arg was missing or malformed

It was because her token had a hyphen prefixing it, and our previous way of passing that to create_job_secrets within skypilot runs didn't escape that

This change should fix the passing of such tokens

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211320319176404)