### PR TITLE
hotfix: filter describe tags for mettagrid

### DIFF
--- a/packages/mettagrid/pyproject.toml
+++ b/packages/mettagrid/pyproject.toml
@@ -79,3 +79,14 @@ version_scheme = "no-guess-dev"
 local_scheme = "node-and-date"
 root = "../.."
 fallback_version = "0.0.0"
+
+[tool.setuptools_scm.scm.git]
+describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--tags",
+  "--long",
+  "--match",
+  "mettagrid-v*",
+]


### PR DESCRIPTION
## Summary

- force setuptools_scm to run git describe with --match 'mettagrid-v*'
- keep existing tag regex so our mettagrid-vX tags parse cleanly
- ensures local builds either use the nearest mettagrid tag or fallback to 0.0.0

## Testing

- uv sync

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211484402687943)