### PR TITLE
Remove a depenency of StatsTracker on the environment

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -74,7 +74,7 @@ MettaGrid::MettaGrid(const GameConfig& game_config, const py::list map, unsigned
 
   _event_manager = std::make_unique<EventManager>();
   _stats = std::make_unique<StatsTracker>();
-  _stats->set_environment(this);
+  _stats->set_resource_names(&resource_names);
 
   _event_manager->init(_grid.get());
   _event_manager->event_handlers.insert(
@@ -189,7 +189,7 @@ MettaGrid::MettaGrid(const GameConfig& game_config, const py::list map, unsigned
           throw std::runtime_error("Too many agents for agent_id type");
         }
         agent->agent_id = static_cast<decltype(agent->agent_id)>(_agents.size());
-        agent->stats.set_environment(this);
+        agent->stats.set_resource_names(&resource_names);
         // Only initialize visitation grid if visitation counts are enabled
         if (_global_obs_config.visitation_counts) {
           agent->init_visitation_grid(height, width);
@@ -840,11 +840,6 @@ py::none MettaGrid::set_inventory(GridObjectId agent_id, const std::map<Inventor
     this->_agents[agent_id]->set_inventory(inventory);
   }
   return py::none();
-}
-
-const std::string& StatsTracker::resource_name(InventoryItem item) const {
-  if (!_env) return get_no_env_resource_name();
-  return _env->resource_names[item];
 }
 
 // Pybind11 module definition

--- a/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
@@ -14,25 +14,32 @@ using InventoryItem = uint8_t;
 class StatsTracker {
 private:
   std::map<std::string, float> _stats;
-  MettaGrid* _env;
+  // StatsTracker holds a reference to resource_names to make it easier to track stats for each resource.
+  // The environment owns this reference, so it should live as long as we're going to use it.
+  const std::vector<std::string>* _resource_names;
 
   // Test class needs access for testing
   friend class StatsTrackerTest;
 
   // Use a static function to avoid global destructor
-  static const std::string& get_no_env_resource_name() {
-    static const std::string name = "[unknown -- stats tracker not initialized]";
+  static const std::string& get_unknown_resource_name() {
+    static const std::string name = "[unknown -- StatsTracker resource names not initialized]";
     return name;
   }
 
 public:
-  StatsTracker() : _stats(), _env(nullptr) {}
+  StatsTracker() : _stats(), _resource_names(nullptr) {}
 
-  void set_environment(MettaGrid* env) {
-    _env = env;
+  void set_resource_names(const std::vector<std::string>* resource_names) {
+    _resource_names = resource_names;
   }
 
-  const std::string& resource_name(InventoryItem item) const;
+  const std::string& resource_name(InventoryItem item) const {
+    if (_resource_names == nullptr) {
+      return get_unknown_resource_name();
+    }
+    return (*_resource_names)[item];
+  }
 
   void add(const std::string& key, float amount) {
     _stats[key] += amount;


### PR DESCRIPTION
This removes a direct dependency of stats tracking on the environment, and scopes it down to stats tracking depending on having a reference to resource names.

The only direct effect of this is to make things feel cleaner. But this cleanliness makes me a lot more comfortable writing tests around moving rewards to all be stats based.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211472656523570)