### PR TITLE
fix: importing create_simulation from play.py fail

### DIFF
--- a/metta/tools/play.py
+++ b/metta/tools/play.py
@@ -17,6 +17,18 @@ from metta.tools.utils.auto_config import auto_wandb_config
 logger = logging.getLogger(__name__)
 
 
+def create_simulation(cfg: "PlayTool") -> Simulation:
+    """Create a simulation instance configured for the play tool."""
+    return Simulation.create(
+        sim_config=cfg.sim,
+        device=cfg.system.device,
+        vectorization=cfg.system.vectorization,
+        stats_dir=cfg.effective_stats_dir,
+        replay_dir=cfg.effective_replay_dir,
+        policy_uri=cfg.policy_uri,
+    )
+
+
 class PlayTool(Tool):
     wandb: WandbConfig = auto_wandb_config()
     sim: SimulationConfig
@@ -44,14 +56,7 @@ class PlayTool(Tool):
             import mettascope2
             from mettagrid.util.grid_object_formatter import format_grid_object
 
-            sim = Simulation.create(
-                sim_config=self.sim,
-                device=self.system.device,
-                vectorization=self.system.vectorization,
-                stats_dir=self.effective_stats_dir,
-                replay_dir=self.effective_replay_dir,
-                policy_uri=self.policy_uri,
-            )
+            sim = create_simulation(self)
             sim.start_simulation()
             env = sim.get_env()
             initial_replay = sim.get_replay()


### PR DESCRIPTION
Importing `create_simulation` function from `play.py` fails the function as the simulation object creation is inline. Moved this   function outside of the class definition to fix this issue. 