### PR TITLE
Revert "Switch to slim image in skypilot"

### DIFF
--- a/devops/skypilot/config/skypilot_run.yaml
+++ b/devops/skypilot/config/skypilot_run.yaml
@@ -22,7 +22,7 @@ resources:
     - region: us-west-2
       accelerators: "A10G:1"
   cpus: 8+
-  image_id: docker:metta:latest-slim
+  image_id: docker:metta:latest
   job_recovery:
     strategy: EAGER_NEXT_REGION
     max_restarts_on_errors: 20


### PR DESCRIPTION
Fails on skypilot with `Could not run 'pufferlib::compute_puff_advantage' with arguments from the 'CUDA' backend.`.