### PR TITLE
db changes?

### DIFF
--- a/metta/sim/simulation_stats_db.py
+++ b/metta/sim/simulation_stats_db.py
@@ -261,7 +261,37 @@ class SimulationStatsDB(EpisodeStatsDB):
         Used both by `from_shards_and_context` (i.e. Simulation merging envs) and `export` (i.e. export merging
         with former data).
         """
-        self.con.execute(f"ATTACH '{other_path}' AS other")
+        other_path = Path(other_path)
+        db_list = self.con.execute("PRAGMA database_list").fetchall()
+        existing_alias: str | None = None
+        existing_names = {row[1] for row in db_list}
+        resolved_other = other_path.resolve()
+        for _, name, file_path in db_list:
+            if not file_path:
+                continue
+            try:
+                if Path(file_path).resolve() == resolved_other:
+                    existing_alias = name
+                    break
+            except FileNotFoundError:
+                continue
+
+        attached_here = False
+        if existing_alias is not None:
+            alias = existing_alias
+        else:
+            base_alias = "other"
+            alias = base_alias
+            counter = 0
+            while alias in existing_names:
+                counter += 1
+                alias = f"{base_alias}_{counter}"
+
+            attached_here = True
+            alias_sql = duckdb.escape_identifier(alias)
+            self.con.execute(f"ATTACH '{other_path}' AS {alias_sql}")
+
+        alias_sql = duckdb.escape_identifier(alias)
 
         # helpers
         def _table_exists(table: str) -> bool:
@@ -274,7 +304,7 @@ class SimulationStatsDB(EpisodeStatsDB):
             try:
                 # Returns an empty result set if the table exists but has no
                 # columns (impossible here) – that's still "exists".
-                self.con.execute(f"PRAGMA table_info(other.{table})").fetchall()
+                self.con.execute(f"PRAGMA table_info({alias_sql}.{table})").fetchall()
                 return True
             except duckdb.CatalogException:
                 return False
@@ -284,7 +314,7 @@ class SimulationStatsDB(EpisodeStatsDB):
                 logger = logging.getLogger(__name__)
                 logger.debug("Skipping %s – not present in shard %s", table, other_path.name)
                 return
-            self.con.execute(f"INSERT OR IGNORE INTO {table} SELECT * FROM other.{table}")
+            self.con.execute(f"INSERT OR IGNORE INTO {table} SELECT * FROM {alias_sql}.{table}")
 
         try:
             self.con.begin()
@@ -298,4 +328,5 @@ class SimulationStatsDB(EpisodeStatsDB):
             logger.error(f"Error merging {other_path}: {e}")
             raise
         finally:
-            self.con.execute("DETACH other")
+            if attached_here:
+                self.con.execute(f"DETACH {alias_sql}")


### PR DESCRIPTION
▌ │ /workspace/metta/metta/sim/simulation_stats_db.py:264 in _merge_db
▌ │
▌                            │
▌ │
▌                            │   261 │   │   Used both by `from_shards_and_context` (i.e. Simulation merging envs) and
▌ │
▌                            │       `export` (i.e. export merging
▌ │
▌                            │   262 │   │   with former data).
▌ │
▌                            │   263 │   │   """
▌ │
▌                            │ _ 264 │   │   self.con.execute(f"ATTACH '{other_path}' AS other")
▌ │
▌                            │   265 │   │
▌ │
▌                            │   266 │   │   # helpers
▌ │
▌                            │   267 │   │   def _table_exists(table: str) -> bool:
▌ │
▌
▌ _──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
▌ ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
▌ ─────────────────────────────────────────────────────────────────────────────────────────_
▌                            BinderException: Binder Error: Unique file handle conflict: Cannot attach "other" - the database
▌ file "/tmp/stats/e0141352df98/1578442_c96105.duckdb" is already attached by database "1578442_c96105". I see this too but
▌ it might be a deeper problem..



[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211403626896174)