### PR TITLE
Update hyperparameters based on sweep results

### DIFF
--- a/metta/rl/loss/ppo_config.py
+++ b/metta/rl/loss/ppo_config.py
@@ -43,11 +43,11 @@ class PPOConfig(Config):
     schedule: None = None  # TODO: Implement this
     # PPO hyperparameters
     # Clip coefficient: 0.1 is conservative, common range 0.1-0.3 from PPO paper (Schulman et al., 2017)
-    clip_coef: float = Field(default=0.1, gt=0, le=1.0)
+    clip_coef: float = Field(default=0.264407, gt=0, le=1.0)
     # Entropy coefficient: Type 2 default chosen from sweep
-    ent_coef: float = Field(default=0.0021, ge=0)
+    ent_coef: float = Field(default=0.010000, ge=0)
     # GAE lambda: Type 2 default chosen from sweep, deviates from typical 0.95, bias/variance tradeoff
-    gae_lambda: float = Field(default=0.916, ge=0, le=1.0)
+    gae_lambda: float = Field(default=0.891477, ge=0, le=1.0)
     # Gamma: Type 2 default chosen from sweep, deviates from typical 0.99, suggests shorter
     # effective horizon for multi-agent
     gamma: float = Field(default=0.977, ge=0, le=1.0)
@@ -58,7 +58,7 @@ class PPOConfig(Config):
     # Value function clipping: Matches policy clip for consistency
     vf_clip_coef: float = Field(default=0.1, ge=0)
     # Value coefficient: Type 2 default chosen from sweep, balances policy vs value loss
-    vf_coef: float = Field(default=0.44, ge=0)
+    vf_coef: float = Field(default=0.897619, ge=0)
     # L2 regularization: Disabled by default, common in RL
     l2_reg_loss_coef: float = Field(default=0, ge=0)
     l2_init_loss_coef: float = Field(default=0, ge=0)

--- a/metta/rl/trainer_config.py
+++ b/metta/rl/trainer_config.py
@@ -13,13 +13,13 @@ from metta.sim.simulation_config import SimulationConfig
 class OptimizerConfig(Config):
     type: Literal["adam", "muon"] = "adam"
     # Learning rate: Type 2 default chosen by sweep
-    learning_rate: float = Field(default=0.000457, gt=0, le=1.0)
+    learning_rate: float = Field(default=0.001153637, gt=0, le=1.0)
     # Beta1: Standard Adam default from Kingma & Ba (2014) "Adam: A Method for Stochastic Optimization"
     beta1: float = Field(default=0.9, ge=0, le=1.0)
     # Beta2: Standard Adam default from Kingma & Ba (2014)
     beta2: float = Field(default=0.999, ge=0, le=1.0)
     # Epsilon: Type 2 default chosen arbitrarily
-    eps: float = Field(default=1e-12, gt=0)
+    eps: float = Field(default=3.186531e-07, gt=0)
     # Weight decay: Disabled by default, common practice for RL to avoid over-regularization
     weight_decay: float = Field(default=0, ge=0)
 


### PR DESCRIPTION
**NB: The analysis below is NOT the sweep analysis. It's an analysis produced by Claude code to make the changes as transparent as possible**
# Hyperparameter Update Analysis

This document analyzes the differences between the old and new hyperparameter configurations for the Metta AI training pipeline.

## Configuration File Locations

The updated hyperparameters are located in:
- **PPO Loss Parameters**: `metta/rl/loss/ppo_config.py`
- **Optimizer Parameters**: `metta/rl/trainer_config.py`

## Parameter Changes Summary

### PPO Loss Configuration Parameters

| Parameter | Old Value | New Value | Absolute Change | Percentage Change | Impact Level |
|-----------|-----------|-----------|-----------------|-------------------|--------------|
| `clip_coef` | 0.1 | 0.264407 | +0.164407 | **+164.4%** | High |
| `ent_coef` | 0.0021 | 0.010000 | +0.0079 | **+376.2%** | Very High |
| `gae_lambda` | 0.916 | 0.891477 | -0.024523 | **-2.7%** | Low |
| `vf_coef` | 0.44 | 0.897619 | +0.457619 | **+104.0%** | High |

### Optimizer Configuration Parameters

| Parameter | Old Value | New Value | Absolute Change | Percentage Change | Impact Level |
|-----------|-----------|-----------|-----------------|-------------------|--------------|
| `learning_rate` | 0.000457 | 0.001153637 | +0.000696637 | **+152.5%** | High |
| `eps` | 1e-12 | 3.186531e-07 | +3.185531e-07 | **+31,855,310%** | Low* |

