### PR TITLE
Remove unused derivative stats from StatsTracker

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -842,12 +842,6 @@ py::none MettaGrid::set_inventory(GridObjectId agent_id, const std::map<Inventor
   return py::none();
 }
 
-// StatsTracker implementation that needs complete MettaGrid definition
-unsigned int StatsTracker::get_current_step() const {
-  if (!_env) return 0;
-  return static_cast<MettaGrid*>(_env)->current_step;
-}
-
 const std::string& StatsTracker::resource_name(InventoryItem item) const {
   if (!_env) return get_no_env_resource_name();
   return _env->resource_names[item];

--- a/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
@@ -14,41 +14,7 @@ using InventoryItem = uint8_t;
 class StatsTracker {
 private:
   std::map<std::string, float> _stats;
-  std::map<std::string, unsigned int> _first_seen_at;
-  std::map<std::string, unsigned int> _last_seen_at;
-  std::map<std::string, float> _min_value;
-  std::map<std::string, float> _max_value;
-  std::map<std::string, unsigned int> _update_count;
   MettaGrid* _env;
-
-  // Track timing for any update
-  void track_timing(const std::string& key) {
-    if (_env) {
-      unsigned int step = get_current_step();
-      if (_first_seen_at.find(key) == _first_seen_at.end()) {
-        _first_seen_at[key] = step;
-      }
-      _last_seen_at[key] = step;
-      _update_count[key]++;
-    }
-  }
-
-  // Helper to get current step - implemented where MettaGrid is complete
-  unsigned int get_current_step() const;
-
-  // Track min/max values automatically
-  void track_bounds(const std::string& key, float value) {
-    if (_min_value.find(key) == _min_value.end()) {
-      _min_value[key] = value;
-      _max_value[key] = value;
-    } else {
-      if (value < _min_value[key]) _min_value[key] = value;
-      if (value > _max_value[key]) _max_value[key] = value;
-    }
-  }
-
-  // MettaGrid needs access to implement get_current_step
-  friend class MettaGrid;
 
   // Test class needs access for testing
   friend class StatsTrackerTest;
@@ -60,23 +26,16 @@ private:
   }
 
 public:
-  StatsTracker()
-      : _stats(), _first_seen_at(), _last_seen_at(), _min_value(), _max_value(), _update_count(), _env(nullptr) {}
+  StatsTracker() : _stats(), _env(nullptr) {}
 
   void set_environment(MettaGrid* env) {
     _env = env;
-  }
-
-  MettaGrid* get_env() const {
-    return _env;
   }
 
   const std::string& resource_name(InventoryItem item) const;
 
   void add(const std::string& key, float amount) {
     _stats[key] += amount;
-    track_timing(key);
-    track_bounds(key, _stats[key]);
   }
 
   // Increment by 1 (convenience method)
@@ -86,79 +45,20 @@ public:
 
   void set(const std::string& key, float value) {
     _stats[key] = value;
-    track_timing(key);
-    track_bounds(key, value);
   }
 
   float get(const std::string& key) {
     return _stats[key];
   }
 
-  // Calculate rate (updates per step)
-  float rate(const std::string& key) const {
-    if (!_env) return 0.0f;
-
-    auto it = _update_count.find(key);
-    if (it == _update_count.end()) return 0.0f;
-
-    unsigned int steps = get_current_step();
-    return (steps > 0) ? static_cast<float>(it->second) / static_cast<float>(steps) : 0.0f;
-  }
-
-  // Convert to map for Python API (all values as floats)
+  // Convert to map for Python API
   std::map<std::string, float> to_dict() const {
-    std::map<std::string, float> result;
-
-    // Add all stats
-    for (const auto& [key, value] : _stats) {
-      result[key] = value;
-    }
-
-    // // Add timing metadata and calculated stats
-    // for (const auto& [key, step] : _first_seen_at) {
-    //   result[key + ".first_step"] = static_cast<float>(step);
-    // }
-
-    // for (const auto& [key, step] : _last_seen_at) {
-    //   result[key + ".last_step"] = static_cast<float>(step);
-    // }
-
-    // for (const auto& [key, count] : _update_count) {
-    //   result[key + ".updates"] = static_cast<float>(count);
-    //   result[key + ".rate"] = rate(key);
-    //   result[key + ".avg"] = result[key] / count;
-
-    //   // Also calculate activity rate if there's a time span
-    //   auto first_it = _first_seen_at.find(key);
-    //   auto last_it = _last_seen_at.find(key);
-    //   if (first_it != _first_seen_at.end() && last_it != _last_seen_at.end()) {
-    //     int duration = static_cast<int>(last_it->second) - static_cast<int>(first_it->second);
-    //     if (duration > 0 && count > 1) {
-    //       result[key + ".activity_rate"] = static_cast<float>(count - 1) / static_cast<float>(duration);
-    //     }
-    //   }
-    // }
-
-    // // Add min/max values
-    // for (const auto& [key, min_val] : _min_value) {
-    //   result[key + ".min"] = min_val;
-    // }
-
-    // for (const auto& [key, max_val] : _max_value) {
-    //   result[key + ".max"] = max_val;
-    // }
-
-    return result;
+    return _stats;
   }
 
   // Reset all statistics
   void reset() {
     _stats.clear();
-    _first_seen_at.clear();
-    _last_seen_at.clear();
-    _min_value.clear();
-    _max_value.clear();
-    _update_count.clear();
   }
 };
 

