### PR TITLE
fix: update mettascope2 build in github pages deploy

### DIFF
--- a/.github/actions/build-mettascope2/action.yml
+++ b/.github/actions/build-mettascope2/action.yml
@@ -1,0 +1,51 @@
+name: "Build mettascope2 (native + emscripten)"
+description: |
+  Builds the native and browser (emscripten) versions of mettascope2.
+runs:
+  using: "composite"
+  steps:
+    - name: Cache nimble
+      uses: actions/cache@v4
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-nimble-${{ hashFiles('mettascope2/mettascope.nimble') }}
+        restore-keys: |
+          ${{ runner.os }}-nimble-
+
+    - name: Setup Nim
+      uses: jiro4989/setup-nim-action@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup Emscripten
+      uses: mymindstorm/setup-emsdk@v14
+
+    - name: Install dependencies
+      run: |
+        cd mettascope2
+
+        # relying on installation based on the nimble file was resulting in the wrong
+        # version of pixie being installed
+
+        nimble install pixie@#head -y
+        nimble install fidget2@#head -y
+
+        nimble install -y
+      shell: bash
+
+    - name: Build mettascope2 (release)
+      run: |
+        cd mettascope2
+        nim c -d:release --out:mettascope src/mettascope.nim
+      shell: bash
+
+    - name: Build mettascope2 (browser)
+      run: |
+        cd mettascope2
+
+        # The ERROR_ON_UNDEFINED_SYMBOLS=0 flag is needed because the Nim OpenGL bindings
+        # include desktop OpenGL functions like glGetTexImage that don't exist in WebGL.
+        # Since our code doesn't actually use these functions, it's safe to ignore them.
+
+        nim c -d:emscripten -d:release --passL:"-s ERROR_ON_UNDEFINED_SYMBOLS=0" src/mettascope.nim
+      shell: bash

--- a/.github/workflows/build-mettascope2.yml
+++ b/.github/workflows/build-mettascope2.yml
@@ -1,4 +1,4 @@
-name: Build mettascope2 (nim)
+name: Build mettascope2 (Nim)
 
 on:
   pull_request:
@@ -14,32 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Cache nimble
-        id: cache-nimble
-        uses: actions/cache@v4
-        with:
-          path: ~/.nimble
-          key: ${{ runner.os }}-nimble-${{ hashFiles('mettascope2/mettascope.nimble') }}
-          restore-keys: |
-            ${{ runner.os }}-nimble-
+      - name: Build mettascope2
+        uses: ./.github/actions/build-mettascope2
 
-      - uses: jiro4989/setup-nim-action@v2
-        with:
-          # repo-token is used for rate limiting.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: mymindstorm/setup-emsdk@v14
-
-      - run: |
-          cd mettascope2
-          nimble install pixie@#head -y  # Explicitly install pixie#head first
-          nimble install fidget2@#head -y  # Reinstall fidget2 to ensure it uses the new pixie
-          nimble install -y  # Then install remaining dependencies
-
-      - name: Build mettascope2 (release)
-        run: cd mettascope2 && nim c -d:release --out:mettascope src/mettascope.nim
-
-      - name: Upload mettascope2 artifact
+      - name: Upload native binary
         uses: actions/upload-artifact@v4
         with:
           name: mettascope2
@@ -49,17 +27,7 @@ jobs:
             mettascope2/replays
           if-no-files-found: error
 
-      - name: Build mettascope2 (browser)
-        run: |
-          cd mettascope2
-
-          # The ERROR_ON_UNDEFINED_SYMBOLS=0 flag is needed because the Nim OpenGL bindings
-          # include desktop OpenGL functions like glGetTexImage that don't exist in WebGL.
-          # Since our code doesn't actually use these functions, it's safe to ignore them.
-
-          nim c -d:emscripten -d:release --passL:"-s ERROR_ON_UNDEFINED_SYMBOLS=0" src/mettascope.nim
-
-      - name: Upload mettascope2 browser artifact
+      - name: Upload browser build
         uses: actions/upload-artifact@v4
         with:
           name: mettascope2-dist

--- a/.github/workflows/deploy-mettascope.yml
+++ b/.github/workflows/deploy-mettascope.yml
@@ -77,23 +77,8 @@ jobs:
           cd mettascope
           uv run tools/gen_atlas.py
 
-      - name: Setup Nim
-        uses: jiro4989/setup-nim-action@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
-
-      - name: Install mettascope2 dependencies
-        run: |
-          cd mettascope2
-          nimble install -y
-
-      - name: Build mettascope2 (emscripten)
-        run: |
-          cd mettascope2
-          nim c -d:emscripten -d:release src/mettascope.nim
+      - name: Build mettascope2
+        uses: ./.github/actions/build-mettascope2
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.7"
 resolution-markers = [
     "sys_platform == 'linux'",
@@ -579,7 +579,7 @@ requires-dist = [
 [[package]]
 name = "cogames"
 version = "0.2.0"
-source = { virtual = "cogames" }
+source = { editable = "cogames" }
 dependencies = [
     { name = "mettagrid" },
     { name = "pufferlib" },


### PR DESCRIPTION

This PR refactors the `mettascope2` build logic to eliminate duplication between the `build-mettascope2.yml` and `deploy-mettascope.yml` workflows.

### `.github/actions/build-mettascope2/`:

  * Installs correct versions of dependencies (`pixie@#head`, `fidget2@#head`)
  * Builds both:
    * Native binary (`nim c -d:release`)
    * Browser build using emscripten (`nim c -d:emscripten -d:release ...`)
  * Includes proper `~/.nimble` caching
  * Applies necessary linker flags to avoid WebGL/OpenGL mismatches

### `build-mettascope2.yml`**:

  * Calls the composite action
  * Uploads native and browser artifacts as before

### `deploy-mettascope.yml`**:

  * Replaces inline `mettascope2` build logic with a call to the new action
  * Keeps deploy directory logic unchanged
