### PR TITLE
fix: fetch remote tags before publishing

### DIFF
--- a/metta/setup/metta_cli.py
+++ b/metta/setup/metta_cli.py
@@ -480,6 +480,13 @@ def cmd_publish(
     prefix = PACKAGE_TAG_PREFIXES[package]
 
     try:
+        info(f"Fetching tags from {remote}...")
+        _run_git_command(["fetch", remote, "--tags"], capture_output=False)
+    except subprocess.CalledProcessError as exc:
+        error(f"Failed to fetch tags from {remote}: {exc}")
+        raise typer.Exit(exc.returncode) from exc
+
+    try:
         status_output = _get_git_output(["status", "--porcelain"])
     except subprocess.CalledProcessError as exc:
         error(f"Failed to read git status: {exc}")


### PR DESCRIPTION
## Summary
- fetch remote tags before calculating next version in `metta/setup/metta_cli.py:479`
- error out early if the fetch fails so publish never uses stale refs

## Testing
- uv run ruff format metta/setup/metta_cli.py
- uv run ruff check metta/setup/metta_cli.py