--- a/packages/mettagrid/tests/test_stats_tracker.cpp
+++ b/packages/mettagrid/tests/test_stats_tracker.cpp
@@ -2,32 +2,10 @@
 
 #include "systems/stats_tracker.hpp"
 
-// Mock MettaGrid for testing
-class MockMettaGrid {
-public:
-  unsigned int current_step = 0;
-};
-
-// Provide implementation for get_current_step() for testing
-unsigned int StatsTracker::get_current_step() const {
-  // For testing, return 0 if no environment is set
-  if (!_env) return 0;
-  // In real implementation, this would return _env->current_step
-  // For testing we use a static value
-  return 0;
-}
-
 // Test fixture for StatsTracker
 class StatsTrackerTest : public ::testing::Test {
 protected:
   StatsTracker stats;
-
-  MockMettaGrid mock_env;
-
-  void SetUp() override {
-    stats.reset();
-    mock_env.current_step = 0;
-  }
 };
 
 // Test basic increment functionality
@@ -72,108 +50,6 @@ TEST_F(StatsTrackerTest, SetOperations) {
   EXPECT_FLOAT_EQ(90.0f, result["health"]);  // Should be the last set value
 }
 
-// Test min/max tracking
-TEST_F(StatsTrackerTest, MinMaxTracking) {
-  stats.set("temperature", 20.0f);
-  stats.set("temperature", 15.0f);
-  stats.set("temperature", 25.0f);
-  stats.set("temperature", 18.0f);
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(18.0f, result["temperature"]);  // Current value
-  // EXPECT_FLOAT_EQ(15.0f, result["temperature.min"]);  // Minimum
-  // EXPECT_FLOAT_EQ(25.0f, result["temperature.max"]);  // Maximum
-}
-
-// Test average calculation
-TEST_F(StatsTrackerTest, AverageCalculation) {
-  // For tests that need timing, we'll test without environment
-  // since we can't easily mock MettaGrid
-  stats.add("points", 10);
-  stats.add("points", 20);
-  stats.add("points", 30);
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(60.0f, result["points"]);  // Total
-
-  // Without environment, we don't get timing metadata
-  // EXPECT_EQ(0, result.count("points.updates"));
-  // EXPECT_EQ(0, result.count("points.avg"));
-}
-
-// Test time tracking without environment =
-TEST_F(StatsTrackerTest, TimingWithoutEnvironment) {
-  // We can't easily test timing with a mock environment since
-  // get_current_step() expects a real MettaGrid pointer.
-  // This test will verify expected behavior when no environment
-  // timing is available.
-
-  stats.incr("action.move");
-  stats.incr("action.move");
-  stats.incr("action.move");
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(3.0f, result["action.move"]);
-
-  // Without environment, no timing data
-  // EXPECT_EQ(0, result.count("action.move.first_step"));
-  // EXPECT_EQ(0, result.count("action.move.last_step"));
-  // EXPECT_EQ(0, result.count("action.move.updates"));
-  // EXPECT_EQ(0, result.count("action.move.rate"));
-}
-
-// Test rate calculation
-TEST_F(StatsTrackerTest, RateCalculation) {
-  // Without environment, rate should be 0
-  for (int i = 0; i < 10; i++) {
-    stats.incr("event");
-  }
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(10.0f, result["event"]);
-  EXPECT_EQ(0, result.count("event.rate"));  // No rate without environment
-}
-
-// Test reset functionality
-TEST_F(StatsTrackerTest, ResetClearsAllData) {
-  // Add some data
-  stats.incr("counter");
-  stats.set("value", 100);
-  stats.add("score", 50);
-
-  // Reset
-  stats.reset();
-
-  // All data should be cleared
-  auto result = stats.to_dict();
-  EXPECT_TRUE(result.empty());
-}
-
-// Test without environment (no timing)
-TEST_F(StatsTrackerTest, NoEnvironmentNoTiming) {
-  // Don't set environment
-  stats.incr("action");
-  stats.incr("action");
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(2.0f, result["action"]);
-  // EXPECT_EQ(0, result.count("action.first_step"));  // No timing data
-  // EXPECT_EQ(0, result.count("action.last_step"));
-  // EXPECT_EQ(0, result.count("action.rate"));
-}
-
-// Test complex stat keys
-TEST_F(StatsTrackerTest, ComplexStatKeys) {
-  stats.incr("action.attack.agent.red_team.blue_team");
-  stats.add("inventory.armor.gained", 5);
-  stats.set("status.health.current", 85.5f);
-
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(1.0f, result["action.attack.agent.red_team.blue_team"]);
-  EXPECT_FLOAT_EQ(5.0f, result["inventory.armor.gained"]);
-  EXPECT_FLOAT_EQ(85.5f, result["status.health.current"]);
-}
-
 // Test edge cases
 TEST_F(StatsTrackerTest, EdgeCases) {
   // Zero values
@@ -187,8 +63,6 @@ TEST_F(StatsTrackerTest, EdgeCases) {
   auto result = stats.to_dict();
   EXPECT_FLOAT_EQ(0.0f, result["zero"]);
   EXPECT_FLOAT_EQ(-5.0f, result["negative"]);
-  // EXPECT_FLOAT_EQ(-10.0f, result["negative.min"]);
-  // EXPECT_FLOAT_EQ(-5.0f, result["negative.max"]);
 }
 
 // Test large numbers
@@ -198,31 +72,4 @@ TEST_F(StatsTrackerTest, LargeNumbers) {
 
   auto result = stats.to_dict();
   EXPECT_FLOAT_EQ(3000000.0f, result["large"]);
-
-  // Without environment, no average calculation
-  // EXPECT_EQ(0, result.count("large.avg"));
-  EXPECT_EQ(0, result.count("large.updates"));
-}
-
-// Test all metadata is generated correctly
-TEST_F(StatsTrackerTest, CompleteMetadata) {
-  // Without a real MettaGrid, we can only test non-timing metadata
-  stats.add("resource", 10);
-  stats.add("resource", 20);
-  stats.add("resource", 15);
-  stats.add("resource", 5);
-
-  auto result = stats.to_dict();
-
-  // Check basic values
-  EXPECT_FLOAT_EQ(50.0f, result["resource"]);  // Total: 10+20+15+5
-  // EXPECT_FLOAT_EQ(10.0f, result["resource.min"]);  // Min cumulative value
-  // EXPECT_FLOAT_EQ(50.0f, result["resource.max"]);  // Max cumulative value
-
-  // Timing-related metadata won't be present without environment
-  // EXPECT_EQ(0, result.count("resource.avg"));
-  // EXPECT_EQ(0, result.count("resource.first_step"));
-  // EXPECT_EQ(0, result.count("resource.last_step"));
-  // EXPECT_EQ(0, result.count("resource.updates"));
-  // EXPECT_EQ(0, result.count("resource.rate"));
 }


### PR DESCRIPTION
We used to report a lot of derivative stats from StatsTracker, like maxes and mins. We stopped doing this because it was noisy, but when we stopped, we just commented out the code. I'm now removing it.

The main reason I'm touching this code is that I want to reduce the dependency of stats on the environment; and I want to do that for a combination of code cleanliness and having an easier time writing tests. The removed code required StatsTracker to know the current step. This isn't unreasonable on its own, but it was part of StatsTracker having a direct dependency on env.

I've confirmed with Cybernetics folks that they don't feel a short term need for these derivative stats (that we're not recording).

After this PR, StatsTracker still depends on the environment for resource names. So that'll have to be its own PR.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211472517635377)