### PR TITLE
feat: improve wandb config logging

### DIFF
--- a/common/src/metta/common/wandb/context.py
+++ b/common/src/metta/common/wandb/context.py
@@ -61,6 +61,7 @@ class WandbContext:
         wandb_cfg: WandbConfig,
         extra_cfg: Config | dict[str, Any] | None = None,
         timeout: int = 30,
+        extra_cfg_name: str | None = None,
     ):
         """
         Initialize WandbContext.
@@ -72,6 +73,7 @@ class WandbContext:
         """
         self.cfg = wandb_cfg
         self.extra_cfg = extra_cfg
+        self.extra_cfg_name = extra_cfg_name
         self.run: WandbRun | None = None
         self.timeout = timeout  # Add configurable timeout (wandb default is 90 seconds)
         self.wandb_host = "api.wandb.ai"
@@ -104,10 +106,13 @@ class WandbContext:
             config = None
             if self.extra_cfg:
                 if isinstance(self.extra_cfg, dict):
-                    config = self.extra_cfg
+                    key = self.extra_cfg_name or "extra_config_dict"
+                    config = {key: self.extra_cfg}
                 else:
                     # Assume it's a Config object with model_dump method
-                    config = self.extra_cfg.model_dump()
+                    class_name = self.extra_cfg.__class__.__name__
+                    key = self.extra_cfg_name or class_name or "extra_config_object"
+                    config = {key: self.extra_cfg.model_dump()}
 
             self.run = wandb.init(
                 id=self.cfg.run_id,


### PR DESCRIPTION

This PR enhances the WandbContext to provide more flexible config logging:

- We now support both Config objects and plain dicts for the `extra_cfg` param (previously `global_cfg`)
- Automatically uses Config class names as section headers in wandb UI (e.g., `TrainingConfig`, `ModelConfig`)
- Adds optional `extra_cfg_name` parameter to override automatic naming
- Provides sensible defaults: `"extra_config_dict"` for dicts, class name for Config objects

**Before**: All configs were logged flat at the top level
**After**: Configs are organized in named sections for better wandb UI organization

Example usage:
```python
# With Config object - uses class name
with WandbContext(wandb_cfg, extra_cfg=training_config) as run:
    ...  # Shows as "TrainingConfig" section in wandb

# With dict and custom name  
with WandbContext(wandb_cfg, extra_cfg={"lr": 0.001}, extra_cfg_name="hyperparameters") as run:
    ...  # Shows as "hyperparameters" section in wandb
```


