### PR TITLE
fix: mettascope2 build requires pixie#head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,11 @@ identified-figures/
 # TODO - remove after troubleshooting stability and re-add to keys in .github/workflows/checks.yml
 mettagrid/MODULE.bazel.lock
 
+# skypilot testing
+recipe_test_jobs.json
+cluster_test_jobs.json
+
 # MetaScope
 mettascope2/dist/
 mettascope2/data/fidget/
-recipe_test_jobs.json
-cluster_test_jobs.json
+mettascope2/mettascope

--- a/mettascope2/mettascope.nimble
+++ b/mettascope2/mettascope.nimble
@@ -11,4 +11,5 @@ requires "cligen >= 1.9.0"
 requires "jsony >= 1.1.5"
 requires "windy >= 0.1.2"
 requires "puppy >= 2.1.2"
+requires "pixie#head"       # Added to ensure compatibility with fidget2#head
 requires "fidget2#head"


### PR DESCRIPTION

The mettascope2 build was failing with:
```
Error: undeclared field: 'capHeight' for type fonts.Typeface
```

This occurred because `fidget2#head` expects a newer version of pixie that includes the `capHeight` field, but the build was using pixie 5.0.7 which doesn't have this field.

This PR adds an explicit dependency `requires "pixie#head"` to ensure a compatible version of pixie is installed alongside fidget2#head.

## Testing
- Reproduced the build error locally
- Confirmed the fix resolves the issue
- Build now completes successfully

This ensures CI builds will pass and prevents version mismatch issues for other developers.
