### PR TITLE
Add Python 3.12 wheels

### DIFF
--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -67,6 +67,7 @@ jobs:
             chmod +x /usr/local/bin/bazelisk
             ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
           CIBW_BEFORE_ALL_MACOS: python3 -m pip install "pip<25"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
           CI: "true"
         with:

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v3
         if: runner.os == 'macOS'
 
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v3.2.0
         env:
           CIBW_BUILD: "cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux* *i686"

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -65,6 +65,7 @@ jobs:
             curl -sSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
             chmod +x /usr/local/bin/bazelisk
             ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
           CI: "true"
         with:
           package-dir: packages/mettagrid

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11.7"
+          python-version: "3.12.1"
       - run: pipx run build --sdist --outdir dist packages/mettagrid
       - uses: actions/upload-artifact@v4
         with:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11.7"
+          python-version: "3.12.1"
 
       # Install Bazel on macOS
       - uses: bazelbuild/setup-bazelisk@v3
@@ -57,7 +57,7 @@ jobs:
 
       - uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_BUILD: cp311-*
+          CIBW_BUILD: "cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux* *i686"
           CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -62,9 +62,11 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_BEFORE_ALL_LINUX: |
+            python3 -m pip install "pip<25"
             curl -sSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
             chmod +x /usr/local/bin/bazelisk
             ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          CIBW_BEFORE_ALL_MACOS: python3 -m pip install "pip<25"
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
           CI: "true"
         with:


### PR DESCRIPTION
## Summary
- update  to build under Python 3.12.1 and emit cp311+cp312 wheels
- upgrade to , pin pip<25 during builds, and set 
- ensure macOS delocate passes while retaining existing Bazel bootstrap steps

## Testing
- gh workflow run release-mettagrid.yml --ref dominik/python312-wheels --field publish=no --field target=testpypi (run 17928209889)