*Note: While the percentage change for `eps` is enormous, both values are extremely small, so the practical impact is likely minimal.

## Detailed Analysis

### High Impact Changes

#### 1. Entropy Coefficient (`ent_coef`): 0.0021 → 0.010000 (+376.2%)
- **Effect**: Dramatically increased exploration
- **Implications**: 
  - Agents will take more random actions during training
  - May slow initial convergence but improve final policy diversity
  - Better exploration of action space, potentially finding better solutions
  - Risk of instability if too high for the environment

#### 2. Clip Coefficient (`clip_coef`): 0.1 → 0.264407 (+164.4%)
- **Effect**: Allows much larger policy updates per training step
- **Implications**:
  - Faster learning and adaptation
  - Higher risk of policy instability
  - May overshoot optimal policies
  - Could lead to more aggressive policy changes

#### 3. Learning Rate (`learning_rate`): 0.000457 → 0.001153637 (+152.5%)
- **Effect**: 2.5x faster parameter updates
- **Implications**:
  - Accelerated learning, especially early in training
  - Higher risk of overshooting minima
  - May require careful monitoring for instability
  - Could improve sample efficiency

#### 4. Value Function Coefficient (`vf_coef`): 0.44 → 0.897619 (+104.0%)
- **Effect**: Doubles the weight given to value function loss
- **Implications**:
  - More emphasis on accurate value estimation
  - Better critic performance, leading to better advantage estimates
  - May slow policy learning relative to value learning
  - Could improve training stability through better baselines

### Low Impact Changes

#### 5. GAE Lambda (`gae_lambda`): 0.916 → 0.891477 (-2.7%)
- **Effect**: Slightly reduces the weight of future rewards in advantage estimation
- **Implications**:
  - Minor adjustment to bias-variance tradeoff in advantage estimation
  - Slightly more focus on immediate rewards
  - Minimal expected impact on training behavior

#### 6. Optimizer Epsilon (`eps`): 1e-12 → 3.186531e-07 (+31,855,310%)
- **Effect**: Changes numerical stability parameter for Adam optimizer
- **Implications**:
  - Both values are extremely small
  - Unlikely to have practical impact on training
  - May provide slightly different numerical behavior in edge cases

## Expected Training Behavior Changes

### Positive Effects
1. **Faster Learning**: Higher learning rate and clip coefficient should accelerate convergence
2. **Better Exploration**: Increased entropy coefficient will improve action space coverage
3. **Improved Value Estimation**: Higher value coefficient should lead to better critic performance
4. **Potentially Better Final Performance**: More exploration may find better solutions

### Potential Risks
1. **Training Instability**: Multiple parameters pushing toward faster, more aggressive updates
2. **Overshooting**: Risk of missing optimal policies due to large update steps
3. **Exploration-Exploitation Balance**: Very high entropy may slow convergence to good policies
4. **Hyperparameter Sensitivity**: Configuration may be more sensitive to environment changes

## Recommendations

### Monitoring During Training
1. **Policy Loss Stability**: Watch for oscillations or divergence
2. **Value Function Convergence**: Monitor critic loss for stability
3. **Entropy Decay**: Track entropy levels to ensure appropriate exploration decay
4. **Learning Rate Scheduling**: Consider adaptive learning rate if instability occurs

### Potential Adjustments
If training becomes unstable:
1. Reduce `clip_coef` to 0.15-0.2 range
2. Lower `learning_rate` to 0.0008-0.001 range
3. Decrease `ent_coef` to 0.005-0.007 range
4. Consider learning rate scheduling or adaptive clipping

### Success Metrics
- Faster initial learning curves
- Better final policy performance
- Maintained training stability
- Appropriate exploration throughout training

## Conclusion

These hyperparameter changes represent a significant shift toward more aggressive training with increased exploration. The configuration prioritizes faster learning and better exploration at the potential cost of training stability. Careful monitoring will be essential to ensure the benefits are realized without compromising training reliability.

The changes are particularly well-suited for:
- Environments requiring extensive exploration
- Complex multi-agent scenarios
- Cases where previous training was too conservative
- Situations where sample efficiency is critical

Success with this configuration will likely depend on the specific environment characteristics and may require fine-tuning based on observed training dynamics.



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211367499705756)