### PR TITLE
feat: historical newsletter support

### DIFF
--- a/.github/scripts/create_pr_digest.py
+++ b/.github/scripts/create_pr_digest.py
@@ -367,7 +367,7 @@ def main():
             until_date = datetime.strptime(historical_end_date, "%Y-%m-%d")
             # Make it end of day in UTC
             until_date = until_date.replace(hour=23, minute=59, second=59)
-            logging.info(f"📅 Historical mode: Using end date {historical_end_date}")
+            logging.info(f"Using end date {historical_end_date}")
         except ValueError:
             logging.error(f"Invalid historical date format: {historical_end_date}. Expected YYYY-MM-DD")
             sys.exit(1)
@@ -431,10 +431,8 @@ def main():
                 since_formatted = since_pst.strftime("%B %d, %Y")
                 until_formatted = until_pst.strftime("%B %d, %Y")
 
-                # Add historical marker if applicable
+                # Simple date range display
                 date_display = f"{since_formatted} to {until_formatted}"
-                if is_historical:
-                    date_display = f"📅 Historical: {date_display}"
 
                 f.write(f"date_range_display={date_display}\n")
 

--- a/.github/scripts/create_pr_digest.py
+++ b/.github/scripts/create_pr_digest.py
@@ -357,8 +357,24 @@ def main():
     include_drafts = os.getenv("INCLUDE_DRAFT_PRS", "false").lower() == "true"
     output_file = os.getenv("PR_DIGEST_FILE", "pr_digest_output.json")
 
+    # Check for historical date support
+    historical_end_date = os.getenv("HISTORICAL_END_DATE")
+    is_historical = os.getenv("IS_HISTORICAL_RUN", "false").lower() == "true"
+
+    # Determine the end date
+    if historical_end_date and is_historical:
+        try:
+            until_date = datetime.strptime(historical_end_date, "%Y-%m-%d")
+            # Make it end of day in UTC
+            until_date = until_date.replace(hour=23, minute=59, second=59)
+            logging.info(f"📅 Historical mode: Using end date {historical_end_date}")
+        except ValueError:
+            logging.error(f"Invalid historical date format: {historical_end_date}. Expected YYYY-MM-DD")
+            sys.exit(1)
+    else:
+        until_date = datetime.now()
+
     days = int(days_to_scan)
-    until_date = datetime.now()
     since_date = until_date - timedelta(days=days)
     since = since_date.isoformat() + "Z"
     until = until_date.isoformat() + "Z"
@@ -388,6 +404,10 @@ def main():
 
         # Save statistics for the workflow
         stats_file = Path("pr_digest_stats.json")
+        # Add historical run info to stats
+        stats["is_historical"] = is_historical
+        stats["end_date"] = until_date.strftime("%Y-%m-%d")
+
         with open(stats_file, "w") as f:
             json.dump(stats, f, indent=2)
 
@@ -410,7 +430,13 @@ def main():
                 # Format for display
                 since_formatted = since_pst.strftime("%B %d, %Y")
                 until_formatted = until_pst.strftime("%B %d, %Y")
-                f.write(f"date_range_display={since_formatted} to {until_formatted}\n")
+
+                # Add historical marker if applicable
+                date_display = f"{since_formatted} to {until_formatted}"
+                if is_historical:
+                    date_display = f"📅 Historical: {date_display}"
+
+                f.write(f"date_range_display={date_display}\n")
 
                 # Add author info if filtering
                 if filter_author:

