### PR TITLE
Fix test duration sorting to use second column

### DIFF
--- a/.github/scripts/run_package_tests.sh
+++ b/.github/scripts/run_package_tests.sh
@@ -210,7 +210,7 @@ for package in agent common app_backend packages/mettagrid packages/cogames code
         # Add package name to each line
         sed "s/^/[${package_name}] /" "test-results/${package_name}_durations.txt"
     fi
-done | sort -rn | head -10 | nl -w2 -s'. '
+done | sort -t' ' -k2 -rn | head -10 | nl -w2 -s'. '
 
 echo -e "\n${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 


### PR DESCRIPTION
### TL;DR

Fixed the sorting of test duration output to properly sort by numeric values.

### What changed?

Modified the `sort` command in `run_package_tests.sh` to use field-based sorting with `-t' ' -k2` options. This ensures that test durations are sorted by the numeric value in the second field rather than lexicographically sorting the entire line.


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211401932193420)