### PR TITLE
Feat: Prevent Theft of Soul-Bound Resources During Attacks

### DIFF
--- a/metta/tools/play.py
+++ b/metta/tools/play.py
@@ -17,18 +17,6 @@ from mettagrid.util.grid_object_formatter import format_grid_object
 logger = logging.getLogger(__name__)
 
 
-def create_simulation(cfg: "PlayTool") -> Simulation:
-    """Create a simulation instance configured for the play tool."""
-    return Simulation.create(
-        sim_config=cfg.sim,
-        device=cfg.system.device,
-        vectorization=cfg.system.vectorization,
-        stats_dir=cfg.effective_stats_dir,
-        replay_dir=cfg.effective_replay_dir,
-        policy_uri=cfg.policy_uri,
-    )
-
-
 class PlayTool(Tool):
     wandb: WandbConfig = auto_wandb_config()
     sim: SimulationConfig
@@ -52,7 +40,14 @@ class PlayTool(Tool):
         if self.mettascope2:
             import mettagrid.mettascope as mettascope2
 
-            sim = create_simulation(self)
+            sim = Simulation.create(
+                sim_config=self.sim,
+                device=self.system.device,
+                vectorization=self.system.vectorization,
+                stats_dir=self.effective_stats_dir,
+                replay_dir=self.effective_replay_dir,
+                policy_uri=self.policy_uri,
+            )
             sim.start_simulation()
             env = sim.get_env()
             initial_replay = sim.get_replay()

--- a/metta/tools/play.py
+++ b/metta/tools/play.py
@@ -17,6 +17,18 @@ from mettagrid.util.grid_object_formatter import format_grid_object
 logger = logging.getLogger(__name__)
 
 
+def create_simulation(cfg: "PlayTool") -> Simulation:
+    """Create a simulation instance configured for the play tool."""
+    return Simulation.create(
+        sim_config=cfg.sim,
+        device=cfg.system.device,
+        vectorization=cfg.system.vectorization,
+        stats_dir=cfg.effective_stats_dir,
+        replay_dir=cfg.effective_replay_dir,
+        policy_uri=cfg.policy_uri,
+    )
+
+
 class PlayTool(Tool):
     wandb: WandbConfig = auto_wandb_config()
     sim: SimulationConfig
@@ -40,14 +52,7 @@ class PlayTool(Tool):
         if self.mettascope2:
             import mettagrid.mettascope as mettascope2
 
-            sim = Simulation.create(
-                sim_config=self.sim,
-                device=self.system.device,
-                vectorization=self.system.vectorization,
-                stats_dir=self.effective_stats_dir,
-                replay_dir=self.effective_replay_dir,
-                policy_uri=self.policy_uri,
-            )
+            sim = create_simulation(self)
             sim.start_simulation()
             env = sim.get_env()
             initial_replay = sim.get_replay()

--- a/packages/mettagrid/cpp/include/mettagrid/actions/attack.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/attack.hpp
@@ -4,6 +4,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
@@ -175,8 +176,16 @@ private:
       snapshot.emplace_back(item, amount);
     }
 
-    // Transfer resources
+    // Transfer resources (excluding soul-bound resources)
     for (const auto& [item, amount] : snapshot) {
+      // Check if this resource is soul-bound for the target
+      if (std::find(target.soul_bound_resources.begin(),
+                    target.soul_bound_resources.end(),
+                    item) != target.soul_bound_resources.end()) {
+        // Skip soul-bound resources
+        continue;
+      }
+
       InventoryDelta stolen = actor.update_inventory(item, amount);
       target.update_inventory(item, -stolen);
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -29,6 +29,7 @@ public:
   std::map<InventoryItem, InventoryQuantity> resource_limits;
   float action_failure_penalty;
   std::string group_name;
+  // We expect only a small number (single-digit) of soul-bound resources.
   std::vector<InventoryItem> soul_bound_resources;
   ObservationType color;
   ObservationType glyph;

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -29,6 +29,7 @@ public:
   std::map<InventoryItem, InventoryQuantity> resource_limits;
   float action_failure_penalty;
   std::string group_name;
+  std::vector<InventoryItem> soul_bound_resources;
   ObservationType color;
   ObservationType glyph;
   // Despite being a GridObjectId, this is different from the `id` property.
@@ -56,6 +57,7 @@ public:
         resource_limits(config.resource_limits),
         action_failure_penalty(config.action_failure_penalty),
         group_name(config.group_name),
+        soul_bound_resources(config.soul_bound_resources),
         color(0),
         glyph(0),
         agent_id(0),

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
@@ -25,7 +25,8 @@ struct AgentConfig : public GridObjectConfig {
               const std::map<std::string, RewardType>& stat_reward_max = {},
               float group_reward_pct = 0,
               const std::map<InventoryItem, InventoryQuantity>& initial_inventory = {},
-              const std::vector<int>& tag_ids = {})
+              const std::vector<int>& tag_ids = {},
+              const std::vector<InventoryItem>& soul_bound_resources = {})
       : GridObjectConfig(type_id, type_name, tag_ids),
         group_id(group_id),
         group_name(group_name),
