### PR TITLE
fix evals for sweeps + fix timestep parsing for sweep

### DIFF
--- a/metta/adaptive/utils.py
+++ b/metta/adaptive/utils.py
@@ -162,7 +162,7 @@ def create_eval_job(
     experiment_id: str,
     recipe_module: str,
     eval_entrypoint: str,
-    stats_server_uri: Optional[str] = None,
+    stats_server_uri: Optional[str] = PROD_STATS_SERVER_URI,
     eval_overrides: Optional[Dict[str, Any]] = None,
 ) -> "JobDefinition":
     """Create an evaluation job definition.

--- a/metta/adaptive/utils.py
+++ b/metta/adaptive/utils.py
@@ -6,7 +6,7 @@ import time
 from typing import Any, Dict, Optional
 
 from metta.adaptive.models import JobDefinition, JobTypes, RunInfo
-from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX, PROD_STATS_SERVER_URI
+from metta.common.util.constants import PROD_STATS_SERVER_URI, SOFTMAX_S3_POLICY_PREFIX
 
 logger = logging.getLogger(__name__)
 

--- a/metta/adaptive/utils.py
+++ b/metta/adaptive/utils.py
@@ -6,7 +6,7 @@ import time
 from typing import Any, Dict, Optional
 
 from metta.adaptive.models import JobDefinition, JobTypes, RunInfo
-from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX
+from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX, PROD_STATS_SERVER_URI
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def get_display_id(run_id: str) -> str:
 def build_eval_overrides(
     run_id: str,
     experiment_id: str,
-    stats_server_uri: Optional[str] = None,
+    stats_server_uri: Optional[str] = PROD_STATS_SERVER_URI,
     additional_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build evaluation override parameters.

--- a/metta/adaptive/utils.py
+++ b/metta/adaptive/utils.py
@@ -4,9 +4,10 @@ import hashlib
 import logging
 import time
 from typing import Any, Dict, Optional
-from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX
 
 from metta.adaptive.models import JobDefinition, JobTypes, RunInfo
+from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX
+
 logger = logging.getLogger(__name__)
 
 
@@ -185,7 +186,6 @@ def create_eval_job(
         stats_server_uri=stats_server_uri,
         additional_overrides=eval_overrides,
     )
-
 
     return JobDefinition(
         run_id=run_id,

--- a/metta/adaptive/utils.py
+++ b/metta/adaptive/utils.py
@@ -4,9 +4,9 @@ import hashlib
 import logging
 import time
 from typing import Any, Dict, Optional
+from metta.common.util.constants import SOFTMAX_S3_POLICY_PREFIX
 
 from metta.adaptive.models import JobDefinition, JobTypes, RunInfo
-
 logger = logging.getLogger(__name__)
 
 
@@ -178,7 +178,6 @@ def create_eval_job(
     Returns:
         JobDefinition for evaluation
     """
-    from metta.adaptive.models import JobDefinition, JobTypes
 
     overrides = build_eval_overrides(
         run_id=run_id,
@@ -187,11 +186,12 @@ def create_eval_job(
         additional_overrides=eval_overrides,
     )
 
+
     return JobDefinition(
         run_id=run_id,
         cmd=f"{recipe_module}.{eval_entrypoint}",
         type=JobTypes.LAUNCH_EVAL,
-        args={"run": run_id},
+        args={"policy_uri": f"{SOFTMAX_S3_POLICY_PREFIX}/{run_id}/{run_id}:latest.pt"},
         overrides=overrides,
         metadata={},
     )

--- a/metta/sweep/schedulers/batched_synced.py
+++ b/metta/sweep/schedulers/batched_synced.py
@@ -49,6 +49,8 @@ class SchedulerState:
     runs_in_training: set[str] = field(default_factory=set)
     runs_in_eval: set[str] = field(default_factory=set)
     runs_completed: set[str] = field(default_factory=set)
+    # Runs detected in IN_EVAL at startup that should be re-evaluated
+    runs_pending_force_eval: set[str] = field(default_factory=set)
 
     def model_dump(self) -> dict[str, Any]:
         """Serialize state to dictionary."""
@@ -56,6 +58,7 @@ class SchedulerState:
             "runs_in_training": list(self.runs_in_training),
             "runs_in_eval": list(self.runs_in_eval),
             "runs_completed": list(self.runs_completed),
+            "runs_pending_force_eval": list(self.runs_pending_force_eval),
         }
 
     @classmethod
