### PR TITLE
Update mettagrid to v0.2.0.3 with macOS build fixes and dependency markers

### DIFF
--- a/packages/cogames/pyproject.toml
+++ b/packages/cogames/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cogames"
-version = "0.2.0"
+version = "0.2.0.1"
 description = "Multi-agent cooperative games"
 readme = "README.md"
 requires-python = ">=3.11.7"
 dependencies = [
-  "mettagrid>=0.2",
+  "mettagrid>=0.2.0.3",
   "pufferlib>=3.0.0",
   "pydantic>=2.11.5",
   "pyyaml>=6.0.2",

--- a/packages/mettagrid/.bazelrc
+++ b/packages/mettagrid/.bazelrc
@@ -33,6 +33,12 @@ coverage --instrumentation_filter=//:mettagrid_lib,//:mettagrid_c
 build:macos --copt=-fvisibility=hidden
 build:macos --cxxopt=-stdlib=libc++
 build:macos --linkopt=-stdlib=libc++
+# Set minimum macOS deployment target to prevent platform tag issues
+build:macos --macos_minimum_os=11.0
+build:macos --copt=-mmacosx-version-min=11.0
+build:macos --linkopt=-mmacosx-version-min=11.0
+build:macos --host_copt=-mmacosx-version-min=11.0
+build:macos --host_linkopt=-mmacosx-version-min=11.0
 
 # Platform-specific settings for Linux
 build:linux --copt=-fvisibility=hidden

--- a/packages/mettagrid/MANIFEST.in
+++ b/packages/mettagrid/MANIFEST.in
@@ -3,5 +3,10 @@ include BUILD.bazel
 include MODULE.bazel
 include MODULE.bazel.lock
 include .bazelrc
-recursive-include cpp/src/mettagrid *.cpp *.hpp
+
+# Include the entire cpp directory with all BUILD files, source and header files
+recursive-include cpp *.cpp *.hpp *.bazel BUILD
+recursive-include benchmarks *.cpp *.py BUILD
+recursive-include tests *.cpp *.py BUILD
+recursive-include lint *.sh *.bzl BUILD
 

--- a/packages/mettagrid/pyproject.toml
+++ b/packages/mettagrid/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "mettagrid" # Do not change! Has to be 'mettagrid' for our PyPi package
-version = "0.2.0.2"
+version = "0.2.0.3"
 description = "A fast grid-based open-ended MARL environment"
 authors = [{ name = "David Bloomin", email = "daveey@gmail.com" }]
 requires-python = ">=3.11,<3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ requires-dist = [
 
 [[package]]
 name = "cogames"
-version = "0.2.0"
+version = "0.2.0.1"
 source = { editable = "packages/cogames" }
 dependencies = [
     { name = "mettagrid" },
@@ -2372,7 +2372,7 @@ dev = [
 
 [[package]]
 name = "mettagrid"
-version = "0.2.0.2"
+version = "0.2.0.3"
 source = { editable = "packages/mettagrid" }
 dependencies = [
     { name = "boto3" },
@@ -2739,7 +2739,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2750,7 +2750,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2777,9 +2777,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2790,7 +2790,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4623,7 +4623,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/39/43325b3b651d50187e591eefa22e236b2981afcebaefd4f2fc0ea99df191/triton-3.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b70f5e6a41e52e48cfc087436c8a28c17ff98db369447bcaff3b887a3ab4467", size = 155531138, upload-time = "2025-07-30T19:58:29.908Z" },


### PR DESCRIPTION
### TL;DR

Update mettagrid to version 0.2.0.3 and cogames to version 0.2.0.1, with macOS build improvements.

### What changed?

- Bumped mettagrid version from 0.2.0.2 to 0.2.0.3
- Bumped cogames version from 0.2.0 to 0.2.0.1
- Updated cogames dependency on mettagrid to require >=0.2.0.3
- Added macOS minimum deployment target settings (11.0) to mettagrid's .bazelrc


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211402145805603)