### PR TITLE
hotfix: global ignore bazel build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,8 @@ build-debug/
 build-coverage/
 
 # Bazel build artifacts
-bazel-bin
-bazel-out
-bazel-testlogs
-bazel-mettagrid
+**/bazel-*
+**/.bazel_output/
 
 # Node.js / Frontend
 node_modules/


### PR DESCRIPTION

Simplifies `.gitignore` rules by replacing individual Bazel output entries with global patterns. This ensures all `bazel-*` directories and `.bazel_output/` are ignored across the repository, including subpackages like `packages/mettagrid`.