@@ -37,7 +38,8 @@ struct AgentConfig : public GridObjectConfig {
         stat_rewards(stat_rewards),
         stat_reward_max(stat_reward_max),
         group_reward_pct(group_reward_pct),
-        initial_inventory(initial_inventory) {}
+        initial_inventory(initial_inventory),
+        soul_bound_resources(soul_bound_resources) {}
 
   unsigned char group_id;
   std::string group_name;
@@ -50,6 +52,7 @@ struct AgentConfig : public GridObjectConfig {
   std::map<std::string, RewardType> stat_reward_max;
   float group_reward_pct;
   std::map<InventoryItem, InventoryQuantity> initial_inventory;
+  std::vector<InventoryItem> soul_bound_resources;
 };
 
 namespace py = pybind11;
@@ -69,7 +72,8 @@ inline void bind_agent_config(py::module& m) {
                     const std::map<std::string, RewardType>&,
                     float,
                     const std::map<InventoryItem, InventoryQuantity>&,
-                    const std::vector<int>&>(),
+                    const std::vector<int>&,
+                    const std::vector<InventoryItem>&>(),
            py::arg("type_id"),
            py::arg("type_name") = "agent",
            py::arg("group_id"),
@@ -83,7 +87,8 @@ inline void bind_agent_config(py::module& m) {
            py::arg("stat_reward_max") = std::map<std::string, RewardType>(),
            py::arg("group_reward_pct") = 0,
            py::arg("initial_inventory") = std::map<InventoryItem, InventoryQuantity>(),
-           py::arg("tag_ids") = std::vector<int>())
+           py::arg("tag_ids") = std::vector<int>(),
+           py::arg("soul_bound_resources") = std::vector<InventoryItem>())
       .def_readwrite("type_id", &AgentConfig::type_id)
       .def_readwrite("type_name", &AgentConfig::type_name)
       .def_readwrite("group_name", &AgentConfig::group_name)
@@ -97,7 +102,8 @@ inline void bind_agent_config(py::module& m) {
       .def_readwrite("stat_reward_max", &AgentConfig::stat_reward_max)
       .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct)
       .def_readwrite("initial_inventory", &AgentConfig::initial_inventory)
-      .def_readwrite("tag_ids", &AgentConfig::tag_ids);
+      .def_readwrite("tag_ids", &AgentConfig::tag_ids)
+      .def_readwrite("soul_bound_resources", &AgentConfig::soul_bound_resources);
 }
 
 #endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_AGENT_CONFIG_HPP_

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -178,6 +178,13 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
         # Convert tag names to IDs for first agent in team
         tag_ids = [tag_name_to_id[tag] for tag in first_agent.tags if tag in tag_name_to_id]
 
+        # Convert soul bound resources from names to IDs
+        soul_bound_resources = [
+            resource_name_to_id[resource_name]
+            for resource_name in agent_props.get("soul_bound_resources", [])
+            if resource_name in resource_name_to_id
+        ]
+
         agent_cpp_params = {
             "freeze_duration": agent_props["freeze_duration"],
             "group_id": team_id,
@@ -196,6 +203,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             "type_name": "agent",
             "initial_inventory": initial_inventory,
             "tag_ids": tag_ids,
+            "soul_bound_resources": soul_bound_resources,
         }
 
         objects_cpp_params["agent." + group_name] = CppAgentConfig(**agent_cpp_params)

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -34,6 +34,9 @@ class AgentConfig(Config):
     initial_inventory: dict[str, int] = Field(default_factory=dict)
     team_id: int = Field(default=0, ge=0, description="Team identifier for grouping agents")
     tags: list[str] = Field(default_factory=list, description="Tags for this agent instance")
+    soul_bound_resources: list[str] = Field(
+        default_factory=list, description="Resources that cannot be stolen during attacks"
+    )
 
 
 class ActionConfig(Config):


### PR DESCRIPTION
## What Changed
Added a new **`soul_bound_resources`** feature that allows certain resources to be protected from theft during attacks in the **MettaGrid** environment.

---

## Implementation Details
- **Python Config:** Added `soul_bound_resources: list[str]` field to `AgentConfig`.
- **C++ Core:** Extended `AgentConfig` struct and `Agent` class with `soul_bound_resources` vector.
- **Attack Logic:** Modified `attack.hpp` to skip soul-bound resources during resource theft.
- **Bindings:** Updated Python–C++ bindings to properly pass soul-bound resources between layers.
- **Example Usage:** Modified `subho.py` to mark `"oil"` as soul-bound for prey agents.

---

## Behavior
When an agent with soul-bound resources is attacked:
- The agent still gets frozen (normal attack behavior)
- Regular resources are stolen as usual
- **Soul-bound resources remain with the victim and cannot be transferred**

---

## Use Case
In the predator–prey scenario, prey agents now have `"oil"` as a soul-bound resource.  
This means predators can freeze prey but cannot steal their oil, adding a new strategic element to the game.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211431678692919)