### PR TITLE
Make axel's live run monitor available as `metta run-monitor`

### DIFF
--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -12,7 +12,11 @@ from rich.table import Table
 
 from metta.common.util.fs import get_repo_root
 from metta.setup.components.base import SetupModuleStatus
+from metta.setup.local_commands import app as local_app
+from metta.setup.symlink_setup import app as symlink_app
+from metta.setup.tools.book import app as book_app
 from metta.setup.utils import debug, error, info, success, warning
+from metta.utils.live_run_monitor import app as run_monitor_app
 
 if TYPE_CHECKING:
     from metta.setup.registry import SetupModule
@@ -575,16 +579,13 @@ def cmd_clip(ctx: typer.Context):
         raise typer.Exit(1) from None
 
 
-def main() -> None:
-    from metta.setup.local_commands import app as local_app
-    from metta.setup.symlink_setup import app as symlink_app
-    from metta.setup.tools.book import app as book_app
-    from metta.utils.live_run_monitor import app as run_monitor_app
+app.add_typer(run_monitor_app, name="run-monitor", help="Monitor training runs.")
+app.add_typer(local_app, name="local")
+app.add_typer(book_app, name="book")
+app.add_typer(symlink_app, name="symlink-setup")
 
-    app.add_typer(run_monitor_app, name="run-monitor", help="Monitor training runs.")
-    app.add_typer(local_app, name="local")
-    app.add_typer(book_app, name="book")
-    app.add_typer(symlink_app, name="symlink-setup")
+
+def main() -> None:
     app()
 
 

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -585,6 +585,7 @@ def main() -> None:
     app.add_typer(local_app, name="local")
     app.add_typer(book_app, name="book")
     app.add_typer(symlink_app, name="symlink-setup")
+    app()
 
 
 if __name__ == "__main__":

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -16,6 +16,7 @@ from metta.setup.local_commands import app as local_app
 from metta.setup.symlink_setup import app as symlink_app
 from metta.setup.tools.book import app as book_app
 from metta.setup.utils import debug, error, info, success, warning
+from metta.utils.live_run_monitor import app as run_monitor_app
 
 if TYPE_CHECKING:
     from metta.setup.registry import SetupModule
@@ -578,6 +579,7 @@ def cmd_clip(ctx: typer.Context):
         raise typer.Exit(1) from None
 
 
+app.add_typer(run_monitor_app, name="run-monitor", help="Monitor training runs.")
 app.add_typer(local_app, name="local")
 app.add_typer(book_app, name="book")
 app.add_typer(symlink_app, name="symlink-setup")

--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -12,11 +12,7 @@ from rich.table import Table
 
 from metta.common.util.fs import get_repo_root
 from metta.setup.components.base import SetupModuleStatus
-from metta.setup.local_commands import app as local_app
-from metta.setup.symlink_setup import app as symlink_app
-from metta.setup.tools.book import app as book_app
 from metta.setup.utils import debug, error, info, success, warning
-from metta.utils.live_run_monitor import app as run_monitor_app
 
 if TYPE_CHECKING:
     from metta.setup.registry import SetupModule
@@ -579,14 +575,16 @@ def cmd_clip(ctx: typer.Context):
         raise typer.Exit(1) from None
 
 
-app.add_typer(run_monitor_app, name="run-monitor", help="Monitor training runs.")
-app.add_typer(local_app, name="local")
-app.add_typer(book_app, name="book")
-app.add_typer(symlink_app, name="symlink-setup")
-
-
 def main() -> None:
-    app()
+    from metta.setup.local_commands import app as local_app
+    from metta.setup.symlink_setup import app as symlink_app
+    from metta.setup.tools.book import app as book_app
+    from metta.utils.live_run_monitor import app as run_monitor_app
+
+    app.add_typer(run_monitor_app, name="run-monitor", help="Monitor training runs.")
+    app.add_typer(local_app, name="local")
+    app.add_typer(book_app, name="book")
+    app.add_typer(symlink_app, name="symlink-setup")
 
 
 if __name__ == "__main__":

