### PR TITLE
Add limits to Inventory

### DIFF
--- a/packages/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/packages/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -61,28 +61,8 @@ GameConfig CreateBenchmarkConfig(size_t num_agents) {
   std::map<std::string, std::shared_ptr<GridObjectConfig>> objects_cfg;
 
   objects_cfg["wall"] = std::make_shared<WallConfig>(1, "wall", false);
-  objects_cfg["agent.team1"] = std::make_shared<AgentConfig>(0,
-                                                             "agent",
-                                                             0,
-                                                             "team1",
-                                                             0,
-                                                             0.0f,
-                                                             std::map<InventoryItem, InventoryQuantity>(),
-                                                             std::map<std::string, RewardType>(),
-                                                             std::map<std::string, RewardType>(),
-                                                             0.0f,
-                                                             std::map<InventoryItem, InventoryQuantity>());
-  objects_cfg["agent.team2"] = std::make_shared<AgentConfig>(0,
-                                                             "agent",
-                                                             1,
-                                                             "team2",
-                                                             0,
-                                                             0.0f,
-                                                             std::map<InventoryItem, InventoryQuantity>(),
-                                                             std::map<std::string, RewardType>(),
-                                                             std::map<std::string, RewardType>(),
-                                                             0.0f,
-                                                             std::map<InventoryItem, InventoryQuantity>());
+  objects_cfg["agent.team1"] = std::make_shared<AgentConfig>(0, "agent", 0, "team1");
+  objects_cfg["agent.team2"] = std::make_shared<AgentConfig>(0, "agent", 1, "team2");
 
   // Create default global observation config
   GlobalObsConfig global_obs_config;

--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -29,6 +29,7 @@
 #include "objects/constants.hpp"
 #include "objects/converter.hpp"
 #include "objects/converter_config.hpp"
+#include "objects/inventory_config.hpp"
 #include "objects/production_handler.hpp"
 #include "objects/recipe.hpp"
 #include "objects/wall.hpp"
@@ -691,11 +692,12 @@ py::dict MettaGrid::grid_objects() {
         inventory_dict[py::int_(resource)] = quantity;
       }
       obj_dict["inventory"] = inventory_dict;
-      py::dict resource_limits_dict;
-      for (const auto& [resource, quantity] : agent->resource_limits) {
-        resource_limits_dict[py::int_(resource)] = quantity;
-      }
-      obj_dict["resource_limits"] = resource_limits_dict;
+      // We made resource limits more complicated than this, and need to review how to expose them.
+      // py::dict resource_limits_dict;
+      // for (const auto& [resource, quantity] : agent->inventory.limits) {
+      //   resource_limits_dict[py::int_(resource)] = quantity;
+      // }
+      // obj_dict["resource_limits"] = resource_limits_dict;
       obj_dict["agent_id"] = agent->agent_id;
     }
 
@@ -897,6 +899,7 @@ PYBIND11_MODULE(mettagrid_c, m) {
   // This comes from us creating (e.g.) various config objects, and then storing them in GameConfig's maps.
   // We're, like 80% sure on this reasoning.
 
+  bind_inventory_config(m);
   bind_agent_config(m);
   bind_converter_config(m);
   bind_assembler_config(m);

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -144,8 +144,7 @@ public:
       } else if (delta < 0) {
         this->stats.add(this->stats.resource_name(item) + ".lost", -delta);
       }
-      InventoryQuantity current_amount = this->inventory.amount(item);
-      this->stats.set(this->stats.resource_name(item) + ".amount", current_amount);
+      this->stats.set(this->stats.resource_name(item) + ".amount", this->inventory.amount(item));
     }
 
     return delta;

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -24,7 +24,6 @@ public:
   // however, this should not be relied on for correctness.
   std::map<std::string, RewardType> stat_rewards;
   std::map<std::string, RewardType> stat_reward_max;
-  std::map<InventoryItem, InventoryQuantity> resource_limits;
   float action_failure_penalty;
   std::string group_name;
   // We expect only a small number (single-digit) of soul-bound resources.
@@ -45,13 +44,14 @@ public:
   unsigned int steps_without_motion;
 
   Agent(GridCoord r, GridCoord c, const AgentConfig& config)
-      : group(config.group_id),
+      : GridObject(),
+        HasInventory(config.inventory_config),
+        group(config.group_id),
         frozen(0),
         freeze_duration(config.freeze_duration),
         orientation(Orientation::North),
         stat_rewards(config.stat_rewards),
         stat_reward_max(config.stat_reward_max),
-        resource_limits(config.resource_limits),
         action_failure_penalty(config.action_failure_penalty),
         group_name(config.group_name),
         soul_bound_resources(config.soul_bound_resources),