--- a/.github/scripts/gemini_analyze_pr_digest.py
+++ b/.github/scripts/gemini_analyze_pr_digest.py
@@ -372,12 +372,8 @@ def create_discord_summary(
         category_stats[pr.category] = category_stats.get(pr.category, 0) + 1
         impact_stats[pr.impact_level] = impact_stats.get(pr.impact_level, 0) + 1
 
-    # Check if this is a historical run
-    is_historical = stats.get("is_historical", False)
-    title = f"📊 **{github_repository} Newsletter{' (Historical)' if is_historical else ''}** • {date_range}"
-
     lines = [
-        title,
+        f"📊 **{github_repository} Newsletter** • {date_range}",
         "",
         "**📈 Statistics**",
         f"• Total PRs analyzed: {len(pr_summaries)}",

--- a/.github/scripts/gemini_analyze_pr_digest.py
+++ b/.github/scripts/gemini_analyze_pr_digest.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from gemini_analyze_pr import PRAnalyzer, PRSummary, load_pr_summary, save_pr_summary
 from gemini_client import GeminiAIClient
@@ -25,6 +26,42 @@ class PreviousReportExtractor:
     def __init__(self, report_type: str = "newsletter", report_dir: str | None = None):
         self.report_type = report_type
         self.report_dir = Path(report_dir or f"previous-{report_type}s")
+
+    def _extract_date_from_content(self, content: str) -> Optional[datetime]:
+        """Extract end date from newsletter content as fallback."""
+        import re
+
+        # Look for date patterns in the newsletter header
+        # Pattern 1: "• Month DD, YYYY to Month DD, YYYY"
+        pattern1 = r"•\s*(\w+\s+\d{1,2},\s+\d{4})\s+to\s+(\w+\s+\d{1,2},\s+\d{4})"
+        match = re.search(pattern1, content[:500])  # Check first 500 chars
+
+        if match:
+            try:
+                # Extract the end date (second date in the range)
+                end_date_str = match.group(2)
+                # Parse the date
+                from datetime import datetime
+
+                end_date = datetime.strptime(end_date_str, "%B %d, %Y")
+                return end_date
+            except ValueError:
+                logging.debug(f"Failed to parse date from content pattern: {match.group(2)}")
+
+        # Pattern 2: Try ISO date format if present
+        # "Historical: YYYY-MM-DD to YYYY-MM-DD"
+        pattern2 = r"(\d{4}-\d{2}-\d{2})\s+to\s+(\d{4}-\d{2}-\d{2})"
+        match = re.search(pattern2, content[:500])
+
+        if match:
+            try:
+                end_date_str = match.group(2)
+                end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
+                return end_date
+            except ValueError:
+                logging.debug(f"Failed to parse ISO date from content: {match.group(2)}")
+
+        return None
 
     def extract_report_summaries(self) -> list[dict[str, str]]:
         """Extract summaries from previous report artifacts."""
@@ -44,6 +81,20 @@ class PreviousReportExtractor:
         for zip_path in zip_files:
             try:
                 artifact_name = zip_path.stem
+
+                # Extract date from artifact name if possible
+                # Expected format: newsletter-YYYY-MM-DD-to-YYYY-MM-DD
+                artifact_date = None
+                if "newsletter-" in artifact_name and "-to-" in artifact_name:
+                    try:
+                        # Extract end date from artifact name
+                        date_parts = artifact_name.split("-to-")
+                        if len(date_parts) == 2:
+                            end_date_str = date_parts[1]
+                            artifact_date = datetime.strptime(end_date_str, "%Y-%m-%d")
+                    except ValueError:
+                        logging.debug(f"Could not parse date from artifact name: {artifact_name}")
+
                 run_id = artifact_name.split("_")[-1] if "_" in artifact_name else artifact_name
 
                 with zipfile.ZipFile(zip_path, "r") as zf:
@@ -62,11 +113,18 @@ class PreviousReportExtractor:
                         file_date = file_info.date_time
                         timestamp = datetime(*file_date[:6])
 
+                        # If we couldn't get date from filename, try to extract from content
+                        if not artifact_date:
+                            artifact_date = self._extract_date_from_content(content)
+                            if artifact_date:
+                                logging.debug(f"Extracted date from content for {artifact_name}: {artifact_date}")
+
                         summaries.append(
                             {
                                 "content": content,
                                 "run_id": run_id,
                                 "date": timestamp.isoformat(),
+                                "artifact_date": artifact_date.isoformat() if artifact_date else None,
                                 "artifact_name": artifact_name,
                                 "report_type": self.report_type,
                             }
@@ -80,7 +138,7 @@ class PreviousReportExtractor:
                 logging.error(f"❌ Error processing {zip_path.name}: {e}")
                 continue
 
-        summaries.sort(key=lambda x: x["date"])
+        summaries.sort(key=lambda x: x["artifact_date"] or x["date"])
         logging.info(f"Successfully extracted {len(summaries)} {self.report_type} summaries")
         return summaries
 
@@ -91,8 +149,16 @@ class PreviousReportExtractor:
                 return name
         return None
 
-    def get_recent_summaries(self, max_summaries: int = 3, author: str | None = None) -> list[dict[str, str]]:
-        """Get formatted context from previous summaries for AI prompt."""
+    def get_recent_summaries(
+        self, max_summaries: int = 3, author: str | None = None, end_date: Optional[datetime] = None
+    ) -> list[dict[str, str]]:
+        """Get formatted context from previous summaries for AI prompt.
+
+        Args:
+            max_summaries: Maximum number of summaries to return
+            author: Filter by author (for author reports)
+            end_date: Only include summaries before this date (for historical runs)
+        """
         summaries = self.extract_report_summaries()
 
         if not summaries:
@@ -101,6 +167,23 @@ class PreviousReportExtractor:
         # Filter by author if specified (for author reports)
         if author and self.report_type == "author-report":
             summaries = [s for s in summaries if author.lower() in s["artifact_name"].lower()]
+
+        # Filter by date if specified (for historical runs)
+        if end_date:
+            filtered_summaries = []
+            for summary in summaries:
+                # Use artifact_date if available, otherwise fall back to file date
+                date_str = summary.get("artifact_date") or summary["date"]
+                summary_date = datetime.fromisoformat(date_str)
+
+                # Only include summaries from before the end date
+                if summary_date < end_date:
+                    filtered_summaries.append(summary)
+                else:
+                    logging.debug(f"Excluding future summary from {date_str} (after {end_date})")
+
+            summaries = filtered_summaries
+            logging.info(f"After date filtering: {len(summaries)} summaries remain")
 
         return summaries[-max_summaries:] if len(summaries) > max_summaries else summaries
 
@@ -289,8 +372,12 @@ def create_discord_summary(
         category_stats[pr.category] = category_stats.get(pr.category, 0) + 1
         impact_stats[pr.impact_level] = impact_stats.get(pr.impact_level, 0) + 1
 
+    # Check if this is a historical run
+    is_historical = stats.get("is_historical", False)
+    title = f"📊 **{github_repository} Newsletter{' (Historical)' if is_historical else ''}** • {date_range}"
+
     lines = [
-        f"📊 ** {github_repository} Newsletter ** • {date_range}",
+        title,
         "",
         "**📈 Statistics**",
         f"• Total PRs analyzed: {len(pr_summaries)}",
@@ -298,7 +385,7 @@ def create_discord_summary(
         f"• Previously cached: {stats.get('cached_pr_count', 0)}",
         f"• Categories: {', '.join(f'{k}: {v}' for k, v in category_stats.items())}",
         f"• Impact: {', '.join(f'{k}: {v}' for k, v in impact_stats.items())}",
-        f"• Generated: <t:{int(time.time())}:R> using Gemini 2.5 with full context analysis",
+        f"• Generated: <t:{int(time.time())}:R> using Gemini with full context analysis",
         "",
         newsletter_content,
         "",

--- a/.github/scripts/gemini_create_newsletter.py
+++ b/.github/scripts/gemini_create_newsletter.py
@@ -266,8 +266,7 @@ def main():
 
     # Log if this is a historical run
     if is_historical:
-        logging.info("📅 Running in HISTORICAL mode")
-        logging.info(f"Generating historical newsletter for: {report_period}")
+        logging.info(f"Generating newsletter for: {report_period}")
 
     # Construct GitHub run URL
     github_run_url = f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"

--- a/.github/scripts/gemini_create_newsletter.py
+++ b/.github/scripts/gemini_create_newsletter.py
@@ -10,7 +10,9 @@ import json
 import logging
 import random
 import sys
+from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from gemini_analyze_pr import PRSummary
 from gemini_analyze_pr_digest import (
@@ -27,13 +29,17 @@ from gemini_client import GeminiAIClient
 class NewsletterGenerator:
     """Generates newsletter summaries from multiple PR summaries."""
 
-    def __init__(self, ai_client: GeminiAIClient):
+    def __init__(self, ai_client: GeminiAIClient, is_historical: bool = False):
         self.ai_client = ai_client
+        self.is_historical = is_historical
         self.newsletter_extractor = PreviousReportExtractor(report_type="newsletter")
 
-    def get_previous_newsletter_context(self) -> str:
+    def get_previous_newsletter_context(self, end_date: Optional[datetime] = None) -> str:
         """Format newsletter summaries for context."""
-        recent_summaries = self.newsletter_extractor.get_recent_summaries()
+        # For historical runs, pass the end date to filter out future newsletters
+        recent_summaries = self.newsletter_extractor.get_recent_summaries(
+            end_date=end_date if self.is_historical else None
+        )
 
         all_shout_outs = []
         for summary in recent_summaries:
@@ -122,10 +128,12 @@ class NewsletterGenerator:
         ]
         return random.choice(bonus_prompts)
 
-    def generate_newsletter(self, pr_summaries: list[PRSummary], date_range: str, repository: str) -> str:
+    def generate_newsletter(
+        self, pr_summaries: list[PRSummary], date_range: str, repository: str, end_date: Optional[datetime] = None
+    ) -> str:
         """Generate a comprehensive newsletter summary."""
         context = self.prepare_context(pr_summaries, date_range, repository)
-        previous_context = self.get_previous_newsletter_context()
+        previous_context = self.get_previous_newsletter_context(end_date)
 
         prompt = f"""
 You are creating an executive summary of development activity for {repository} from {date_range}.
@@ -240,6 +248,7 @@ def main():
         "PR_DIGEST_FILE": "pr_digest_output.json",
         "PR_DIGEST_STATS_FILE": "pr_digest_stats.json",
         "REPORT_PERIOD": "(unknown)",
+        "IS_HISTORICAL_RUN": "false",
     }
 
     # Parse configuration
@@ -253,6 +262,12 @@ def main():
     pr_digest_file = env_values["PR_DIGEST_FILE"]
     stats_file = env_values["PR_DIGEST_STATS_FILE"]
     report_period = env_values["REPORT_PERIOD"]
+    is_historical = env_values["IS_HISTORICAL_RUN"].lower() == "true"
+
+    # Log if this is a historical run
+    if is_historical:
+        logging.info("📅 Running in HISTORICAL mode")
+        logging.info(f"Generating historical newsletter for: {report_period}")
 
     # Construct GitHub run URL
     github_run_url = f"{github_server_url}/{github_repository}/actions/runs/{github_run_id}"
@@ -311,8 +326,22 @@ def main():
     # Generate newsletter content
     print("Generating newsletter content...")
     ai_client = GeminiAIClient(api_key)
-    newsletter_generator = NewsletterGenerator(ai_client)
-    newsletter_content = newsletter_generator.generate_newsletter(all_summaries, report_period, github_repository)
+    newsletter_generator = NewsletterGenerator(ai_client, is_historical)
+
+    # Parse end date for historical context filtering
+    end_date = None
+    if is_historical:
+        # Get the end date from the stats file
+        end_date_str = stats.get("end_date")
+        if end_date_str:
+            try:
+                end_date = datetime.fromisoformat(end_date_str)
+            except ValueError:
+                logging.warning(f"Could not parse end date from stats: {end_date_str}")
+
+    newsletter_content = newsletter_generator.generate_newsletter(
+        all_summaries, report_period, github_repository, end_date
+    )
 
     with open("newsletter_output.txt", "w") as f:
         f.write(newsletter_content)

--- a/.github/workflows/generate-newsletter.yml
+++ b/.github/workflows/generate-newsletter.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      historical_date:
+        description: "Generate newsletter for a historical date (YYYY-MM-DD format). Leave empty for current date."
+        required: false
+        default: ""
+        type: string
 
 jobs:
   generate-newsletter:
@@ -29,40 +34,70 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set days to scan
+      - name: Set days to scan and date range
         id: set-days
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            # Get current day of week (0=Sunday, 1=Monday, etc.)
-            DAY_OF_WEEK=$(date +%w)
+          # Validate and set historical date if provided
+          if [ -n "${{ inputs.historical_date }}" ]; then
+            # Validate date format
+            if ! date -d "${{ inputs.historical_date }}" >/dev/null 2>&1; then
+              echo "❌ Invalid date format. Please use YYYY-MM-DD format."
+              exit 1
+            fi
 
-            # Set days based on day of week (in GMT)
-            # Remember: this runs Tue/Thu/Sat GMT = Mon/Wed/Fri PST
-            case $DAY_OF_WEEK in
-              2) # Tuesday GMT = Monday PST
-                DAYS=3
-                echo "Monday run: using 3 days of history"
-                ;;
-              4) # Thursday GMT = Wednesday PST
-                DAYS=2
-                echo "Wednesday run: using 2 days of history"
-                ;;
-              6) # Saturday GMT = Friday PST
-                DAYS=2
-                echo "Friday run: using 2 days of history"
-                ;;
-              *) # Fallback (shouldn't happen with your cron schedule)
-                DAYS="${{ vars.PR_NEWSLETTER_HISTORY_DAYS || '1' }}"
-                echo "Unexpected day, using default: $DAYS days"
-                ;;
-            esac
+            # Set the end date to the historical date
+            END_DATE="${{ inputs.historical_date }}"
+            echo "📅 Using historical date: $END_DATE"
+            echo "is_historical=true" >> $GITHUB_OUTPUT
+            echo "end_date=$END_DATE" >> $GITHUB_OUTPUT
+
+            # For historical runs, always use workflow input for days
+            DAYS="${{ inputs.days_to_scan || '7' }}"
+            echo "Using $DAYS days before $END_DATE"
           else
-            # Use workflow input for manual runs, fallback to 1 if not provided
-            DAYS="${{ inputs.days_to_scan || '1' }}"
-            echo "Using workflow input: $DAYS days"
+            # Normal operation - use current date
+            END_DATE=$(date +%Y-%m-%d)
+            echo "is_historical=false" >> $GITHUB_OUTPUT
+            echo "end_date=$END_DATE" >> $GITHUB_OUTPUT
+
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              # Get current day of week (0=Sunday, 1=Monday, etc.)
+              DAY_OF_WEEK=$(date +%w)
+
+              # Set days based on day of week (in GMT)
+              # Remember: this runs Tue/Thu/Sat GMT = Mon/Wed/Fri PST
+              case $DAY_OF_WEEK in
+                2) # Tuesday GMT = Monday PST
+                  DAYS=3
+                  echo "Monday run: using 3 days of history"
+                  ;;
+                4) # Thursday GMT = Wednesday PST
+                  DAYS=2
+                  echo "Wednesday run: using 2 days of history"
+                  ;;
+                6) # Saturday GMT = Friday PST
+                  DAYS=2
+                  echo "Friday run: using 2 days of history"
+                  ;;
+                *) # Fallback (shouldn't happen with your cron schedule)
+                  DAYS="${{ vars.PR_NEWSLETTER_HISTORY_DAYS || '1' }}"
+                  echo "Unexpected day, using default: $DAYS days"
+                  ;;
+              esac
+            else
+              # Use workflow input for manual runs, fallback to 1 if not provided
+              DAYS="${{ inputs.days_to_scan || '1' }}"
+              echo "Using workflow input: $DAYS days"
+            fi
           fi
+
           echo "days=$DAYS" >> $GITHUB_OUTPUT
-          echo "Selected days to scan: $DAYS"
+          echo "Selected days to scan: $DAYS (ending on $END_DATE)"
+
+          # Calculate start date for display
+          START_DATE=$(date -d "$END_DATE - $((DAYS - 1)) days" +%Y-%m-%d)
+          echo "start_date=$START_DATE" >> $GITHUB_OUTPUT
+          echo "Date range: $START_DATE to $END_DATE"
 
       - name: Restore PR Summaries Cache
         uses: actions/cache@v4
@@ -85,8 +120,13 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           DAYS_TO_SCAN: ${{ steps.set-days.outputs.days }}
           PR_DIGEST_FILE: "pr_digest_output.json"
+          HISTORICAL_END_DATE: ${{ steps.set-days.outputs.end_date }}
+          IS_HISTORICAL_RUN: ${{ steps.set-days.outputs.is_historical }}
         run: |
           echo "Creating PR digest for last ${{ steps.set-days.outputs.days }} days..."
+          if [ "${{ steps.set-days.outputs.is_historical }}" = "true" ]; then
+            echo "📅 Historical mode: ending on ${{ steps.set-days.outputs.end_date }}"
+          fi
 
           # Show cache status before running
           if [ -d "pr-summaries" ]; then
@@ -162,6 +202,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           FORCE_REFRESH: ${{ inputs.force_refresh || 'false' }}
           PREVIOUS_NEWSLETTERS_DIR: "previous-newsletters"
+          IS_HISTORICAL_RUN: ${{ steps.set-days.outputs.is_historical }}
         run: |
           echo "Analyzing ${{ steps.pr-digest.outputs.total_pr_count }} PRs with AI..."
           echo "(${{ steps.pr-digest.outputs.new_pr_count }} new, rest from cache)"
@@ -205,7 +246,7 @@ jobs:
       - name: Handle No PRs Case
         if: ${{ steps.pr-digest.outputs.has_prs_in_range == 'false' }}
         run: |
-          echo "ℹ️  No PRs found in the time period, creating minimal newsletter..."
+          echo "ℹ️ No PRs found in the time period, creating minimal newsletter..."
 
           cat > discord_summary_output.txt << EOF
           📊 **PR Summary Report** • ${{ steps.pr-digest.outputs.date_range_display }}
@@ -234,7 +275,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: newsletter-${{ github.run_number }}
+          name: newsletter-${{ steps.set-days.outputs.start_date }}-to-${{ steps.set-days.outputs.end_date }}
           path: |
             discord_summary_output.txt
             newsletter_output.txt

--- a/.github/workflows/generate-newsletter.yml
+++ b/.github/workflows/generate-newsletter.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           echo "Creating PR digest for last ${{ steps.set-days.outputs.days }} days..."
           if [ "${{ steps.set-days.outputs.is_historical }}" = "true" ]; then
-            echo "📅 Historical mode: ending on ${{ steps.set-days.outputs.end_date }}"
+            echo "Using date: ${{ steps.set-days.outputs.end_date }}"
           fi
 
           # Show cache status before running


### PR DESCRIPTION

Enables generating newsletters for past date ranges, useful for backfilling missing newsletters or creating reports for historical periods.

### What's New
- Added optional `historical_date` parameter to the workflow
- When provided, generates newsletter as if running on that date
- Automatically filters previous newsletter context to only include newsletters from before the historical date

### Usage
```bash
# Generate newsletter for a specific historical date
gh workflow run generate-newsletter.yml \
  -f historical_date=2024-12-31 \
  -f days_to_scan=30
```

### Implementation Details
- Updated workflow to validate and use historical dates as the end date
- Modified Python scripts to accept `HISTORICAL_END_DATE` environment variable
- Enhanced `PreviousReportExtractor` to parse dates from both new (`newsletter-YYYY-MM-DD-to-YYYY-MM-DD`) and old (`newsletter-{run_id}`) artifact formats
- Maintains temporal consistency by filtering out "future" newsletters from context

### Behavior
- Historical newsletters are identical to regular newsletters - no special markers or formatting
- Discord posting works normally (use `skip_discord=true` if not desired)
- Artifacts use consistent naming: `newsletter-YYYY-MM-DD-to-YYYY-MM-DD`

### Use Cases
- Backfill newsletters for periods that were missed
- Generate year-end summaries or quarterly reports
- Create newsletters for specific events or milestones
- Test newsletter generation without waiting for scheduled runs