### PR TITLE
Add support for loading game configs from Python files and saving configs

### DIFF
--- a/packages/cogames/README.md
+++ b/packages/cogames/README.md
@@ -1,29 +1,289 @@
-CoGames is a collection of environments and scenarios for multi-agent cooperative and competitive games.
+# CoGames: Cogs vs Clips Multi-Agent RL Environment
 
-## Installation
+CoGames is a collection of multi-agent cooperative and competitive environments designed for reinforcement learning
+research. The primary focus is the **Cogs vs Clips** competition - a challenging multi-agent resource management and
+assembly game built on the MettagGrid framework.
+
+## 🎮 Cogs vs Clips Competition
+
+In Cogs vs Clips, multiple "Cog" agents must cooperate to gather resources, operate machinery, and assemble components
+to achieve objectives. The environment features:
+
+- **Multi-agent cooperation**: Agents must coordinate to efficiently use shared resources and stations
+- **Resource management**: Energy, materials (carbon, oxygen, geranium, silicon), and crafted components
+- **Station-based interactions**: Different stations provide unique capabilities (extractors, assemblers, chargers,
+  chests)
+- **Sparse rewards**: Agents receive rewards only upon successfully crafting target items (hearts)
+- **Partial observability**: Agents have limited visibility of the environment
+
+### Game Mechanics
+
+**Resources:**
+
+- `energy`: Consumed for movement and operating extractors
+- `carbon`, `oxygen`, `geranium`, `silicon`: Base materials extracted from stations
+- `heart`: The target objective item
+- `disruptor`, `modulator`, `resonator`, `scrabbler`: Advanced components
+
+**Station Types:**
+
+- **Charger**: Provides energy to agents
+- **Extractors** (Carbon/Oxygen/Geranium/Silicon): Convert energy into materials
+- **Assembler**: Combines resources to create components or objectives
+- **Chest**: Storage for resource sharing between agents
+
+## 🚀 Quick Start
+
+### Installation
 
 ```bash
+# Install the package
 uv pip install cogames
 ```
 
-## Usage
+### Running Your First Game
 
 ```bash
-# Help
-cogames --help
+# List all available games
+cogames games
 
-# List games and scenarios
-cogames games                      # List all available games
-cogames games [game]               # Describe a game and list its scenarios
-cogames scenario [game] [scenario] # Describe a specific scenario
+# Play a simple single-agent assembler scenario
+cogames play assembler_1_simple --steps 100 --render
 
-# Play a game
-cogames play [game] [scenario]
-cogames make-scenario [game]
+# Play a multi-agent scenario
+cogames play assembler_2_complex --steps 200 --render
 
-# Train a policy
-cogames train [game] [scenario]
-
-# Evaluate a policy
-cogames evaluate [game] [scenario] [policy]
+# Run without rendering for faster execution
+cogames play machina_2 --no-render --steps 500
 ```