@@ -65,6 +68,7 @@ class SchedulerState:
             runs_in_training=set(data.get("runs_in_training", [])),
             runs_in_eval=set(data.get("runs_in_eval", [])),
             runs_completed=set(data.get("runs_completed", [])),
+            runs_pending_force_eval=set(data.get("runs_pending_force_eval", [])),
         )
 
 
@@ -131,11 +135,12 @@ class BatchedSyncedOptimizingScheduler:
                         logger.info(f"[BatchedSyncedOptimizingScheduler] Found run {run_id} in training")
                     elif status == JobStatus.IN_EVAL:
                         if self.config.force_eval:
-                            # Don't track in runs_in_eval - this will cause re-dispatch
+                            # Do not mark as in_eval so we can re-dispatch an eval job
                             logger.info(
                                 f"[BatchedSyncedOptimizingScheduler] Found run {run_id} in evaluation - "
                                 "FORCING RE-EVALUATION due to force_eval=True"
                             )
+                            self.state.runs_pending_force_eval.add(run_id)
                             force_eval_count += 1
                         else:
                             self.state.runs_in_eval.add(run_id)
@@ -192,6 +197,33 @@ class BatchedSyncedOptimizingScheduler:
 
         # Update internal state from observed runs
         self._update_state_from_runs(runs)
+
+        # 0) Handle any runs pending forced re-evaluation first
+        if self.state.runs_pending_force_eval:
+            for run_id in list(self.state.runs_pending_force_eval):
+                # Only schedule if the run still exists
+                run = next((r for r in runs if r.run_id == run_id), None)
+                if run is None:
+                    # Drop if not visible in current run list
+                    self.state.runs_pending_force_eval.discard(run_id)
+                    continue
+
+                job = create_eval_job(
+                    run_id=run_id,
+                    experiment_id=self.config.experiment_id,
+                    recipe_module=self.config.recipe_module,
+                    eval_entrypoint=self.config.eval_entrypoint,
+                    stats_server_uri=self.config.stats_server_uri,
+                    eval_overrides=self.config.eval_overrides,
+                )
+                jobs.append(job)
+                # Mark as in eval to avoid duplicate dispatch
+                self.state.runs_in_eval.add(run_id)
+                self.state.runs_pending_force_eval.discard(run_id)
+                logger.info(f"[BatchedSyncedOptimizingScheduler] Scheduling forced re-evaluation for {run_id}")
+
+            if jobs:
+                return jobs
 
         # 1) Schedule evals for any runs with training done but no eval yet
         eval_candidates = [r for r in runs if r.status == JobStatus.TRAINING_DONE_NO_EVAL]

--- a/metta/tools/sim.py
+++ b/metta/tools/sim.py
@@ -77,9 +77,7 @@ class SimTool(Tool):
             return
 
         # Resume the existing training run without overriding its group
-        wandb = auto_wandb_config()
-        wandb.run_id = run_name  # resume existing
-        # Only override group if explicitly provided
+        wandb = auto_wandb_config(run_name)
         if self.group:
             wandb.group = self.group
 

--- a/metta/tools/sim.py
+++ b/metta/tools/sim.py
@@ -76,7 +76,10 @@ class SimTool(Tool):
             logger.info("Could not determine run name, skipping wandb logging")
             return
 
-        wandb = auto_wandb_config(run_name)
+        # Resume the existing training run without overriding its group
+        wandb = auto_wandb_config()
+        wandb.run_id = run_name  # resume existing
+        # Only override group if explicitly provided
         if self.group:
             wandb.group = self.group
 
@@ -104,8 +107,23 @@ class SimTool(Tool):
                     return
 
                 rl_stats.process_policy_evaluator_stats(policy_uri, eval_results, wandb_run, epoch, agent_step, False)
