### PR TITLE
[MettaScope2] disable mettascope2 CI for now

### DIFF
--- a/.github/workflows/build-mettascope2.yml
+++ b/.github/workflows/build-mettascope2.yml
@@ -1,57 +1,58 @@
-name: Build mettascope2 (nim)
+# Disabled: Build mettascope2 (nim)
+# disabling until our dependencies are more stable.
 
-on:
-  pull_request:
-    paths:
-      - "mettascope2/**"
-      - ".github/workflows/build-mettascope2.yml"
-  workflow_dispatch: {}
+# on:
+#   pull_request:
+#     paths:
+#       - "mettascope2/**"
+#       - ".github/workflows/build-mettascope2.yml"
+#   workflow_dispatch: {}
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v4
 
-      - name: Cache nimble
-        id: cache-nimble
-        uses: actions/cache@v4
-        with:
-          path: ~/.nimble
-          key: ${{ runner.os }}-nimble-${{ hashFiles('mettascope2/mettascope2.nimble') }}
-          restore-keys: |
-            ${{ runner.os }}-nimble-
-      - uses: jiro4989/setup-nim-action@v2
-        with:
-          # repo-token is used for rate limiting.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#       - name: Cache nimble
+#         id: cache-nimble
+#         uses: actions/cache@v4
+#         with:
+#           path: ~/.nimble
+#           key: ${{ runner.os }}-nimble-${{ hashFiles('mettascope2/mettascope2.nimble') }}
+#           restore-keys: |
+#             ${{ runner.os }}-nimble-
+#       - uses: jiro4989/setup-nim-action@v2
+#         with:
+#           # repo-token is used for rate limiting.
+#           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: cd mettascope2 && nimble install -y
+#       - run: cd mettascope2 && nimble install -y
 
-      - name: Build mettascope2 (release)
-        run: cd mettascope2 && nim c -d:release --out:mettascope src/mettascope.nim
+#       - name: Build mettascope2 (release)
+#         run: cd mettascope2 && nim c -d:release --out:mettascope src/mettascope.nim
 
-      - uses: mymindstorm/setup-emsdk@v14
+#       - uses: mymindstorm/setup-emsdk@v14
 
-      - name: Upload mettascope2 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mettascope2
-          path: |
-            mettascope2/mettascope
-            mettascope2/data/
-            mettascope2/replays
-          if-no-files-found: error
+#       - name: Upload mettascope2 artifact
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: mettascope2
+#           path: |
+#             mettascope2/mettascope
+#             mettascope2/data/
+#             mettascope2/replays
+#           if-no-files-found: error
           
-      - name: Build mettascope2 (browser)
-        run: cd mettascope2 && nim c -d:emscripten -d:release src/mettascope.nim
+#       - name: Build mettascope2 (browser)
+#         run: cd mettascope2 && nim c -d:emscripten -d:release src/mettascope.nim
 
-      - name: Upload mettascope2 browser artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mettascope2-dist
-          path: mettascope2/dist
-          if-no-files-found: error
+#       - name: Upload mettascope2 browser artifact
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: mettascope2-dist
+#           path: mettascope2/dist
+#           if-no-files-found: error
 
 

--- a/.github/workflows/deploy-mettascope.yml
+++ b/.github/workflows/deploy-mettascope.yml
@@ -5,7 +5,6 @@ on:
       - main
     paths:
       - "mettascope/**"
-      - "mettascope2/**"
       - "observatory/**"
       - ".github/workflows/**"
   workflow_dispatch: {}
@@ -77,23 +76,21 @@ jobs:
           cd mettascope
           uv run tools/gen_atlas.py
 
-      - name: Setup Nim
-        uses: jiro4989/setup-nim-action@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
-
-      - name: Install mettascope2 dependencies
-        run: |
-          cd mettascope2
-          nimble install -y
-
-      - name: Build mettascope2 (emscripten)
-        run: |
-          cd mettascope2
-          nim c -d:emscripten -d:release src/mettascope.nim
+      # Disabled: mettascope2
+      # - name: Setup Nims
+      #   uses: jiro4989/setup-nim-action@v2
+      #   with:
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Setup Emscripten
+      #   uses: mymindstorm/setup-emsdk@v14
+      # - name: Install mettascope2 dependencies
+      #   run: |
+      #     cd mettascope2
+      #     nimble install -y
+      # - name: Build mettascope2 (emscripten)
+      #   run: |
+      #     cd mettascope2
+      #     nim c -d:emscripten -d:release src/mettascope.nim
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -101,10 +98,10 @@ jobs:
       - name: Create deployment directory
         run: |
           mkdir -p deploy/observatory
-          mkdir -p deploy/mettascope2
+          # mkdir -p deploy/mettascope2
           cp -r mettascope/* deploy/
           cp -r observatory/dist/* deploy/observatory/
-          cp -r mettascope2/dist/* deploy/mettascope2/
+          # cp -r mettascope2/dist/* deploy/mettascope2/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- Mettascope2 dependencies are frequently being updated and not always getting version bumps, this is causing CI to break
- disabling mettascope2 CI for now until things are more stable.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211399918127050)