### PR TITLE
Fix: Passing Wrong Config

### DIFF
--- a/agent/src/metta/agent/policy.py
+++ b/agent/src/metta/agent/policy.py
@@ -41,7 +41,7 @@ class PolicyArchitecture(Config):
         """Create an agent instance from configuration."""
 
         AgentClass = load_symbol(self.class_path)
-        return AgentClass(env_metadata, self)
+        return AgentClass(env_metadata)
 
 
 class Policy(ABC, nn.Module):


### PR DESCRIPTION
During initialization of policy, it passes base config which we don't need as policy config is already defined in it's script. 