### PR TITLE
fix: include c++ test results in branch protection

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -217,7 +217,7 @@ jobs:
           pnpm run lint
 
   unit-tests:
-    name: "Unit Tests - All Packages"
+    name: "Unit Tests - Python"
     needs: [graphite-ci-optimizer, setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
@@ -260,27 +260,8 @@ jobs:
           chmod +x .github/scripts/upload_codecov.py
           .github/scripts/upload_codecov.py
 
-  unit-tests-summary:
-    name: "Tests"
-    needs: [unit-tests]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check test results
-        run: |
-          echo "Test job results: ${{ toJSON(needs) }}"
-          if [ "${{ contains(join(needs.*.result, ','), 'failure') }}" == "true" ]; then
-            echo "One or more test jobs failed"
-            exit 1
-          elif [ "${{ contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]; then
-            echo "One or more test jobs were cancelled"
-            exit 1
-          else
-            echo "All test jobs completed successfully"
-          fi
-
   mettagrid-cpp-build:
-    name: "MettaGrid C++ Build & Coverage"
+    name: "MettaGrid C++ Build & Test"
     needs: [graphite-ci-optimizer, setup-checks]
     if: |
       (needs.graphite-ci-optimizer.outputs.should_skip == 'false') &&
@@ -345,6 +326,25 @@ jobs:
           name: mettagrid-cpp-coverage
           fail_ci_if_error: false
           verbose: true
+
+  unit-tests-summary:
+    name: "Tests"
+    needs: [unit-tests, mettagrid-cpp-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          echo "Test job results: ${{ toJSON(needs) }}"
+          if [ "${{ contains(join(needs.*.result, ','), 'failure') }}" == "true" ]; then
+            echo "One or more test jobs failed"
+            exit 1
+          elif [ "${{ contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]; then
+            echo "One or more test jobs were cancelled"
+            exit 1
+          else
+            echo "All test jobs completed successfully"
+          fi
 
   python-benchmark:
     name: "Python Benchmarks"


### PR DESCRIPTION

### Problem
C++ test failures are not blocking merges because the `unit-tests-summary` job (which branch protection watches) only checks Python test results, not C++ test results.

### Root Cause
When we refactored the workflow to split C++ tests into a separate `mettagrid-cpp-build` job, we didn't update the summary job to include it as a dependency.

### Solution
Add `mettagrid-cpp-build` to the `needs` array of `unit-tests-summary` so it waits for and checks both Python and C++ test results.

```yaml
needs: [unit-tests, mettagrid-cpp-build]
```

This ensures our branch protection rule "Tests" correctly blocks merges when C++ tests fail.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211412965521271)