### PR TITLE
expose tag spec

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -758,6 +758,16 @@ py::dict MettaGrid::feature_spec() {
     py::dict spec;
     spec["normalization"] = py::float_(normalizations.at(feature_id));
     spec["id"] = py::int_(feature_id);
+
+    // Add tag mapping for the tag feature
+    if (feature_name == "tag") {
+      py::dict tag_map;
+      for (const auto& [tag_id, tag_name] : _game_config.tag_id_map) {
+        tag_map[py::int_(tag_id)] = py::str(tag_name);
+      }
+      spec["values"] = tag_map;
+    }
+
     feature_spec[py::str(feature_name)] = spec;
   }
   return feature_spec;


### PR DESCRIPTION
This exposes tags as a part of `env.c_env.feature_spec()`.

https://app.asana.com/1/1209016784099267/project/1209041170403474/task/1211416595158309?focus=true
https://github.com/Metta-AI/metta/pull/2688#issuecomment-3315153544