### PR TITLE
Improve size of sweep controller + copy AWS credentials

### DIFF
--- a/devops/skypilot/config/sandbox_cheap.yaml
+++ b/devops/skypilot/config/sandbox_cheap.yaml
@@ -1,9 +1,9 @@
 resources:
   cloud: aws
   region: us-east-1
-  instance_type: t3.large  # 2 vCPUs, 8GB RAM - cheap (~$0.08/hour on-demand)
-  cpus: 2+
-  memory: 8+
+  instance_type: m6i.2xlarge  # 8 vCPUs, 32GB RAM (~$0.384/hour on-demand)
+  cpus: 8+
+  memory: 32+
   image_id: docker:metta:latest
 
 config:

--- a/devops/skypilot/utils/job_helpers.py
+++ b/devops/skypilot/utils/job_helpers.py
@@ -3,7 +3,7 @@ import netrc
 import os
 import re
 import time
-from io import TextIOBase
+from io import StringIO, TextIOBase
 from pathlib import Path
 from typing import cast
 
@@ -339,8 +339,6 @@ def tail_job_log(job_id: str, lines: int = 100) -> str | None:
             return f"Error: Job {job_id} not found"
 
         # Use a StringIO to capture output
-        from io import StringIO
-
         output = StringIO()
 
         try:


### PR DESCRIPTION
# Upgrade CPU-only sandbox instance type and improve AWS integration

### TL;DR

Upgrades the CPU-only sandbox from t3.large to m6i.2xlarge for better performance and adds AWS credentials synchronization. Remote evals were (are?) not fully functional, so sweep controllers need to handle parallel local evals. This machine should handle a reasonable (~4 evals in parallel) load.

### What changed?

- Upgraded the CPU-only sandbox instance type from t3.large (2 vCPUs, 8GB RAM) to m6i.2xlarge (8 vCPUs, 32GB RAM)
- Added dynamic cost calculation for CPU-only instances
- Added automatic transfer of AWS credentials and SSO configuration to the sandbox
- Updated help text and messaging to reflect the new instance type
- Improved error handling for cost calculation

### How to test?

1. Launch a CPU-only sandbox:
   ```
   python devops/skypilot/launch/sandbox.py --new --sweep-controller
   ```
### Why make this change?

The t3.large instance was too resource-constrained for many workloads. The m6i.2xlarge provides 4x the CPU cores and 4x the memory, enabling more complex workloads to run efficiently. AWS credentials were necessary skypilot dispatch.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211503195908044)