### PR TITLE
Add agent resource sharing

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -492,9 +492,7 @@ void MettaGrid::_step(Actions actions) {
   if (_inventory_regen_interval > 0 && current_step % _inventory_regen_interval == 0) {
     for (auto* agent : _agents) {
       for (const auto& [item, amount] : _inventory_regen_amounts) {
-        if (amount > 0) {
-          agent->update_inventory(item, amount);
-        }
+        agent->update_inventory(item, amount);
       }
     }
   }

--- a/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/actions/move.hpp
@@ -8,6 +8,8 @@
 #include "core/grid_object.hpp"
 #include "core/types.hpp"
 #include "objects/agent.hpp"
+#include "objects/constants.hpp"
+#include "objects/usable.hpp"
 
 // Forward declaration
 struct GameConfig;
@@ -59,12 +61,26 @@ protected:
     // In the future, we may want to split 'Move' and 'MoveOrUse', if we want to allow agents to run into usable
     // objects without using them.
     if (!_grid->is_empty(target_location.r, target_location.c)) {
-      GridLocation object_location = {target_location.r, target_location.c, GridLayer::ObjectLayer};
-      GridObject* target = _grid->object_at(object_location);
-      Usable* usable = dynamic_cast<Usable*>(target);
-      if (usable) {
-        return usable->onUse(actor, arg);
+      // Check the AgentLayer first for other agents
+      GridLocation agent_location = {target_location.r, target_location.c, GridLayer::AgentLayer};
+      GridObject* target_agent = _grid->object_at(agent_location);
+      if (target_agent) {
+        Usable* usable_agent = dynamic_cast<Usable*>(target_agent);
+        if (usable_agent) {
+          return usable_agent->onUse(actor, arg);
+        }
       }
+
+      // Then check the ObjectLayer for other usable objects
+      GridLocation object_location = {target_location.r, target_location.c, GridLayer::ObjectLayer};
+      GridObject* target_object = _grid->object_at(object_location);
+      if (target_object) {
+        Usable* usable_object = dynamic_cast<Usable*>(target_object);
+        if (usable_object) {
+          return usable_object->onUse(actor, arg);
+        }
+      }
+
       return false;
     }
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent.hpp
@@ -11,9 +11,10 @@
 #include "objects/agent_config.hpp"
 #include "objects/constants.hpp"
 #include "objects/has_inventory.hpp"
+#include "objects/usable.hpp"
 #include "systems/stats_tracker.hpp"
 
-class Agent : public GridObject, public HasInventory {
+class Agent : public GridObject, public HasInventory, public Usable {
 public:
   ObservationType group;
   short frozen;
@@ -28,6 +29,8 @@ public:
   std::string group_name;
   // We expect only a small number (single-digit) of soul-bound resources.
   std::vector<InventoryItem> soul_bound_resources;
+  // Resources that this agent will try to share when it uses another agent.
+  std::vector<InventoryItem> shareable_resources;
   ObservationType color;
   ObservationType glyph;
   // Despite being a GridObjectId, this is different from the `id` property.
@@ -55,6 +58,7 @@ public:
         action_failure_penalty(config.action_failure_penalty),
         group_name(config.group_name),
         soul_bound_resources(config.soul_bound_resources),
+        shareable_resources(config.shareable_resources),
         color(0),
         glyph(0),
         agent_id(0),
@@ -180,6 +184,23 @@ public:
 
   bool swappable() const override {
     return this->frozen;
+  }
+
+  // Implementation of Usable interface
+  bool onUse(Agent& actor, ActionArg arg) override {
+    // Share half of shareable resources from actor to this agent
+    for (InventoryItem resource : actor.shareable_resources) {
+      InventoryQuantity actor_amount = actor.inventory.amount(resource);
+      // Calculate half (rounded down)
+      InventoryQuantity share_attempted_amount = actor_amount / 2;
+      if (share_attempted_amount > 0) {
+        // The actor is trying to give us resources. We need to make sure we can take them.
+        InventoryDelta successful_share_amount = this->update_inventory(resource, share_attempted_amount);
+        actor.update_inventory(resource, -successful_share_amount);
+      }
+    }
+
+    return true;
   }
 
   std::vector<PartialObservationToken> obs_features() const override {

--- a/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/agent_config.hpp
@@ -25,7 +25,8 @@ struct AgentConfig : public GridObjectConfig {
               float group_reward_pct = 0,
               const std::map<InventoryItem, InventoryQuantity>& initial_inventory = {},
               const std::vector<int>& tag_ids = {},
-              const std::vector<InventoryItem>& soul_bound_resources = {})
+              const std::vector<InventoryItem>& soul_bound_resources = {},
+              const std::vector<InventoryItem>& shareable_resources = {})
       : GridObjectConfig(type_id, type_name, tag_ids),
         group_id(group_id),
         group_name(group_name),
@@ -36,7 +37,8 @@ struct AgentConfig : public GridObjectConfig {
         stat_reward_max(stat_reward_max),
         group_reward_pct(group_reward_pct),
         initial_inventory(initial_inventory),
-        soul_bound_resources(soul_bound_resources) {}
+        soul_bound_resources(soul_bound_resources),
+        shareable_resources(shareable_resources) {}
 
   unsigned char group_id;
   std::string group_name;
@@ -48,6 +50,7 @@ struct AgentConfig : public GridObjectConfig {
   float group_reward_pct;
   std::map<InventoryItem, InventoryQuantity> initial_inventory;
   std::vector<InventoryItem> soul_bound_resources;
+  std::vector<InventoryItem> shareable_resources;
 };
 
 namespace py = pybind11;
@@ -66,6 +69,7 @@ inline void bind_agent_config(py::module& m) {
                     float,
                     const std::map<InventoryItem, InventoryQuantity>&,
                     const std::vector<int>&,
+                    const std::vector<InventoryItem>&,
                     const std::vector<InventoryItem>&>(),
            py::arg("type_id"),
            py::arg("type_name") = "agent",
@@ -79,7 +83,8 @@ inline void bind_agent_config(py::module& m) {
            py::arg("group_reward_pct") = 0,
            py::arg("initial_inventory") = std::map<InventoryItem, InventoryQuantity>(),
            py::arg("tag_ids") = std::vector<int>(),
-           py::arg("soul_bound_resources") = std::vector<InventoryItem>())
+           py::arg("soul_bound_resources") = std::vector<InventoryItem>(),
+           py::arg("shareable_resources") = std::vector<InventoryItem>())
       .def_readwrite("type_id", &GridObjectConfig::type_id)
       .def_readwrite("type_name", &GridObjectConfig::type_name)
       .def_readwrite("group_name", &AgentConfig::group_name)
@@ -92,7 +97,8 @@ inline void bind_agent_config(py::module& m) {
       .def_readwrite("group_reward_pct", &AgentConfig::group_reward_pct)
       .def_readwrite("initial_inventory", &AgentConfig::initial_inventory)
       .def_readwrite("tag_ids", &GridObjectConfig::tag_ids)
-      .def_readwrite("soul_bound_resources", &AgentConfig::soul_bound_resources);
+      .def_readwrite("soul_bound_resources", &AgentConfig::soul_bound_resources)
+      .def_readwrite("shareable_resources", &AgentConfig::shareable_resources);
 }
 
 #endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_AGENT_CONFIG_HPP_

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -188,6 +188,13 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             if resource_name in resource_name_to_id
         ]
 
+        # Convert shareable resources from names to IDs
+        shareable_resources = [
+            resource_name_to_id[resource_name]
+            for resource_name in agent_props.get("shareable_resources", [])
+            if resource_name in resource_name_to_id
+        ]
+
         inventory_config = CppInventoryConfig(
             limits=[
                 [
@@ -212,6 +219,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             "initial_inventory": initial_inventory,
             "tag_ids": tag_ids,
             "soul_bound_resources": soul_bound_resources,
+            "shareable_resources": shareable_resources,
         }
 
         objects_cpp_params["agent." + group_name] = CppAgentConfig(**agent_cpp_params)

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -39,6 +39,9 @@ class AgentConfig(Config):
     soul_bound_resources: list[str] = Field(
         default_factory=list, description="Resources that cannot be stolen during attacks"
     )
+    shareable_resources: list[str] = Field(
+        default_factory=list, description="Resources that will be shared when we use another agent"
+    )
 
 
 class ActionConfig(Config):

--- a/packages/mettagrid/tests/test_agent_resource_sharing.py
+++ b/packages/mettagrid/tests/test_agent_resource_sharing.py
@@ -1,0 +1,103 @@
+import numpy as np
+
+from mettagrid.config.mettagrid_config import MettaGridConfig
+from mettagrid.core import MettaGridCore
+from mettagrid.mettagrid_c import dtype_actions
+
+
+class TestAgentResourceSharing:
+    """Test agent resource sharing functionality when agents use each other."""
+
+    def test_basic_resource_sharing(self):
+        """Test that agents can share resources when one moves onto another."""
+        # Create a simple environment with 2 agents
+        cfg = MettaGridConfig.EmptyRoom(num_agents=2, with_walls=True).with_ascii_map(
+            [
+                ["#", "#", "#", "#"],
+                ["#", "@", "@", "#"],
+                ["#", "#", "#", "#"],
+            ]
+        )
+
+        # Configure resources and sharing
+        cfg.game.resource_names = ["energy", "water", "food"]
+        cfg.game.agent.initial_inventory = {"energy": 10, "water": 8, "food": 6}
+        cfg.game.agent.shareable_resources = ["energy", "water"]  # Only energy and water are shareable
+
+        # Enable the move action to allow agents to interact
+        cfg.game.actions.move.enabled = True
+        cfg.game.actions.noop.enabled = True
+
+        env = MettaGridCore(cfg)
+        obs, info = env.reset()
+
+        # Get initial state
+        grid_objects = env.grid_objects
+        agents = []
+        for _obj_id, obj in grid_objects.items():
+            if "agent_id" in obj:
+                agents.append(obj)
+
+        assert len(agents) == 2, "Should find 2 agents"
+
+        # Check initial inventory
+        energy_idx = env.resource_names.index("energy")
+        water_idx = env.resource_names.index("water")
+        food_idx = env.resource_names.index("food")
+
+        agent0 = agents[0]
+        agent1 = agents[1]
+
+        assert agent0["inventory"][energy_idx] == 10, "Agent 0 should start with 10 energy"
+        assert agent0["inventory"][water_idx] == 8, "Agent 0 should start with 8 water"
+        assert agent0["inventory"][food_idx] == 6, "Agent 0 should start with 6 food"
+
+        assert agent1["inventory"][energy_idx] == 10, "Agent 1 should start with 10 energy"
+        assert agent1["inventory"][water_idx] == 8, "Agent 1 should start with 8 water"
+        assert agent1["inventory"][food_idx] == 6, "Agent 1 should start with 6 food"
+
+        # Have agent 0 move onto agent 1 to trigger onUse
+        # Agent 0 is at position (1,1), Agent 1 is at position (1,2)
+        # So agent 0 needs to move to the right (East)
+        move_idx = env.action_names.index("move")
+        noop_idx = env.action_names.index("noop")
+        actions = np.array([[move_idx, 3], [noop_idx, 0]], dtype=dtype_actions)
+
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Check inventory after sharing
+        grid_objects_after = env.grid_objects
+        agents_after = []
+        for _obj_id, obj in grid_objects_after.items():
+            if "agent_id" in obj:
+                agents_after.append(obj)
+
+        agent0_after = agents_after[0]
+        agent1_after = agents_after[1]
+
+        assert (agent0_after["r"], agent0_after["c"]) == (1, 1), "Agent 0 should still be at (1,1)"
+        assert (agent1_after["r"], agent1_after["c"]) == (1, 2), "Agent 1 should still be at (1,2)"
+
+        # Agent 0 should have given half of shareable resources to agent 1
+        # Energy: 10 -> 5 (agent 0), 10 -> 15 (agent 1)
+        # Water: 8 -> 4 (agent 0), 8 -> 12 (agent 1)
+        # Food: 6 -> 6 (agent 0, unchanged), 6 -> 6 (agent 1, unchanged)
+        assert agent0_after["inventory"][energy_idx] == 5, (
+            f"Agent 0 should have 5 energy after sharing. Has {agent0_after['inventory'][energy_idx]}"
+        )
+        assert agent0_after["inventory"][water_idx] == 4, (
+            f"Agent 0 should have 4 water after sharing. Has {agent0_after['inventory'][water_idx]}"
+        )
+        assert agent0_after["inventory"][food_idx] == 6, (
+            f"Agent 0 should still have 6 food (not shareable). Has {agent0_after['inventory'][food_idx]}"
+        )
+
+        assert agent1_after["inventory"][energy_idx] == 15, (
+            f"Agent 1 should have 15 energy after receiving. Has {agent1_after['inventory'][energy_idx]}"
+        )
+        assert agent1_after["inventory"][water_idx] == 12, (
+            f"Agent 1 should have 12 water after receiving. Has {agent1_after['inventory'][water_idx]}"
+        )
+        assert agent1_after["inventory"][food_idx] == 6, (
+            f"Agent 1 should still have 6 food (not shareable). Has {agent1_after['inventory'][food_idx]}"
+        )


### PR DESCRIPTION
Adds the ability for agents to share resources with other agents they "use". This is aimed at allowing agents to share energy.

The shared resource is configurable. The fraction shared is always 1/2 -- not configurable at the moment.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211502764447792)