+
+## 🤖 For RL Researchers
+
+### Training a Policy
+
+CoGames integrates with standard RL training frameworks. Currently supports:
+
+- PPO (Proximal Policy Optimization)
+- A2C (Advantage Actor-Critic)
+- DQN (Deep Q-Networks)
+
+```bash
+# Train a PPO agent on a single-agent scenario
+cogames train assembler_1_simple --algorithm ppo --steps 50000 --save ./my_policy.ckpt
+
+# Train with Weights & Biases logging
+cogames train assembler_2_complex --algorithm ppo --steps 100000 --wandb my-project
+```
+
+### Evaluating Policies
+
+```bash
+# Evaluate a trained policy
+cogames evaluate assembler_1_simple ./my_policy.ckpt --episodes 100
+
+# Evaluate with video recording
+cogames evaluate assembler_2_complex ./my_policy.ckpt --episodes 10 --render --video ./evaluation.mp4
+
+# Baseline comparison with random policy
+cogames evaluate assembler_1_simple random --episodes 100
+```
+
+### Implementing Custom Policies
+
+Create your own policy by extending the `Policy` base class:
+
+```python
+from cogames.policy import Policy
+from typing import Any, Optional
+import torch
+import torch.nn as nn
+
+class MyCustomPolicy(Policy):
+    def __init__(self, observation_space, action_space):
+        self.network = MyNeuralNetwork(observation_space, action_space)
+
+    def get_action(self, observation: Any, agent_id: Optional[int] = None) -> Any:
+        """Compute action from observation."""
+        with torch.no_grad():
+            action_logits = self.network(observation)
+            action = torch.argmax(action_logits).item()
+        return action
+
+    def reset(self) -> None:
+        """Reset any internal state (e.g., RNN hidden states)."""
+        pass
+
+    def save(self, path: str) -> None:
+        """Save model checkpoint."""
+        torch.save(self.network.state_dict(), path)
+
+    @classmethod
+    def load(cls, path: str, env=None) -> "MyCustomPolicy":
+        """Load model from checkpoint."""
+        policy = cls(env.observation_space, env.action_space)
+        policy.network.load_state_dict(torch.load(path))
+        return policy
+```
+
+### Environment API
+
+The underlying MettagGrid environment follows the Gymnasium API:
+
+```python
+from cogames import get_game
+from mettagrid.envs import MettaGridEnv
+
+# Load a game configuration
+config = get_game("assembler_2_complex")
+
+# Create environment
+env = MettaGridEnv(env_cfg=config)
+
+# Reset environment
+obs, info = env.reset()
+
+# Game loop
+for step in range(1000):
+    # Your policy computes actions for all agents
+    actions = policy.get_actions(obs)  # Dict[agent_id, action]
+
+    # Step environment
+    obs, rewards, terminated, truncated, info = env.step(actions)
+
+    if terminated or truncated:
+        obs, info = env.reset()
+```
+
+### Observation Space
+
+Observations are dictionaries containing:
+
+- `rgb`: RGB image of the agent's view (H×W×3)
+- `inventory`: Agent's current resources
+- `position`: Agent's (x, y) coordinates
+- `orientation`: Agent's facing direction
+- `glyph`: Agent's current communication symbol
+
+### Action Space
+
+Available actions:
+
+- `0`: No-op (do nothing)
+- `1-4`: Move (forward, backward, left, right)
+- `5-8`: Rotate (turn left/right)
+- `9-24`: Change glyph (for communication)
+- Additional actions may be available based on scenario
+
+## 📊 Available Scenarios
+
+### Tutorial Scenarios
+
+- `assembler_1_simple`: Single agent, simple assembly recipe
+- `assembler_1_complex`: Single agent, complex recipes
+- `assembler_2_simple`: 4 agents, simple cooperation
+- `assembler_2_complex`: 4 agents, complex cooperation
+
+### Competition Scenarios
+
+- `machina_1`: Single agent, full game mechanics
+- `machina_2`: 4 agents, full game mechanics
+
+Use `cogames games [scenario_name]` for detailed information about each scenario.
+
+## 🔧 Creating Custom Scenarios
+
+```python
+from cogames.cogs_vs_clips.scenarios import make_game
+
+# Create a custom game configuration
+config = make_game(
+    num_cogs=4,                    # Number of agents
+    num_assemblers=2,              # Number of assembler stations
+    num_chargers=1,                # Energy stations
+    num_carbon_extractors=1,       # Material extractors
+    num_oxygen_extractors=1,
+    num_geranium_extractors=1,
+    num_silicon_extractors=1,
+    num_chests=2,                  # Storage chests
+)
+
+# Modify map size
+config.game.map_builder.width = 15
+config.game.map_builder.height = 15
+
+# Save configuration
+cogames make-scenario --name my_scenario --agents 4 --width 15 --height 15 --output my_scenario.yaml
+```
+
+## 🏆 Competition Tips
+
+1. **Coordination is Key**: Multi-agent scenarios require effective coordination. Consider:
+   - Task allocation strategies
+   - Communication through glyph changes
+   - Resource sharing via chests
+
+2. **Energy Management**: Energy is limited and required for most actions:
+   - Plan efficient paths
+   - Use chargers strategically
+   - Balance exploration vs exploitation
+
+3. **Hierarchical Planning**: Break down the assembly task:
+   - Gathering phase (collect base materials)
+   - Processing phase (operate extractors)
+   - Assembly phase (combine at assemblers)
+
+4. **Curriculum Learning**: Start with simpler scenarios:
+   - Master single-agent tasks first
+   - Graduate to multi-agent coordination
+   - Increase complexity gradually
+
+## 🔬 Research Integration
+
+CoGames is designed to integrate with the Metta RL framework:
+
+```bash
+# Using Metta's recipe system for advanced training
+uv run ./tools/run.py experiments.recipes.cogames.train scenario=assembler_2_complex
+
+# Distributed training with Metta
+uv run ./tools/run.py experiments.recipes.cogames.distributed_train \
+    num_workers=4 \
+    scenario=machina_2
+```
+
+## 📚 Additional Resources
+
+- **MettagGrid Documentation**: The underlying grid world engine
+- **Metta RL Framework**: Advanced training recipes and algorithms
+- **Competition Leaderboard**: Track your progress against other researchers
+
+## 🐛 Debugging and Visualization
+
+```bash
+# Interactive mode for debugging
+cogames play assembler_1_simple --interactive --render
+
+# Step-by-step execution
+cogames play machina_2 --steps 10 --render --interactive
+```
+
+## 📝 Citation
+
+If you use CoGames in your research, please cite:
+
+```bibtex
+@software{cogames2024,
+  title={CoGames: Multi-Agent Cooperative Game Environments},
+  author={Metta AI},
+  year={2024},
+  url={https://github.com/metta-ai/metta}
+}
+```
+
+## 💡 Support
+
+For questions about the Cogs vs Clips competition or CoGames environments:
+
+- Open an issue in the repository
+- Contact the competition organizers
+- Check the competition Discord channel

