### PR TITLE
Reduce the use of grid_object_id

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -456,15 +456,15 @@ void MettaGrid::_step(Actions actions) {
         continue;
       }
 
-      auto& agent = _agents[agent_idx];
+      auto* agent = _agents[agent_idx];
       // handle_action expects a GridObjectId, rather than an agent_id, because of where it does its lookup
       // note that handle_action will assign a penalty for attempting invalid actions as a side effect
-      _action_success[agent_idx] = handler->handle_action(agent->id, arg);
+      _action_success[agent_idx] = handler->handle_action(*agent, arg);
     }
   }
 
   // Handle resource loss
-  for (auto& agent : _agents) {
+  for (auto* agent : _agents) {
     if (_resource_loss_prob > 0.0f) {
       // For every resource in an agent's inventory, it should disappear with probability _resource_loss_prob
       // Make a real copy of the agent's inventory map to avoid iterator invalidation

--- a/packages/mettagrid/cpp/include/mettagrid/actions/attack.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/attack.hpp
@@ -45,7 +45,7 @@ protected:
   std::map<InventoryItem, InventoryQuantity> _defense_resources;
   const GameConfig* _game_config;
 
-  bool _handle_action(Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent& actor, ActionArg arg) override {
     Agent* last_agent = nullptr;
     short num_skipped = 0;
 
@@ -61,14 +61,14 @@ protected:
 
       for (short distance = 1; distance <= 3; distance++) {
         for (short offset : COL_OFFSETS) {
-          GridLocation target_loc = _grid->relative_location(actor->location, actor->orientation, distance, offset);
+          GridLocation target_loc = _grid->relative_location(actor.location, actor.orientation, distance, offset);
           target_loc.layer = GridLayer::AgentLayer;
 
           Agent* target_agent = static_cast<Agent*>(_grid->object_at(target_loc));
           if (target_agent) {
             last_agent = target_agent;
             if (num_skipped == arg) {
-              return _handle_target(*actor, *target_agent);
+              return _handle_target(actor, *target_agent);
             }
             num_skipped++;
           }
@@ -99,15 +99,14 @@ protected:
       };
 
       for (const auto& pos : DIAGONAL_POSITIONS) {
-        GridLocation target_loc =
-            _grid->relative_location(actor->location, actor->orientation, pos.forward, pos.lateral);
+        GridLocation target_loc = _grid->relative_location(actor.location, actor.orientation, pos.forward, pos.lateral);
         target_loc.layer = GridLayer::AgentLayer;
 
         Agent* target_agent = static_cast<Agent*>(_grid->object_at(target_loc));
         if (target_agent) {
           last_agent = target_agent;
           if (num_skipped == arg) {
-            return _handle_target(*actor, *target_agent);
+            return _handle_target(actor, *target_agent);
           }
           num_skipped++;
         }
@@ -116,7 +115,7 @@ protected:
 
     // If we got here, it means we skipped over all the targets. Attack the last one.
     if (last_agent) {
-      return _handle_target(*actor, *last_agent);
+      return _handle_target(actor, *last_agent);
     }
 
     return false;

--- a/packages/mettagrid/cpp/include/mettagrid/actions/change_color.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/change_color.hpp
@@ -4,8 +4,8 @@
 #include <string>
 
 #include "actions/action_handler.hpp"
-#include "objects/agent.hpp"
 #include "core/types.hpp"
+#include "objects/agent.hpp"
 
 class ChangeColor : public ActionHandler {
 public:
@@ -16,7 +16,7 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent& actor, ActionArg arg) override {
     // Note: 'color' is uint8_t which naturally wraps at 256.
     // This could be interpreted as circular hue behavior (red -> orange -> ... -> violet -> red)
 
@@ -24,13 +24,13 @@ protected:
     const uint8_t step_size = static_cast<uint8_t>(255 / (max_arg() + 1));
 
     if (arg == 0) {  // Increment
-      actor->color = static_cast<uint8_t>(actor->color + 1);
+      actor.color = static_cast<uint8_t>(actor.color + 1);
     } else if (arg == 1) {  // Decrement
-      actor->color = static_cast<uint8_t>(actor->color - 1);
+      actor.color = static_cast<uint8_t>(actor.color - 1);
     } else if (arg == 2) {  // Large increment
-      actor->color = static_cast<uint8_t>(actor->color + step_size);
+      actor.color = static_cast<uint8_t>(actor.color + step_size);
     } else if (arg == 3) {  // Large decrement
-      actor->color = static_cast<uint8_t>(actor->color - step_size);
+      actor.color = static_cast<uint8_t>(actor.color - step_size);
     }
 
     return true;

--- a/packages/mettagrid/cpp/include/mettagrid/actions/change_glyph.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/change_glyph.hpp
@@ -7,8 +7,8 @@
 #include <string>
 
 #include "actions/action_handler.hpp"
-#include "objects/agent.hpp"
 #include "core/types.hpp"
+#include "objects/agent.hpp"
 
 struct ChangeGlyphActionConfig : public ActionConfig {
   const ObservationType number_of_glyphs;
@@ -32,8 +32,8 @@ public:
 protected:
   const ObservationType _number_of_glyphs;
 
-  bool _handle_action(Agent* actor, ActionArg arg) override {
-    actor->glyph = static_cast<ObservationType>(arg);  // ActionArg is int32 for puffer compatibility
+  bool _handle_action(Agent& actor, ActionArg arg) override {
+    actor.glyph = static_cast<ObservationType>(arg);  // ActionArg is int32 for puffer compatibility
     return true;
   }
 };

--- a/packages/mettagrid/cpp/include/mettagrid/actions/get_output.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/get_output.hpp
@@ -19,8 +19,8 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg /*arg*/) override {
-    GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
+  bool _handle_action(Agent& actor, ActionArg /*arg*/) override {
+    GridLocation target_loc = _grid->relative_location(actor.location, static_cast<Orientation>(actor.orientation));
     target_loc.layer = GridLayer::ObjectLayer;
     // get_output only works on Converters, since only Converters have an output.
     // Once we generalize this to `get`, we should be able to get from any HasInventory object, which
@@ -37,10 +37,10 @@ protected:
 
       for (const auto& [item, _] : converter->output_resources) {
         InventoryDelta resources_available = converter->inventory.amount(item);
-        InventoryDelta taken = actor->update_inventory(item, resources_available);
+        InventoryDelta taken = actor.update_inventory(item, resources_available);
 
         if (taken > 0) {
-          actor->stats.add(actor->stats.resource_name(item) + ".get", taken);
+          actor.stats.add(actor.stats.resource_name(item) + ".get", taken);
           converter->update_inventory(item, -taken);
           resources_taken = true;
         }

--- a/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
@@ -22,7 +22,7 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent& actor, ActionArg arg) override {
     // Get the orientation from the action argument
     Orientation move_direction = static_cast<Orientation>(arg);
 
@@ -31,7 +31,7 @@ protected:
       return false;
     }
 
-    GridLocation current_location = actor->location;
+    GridLocation current_location = actor.location;
     GridLocation target_location = current_location;
 
     // Get movement deltas for the direction
@@ -49,7 +49,7 @@ protected:
     target_location.c = static_cast<GridCoord>(static_cast<int>(target_location.c) + dc);
 
     // Update orientation to face the movement direction (even if movement fails)
-    actor->orientation = move_direction;
+    actor.orientation = move_direction;
 
     if (!_grid->is_valid_location(target_location)) {
       return false;
@@ -63,13 +63,13 @@ protected:
       GridObject* target = _grid->object_at(object_location);
       Usable* usable = dynamic_cast<Usable*>(target);
       if (usable) {
-        return usable->onUse(*actor, arg);
+        return usable->onUse(actor, arg);
       }
       return false;
     }
 
     // Move the agent
-    return _grid->move_object(actor->id, target_location);
+    return _grid->move_object(actor, target_location);
   }
 
 private:

--- a/packages/mettagrid/cpp/include/mettagrid/actions/noop.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/noop.hpp
@@ -4,8 +4,8 @@
 #include <string>
 
 #include "actions/action_handler.hpp"
-#include "objects/agent.hpp"
 #include "core/types.hpp"
+#include "objects/agent.hpp"
 
 class Noop : public ActionHandler {
 public:
@@ -16,7 +16,7 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* /*actor*/, ActionArg /*arg*/) override {
+  bool _handle_action(Agent& /*actor*/, ActionArg /*arg*/) override {
     return true;
   }
 };

--- a/packages/mettagrid/cpp/include/mettagrid/actions/put_recipe_items.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/put_recipe_items.hpp
@@ -19,8 +19,8 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg /*arg*/) override {
-    GridLocation target_loc = _grid->relative_location(actor->location, static_cast<Orientation>(actor->orientation));
+  bool _handle_action(Agent& actor, ActionArg /*arg*/) override {
+    GridLocation target_loc = _grid->relative_location(actor.location, static_cast<Orientation>(actor.orientation));
     target_loc.layer = GridLayer::ObjectLayer;
     // put_recipe_items only works on Converters, since only Converters have a recipe.
     // Once we generalize this to `put`, we should be able to put to any HasInventory object, which
@@ -32,13 +32,13 @@ protected:
 
     bool success = false;
     for (const auto& [item, resources_required] : converter->input_resources) {
-      InventoryQuantity resources_available = actor->inventory.amount(item);
+      InventoryQuantity resources_available = actor.inventory.amount(item);
       InventoryQuantity resources_to_put = std::min(resources_required, resources_available);
       InventoryDelta resources_put = converter->update_inventory(item, resources_to_put);
       if (resources_put > 0) {
-        [[maybe_unused]] InventoryDelta delta = actor->update_inventory(item, -resources_put);
+        [[maybe_unused]] InventoryDelta delta = actor.update_inventory(item, -resources_put);
         assert(delta == -resources_put);
-        actor->stats.add(actor->stats.resource_name(item) + ".put", resources_put);
+        actor.stats.add(actor.stats.resource_name(item) + ".put", resources_put);
         success = true;
       }
     }

--- a/packages/mettagrid/cpp/include/mettagrid/actions/rotate.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/rotate.hpp
@@ -6,9 +6,9 @@
 #include "actions/action_handler.hpp"
 #include "actions/orientation.hpp"
 #include "config/mettagrid_config.hpp"
+#include "core/types.hpp"
 #include "objects/agent.hpp"
 #include "objects/constants.hpp"
-#include "core/types.hpp"
 
 class Rotate : public ActionHandler {
 public:
@@ -20,22 +20,22 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg arg) override {
+  bool _handle_action(Agent& actor, ActionArg arg) override {
     // Validate the orientation argument
     Orientation orientation = static_cast<Orientation>(arg);
     if (!_game_config->allow_diagonals && isDiagonal(orientation)) {
       return false;
     }
 
-    actor->orientation = orientation;
+    actor.orientation = orientation;
 
     // Track which orientation the agent rotated to (only if tracking enabled)
     if (_game_config->track_movement_metrics) {
-      actor->stats.add(std::string("movement.rotation.to_") + OrientationNames[static_cast<int>(orientation)], 1);
+      actor.stats.add(std::string("movement.rotation.to_") + OrientationNames[static_cast<int>(orientation)], 1);
 
       // Check if last action was also a rotation for sequential tracking
-      if (actor->prev_action_name == _action_name) {
-        actor->stats.add("movement.sequential_rotations", 1);
+      if (actor.prev_action_name == _action_name) {
+        actor.stats.add("movement.sequential_rotations", 1);
       }
     }
 

--- a/packages/mettagrid/cpp/include/mettagrid/actions/swap.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/swap.hpp
@@ -6,8 +6,8 @@
 #include "actions/action_handler.hpp"
 #include "core/grid.hpp"
 #include "core/grid_object.hpp"
-#include "objects/agent.hpp"
 #include "core/types.hpp"
+#include "objects/agent.hpp"
 
 class Swap : public ActionHandler {
 public:
@@ -18,9 +18,9 @@ public:
   }
 
 protected:
-  bool _handle_action(Agent* actor, ActionArg /*arg*/) override {
+  bool _handle_action(Agent& actor, ActionArg /*arg*/) override {
     // target the square we are facing
-    GridLocation target_loc = _grid->relative_location(actor->location, actor->orientation);
+    GridLocation target_loc = _grid->relative_location(actor.location, actor.orientation);
 
     // Check layers in swap priority order
     const auto layers = {GridLayer::ObjectLayer, GridLayer::AgentLayer};
@@ -29,8 +29,8 @@ protected:
       target_loc.layer = layer;
       GridObject* target = this->_grid->object_at(target_loc);
       if (target && target->swappable()) {
-        actor->stats.incr("action." + this->_action_name + "." + target->type_name);
-        this->_grid->swap_objects(actor->id, target->id);
+        actor.stats.incr("action." + this->_action_name + "." + target->type_name);
+        this->_grid->swap_objects(actor, *target);
         return true;
       }
     }

--- a/packages/mettagrid/cpp/include/mettagrid/core/grid.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/core/grid.hpp
@@ -69,7 +69,7 @@ public:
     return true;
   }
 
-  inline bool move_object(GridObjectId id, const GridLocation& loc) {
+  inline bool move_object(GridObject& obj, const GridLocation& loc) {
     if (!is_valid_location(loc)) {
       return false;
     }
@@ -78,32 +78,28 @@ public:
       return false;
     }
 
-    GridObject* obj = object(id);
-    grid[loc.r][loc.c][loc.layer] = id;
-    grid[obj->location.r][obj->location.c][obj->location.layer] = 0;
-    obj->location = loc;
+    grid[loc.r][loc.c][loc.layer] = obj.id;
+    grid[obj.location.r][obj.location.c][obj.location.layer] = 0;
+    obj.location = loc;
     return true;
   }
 
-  inline void swap_objects(GridObjectId id1, GridObjectId id2) {
-    GridObject* obj1 = object(id1);
-    GridObject* obj2 = object(id2);
-
+  inline void swap_objects(GridObject& obj1, GridObject& obj2) {
     // Store the original locations.
-    GridLocation loc1 = obj1->location;
-    GridLocation loc2 = obj2->location;
+    GridLocation loc1 = obj1.location;
+    GridLocation loc2 = obj2.location;
 
     // Clear the objects from their original positions in the grid.
     grid[loc1.r][loc1.c][loc1.layer] = 0;
     grid[loc2.r][loc2.c][loc2.layer] = 0;
 
     // Update the location property of each object, preserving their original layers.
-    obj1->location = {loc2.r, loc2.c, loc1.layer};
-    obj2->location = {loc1.r, loc1.c, loc2.layer};
+    obj1.location = {loc2.r, loc2.c, loc1.layer};
+    obj2.location = {loc1.r, loc1.c, loc2.layer};
 
     // Place the objects in their new positions in the grid.
-    grid[obj1->location.r][obj1->location.c][obj1->location.layer] = id1;
-    grid[obj2->location.r][obj2->location.c][obj2->location.layer] = id2;
+    grid[obj1.location.r][obj1.location.c][obj1.location.layer] = obj1.id;
+    grid[obj2.location.r][obj2.location.c][obj2.location.layer] = obj2.id;
   }
 
   inline GridObject* object(GridObjectId obj_id) const {

--- a/packages/mettagrid/tests/test_mettagrid.cpp
+++ b/packages/mettagrid/tests/test_mettagrid.cpp
@@ -470,7 +470,7 @@ TEST_F(MettaGridCppTest, AttackAction) {
   attack.init(&grid, &rng);
 
   // Perform attack (arg 5 targets directly in front)
-  bool success = attack.handle_action(attacker->id, 5);
+  bool success = attack.handle_action(*attacker, 5);
   // Hitting a target with armor counts as success
   EXPECT_TRUE(success);
 
@@ -483,7 +483,7 @@ TEST_F(MettaGridCppTest, AttackAction) {
   EXPECT_EQ(target->inventory.amount(TestItems::HEART), 3);
 
   // Attack again, now that armor is gone
-  success = attack.handle_action(attacker->id, 5);
+  success = attack.handle_action(*attacker, 5);
   EXPECT_TRUE(success);
 
   // Verify target's inventory was stolen
@@ -534,14 +534,14 @@ TEST_F(MettaGridCppTest, PutRecipeItems) {
   put.init(&grid, &rng);
 
   // Test putting matching items
-  bool success = put.handle_action(agent->id, 0);
+  bool success = put.handle_action(*agent, 0);
   EXPECT_TRUE(success);
   EXPECT_EQ(agent->inventory.amount(TestItems::ORE), 0);      // Ore consumed
   EXPECT_EQ(agent->inventory.amount(TestItems::HEART), 1);    // Heart unchanged
   EXPECT_EQ(generator->inventory.amount(TestItems::ORE), 1);  // Ore added to generator
 
   // Test putting non-matching items
-  success = put.handle_action(agent->id, 0);
+  success = put.handle_action(*agent, 0);
   EXPECT_FALSE(success);                                        // Should fail since we only have heart left
   EXPECT_EQ(agent->inventory.amount(TestItems::HEART), 1);      // Heart unchanged
   EXPECT_EQ(generator->inventory.amount(TestItems::HEART), 0);  // No heart in generator
@@ -586,7 +586,7 @@ TEST_F(MettaGridCppTest, GetOutput) {
   get.init(&grid, &rng);
 
   // Test getting output
-  bool success = get.handle_action(agent->id, 0);
+  bool success = get.handle_action(*agent, 0);
   EXPECT_TRUE(success);
   EXPECT_EQ(agent->inventory.amount(TestItems::ORE), 1);        // Still have ore
   EXPECT_EQ(agent->inventory.amount(TestItems::ARMOR), 1);      // Also have armor
@@ -610,7 +610,7 @@ TEST_F(MettaGridCppTest, ActionTracking) {
   noop.init(&grid, &rng);
 
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 0.0f);
-  noop.handle_action(agent->id, 0);  // count 1, max 1
+  noop.handle_action(*agent, 0);  // count 1, max 1
   EXPECT_EQ(agent->location.r, 5);
   EXPECT_EQ(agent->location.c, 5);
   EXPECT_EQ(agent->prev_location.r, 5);
@@ -619,29 +619,29 @@ TEST_F(MettaGridCppTest, ActionTracking) {
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
   agent->location.r = 6;
   agent->location.c = 6;
-  noop.handle_action(agent->id, 0);  // count 0, max 1
+  noop.handle_action(*agent, 0);  // count 0, max 1
   EXPECT_EQ(agent->location.r, 6);
   EXPECT_EQ(agent->location.c, 6);
   EXPECT_EQ(agent->prev_location.r, 6);
   EXPECT_EQ(agent->prev_location.c, 6);
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
-  noop.handle_action(agent->id, 0);  // count 1, max 1
+  noop.handle_action(*agent, 0);  // count 1, max 1
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 1.0f);
-  noop.handle_action(agent->id, 0);  // count 2, max 2
-  noop.handle_action(agent->id, 0);  // count 3, max 3
+  noop.handle_action(*agent, 0);  // count 2, max 2
+  noop.handle_action(*agent, 0);  // count 3, max 3
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 3.0f);
   agent->location.r = 7;
   agent->location.c = 7;
-  noop.handle_action(agent->id, 0);  // count 0, max 3
+  noop.handle_action(*agent, 0);  // count 0, max 3
   EXPECT_EQ(agent->location.r, 7);
   EXPECT_EQ(agent->location.c, 7);
   EXPECT_EQ(agent->prev_location.r, 7);
   EXPECT_EQ(agent->prev_location.c, 7);
-  noop.handle_action(agent->id, 0);  // count 1, max 3
-  noop.handle_action(agent->id, 0);  // count 2, max 3
+  noop.handle_action(*agent, 0);  // count 1, max 3
+  noop.handle_action(*agent, 0);  // count 2, max 3
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 3.0f);
-  noop.handle_action(agent->id, 0);  // count 3, max 3
-  noop.handle_action(agent->id, 0);  // count 4, max 4
+  noop.handle_action(*agent, 0);  // count 3, max 3
+  noop.handle_action(*agent, 0);  // count 4, max 4
   EXPECT_FLOAT_EQ(agent->stats.get("status.max_steps_without_motion"), 4.0f);
 }
 
@@ -667,7 +667,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionProbability) {
 
   // Execute action multiple times
   for (int i = 0; i < 10; i++) {
-    noop.handle_action(agent->id, 0);
+    noop.handle_action(*agent, 0);
   }
 
   // With 0.5 probability, exactly 4 ore should be consumed (10 - 4 = 6 remaining)
@@ -682,7 +682,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionProbability) {
   poor_agent->init(&poor_reward);
   grid.add_object(poor_agent);
 
-  bool success = noop.handle_action(poor_agent->id, 0);
+  bool success = noop.handle_action(*poor_agent, 0);
   EXPECT_FALSE(success);  // Should fail due to insufficient resources
 }
 
@@ -704,7 +704,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionWithOverflow) {
   std::mt19937 rng(42);
   noop.init(&grid, &rng);
 
-  bool success = noop.handle_action(agent->id, 0);
+  bool success = noop.handle_action(*agent, 0);
   EXPECT_TRUE(success);  // Should succeed as we have enough resources
 
   // With 1.5, should consume either 1 or 2 units
@@ -729,7 +729,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionRequiresCeiledInventory) {
   std::mt19937 rng(42);
   noop.init(&grid, &rng);
 
-  bool success = noop.handle_action(agent->id, 0);
+  bool success = noop.handle_action(*agent, 0);
   EXPECT_FALSE(success);  // Should fail as we only have 1 but need ceil(1.5) = 2
 
   // Verify inventory unchanged
@@ -764,7 +764,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionZero) {
 
   // Execute action multiple times - should never consume
   for (int i = 0; i < 10; i++) {
-    bool success = noop.handle_action(agent->id, 0);
+    bool success = noop.handle_action(*agent, 0);
     EXPECT_TRUE(success);
   }
 
@@ -791,7 +791,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionInteger) {
 
   // Execute action 3 times - should always consume exactly 2
   for (int i = 0; i < 3; i++) {
-    bool success = noop.handle_action(agent->id, 0);
+    bool success = noop.handle_action(*agent, 0);
     EXPECT_TRUE(success);
   }
 
@@ -821,7 +821,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionSmallFraction) {
   int successful_actions = 0;
   for (int i = 0; i < 100; i++) {
     int before = agent->inventory.amount(TestItems::ORE);
-    bool success = noop.handle_action(agent->id, 0);
+    bool success = noop.handle_action(*agent, 0);
     if (success) {
       successful_actions++;
       int after = agent->inventory.amount(TestItems::ORE);
@@ -855,7 +855,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionLargeFraction) {
   int successful_actions = 0;
   for (int i = 0; i < 100; i++) {
     int before = agent->inventory.amount(TestItems::ORE);
-    bool success = noop.handle_action(agent->id, 0);
+    bool success = noop.handle_action(*agent, 0);
     if (success) {
       successful_actions++;
     }
@@ -889,7 +889,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionMultipleResources) {
 
   // Execute action multiple times
   for (int i = 0; i < 10; i++) {
-    bool success = noop.handle_action(agent->id, 0);
+    bool success = noop.handle_action(*agent, 0);
     EXPECT_TRUE(success);
   }
 
@@ -948,7 +948,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionAttackAction) {
   // Do 10 attacks
   for (int i = 0; i < 10; i++) {
     int before = attacker->inventory.amount(TestItems::LASER);
-    bool success = attack.handle_action(attacker->id, 5);  // Attack directly in front
+    bool success = attack.handle_action(*attacker, 5);  // Attack directly in front
     if (success) {
       successful_attacks++;
       int after = attacker->inventory.amount(TestItems::LASER);
@@ -981,7 +981,7 @@ TEST_F(MettaGridCppTest, FractionalConsumptionChangeGlyphAction) {
   int changes = 0;
   ObservationType initial_glyph = agent->glyph;
   while (agent->inventory.amount(TestItems::ORE) >= 2) {
-    bool success = change_glyph.handle_action(agent->id, (initial_glyph + 1) % 4);
+    bool success = change_glyph.handle_action(*agent, (initial_glyph + 1) % 4);
     if (!success) break;
     changes++;
     if (changes > 30) break;  // Safety limit
@@ -1011,11 +1011,11 @@ TEST_F(MettaGridCppTest, FractionalConsumptionBoundaryValues) {
   noop.init(&grid, &rng);
 
   // Should succeed once then likely fail
-  bool first_success = noop.handle_action(agent->id, 0);
+  bool first_success = noop.handle_action(*agent, 0);
   EXPECT_TRUE(first_success);
 
   // Very high chance we consumed the resource (99%)
-  bool second_success = noop.handle_action(agent->id, 0);
+  bool second_success = noop.handle_action(*agent, 0);
   // This will almost certainly fail (99% chance we're out of resources)
   if (agent->inventory.amount(TestItems::ORE) == 0) {
     EXPECT_FALSE(second_success);
@@ -1052,8 +1052,8 @@ TEST_F(MettaGridCppTest, FractionalConsumptionDeterministicWithSameSeed) {
 
   // Execute same sequence on both
   for (int i = 0; i < 50; i++) {
-    noop1.handle_action(agent1->id, 0);
-    noop2.handle_action(agent2->id, 0);
+    noop1.handle_action(*agent1, 0);
+    noop2.handle_action(*agent2, 0);
   }
 
   // Should have identical results with same seed
@@ -1236,8 +1236,8 @@ TEST_F(MettaGridCppTest, AssemblerGetAgentPatternByte) {
   // Test 3: Pattern with agents in multiple positions
   // Move agent1 to NW (bit 0) and agent2 to SW (bit 5), add agent3 at SE (bit 7)
   // This should give us pattern = (1 << 0) | (1 << 5) | (1 << 7) = 1 | 32 | 128 = 161
-  grid->move_object(agent1->id, GridLocation(4, 4, GridLayer::AgentLayer));  // Move to NW
-  grid->move_object(agent2->id, GridLocation(6, 4, GridLayer::AgentLayer));  // Move to SW
+  grid->move_object(*agent1, GridLocation(4, 4, GridLayer::AgentLayer));  // Move to NW
+  grid->move_object(*agent2, GridLocation(6, 4, GridLayer::AgentLayer));  // Move to SW
 
   Agent* agent3 = new Agent(6, 6, agent_cfg);  // SE of assembler
   grid->add_object(agent3);                    // Add new agent


### PR DESCRIPTION
I'm working to remove [GridObject.id](http://GridObject.id) in general, since that id is based on the position of the object in Grid.objects, and this makes it harder to remove objects from the Grid (which I think we want for Clipping -- the Clipped object is temporarily removed and replaced).

This PR captures lots of find-and-replace usage, where we were passing around ids when we could just be passing the objects by reference. So I think this PR is a positive even if we want to keep [GridObject.id](http://GridObject.id).

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211496188259734)