### PR TITLE
Relax python version requirement for mettagrid

### DIFF
--- a/mettagrid/pyproject.toml
+++ b/mettagrid/pyproject.toml
@@ -5,10 +5,10 @@ backend-path = ["."]
 
 [project]
 name = "mettagrid" # Do not change! Has to be 'mettagrid' for our PyPi package
-version = "0.2.0.1"
+version = "0.2.0.2"
 description = "A fast grid-based open-ended MARL environment"
 authors = [{ name = "David Bloomin", email = "daveey@gmail.com" }]
-requires-python = "==3.11.7"
+requires-python = ">=3.11,<3.12"
 license = "MIT"
 readme = "README.md"
 urls = { Homepage = "https://daveey.github.io", Repository = "https://github.com/Metta-AI/mettagrid" }

--- a/uv.lock
+++ b/uv.lock
@@ -2134,7 +2134,7 @@ dev = [
 
 [[package]]
 name = "mettagrid"
-version = "0.2.0.1"
+version = "0.2.0.2"
 source = { editable = "mettagrid" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Now just requiring Python version 3.11.x instead of 3.11.7.



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211378286130559)