@@ -136,20 +136,6 @@ public:
   }
 
   InventoryDelta update_inventory(InventoryItem item, InventoryDelta attempted_delta) {
-    // Apply resource limits if adding items
-    // xcxc move the limit check to Inventory
-    if (attempted_delta > 0) {
-      auto limit_it = this->resource_limits.find(item);
-      if (limit_it != this->resource_limits.end()) {
-        InventoryQuantity current_amount = this->inventory.amount(item);
-        InventoryQuantity limit = limit_it->second;
-        InventoryQuantity max_can_add = limit - current_amount;
-        if (max_can_add < attempted_delta) {
-          attempted_delta = max_can_add;
-        }
-      }
-    }
-
     const InventoryDelta delta = this->inventory.update(item, attempted_delta);
 
     if (delta != 0) {

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
@@ -19,7 +19,7 @@ struct AgentConfig : public GridObjectConfig {
               const std::string& group_name,
               unsigned char freeze_duration = 0,
               float action_failure_penalty = 0,
-              const InventoryConfig& inventory_config = InventoryConfig({}),
+              const InventoryConfig& inventory_config = InventoryConfig(),
               const std::map<std::string, RewardType>& stat_rewards = {},
               const std::map<std::string, RewardType>& stat_reward_max = {},
               float group_reward_pct = 0,

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
@@ -10,6 +10,7 @@
 
 #include "core/grid_object.hpp"
 #include "core/types.hpp"
+#include "objects/inventory_config.hpp"
 
 struct AgentConfig : public GridObjectConfig {
   AgentConfig(TypeId type_id,
@@ -18,7 +19,7 @@ struct AgentConfig : public GridObjectConfig {
               const std::string& group_name,
               unsigned char freeze_duration = 0,
               float action_failure_penalty = 0,
-              const std::map<InventoryItem, InventoryQuantity>& resource_limits = {},
+              const InventoryConfig& inventory_config = InventoryConfig({}),
               const std::map<std::string, RewardType>& stat_rewards = {},
               const std::map<std::string, RewardType>& stat_reward_max = {},
               float group_reward_pct = 0,
@@ -30,7 +31,7 @@ struct AgentConfig : public GridObjectConfig {
         group_name(group_name),
         freeze_duration(freeze_duration),
         action_failure_penalty(action_failure_penalty),
-        resource_limits(resource_limits),
+        inventory_config(inventory_config),
         stat_rewards(stat_rewards),
         stat_reward_max(stat_reward_max),
         group_reward_pct(group_reward_pct),
@@ -41,7 +42,7 @@ struct AgentConfig : public GridObjectConfig {
   std::string group_name;
   short freeze_duration;
   float action_failure_penalty;
-  std::map<InventoryItem, InventoryQuantity> resource_limits;
+  InventoryConfig inventory_config;
   std::map<std::string, RewardType> stat_rewards;
   std::map<std::string, RewardType> stat_reward_max;
   float group_reward_pct;
@@ -59,7 +60,7 @@ inline void bind_agent_config(py::module& m) {
                     const std::string&,
                     unsigned char,
                     float,
-                    const std::map<InventoryItem, InventoryQuantity>&,
+                    const InventoryConfig&,
                     const std::map<std::string, RewardType>&,
                     const std::map<std::string, RewardType>&,
                     float,
@@ -72,25 +73,25 @@ inline void bind_agent_config(py::module& m) {
            py::arg("group_name"),
            py::arg("freeze_duration") = 0,
            py::arg("action_failure_penalty") = 0,
-           py::arg("resource_limits") = std::map<InventoryItem, InventoryQuantity>(),
+           py::arg("inventory_config") = InventoryConfig(),
            py::arg("stat_rewards") = std::map<std::string, RewardType>(),
            py::arg("stat_reward_max") = std::map<std::string, RewardType>(),
            py::arg("group_reward_pct") = 0,
            py::arg("initial_inventory") = std::map<InventoryItem, InventoryQuantity>(),
            py::arg("tag_ids") = std::vector<int>(),
            py::arg("soul_bound_resources") = std::vector<InventoryItem>())
-      .def_readwrite("type_id", &AgentConfig::type_id)
-      .def_readwrite("type_name", &AgentConfig::type_name)
+      .def_readwrite("type_id", &GridObjectConfig::type_id)
+      .def_readwrite("type_name", &GridObjectConfig::type_name)
       .def_readwrite("group_name", &AgentConfig::group_name)
       .def_readwrite("group_id", &AgentConfig::group_id)
       .def_readwrite("freeze_duration", &AgentConfig::freeze_duration)
       .def_readwrite("action_failure_penalty", &AgentConfig::action_failure_penalty)
-      .def_readwrite("resource_limits", &AgentConfig::resource_limits)
+      .def_readwrite("inventory_config", &AgentConfig::inventory_config)
       .def_readwrite("stat_rewards", &AgentConfig::stat_rewards)
       .def_readwrite("stat_reward_max", &AgentConfig::stat_reward_max)
       .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct)
       .def_readwrite("initial_inventory", &AgentConfig::initial_inventory)
-      .def_readwrite("tag_ids", &AgentConfig::tag_ids)
+      .def_readwrite("tag_ids", &GridObjectConfig::tag_ids)
       .def_readwrite("soul_bound_resources", &AgentConfig::soul_bound_resources);
 }
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
@@ -98,7 +98,9 @@ public:
   class Grid* grid;
 
   Chest(GridCoord r, GridCoord c, const ChestConfig& cfg)
-      : resource_type(cfg.resource_type),
+      : GridObject(),
+        HasInventory(InventoryConfig()),  // Chests have nothing to configure in their inventory. Yet.
+        resource_type(cfg.resource_type),
         deposit_positions(cfg.deposit_positions),
         withdrawal_positions(cfg.withdrawal_positions),
         grid(nullptr) {

--- a/packages/mettagrid/cpp/include/mettagrid/objects/converter.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/converter.hpp
@@ -85,7 +85,9 @@ public:
   unsigned short conversions_completed;
 
   Converter(GridCoord r, GridCoord c, const ConverterConfig& cfg)
-      : input_resources(cfg.input_resources),
+      : GridObject(),
+        HasInventory(InventoryConfig()),  // Converts have nothing to configure in their inventory. Yet.
+        input_resources(cfg.input_resources),
         output_resources(cfg.output_resources),
         max_output(cfg.max_output),
         max_conversions(cfg.max_conversions),

--- a/packages/mettagrid/cpp/include/mettagrid/objects/has_inventory.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/has_inventory.hpp
@@ -10,7 +10,7 @@
 #include "objects/inventory_config.hpp"
 class HasInventory {
 public:
-  HasInventory(const InventoryConfig& inventory_config) : inventory(inventory_config) {}
+  explicit HasInventory(const InventoryConfig& inventory_config) : inventory(inventory_config) {}
   virtual ~HasInventory() = default;
   Inventory inventory;
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/has_inventory.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/has_inventory.hpp
@@ -7,8 +7,11 @@
 
 #include "objects/constants.hpp"
 #include "objects/inventory.hpp"
+#include "objects/inventory_config.hpp"
 class HasInventory {
 public:
+  HasInventory(const InventoryConfig& inventory_config) : inventory(inventory_config) {}
+  virtual ~HasInventory() = default;
   Inventory inventory;
 
   // Whether the inventory is accessible to an agent.

--- a/packages/mettagrid/cpp/include/mettagrid/objects/inventory.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/inventory.hpp
@@ -20,7 +20,7 @@ private:
   std::map<InventoryItem, SharedInventoryLimit*> _limits;
 
 public:
-  Inventory(const InventoryConfig& cfg) : _inventory(), _limits() {
+  explicit Inventory(const InventoryConfig& cfg) : _inventory(), _limits() {
     for (const auto& limit_pair : cfg.limits) {
       const auto& resources = limit_pair.first;
       const auto& limit_value = limit_pair.second;

--- a/packages/mettagrid/cpp/include/mettagrid/objects/inventory.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/inventory.hpp
@@ -7,13 +7,41 @@
 
 #include "core/types.hpp"
 #include "objects/constants.hpp"
+#include "objects/inventory_config.hpp"
+struct SharedInventoryLimit {
+  InventoryQuantity limit;
+  // How much do we have of whatever-this-limit-applies-to
+  InventoryQuantity amount;
+};
 
 class Inventory {
 private:
   std::map<InventoryItem, InventoryQuantity> _inventory;
+  std::map<InventoryItem, SharedInventoryLimit*> _limits;
 
 public:
-  Inventory() : _inventory() {}
+  Inventory(const InventoryConfig& cfg) : _inventory(), _limits() {
+    for (const auto& limit_pair : cfg.limits) {
+      const auto& resources = limit_pair.first;
+      const auto& limit_value = limit_pair.second;
+      SharedInventoryLimit* limit = new SharedInventoryLimit();
+      limit->amount = 0;
+      limit->limit = limit_value;
+      for (const auto& resource : resources) {
+        this->_limits[resource] = limit;
+      }
+    }
+  }
+
+  ~Inventory() {
+    std::set<SharedInventoryLimit*> limits;
+    for (const auto& [item, limit] : this->_limits) {
+      limits.insert(limit);
+    }
+    for (const auto& limit : limits) {
+      delete limit;
+    }
+  }
 
   InventoryDelta update(InventoryItem item, InventoryDelta attempted_delta) {
     InventoryQuantity initial_amount = this->_inventory[item];
@@ -21,6 +49,13 @@ public:
 
     constexpr InventoryQuantity min = std::numeric_limits<InventoryQuantity>::min();
     InventoryQuantity max = std::numeric_limits<InventoryQuantity>::max();
+    SharedInventoryLimit* limit = nullptr;
+    if (this->_limits.count(item) > 0) {
+      limit = this->_limits.at(item);
+      // The max is the total limit, minus whatever's used. But don't count this specific
+      // resource.
+      max = limit->limit - (limit->amount - initial_amount);
+    }
 
     InventoryQuantity clamped_amount = static_cast<InventoryQuantity>(std::clamp<int>(new_amount, min, max));
 
@@ -28,6 +63,10 @@ public:
       this->_inventory.erase(item);
     } else {
       this->_inventory[item] = clamped_amount;
+    }
+
+    if (limit) {
+      limit->amount += clamped_amount - initial_amount;
     }
 
     InventoryDelta clamped_delta = clamped_amount - initial_amount;

--- a/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
@@ -1,0 +1,21 @@
+#ifndef PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_INVENTORY_CONFIG_HPP_
+#define PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_INVENTORY_CONFIG_HPP_
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <vector>
+
+#include "core/types.hpp"
+#include "objects/constants.hpp"
+
+struct InventoryConfig {
+  std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>> limits;
+};
+
+namespace py = pybind11;
+
+inline void bind_inventory_config(py::module& m) {
+  py::class_<InventoryConfig>(m, "InventoryConfig").def(py::init<>()).def_readwrite("limits", &InventoryConfig::limits);
+}
+#endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_INVENTORY_CONFIG_HPP_

--- a/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
@@ -14,7 +14,7 @@ struct InventoryConfig {
 
   InventoryConfig() = default;
 
-  InventoryConfig(const std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>>& limits)
+  explicit InventoryConfig(const std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>>& limits)
       : limits(limits) {}
 };
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/inventory_config.hpp
@@ -11,11 +11,20 @@
 
 struct InventoryConfig {
   std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>> limits;
+
+  InventoryConfig() = default;
+
+  InventoryConfig(const std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>>& limits)
+      : limits(limits) {}
 };
 
 namespace py = pybind11;
 
 inline void bind_inventory_config(py::module& m) {
-  py::class_<InventoryConfig>(m, "InventoryConfig").def(py::init<>()).def_readwrite("limits", &InventoryConfig::limits);
+  py::class_<InventoryConfig>(m, "InventoryConfig")
+      .def(py::init<>())
+      .def(py::init<const std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>>&>(),
+           py::arg("limits") = std::vector<std::pair<std::vector<InventoryItem>, InventoryQuantity>>())
+      .def_readwrite("limits", &InventoryConfig::limits);
 }
 #endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_INVENTORY_CONFIG_HPP_

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -19,6 +19,7 @@ from mettagrid.mettagrid_c import ChestConfig as CppChestConfig
 from mettagrid.mettagrid_c import ConverterConfig as CppConverterConfig
 from mettagrid.mettagrid_c import GameConfig as CppGameConfig
 from mettagrid.mettagrid_c import GlobalObsConfig as CppGlobalObsConfig
+from mettagrid.mettagrid_c import InventoryConfig as CppInventoryConfig
 from mettagrid.mettagrid_c import Recipe as CppRecipe
 from mettagrid.mettagrid_c import WallConfig as CppWallConfig
 
@@ -187,15 +188,22 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             if resource_name in resource_name_to_id
         ]
 
+        inventory_config = CppInventoryConfig(
+            limits=[
+                [
+                    [resource_name_to_id[resource_name]],
+                    agent_props["resource_limits"].get(resource_name, default_resource_limit),
+                ]
+                for resource_name in resource_names
+            ]
+        )
+
         agent_cpp_params = {
             "freeze_duration": agent_props["freeze_duration"],
             "group_id": team_id,
             "group_name": group_name,
             "action_failure_penalty": agent_props["action_failure_penalty"],
-            "resource_limits": {
-                resource_id: agent_props["resource_limits"].get(resource_name, default_resource_limit)
-                for resource_id, resource_name in enumerate(resource_names)
-            },
+            "inventory_config": inventory_config,
             "stat_rewards": stat_rewards,
             "stat_reward_max": stat_reward_max,
             "group_reward_pct": 0.0,  # Default to 0 for direct agents


### PR DESCRIPTION
Adds limits to Inventory in a way that allows groupings of resources to share a limit. E.g., this allows us to have a limit on tools, raw materials, energy, and hearts separately.

https://app.asana.com/1/1209016784099267/project/1211340635624763/task/1211431786762546

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211484303864314)