+            except IndexError:
+                # No rows returned; log with fallback step/epoch
+                logger.info(
+                    "No epoch metadata for %s in stats DB; logging eval metrics to WandB with default step/epoch=0",
+                    policy_uri,
+                )
+                try:
+                    rl_stats.process_policy_evaluator_stats(policy_uri, eval_results, wandb_run, 0, 0, False)
+                except Exception as e:
+                    logger.error("Fallback WandB logging failed: %s", e)
             except Exception as e:
                 logger.error(f"Error logging evaluation results to wandb: {e}")
+                # Best-effort fallback logging with default indices
+                try:
+                    rl_stats.process_policy_evaluator_stats(policy_uri, eval_results, wandb_run, 0, 0, False)
+                except Exception as e2:
+                    logger.error("Fallback WandB logging failed: %s", e2)
 
     def invoke(self, args: dict[str, str]) -> int | None:
         if self.policy_uris is None:

--- a/metta/tools/sweep.py
+++ b/metta/tools/sweep.py
@@ -12,7 +12,7 @@ from metta.adaptive import AdaptiveConfig, AdaptiveController
 from metta.adaptive.dispatcher import LocalDispatcher, SkypilotDispatcher
 from metta.adaptive.stores import WandbStore
 from metta.common.tool import Tool
-from metta.common.constants import PROD_STATS_SERVER_URI
+from metta.common.util.constants import PROD_STATS_SERVER_URI
 from metta.common.util.log_config import init_logging
 from metta.common.wandb.context import WandbConfig
 from metta.sweep.protein_config import ParameterConfig, ProteinConfig

--- a/metta/tools/sweep.py
+++ b/metta/tools/sweep.py
@@ -24,7 +24,7 @@ from metta.sweep.schedulers.batched_synced import (
     BatchedSyncedOptimizingScheduler,
     BatchedSyncedSchedulerConfig,
 )
-from metta.tools.utils.auto_config import auto_stats_server_uri, auto_wandb_config
+from metta.tools.utils.auto_config import auto_wandb_config
 
 logger = logging.getLogger(__name__)
 

--- a/metta/tools/sweep.py
+++ b/metta/tools/sweep.py
@@ -12,6 +12,7 @@ from metta.adaptive import AdaptiveConfig, AdaptiveController
 from metta.adaptive.dispatcher import LocalDispatcher, SkypilotDispatcher
 from metta.adaptive.stores import WandbStore
 from metta.common.tool import Tool
+from metta.common.constants import PROD_STATS_SERVER_URI
 from metta.common.util.log_config import init_logging
 from metta.common.wandb.context import WandbConfig
 from metta.sweep.protein_config import ParameterConfig, ProteinConfig
@@ -135,7 +136,7 @@ class SweepTool(Tool):
     # Controller settings
     max_parallel_jobs: int = 6
     monitoring_interval: int = 60
-    sweep_server_uri: str = "https://api.observatory.softmax-research.net"
+    sweep_server_uri: str = PROD_STATS_SERVER_URI
     gpus: int = 1  # Number of GPUs per training job
     nodes: int = 1  # Number of nodes per training job
 
@@ -151,7 +152,7 @@ class SweepTool(Tool):
 
     # Infrastructure configuration
     wandb: WandbConfig = WandbConfig.Unconfigured()
-    stats_server_uri: Optional[str] = auto_stats_server_uri()  # Stats server for remote evaluations
+    stats_server_uri: str = PROD_STATS_SERVER_URI  # Stats server for remote evaluations
 
     # Dispatcher configuration
     dispatcher_type: DispatcherType = DispatcherType.SKYPILOT  # SKYPILOT or LOCAL


### PR DESCRIPTION
### TL;DR

Improved WandB integration with better config parsing and more robust error handling for evaluation logging.

### What changed?

- Enhanced the `_convert_run_to_info` method in WandB store to better extract total timesteps from both flat and nested configurations
- Improved WandB logging in the simulation tool:
    - Added fallback logging when epoch metadata is missing
    - Modified run resumption to preserve existing run IDs
    - Added better error handling with fallback mechanisms

### Why make this change?

These changes were necessary for the automated sweep workflow to adapt to the changing evaluation code/API.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211502956719515)