### PR TITLE
Add cogames package with initial cogs vs clips scenario

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,7 @@
     "codecvt",
     "coef",
     "coeff",
+    "cogames",
     "cogeval",
     "cogworks",
     "configs",

--- a/cogames/pyproject.toml
+++ b/cogames/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "cogames"
+version = "0.2.0"
+description = "Multi-agent cooperative games"
+readme = "README.md"
+requires-python = ">=3.11.7"
+dependencies = [
+    "mettagrid>=0.2",
+    "pufferlib>=3.0.0",
+    "pydantic>=2.11.5",
+    "pyyaml>=6.0.2",
+    "scipy>=1.15.3",
+]
+
+[project.scripts]
+demo = "cogames.main:main"

--- a/cogames/src/cogames/cogs_vs_clips/scenarios.py
+++ b/cogames/src/cogames/cogs_vs_clips/scenarios.py
@@ -1,0 +1,37 @@
+from metta.mettagrid.map_builder.random import RandomMapBuilder
+from metta.mettagrid.mettagrid_config import (
+    ActionConfig,
+    ActionsConfig,
+    AgentConfig,
+    AgentRewards,
+    GameConfig,
+    MettaGridConfig,
+    WallConfig,
+)
+
+
+def make_cogs_vs_clips_scenario() -> MettaGridConfig:
+    return MettaGridConfig(
+        game=GameConfig(
+            num_agents=2,
+            actions=ActionsConfig(
+                move=ActionConfig(),
+                noop=ActionConfig(),
+                rotate=ActionConfig(),
+            ),
+            objects={"wall": WallConfig(type_id=1)},
+            map_builder=RandomMapBuilder.Config(
+                width=10,
+                height=10,
+                agents=2,
+                seed=42,
+            ),
+            agent=AgentConfig(
+                default_resource_limit=10,
+                resource_limits={"heart": 10},
+                rewards=AgentRewards(
+                    inventory={},
+                ),
+            ),
+        )
+    )

--- a/cogames/src/cogames/main.py
+++ b/cogames/src/cogames/main.py
@@ -1,0 +1,10 @@
+from cogames.cogs_vs_clips.scenarios import make_cogs_vs_clips_scenario
+
+
+def main():
+    scenario = make_cogs_vs_clips_scenario()
+    print(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ members = [
   "gitta",
   "codebot",
   "softmax",
+  "cogames",
 ]
 
 [tool.uv.sources]
@@ -163,6 +164,6 @@ softmax = { workspace = true }
 metta-agent = { workspace = true }
 gitta = { workspace = true }
 codebot = { workspace = true }
-
+cogames = { workspace = true }
 [tool.ruff]
 exclude = ["*.ipynb"]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 [manifest]
 members = [
     "codebot",
+    "cogames",
     "experiments",
     "gitta",
     "metta",
@@ -573,6 +574,27 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "gitta", editable = "gitta" },
     { name = "tiktoken", specifier = ">=0.9.0" },
+]
+
+[[package]]
+name = "cogames"
+version = "0.2.0"
+source = { editable = "cogames" }
+dependencies = [
+    { name = "mettagrid" },
+    { name = "pufferlib" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "scipy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mettagrid", editable = "mettagrid" },
+    { name = "pufferlib", specifier = ">=3.0.0" },
+    { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "scipy", specifier = ">=1.15.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Added a new `cogames` package for multi-agent cooperative games with initial "Cogs vs Clips" scenario.

### What changed?

- Created a new `cogames` package with basic structure
- Added a `cogs_vs_clips` scenario module with configuration for a 2-agent game
- Implemented a simple demo command that prints the scenario configuration
- Added package dependencies including mettagrid, pufferlib, pydantic, pyyaml, and scipy
- Added "cogames" to the workspace members in the root pyproject.toml
- Updated the spell checker dictionary to include "cogames"


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211390561842110)