### PR TITLE
make stats get methods const, return references

### DIFF
--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -171,19 +171,15 @@ public:
     }
 
     float new_stat_reward = 0;
-    auto stat_dict = this->stats.to_dict();
 
     for (const auto& [stat_name, reward_per_unit] : this->stat_rewards) {
-      if (stat_dict.count(stat_name) > 0) {
-        float stat_value = stat_dict[stat_name];
-
-        float stats_reward = stat_value * reward_per_unit;
-        if (this->stat_reward_max.count(stat_name) > 0) {
-          stats_reward = std::min(stats_reward, this->stat_reward_max.at(stat_name));
-        }
-
-        new_stat_reward += stats_reward;
+      float stat_value = this->stats.get(stat_name);
+      float stats_reward = stat_value * reward_per_unit;
+      if (this->stat_reward_max.count(stat_name) > 0) {
+        stats_reward = std::min(stats_reward, this->stat_reward_max.at(stat_name));
       }
+
+      new_stat_reward += stats_reward;
     }
 
     // Update the agent's reward with the difference

--- a/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
@@ -59,7 +59,7 @@ public:
   }
 
   // Convert to map for Python API
-  std::map<std::string, float> to_dict() const {
+  const std::map<std::string, float>& to_dict() const {
     return _stats;
   }
 

--- a/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/systems/stats_tracker.hpp
@@ -54,8 +54,12 @@ public:
     _stats[key] = value;
   }
 
-  float get(const std::string& key) {
-    return _stats[key];
+  float get(const std::string& key) const {
+    auto it = _stats.find(key);
+    if (it == _stats.end()) {
+      return 0.0f;
+    }
+    return it->second;
   }
 
   // Convert to map for Python API

--- a/packages/mettagrid/tests/test_mettagrid.cpp
+++ b/packages/mettagrid/tests/test_mettagrid.cpp
@@ -488,14 +488,14 @@ TEST_F(MettaGridCppTest, ActionTracking) {
   std::mt19937 rng(42);
   noop.init(&grid, &rng);
 
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 0.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 0.0f);
   noop.handle_action(agent->id, 0);  // count 1, max 1
   EXPECT_EQ(agent->location.r, 5);
   EXPECT_EQ(agent->location.c, 5);
   EXPECT_EQ(agent->prev_location.r, 5);
   EXPECT_EQ(agent->prev_location.c, 5);
   EXPECT_EQ(agent->prev_action_name, "noop");
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 1.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
   agent->location.r = 6;
   agent->location.c = 6;
   noop.handle_action(agent->id, 0);  // count 0, max 1
@@ -503,12 +503,12 @@ TEST_F(MettaGridCppTest, ActionTracking) {
   EXPECT_EQ(agent->location.c, 6);
   EXPECT_EQ(agent->prev_location.r, 6);
   EXPECT_EQ(agent->prev_location.c, 6);
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 1.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
   noop.handle_action(agent->id, 0);  // count 1, max 1
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 1.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
   noop.handle_action(agent->id, 0);  // count 2, max 2
   noop.handle_action(agent->id, 0);  // count 3, max 3
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 3.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 3.0f);
   agent->location.r = 7;
   agent->location.c = 7;
   noop.handle_action(agent->id, 0);  // count 0, max 3
@@ -518,10 +518,10 @@ TEST_F(MettaGridCppTest, ActionTracking) {
   EXPECT_EQ(agent->prev_location.c, 7);
   noop.handle_action(agent->id, 0);  // count 1, max 3
   noop.handle_action(agent->id, 0);  // count 2, max 3
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 3.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 3.0f);
   noop.handle_action(agent->id, 0);  // count 3, max 3
   noop.handle_action(agent->id, 0);  // count 4, max 4
-  EXPECT_FLOAT_EQ(agent->stats.to_dict()["status.max_steps_without_motion"], 4.0f);
+  EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 4.0f);
 }
 
 // ==================== Fractional Consumption Tests ====================

--- a/packages/mettagrid/tests/test_stats_tracker.cpp
+++ b/packages/mettagrid/tests/test_stats_tracker.cpp
@@ -14,10 +14,7 @@ TEST_F(StatsTrackerTest, BasicIncrement) {
   stats.incr("test.counter");
   stats.incr("test.counter");
 
-  auto result = stats.to_dict();
-  // Note: to_dict() returns all values as floats for Python compatibility,
-  // so we use EXPECT_FLOAT_EQ even for integer stats
-  EXPECT_FLOAT_EQ(3.0f, result["test.counter"]);
+  EXPECT_FLOAT_EQ(3.0f, stats.get("test.counter"));
 }
 
 // Test add with integers
@@ -26,8 +23,7 @@ TEST_F(StatsTrackerTest, AddIntegers) {
   stats.add("score", 15);
   stats.add("score", 25);
 
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(50.0f, result["score"]);
+  EXPECT_FLOAT_EQ(50.0f, stats.get("score"));
 }
 
 // Test add with floats
@@ -36,8 +32,7 @@ TEST_F(StatsTrackerTest, AddFloats) {
   stats.add("damage", 15.3f);
   stats.add("damage", 24.2f);
 
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(50.0f, result["damage"]);
+  EXPECT_FLOAT_EQ(50.0f, stats.get("damage"));
 }
 
 // Test set operations
@@ -46,8 +41,7 @@ TEST_F(StatsTrackerTest, SetOperations) {
   stats.set("health", 85);
   stats.set("health", 90);
 
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(90.0f, result["health"]);  // Should be the last set value
+  EXPECT_FLOAT_EQ(90.0f, stats.get("health"));  // Should be the last set value
 }
 
 // Test edge cases
@@ -60,9 +54,8 @@ TEST_F(StatsTrackerTest, EdgeCases) {
   stats.add("negative", -10);
   stats.add("negative", 5);
 
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(0.0f, result["zero"]);
-  EXPECT_FLOAT_EQ(-5.0f, result["negative"]);
+  EXPECT_FLOAT_EQ(0.0f, stats.get("zero"));
+  EXPECT_FLOAT_EQ(-5.0f, stats.get("negative"));
 }
 
 // Test large numbers
@@ -70,6 +63,5 @@ TEST_F(StatsTrackerTest, LargeNumbers) {
   stats.add("large", 1000000);
   stats.add("large", 2000000);
 
-  auto result = stats.to_dict();
-  EXPECT_FLOAT_EQ(3000000.0f, result["large"]);
+  EXPECT_FLOAT_EQ(3000000.0f, stats.get("large"));
 }


### PR DESCRIPTION
Previously we were returning the stats map by value, which means we'd copy it. Now we're returning a const reference, which should be better for perf.

But also, and maybe more significantly, now we're not trying to work with the map anyways -- we're just calling stats.get. And we've fixed it and made it const to deal with the terrible habit of cpp map's [] mutating the map.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211487249886693)