### PR TITLE
Add Usable, and make Move trigger Use

### DIFF
--- a/mettagrid/src/metta/mettagrid/actions/move.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/move.hpp
@@ -6,6 +6,7 @@
 #include "action_handler.hpp"
 #include "grid_object.hpp"
 #include "objects/agent.hpp"
+#include "objects/usable.hpp"
 #include "orientation.hpp"
 #include "types.hpp"
 
@@ -55,6 +56,8 @@ protected:
       return false;
     }
     // `Move` is actually `MoveOrUse`, so we need to check if the target location is empty and if the object is usable.
+    // In the future, we may want to split 'Move' and 'MoveOrUse', if we want to allow agents to run into usable
+    // objects without using them.
     if (!_grid->is_empty(target_location.r, target_location.c)) {
       GridObject* target = _grid->object_at(target_location);
       Usable* usable = dynamic_cast<Usable*>(target);

--- a/mettagrid/src/metta/mettagrid/actions/move.hpp
+++ b/mettagrid/src/metta/mettagrid/actions/move.hpp
@@ -51,26 +51,21 @@ protected:
     // Update orientation to face the movement direction (even if movement fails)
     actor->orientation = move_direction;
 
-    // Check if target location is valid and empty
-    if (!_is_valid_square(target_location)) {
+    if (!_grid->is_valid_location(target_location)) {
+      return false;
+    }
+    // `Move` is actually `MoveOrUse`, so we need to check if the target location is empty and if the object is usable.
+    if (!_grid->is_empty(target_location.r, target_location.c)) {
+      GridObject* target = _grid->object_at(target_location);
+      Usable* usable = dynamic_cast<Usable*>(target);
+      if (usable) {
+        return usable->onUse(actor, arg);
+      }
       return false;
     }
 
     // Move the agent
     return _grid->move_object(actor->id, target_location);
-  }
-
-  bool _is_valid_square(GridLocation target_location) {
-    if (!_grid->is_valid_location(target_location)) {
-      return false;
-    }
-    if (!_grid->is_empty_at_layer(target_location.r, target_location.c, GridLayer::ObjectLayer)) {
-      return false;
-    }
-    if (!_grid->is_empty(target_location.r, target_location.c)) {
-      return false;
-    }
-    return true;
   }
 
 private:

--- a/mettagrid/src/metta/mettagrid/objects/usable.hpp
+++ b/mettagrid/src/metta/mettagrid/objects/usable.hpp
@@ -1,0 +1,17 @@
+#ifndef OBJECTS_USABLE_HPP_
+#define OBJECTS_USABLE_HPP_
+
+#include "grid_object.hpp"
+#include "types.hpp"
+
+// Forward declaration
+class Agent;
+
+class Usable : public GridObject {
+public:
+  virtual ~Usable() = default;
+
+  virtual bool onUse(Agent* actor, ActionArg arg) = 0;
+};
+
+#endif  // OBJECTS_USABLE_HPP_


### PR DESCRIPTION
As per title, this adds an abstract Usable class. This also changes Move to be (implicitly -- not in name) MoveOrUse. The latter seemed more reasonable than adding a separate action, since there's not a clear reason to want both Move and MoveOrUse.

Usable isn't helpful in this PR, since nothing implements it; but I'm shipping this first to simplify the code from which I'm trying to fix segfaults.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211386581427044)