### PR TITLE
remove ghost movement

### DIFF
--- a/mettagrid/src/metta/mettagrid/grid.hpp
+++ b/mettagrid/src/metta/mettagrid/grid.hpp
@@ -69,15 +69,6 @@ public:
     return true;
   }
 
-  inline bool ghost_add_object(GridObject* obj) {
-    if (!is_valid_location(obj->location)) {
-      return false;
-    }
-    obj->id = static_cast<GridObjectId>(this->objects.size());
-    this->objects.push_back(std::unique_ptr<GridObject>(obj));
-    return true;
-  }
-
   // Removes an object from the grid and gives ownership of the object to the caller.
   // Since the caller is now the owner, this can make the raw pointer invalid, if the
   // returned unique_ptr is destroyed.
@@ -100,24 +91,6 @@ public:
     GridObject* obj = object(id);
     grid[loc.r][loc.c][loc.layer] = id;
     grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
-    obj->location = loc;
-    return true;
-  }
-
-  // Force move an object to a location without it being registered in the grid at the new location
-  inline bool ghost_move_object(GridObjectId id, const GridLocation& loc) {
-    if (!is_valid_location(loc)) {
-      return false;
-    }
-
-    GridObject* obj = object(id);
-    if (!obj) {
-      return false;
-    }
-
-    // Remove the object from its current location
-    grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
-
     obj->location = loc;
     return true;
   }


### PR DESCRIPTION
This was part of allowing agents to move through each other -- something Greg added, and we no longer want to support.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211380609376110)