### PR TITLE
[MettaScope2] fix frozen icon scale

### DIFF
--- a/mettascope2/src/mettascope/timeline.nim
+++ b/mettascope2/src/mettascope/timeline.nim
@@ -140,7 +140,7 @@ proc drawFrozenMarkers(panel: Panel) =
       if isFrozen and (not prevFrozen):
         let x = trackLeft + (float32(j) / float32(fullSteps)) * scrubberWidth
         # Draw icon above the scrubber and a small tick on the bar.
-        bxy.drawImage("agents/frozen", vec2(x, trackTop - 22), angle = 0, scale = 1/200)
+        bxy.drawImage("agents/frozen", vec2(x, trackTop - 22), angle = 0, scale = 1/10)
         bxy.drawRect(rect(x - 1, trackTop - 10, 2, 8), color(1, 1, 1, 1))
       prevFrozen = isFrozen
 


### PR DESCRIPTION
<img width="686" height="603" alt="Screenshot From 2025-09-19 14-43-36" src="https://github.com/user-attachments/assets/530dc546-fd88-46b5-b623-cf6c7df2b456" />


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211413402499423)