### PR TITLE
Stop using eval_name in observatory - use env_name and eval_category

### DIFF
--- a/app_backend/src/metta/app_backend/config.py
+++ b/app_backend/src/metta/app_backend/config.py
@@ -7,3 +7,5 @@ host = os.getenv("HOST", "127.0.0.1")
 port = int(os.getenv("PORT", "8000"))
 
 anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+
+run_leaderboard_updater = os.getenv("RUN_LEADERBOARD_UPDATER", "true") == "true"

--- a/app_backend/src/metta/app_backend/eval_task_worker.py
+++ b/app_backend/src/metta/app_backend/eval_task_worker.py
@@ -186,7 +186,9 @@ class SimTaskExecutor(AbstractTaskExecutor):
             f"stats_server_uri={self._backend_url}",
             "push_metrics_to_wandb=true",
         ]
-        logger.info(f"Running command: {' '.join(cmd)}")
+        # exclude simulation_json_base64 from logging, since it's too large and undescriptive
+        logged_cmd = [arg for arg in cmd if not arg.startswith("simulations_json_base64")]
+        logger.info(f"Running command: {' '.join(logged_cmd)}")
 
         result = self._run_cmd_from_versioned_checkout(cmd)
 

--- a/app_backend/src/metta/app_backend/routes/scorecard_routes.py
+++ b/app_backend/src/metta/app_backend/routes/scorecard_routes.py
@@ -160,7 +160,7 @@ class PolicyEvaluationResult:
 UNIFIED_POLICIES_QUERY = """SELECT * FROM unified_training_runs ORDER BY created_at DESC"""
 
 GET_EVALS_QUERY = """
-    SELECT DISTINCT eval_name
+    SELECT DISTINCT eval_category || '/' || env_name as eval_name
     FROM wide_episodes
     WHERE (
         training_run_id = ANY(%s) OR  -- Policies from selected training runs
@@ -176,7 +176,7 @@ GET_AVAILABLE_METRICS_QUERY = """
         we.training_run_id = ANY(%s) OR  -- Policies from selected training runs
         (we.training_run_id IS NULL AND we.primary_policy_id = ANY(%s))  -- Selected run-free policies
     )
-    AND we.eval_name = ANY(%s)
+    AND (we.eval_category || '/' || we.env_name) = ANY(%s)
     ORDER BY eam.metric
 """
 
@@ -207,7 +207,7 @@ POLICY_SCORECARD_DATA_QUERY = """
         (we.primary_policy_id = ANY(%s))  -- Selected policies
     )
     AND eam.metric = %s
-    AND we.eval_name = ANY(%s)
+    AND (we.eval_category || '/' || we.env_name) = ANY(%s)
     GROUP BY we.primary_policy_id, we.policy_name, we.eval_category, we.env_name, we.training_run_id,
         we.epoch_end_training_epoch
     ORDER BY we.policy_name, we.eval_category, we.env_name

--- a/app_backend/src/metta/app_backend/server.py
+++ b/app_backend/src/metta/app_backend/server.py
@@ -154,7 +154,7 @@ def create_app(stats_repo: MettaRepo) -> fastapi.FastAPI:
 
 
 if __name__ == "__main__":
-    from metta.app_backend.config import host, port, stats_db_uri
+    from metta.app_backend.config import host, port, run_leaderboard_updater, stats_db_uri
 
     stats_repo = MettaRepo(stats_db_uri)
     app = create_app(stats_repo)
@@ -162,7 +162,8 @@ if __name__ == "__main__":
 
     # Start the updater in an async context
     async def main():
-        await leaderboard_updater.start()
+        if run_leaderboard_updater:
+            await leaderboard_updater.start()
         # Run uvicorn in a way that doesn't block
         config = uvicorn.Config(app, host=host, port=port)
         server = uvicorn.Server(config)


### PR DESCRIPTION
Fixes the currently broken scorecard display.  It's a little hacky, but maintains the current apis with observatory frontend.  I will probably refactor it later, but I think it's important to get the fix first

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211403130288287)