--- a/packages/cogames/src/cogames/main.py
+++ b/packages/cogames/src/cogames/main.py
@@ -21,19 +21,38 @@ def default(ctx: typer.Context) -> None:
 
 
 @app.command()
-def games(game_name: Optional[str] = typer.Argument(None, help="Name of the game to describe")) -> None:
+def games(
+    game_name: Optional[str] = typer.Argument(None, help="Name of the game to describe"),
+    save: Optional[Path] = typer.Option(None, "--save", "-s", help="Save game configuration to file (YAML or JSON)"),  # noqa: B008
+) -> None:
     """List all available games or describe a specific game."""
     if game_name is None:
         # List all games
         table = game.list_games(console)
         console.print(table)
     else:
-        # Describe specific game
+        # Get the game configuration
         try:
-            game.describe_game(game_name, console)
+            game_config = game.get_game(game_name)
         except ValueError as e:
             console.print(f"[red]Error: {e}[/red]")
             raise typer.Exit(1) from e
+
+        # Save configuration if requested
+        if save:
+            try:
+                game.save_game_config(game_config, save)
+                console.print(f"[green]Game configuration saved to: {save}[/green]")
+            except ValueError as e:
+                console.print(f"[red]Error saving configuration: {e}[/red]")
+                raise typer.Exit(1) from e
+        else:
+            # Otherwise describe the game
+            try:
+                game.describe_game(game_name, console)
+            except ValueError as e:
+                console.print(f"[red]Error: {e}[/red]")
+                raise typer.Exit(1) from e
 
 
 @app.command(name="play")

--- a/packages/cogames/src/cogames/utils.py
+++ b/packages/cogames/src/cogames/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for CoGames CLI."""
 
+from pathlib import Path
 from typing import Optional, Tuple
 
 from cogames import game as game_module
@@ -9,7 +10,7 @@ def resolve_game(game_arg: Optional[str]) -> Tuple[Optional[str], Optional[str]]
     """Resolve a game name from user input.
 
     Args:
-        game_arg: User input for game name
+        game_arg: User input for game name or path to config file
 
     Returns:
         Tuple of (resolved_game_name, error_message)
@@ -17,6 +18,17 @@ def resolve_game(game_arg: Optional[str]) -> Tuple[Optional[str], Optional[str]]
     if not game_arg:
         return None, None
 
+    # Check if it's a file path
+    if any(game_arg.endswith(ext) for ext in [".yaml", ".yml", ".json", ".py"]):
+        path = Path(game_arg)
+        if not path.exists():
+            return None, f"File not found: {game_arg}"
+        if not path.is_file():
+            return None, f"Not a file: {game_arg}"
+        # Return the path as the resolved name
+        return game_arg, None
+
+    # Otherwise, treat it as a game name
     resolved = game_module.resolve_game_name(game_arg)
     if resolved:
         return resolved, None


### PR DESCRIPTION
### TL;DR

Added support for loading game configurations from Python files and saving configurations to YAML/JSON files.

### What changed?

- Added `load_game_config_from_python()` function to load game configurations from Python files
- Enhanced `get_game()` to accept file paths (.yaml, .json, .py) in addition to game names
- Added a `--save` option to the `games` command to export game configurations
- Improved serialization by converting tuples to lists and preserving key order in YAML output
- Added helper function `_convert_tuples_to_lists()` for better serialization compatibility
- Updated `resolve_game()` to handle file paths as game identifiers
- Added placeholder README.md

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211414955500412)