### PR TITLE
Further relax python version requirement for mettagrid

### DIFF
--- a/packages/mettagrid/MODULE.bazel
+++ b/packages/mettagrid/MODULE.bazel
@@ -22,6 +22,9 @@ python.toolchain(
 python.toolchain(
     python_version = "3.12",
 )
+python.toolchain(
+    python_version = "3.13",
+)
 
 # pybind11 for Python bindings
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")

--- a/packages/mettagrid/MODULE.bazel
+++ b/packages/mettagrid/MODULE.bazel
@@ -12,9 +12,15 @@ bazel_dep(name = "rules_cc", version = "0.2.0")
 bazel_dep(name = "rules_python", version = "1.5.3")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.defaults(
+    python_version = "3.11",
+    python_version_env = "METTAGRID_BAZEL_PYTHON_VERSION",
+)
 python.toolchain(
     python_version = "3.11",
-    is_default = True,
+)
+python.toolchain(
+    python_version = "3.12",
 )
 
 # pybind11 for Python bindings

--- a/packages/mettagrid/bazel_build.py
+++ b/packages/mettagrid/bazel_build.py
@@ -46,9 +46,26 @@ def _run_bazel_build() -> None:
     else:
         config = "dbg" if debug else "opt"
 
+    # Align Bazel's registered Python toolchain with the active interpreter.
+    py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    env = os.environ.copy()
+    env.setdefault("METTAGRID_BAZEL_PYTHON_VERSION", py_version)
+
+    # Provide a writable output root for environments with restricted /var/tmp access.
+    output_user_root = env.get(
+        "METTAGRID_BAZEL_OUTPUT_ROOT",
+        str(PROJECT_ROOT / ".bazel_output"),
+    )
+
+    # Ensure the output root exists before invoking Bazel.
+    Path(output_user_root).mkdir(parents=True, exist_ok=True)
+
     # Build the Python extension with auto-detected parallelism
     cmd = [
         "bazel",
+        "--batch",
+        f"--output_user_root={output_user_root}",
         "build",
         f"--config={config}",
         "--jobs=auto",
@@ -57,7 +74,7 @@ def _run_bazel_build() -> None:
     ]
 
     print(f"Running Bazel build: {' '.join(cmd)}")
-    result = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True)
+    result = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, env=env)
 
     if result.returncode != 0:
         print("Bazel build failed. STDERR:", file=sys.stderr)

--- a/packages/mettagrid/pyproject.toml
+++ b/packages/mettagrid/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "mettagrid" # Do not change! Has to be 'mettagrid' for our PyPi package
-version = "0.2.0.6"
+version = "0.2.0.7"
 description = "A fast grid-based open-ended MARL environment"
 authors = [{ name = "David Bloomin", email = "daveey@gmail.com" }]
 requires-python = ">=3.11"

--- a/packages/mettagrid/pyproject.toml
+++ b/packages/mettagrid/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "numpy>=1.26.4,<2", "pybind11==2.10.4"]
+requires = ["setuptools>=61.0", "wheel", "numpy>=1.26.4,<2", "pybind11>=2.12.0"]
 build-backend = "bazel_build"
 backend-path = ["."]
 
@@ -8,7 +8,7 @@ name = "mettagrid" # Do not change! Has to be 'mettagrid' for our PyPi package
 version = "0.2.0.6"
 description = "A fast grid-based open-ended MARL environment"
 authors = [{ name = "David Bloomin", email = "daveey@gmail.com" }]
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.11"
 license = "MIT"
 readme = "README.md"
 urls = { Homepage = "https://daveey.github.io", Repository = "https://github.com/Metta-AI/mettagrid" }


### PR DESCRIPTION
In #2640 we went from `==3.11.7` to `>=3.11,<3.12`, no we further relax this to `>=3.11`. 