### PR TITLE
let agents do stats rewards off of game stats

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -491,7 +491,7 @@ void MettaGrid::_step(Actions actions) {
 
   // Compute stat-based rewards for all agents
   for (auto& agent : _agents) {
-    agent->compute_stat_rewards();
+    agent->compute_stat_rewards(_stats.get());
   }
 
   // Update episode rewards
@@ -777,7 +777,6 @@ py::dict MettaGrid::get_episode_stats() {
   //   "game": dict[str, float],  // Global game statistics
   //   "agent": list[dict[str, float]],  // Per-agent statistics
   // }
-  // All stat values are guaranteed to be floats from StatsTracker::to_dict()
 
   py::dict stats;
   stats["game"] = py::cast(_stats->to_dict());

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -150,7 +150,7 @@ public:
     return delta;
   }
 
-  void compute_stat_rewards() {
+  void compute_stat_rewards(StatsTracker* game_stats_tracker = nullptr) {
     if (this->stat_rewards.empty()) {
       return;
     }
@@ -159,6 +159,9 @@ public:
 
     for (const auto& [stat_name, reward_per_unit] : this->stat_rewards) {
       float stat_value = this->stats.get(stat_name);
+      if (game_stats_tracker) {
+        stat_value += game_stats_tracker->get(stat_name);
+      }
       float stats_reward = stat_value * reward_per_unit;
       if (this->stat_reward_max.count(stat_name) > 0) {
         stats_reward = std::min(stats_reward, this->stat_reward_max.at(stat_name));

--- a/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
@@ -70,6 +70,7 @@ private:
       agent.update_inventory(resource_type, -1);
       if (stats_tracker) {
         stats_tracker->incr("chest." + stats_tracker->resource_name(resource_type) + ".deposited");
+        stats_tracker->incr("chest." + stats_tracker->resource_name(resource_type) + ".amount");
       }
       return true;
     }
@@ -89,6 +90,7 @@ private:
       update_inventory(resource_type, -1);
       if (stats_tracker) {
         stats_tracker->incr("chest." + stats_tracker->resource_name(resource_type) + ".withdrawn");
+        stats_tracker->add("chest." + stats_tracker->resource_name(resource_type) + ".amount", -1);
       }
       return true;
     }

--- a/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/chest.hpp
@@ -20,6 +20,8 @@ class Agent;
 
 class Chest : public GridObject, public Usable, public HasInventory {
 private:
+  // a reference to the game stats tracker
+  StatsTracker* stats_tracker;
   // Get the relative position index of the agent from the chest
   // Returns bit index: NW=0, N=1, NE=2, W=3, E=4, SW=5, S=6, SE=7
   int get_agent_relative_position_index(const Agent& agent) const {
@@ -66,6 +68,9 @@ private:
     InventoryDelta deposited = update_inventory(resource_type, 1);
     if (deposited == 1) {
       agent.update_inventory(resource_type, -1);
+      if (stats_tracker) {
+        stats_tracker->incr("chest." + stats_tracker->resource_name(resource_type) + ".deposited");
+      }
       return true;
     }
     // Chest couldn't accept the resource, give it back to agent
@@ -82,6 +87,9 @@ private:
     InventoryDelta withdrawn = agent.update_inventory(resource_type, 1);
     if (withdrawn == 1) {
       update_inventory(resource_type, -1);
+      if (stats_tracker) {
+        stats_tracker->incr("chest." + stats_tracker->resource_name(resource_type) + ".withdrawn");
+      }
       return true;
     }
     // Agent couldn't accept the resource, give it back to chest

--- a/packages/mettagrid/tests/test_mettagrid.cpp
+++ b/packages/mettagrid/tests/test_mettagrid.cpp
@@ -120,7 +120,7 @@ TEST_F(MettaGridCppTest, AgentRewardsWithAdditionalStatsTracker) {
   stats_reward_max["chest.heart.amount"] = 5.0f;
 
   AgentConfig agent_cfg(
-      0, "agent", 1, "test_group", 100, 0.0f, create_test_resource_limits(), rewards, stats_reward_max);
+      0, "agent", 1, "test_group", 100, 0.0f, create_test_inventory_config(), rewards, stats_reward_max);
   std::unique_ptr<Agent> agent(new Agent(0, 0, agent_cfg));
 
   auto resource_names = create_test_resource_names();


### PR DESCRIPTION
This allows agents to get rewards based on overall game stats. It also sets up Chests to use the games stats tracker to track the number of hearts-or-whatever they get.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211486971439550)