--- a/metta/utils/live_run_monitor.py
+++ b/metta/utils/live_run_monitor.py
@@ -30,7 +30,6 @@ from datetime import datetime
 from typing import Annotated, List, Optional
 
 import typer
-import wandb
 from rich.console import Console, Group
 from rich.live import Live
 from rich.table import Table
@@ -487,9 +486,18 @@ def cli(
             raise typer.Exit(0) from None
         return
 
-    if not wandb.api.api_key:
-        typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
-        raise typer.Exit(1)
+    # Validate WandB access
+    try:
+        import wandb  # noqa: F401
+
+        if not wandb.api.api_key:
+            typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
+            raise typer.Exit(1)
+    except ImportError:
+        typer.echo("Error: WandB not installed. Please install with 'pip install wandb'.")
+        raise typer.Exit(1) from None
+    except Exception as e:
+        typer.echo(f"Warning: Could not validate WandB credentials: {e}")
 
     try:
         live_monitor_runs(

--- a/metta/utils/live_run_monitor.py
+++ b/metta/utils/live_run_monitor.py
@@ -489,18 +489,11 @@ def cli(
             raise typer.Exit(0) from None
         return
 
-    # Validate WandB access
-    try:
-        import wandb  # noqa: F401
+    import wandb
 
-        if not wandb.api.api_key:
-            typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
-            raise typer.Exit(1)
-    except ImportError:
-        typer.echo("Error: WandB not installed. Please install with 'pip install wandb'.")
-        raise typer.Exit(1) from None
-    except Exception as e:
-        typer.echo(f"Warning: Could not validate WandB credentials: {e}")
+    if not wandb.api.api_key:
+        typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
+        raise typer.Exit(1)
 
     try:
         live_monitor_runs(

--- a/metta/utils/live_run_monitor.py
+++ b/metta/utils/live_run_monitor.py
@@ -23,13 +23,14 @@ Usage:
     ./metta/util/live_run_monitor.py  # Monitor last 10 runs (fetch 50, display 10)
 """
 
-import argparse
 import logging
 import sys
 import time
 from datetime import datetime
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
+import typer
+import wandb
 from rich.console import Console, Group
 from rich.live import Live
 from rich.table import Table
@@ -41,6 +42,14 @@ logger = logging.getLogger(__name__)
 
 # Display limit for runs
 DISPLAY_LIMIT = 10
+
+# Typer application for CLI usage
+app = typer.Typer(
+    help="Live run monitor with rich terminal display.",
+    no_args_is_help=False,
+    rich_markup_mode="rich",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 
 def _get_status_color(status: JobStatus) -> str:
@@ -413,116 +422,94 @@ def live_monitor_runs_test(
         raise
 
 
-def main():
-    """CLI entry point for live run monitoring."""
-    parser = argparse.ArgumentParser(
-        description="Live monitor runs with rich terminal display",
-        epilog="""
-Examples:
-  %(prog)s --group my_group_name
-  %(prog)s --name-filter "axel.*"
-  %(prog)s --group my_group --name-filter "experiment.*"
-  %(prog)s --refresh 15 --entity myteam --project myproject
-  %(prog)s --fetch-limit 100 --display-limit 20  # Fetch more, display more
-  %(prog)s  # Monitor last 10 runs (fetch 50, display 10)
-
-The monitor will display a live table with color-coded statuses:
-  - Completed runs (blue)
-  - In training runs (green)
-  - Pending runs (gray)
-  - Training done, no eval (orange)
-  - Failed runs (red)
-        """,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("--group", "-g", help="WandB group to monitor (optional)")
-    parser.add_argument("--name-filter", help="Regex filter for run names (e.g., 'axel.*')")
-    parser.add_argument("--refresh", "-r", type=int, default=30, help="Refresh interval in seconds (default: 30)")
-    parser.add_argument(
-        "--entity", "-e", type=str, default="metta-research", help="WandB entity (default: metta-research)"
-    )
-    parser.add_argument("--project", "-p", type=str, default="metta", help="WandB project (default: metta)")
-    parser.add_argument(
-        "--test", action="store_true", help="Run in test mode with mock data (no WandB connection required)"
-    )
-    parser.add_argument("--no-clear", action="store_true", help="Don't clear screen, append output instead")
-    parser.add_argument(
-        "--fetch-limit", type=int, default=50, help="Maximum number of runs to fetch from WandB (default: 50)"
-    )
-    parser.add_argument(
-        "--display-limit", type=int, default=10, help="Maximum number of runs to display in table (default: 10)"
-    )
-    parser.add_argument(
-        "--score-metric",
-        type=str,
-        default="env_agent/heart.get",
-        help="Metric key in run.summary to use for score (default: env_agent/heart.get)",
-    )
-
-    args = parser.parse_args()
-
-    # Validate refresh interval
-    if args.refresh < 1:
-        print("Error: Refresh interval must be at least 1 second")
-        sys.exit(1)
-
-    # Validate limits
-    if args.fetch_limit < 1:
-        print("Error: Fetch limit must be at least 1")
-        sys.exit(1)
-    if args.display_limit < 1:
-        print("Error: Display limit must be at least 1")
-        sys.exit(1)
-    if args.display_limit > args.fetch_limit:
-        print("Warning: Display limit is greater than fetch limit, some runs may not be shown")
-        print(f"  Fetch limit: {args.fetch_limit}, Display limit: {args.display_limit}")
-
-    # Test mode with mock data
-    if args.test:
-        try:
-            live_monitor_runs_test(
-                group=args.group or "test_group",
-                refresh_interval=args.refresh,
-                clear_screen=not args.no_clear,
-                display_limit=args.display_limit,
-            )
-        except KeyboardInterrupt:
-            print("\nTest monitoring stopped by user.")
-            sys.exit(0)
+@app.callback(invoke_without_command=True)
+def cli(
+    ctx: typer.Context,
+    group: Annotated[str | None, typer.Option("--group", "-g", help="WandB group to monitor (optional)")] = None,
+    name_filter: Annotated[
+        str | None, typer.Option("--name-filter", help="Regex filter for run names (e.g., 'axel.*')")
+    ] = None,
+    refresh: Annotated[int, typer.Option("--refresh", "-r", help="Refresh interval in seconds (default: 30)")] = 30,
+    entity: Annotated[
+        str, typer.Option("--entity", "-e", help="WandB entity (default: metta-research)")
+    ] = "metta-research",
+    project: Annotated[str, typer.Option("--project", "-p", help="WandB project (default: metta)")] = "metta",
+    test: Annotated[
+        bool, typer.Option("--test", help="Run in test mode with mock data (no WandB connection required)")
+    ] = False,
+    no_clear: Annotated[bool, typer.Option("--no-clear", help="Don't clear screen, append output instead")] = False,
+    fetch_limit: Annotated[
+        int, typer.Option("--fetch-limit", help="Maximum number of runs to fetch from WandB (default: 50)")
+    ] = 50,
+    display_limit: Annotated[
+        int, typer.Option("--display-limit", help="Maximum number of runs to display in table (default: 10)")
+    ] = 10,
+    score_metric: Annotated[
+        str,
+        typer.Option(
+            "--score-metric",
+            help="Metric key in run.summary to use for score (default: env_agent/heart.get)",
+        ),
+    ] = "env_agent/heart.get",
+) -> None:
+    """Default command for the live run monitor app."""
+    # If a subcommand is provided, do nothing here
+    if ctx.invoked_subcommand:
         return
 
-    # Validate WandB access
-    try:
-        import wandb
+    # Validate refresh interval
+    if refresh < 1:
+        typer.echo("Error: Refresh interval must be at least 1 second")
+        raise typer.Exit(1)
 
-        if not wandb.api.api_key:
-            print("Error: WandB API key not found. Please run 'wandb login' first.")
-            sys.exit(1)
-    except ImportError:
-        print("Error: WandB not installed. Please install with 'pip install wandb'.")
-        sys.exit(1)
-    except Exception as e:
-        print(f"Warning: Could not validate WandB credentials: {e}")
+    # Validate limits
+    if fetch_limit < 1:
+        typer.echo("Error: Fetch limit must be at least 1")
+        raise typer.Exit(1)
+    if display_limit < 1:
+        typer.echo("Error: Display limit must be at least 1")
+        raise typer.Exit(1)
+    if display_limit > fetch_limit:
+        typer.echo("Warning: Display limit is greater than fetch limit, some runs may not be shown")
+        typer.echo(f"  Fetch limit: {fetch_limit}, Display limit: {display_limit}")
+
+    # Test mode with mock data
+    if test:
+        try:
+            live_monitor_runs_test(
+                group=group or "test_group",
+                refresh_interval=refresh,
+                clear_screen=not no_clear,
+                display_limit=display_limit,
+            )
+        except KeyboardInterrupt:
+            typer.echo("\nTest monitoring stopped by user.")
+            raise typer.Exit(0) from None
+        return
+
+    if not wandb.api.api_key:
+        typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
+        raise typer.Exit(1)
 
     try:
         live_monitor_runs(
-            group=args.group,
-            name_filter=args.name_filter,
-            refresh_interval=args.refresh,
-            entity=args.entity,
-            project=args.project,
-            clear_screen=not args.no_clear,
-            display_limit=args.display_limit,
-            fetch_limit=args.fetch_limit,
-            score_metric=args.score_metric,
+            group=group,
+            name_filter=name_filter,
+            refresh_interval=refresh,
+            entity=entity,
+            project=project,
+            clear_screen=not no_clear,
+            display_limit=display_limit,
+            fetch_limit=fetch_limit,
+            score_metric=score_metric,
         )
     except KeyboardInterrupt:
-        print("\nMonitoring stopped by user.")
-        sys.exit(0)
+        typer.echo("\nMonitoring stopped by user.")
+        raise typer.Exit(0) from None
     except Exception as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+        typer.echo(f"Error: {e}")
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/metta/utils/live_run_monitor.py
+++ b/metta/utils/live_run_monitor.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import logging
+import os
 import sys
 import time
 from datetime import datetime
@@ -34,6 +35,8 @@ from rich.console import Console, Group
 from rich.live import Live
 from rich.table import Table
 from rich.text import Text
+
+from metta.common.util.constants import METTA_WANDB_ENTITY, METTA_WANDB_PROJECT
 
 if TYPE_CHECKING:
     from metta.sweep.models import JobStatus, RunInfo
@@ -427,30 +430,26 @@ def live_monitor_runs_test(
 @app.callback(invoke_without_command=True)
 def cli(
     ctx: typer.Context,
-    group: Annotated[str | None, typer.Option("--group", "-g", help="WandB group to monitor (optional)")] = None,
+    group: Annotated[str | None, typer.Option("--group", "-g", help="WandB group to monitor")] = None,
     name_filter: Annotated[
-        str | None, typer.Option("--name-filter", help="Regex filter for run names (e.g., 'axel.*')")
+        str | None, typer.Option("--name-filter", help=f"Regex filter for run names (e.g., '{os.getenv('USER')}.*')")
     ] = None,
-    refresh: Annotated[int, typer.Option("--refresh", "-r", help="Refresh interval in seconds (default: 30)")] = 30,
-    entity: Annotated[
-        str, typer.Option("--entity", "-e", help="WandB entity (default: metta-research)")
-    ] = "metta-research",
-    project: Annotated[str, typer.Option("--project", "-p", help="WandB project (default: metta)")] = "metta",
+    refresh: Annotated[int, typer.Option("--refresh", "-r", help="Refresh interval in seconds")] = 30,
+    entity: Annotated[str, typer.Option("--entity", "-e", help="WandB entity")] = METTA_WANDB_ENTITY,
+    project: Annotated[str, typer.Option("--project", "-p", help="WandB project")] = METTA_WANDB_PROJECT,
     test: Annotated[
         bool, typer.Option("--test", help="Run in test mode with mock data (no WandB connection required)")
     ] = False,
     no_clear: Annotated[bool, typer.Option("--no-clear", help="Don't clear screen, append output instead")] = False,
-    fetch_limit: Annotated[
-        int, typer.Option("--fetch-limit", help="Maximum number of runs to fetch from WandB (default: 50)")
-    ] = 50,
+    fetch_limit: Annotated[int, typer.Option("--fetch-limit", help="Maximum number of runs to fetch from WandB")] = 50,
     display_limit: Annotated[
-        int, typer.Option("--display-limit", help="Maximum number of runs to display in table (default: 10)")
+        int, typer.Option("--display-limit", help="Maximum number of runs to display in table")
     ] = 10,
     score_metric: Annotated[
         str,
         typer.Option(
             "--score-metric",
-            help="Metric key in run.summary to use for score (default: env_agent/heart.get)",
+            help="Metric key in run.summary to use for score",
         ),
     ] = "env_agent/heart.get",
 ) -> None:
@@ -492,7 +491,7 @@ def cli(
     import wandb
 
     if not wandb.api.api_key:
-        typer.echo("Error: WandB API key not found. Please run 'wandb login' first.")
+        typer.echo("Error: WandB API key not found. Please run 'metta install wandb' first.")
         raise typer.Exit(1)
 
     try:

--- a/metta/utils/live_run_monitor.py
+++ b/metta/utils/live_run_monitor.py
@@ -27,7 +27,7 @@ import logging
 import sys
 import time
 from datetime import datetime
-from typing import Annotated, List, Optional
+from typing import TYPE_CHECKING, Annotated, Optional
 
 import typer
 from rich.console import Console, Group
@@ -35,7 +35,8 @@ from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
-from metta.sweep.models import JobStatus, RunInfo
+if TYPE_CHECKING:
+    from metta.sweep.models import JobStatus, RunInfo
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +52,10 @@ app = typer.Typer(
 )
 
 
-def _get_status_color(status: JobStatus) -> str:
+def _get_status_color(status: "JobStatus") -> str:
     """Get color for run status."""
+    from metta.sweep.models import JobStatus
+
     if status == JobStatus.COMPLETED or status == JobStatus.EVAL_DONE_NOT_COMPLETED:
         return "bright_blue"
     elif status == JobStatus.IN_TRAINING:
@@ -71,7 +74,7 @@ def _get_status_color(status: JobStatus) -> str:
         return "white"
 
 
-def make_rich_monitor_table(runs: List[RunInfo], score_metric: str = "env_agent/heart.get") -> Table:
+def make_rich_monitor_table(runs: list["RunInfo"], score_metric: str = "env_agent/heart.get") -> Table:
     """Create rich table for run monitoring."""
 
     # Create table
@@ -132,7 +135,7 @@ def make_rich_monitor_table(runs: List[RunInfo], score_metric: str = "env_agent/
 def create_run_banner(
     group: Optional[str],
     name_filter: Optional[str],
-    runs: List[RunInfo],
+    runs: list["RunInfo"],
     display_limit: int = 10,
     score_metric: str = "env_agent/heart.get",
 ):


### PR DESCRIPTION
Also:
- move it to being a typer app instead of argparse
- remove unneeded carefulness around wandb import
- move around some imports so that gymnasium isn't imported unless metta run-monitor is actually running; this slows down the metta cli otherwise

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211368595727364)