### PR TITLE
fix: add unique log name to SystemMonitor test log capture

### DIFF
--- a/mettagrid/tests/profiling/test_system_monitor.py
+++ b/mettagrid/tests/profiling/test_system_monitor.py
@@ -62,7 +62,8 @@ class TestMonitoringControl:
         """Test starting when already running"""
         monitor.start()
 
-        with caplog.at_level(logging.WARNING):
+        # Capture logs from the specific logger
+        with caplog.at_level(logging.WARNING, logger=monitor.logger.name):
             monitor.start()
 
         assert "Monitor already running" in caplog.text


### PR DESCRIPTION

This PR fixes a failing test in `test_double_start` by specifying the correct logger name when capturing logs with pytest's `caplog`.

### Problem
The `test_double_start` test was failing because it couldn't capture the "Monitor already running" warning message. This happened because `SystemMonitor` creates a unique logger instance using `f"SystemMonitor.{id(self)}"`, but the test was trying to capture logs from all loggers rather than the specific instance.

### Solution
Added `logger=monitor.logger.name` parameter to `caplog.at_level()` to capture logs from the specific SystemMonitor instance being tested.



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211379413769280)