### PR TITLE
Re-add MoveOrUse

### DIFF
--- a/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
@@ -4,10 +4,10 @@
 #include <string>
 
 #include "actions/action_handler.hpp"
-#include "core/grid_object.hpp"
-#include "objects/agent.hpp"
 #include "actions/orientation.hpp"
+#include "core/grid_object.hpp"
 #include "core/types.hpp"
+#include "objects/agent.hpp"
 
 // Forward declaration
 struct GameConfig;
@@ -51,25 +51,24 @@ protected:
     // Update orientation to face the movement direction (even if movement fails)
     actor->orientation = move_direction;
 
-    // Check if target location is valid and empty
-    if (!_is_valid_square(target_location)) {
+    if (!_grid->is_valid_location(target_location)) {
       return false;
+    }
+
+    // `Move` is actually `MoveOrUse`, so we need to check if the target location is empty and if the object is usable.
+    // In the future, we may want to split 'Move' and 'MoveOrUse', if we want to allow agents to run into usable
+    // objects without using them.
+    if (!_grid->is_empty(target_location.r, target_location.c)) {
+      GridLocation object_location = {target_location.r, target_location.c, GridLayer::ObjectLayer};
+      GridObject* target = _grid->object_at(object_location);
+      Usable* usable = dynamic_cast<Usable*>(target);
+      if (usable) {
+        return usable->onUse(*actor, arg);
+      }
     }
 
     // Move the agent
     return _grid->move_object(actor->id, target_location);
-  }
-
-  bool _is_valid_square(GridLocation target_location) {
-    if (!_grid->is_valid_location(target_location)) {
-      return false;
-    }
-    if (!_grid->is_empty_at_layer(target_location.r, target_location.c, GridLayer::ObjectLayer)) {
-      return false;
-    }
-    if (!_grid->is_empty(target_location.r, target_location.c)) {
-      return false;
-    }
     return true;
   }
 

--- a/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
@@ -65,11 +65,11 @@ protected:
       if (usable) {
         return usable->onUse(*actor, arg);
       }
+      return false;
     }
 
     // Move the agent
     return _grid->move_object(actor->id, target_location);
-    return true;
   }
 
 private:

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -126,9 +126,9 @@ private:
   }
 
   // Give output resources to the triggering agent
-  void give_output_to_agent(const Recipe& recipe, Agent* agent) {
+  void give_output_to_agent(const Recipe& recipe, Agent& agent) {
     for (const auto& [item, amount] : recipe.output_resources) {
-      InventoryDelta delta = agent->update_inventory(item, static_cast<InventoryDelta>(amount));
+      InventoryDelta delta = agent.update_inventory(item, static_cast<InventoryDelta>(amount));
       InventoryQuantity actually_produced = static_cast<InventoryQuantity>(delta);
       if (actually_produced > 0) {
         stats.add(stats.resource_name(item) + ".produced", actually_produced);
@@ -170,7 +170,7 @@ public:
   }
 
   // Implement pure virtual method from Usable
-  virtual bool onUse(Agent* actor, ActionArg /*arg*/) override {
+  virtual bool onUse(Agent& actor, ActionArg /*arg*/) override {
     if (!grid || !event_manager) {
       return false;
     }

--- a/packages/mettagrid/cpp/include/mettagrid/objects/usable.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/usable.hpp
@@ -13,7 +13,7 @@ class Usable {
 public:
   virtual ~Usable() = default;
 
-  virtual bool onUse(Agent* actor, ActionArg arg) = 0;
+  virtual bool onUse(Agent& actor, ActionArg arg) = 0;
 };
 
 #endif  // OBJECTS_USABLE_HPP_


### PR DESCRIPTION
MoveOrUse functionality got removed from Move during the recent moving of Mettagrid to packages. This restores that.

This also switches from passing agents by pointer to passing by value in `onUse`, since this should be a mandatory argument.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211406424424521)