### PR TITLE
Workaround: set native thread pools to 1 per worker when running mettagrid package tests

### DIFF
--- a/.github/scripts/run_package_tests.sh
+++ b/.github/scripts/run_package_tests.sh
@@ -3,6 +3,14 @@
 
 set -e # Exit on error
 
+# Keep single-threaded during tests to avoid flaky crashes in xdist workers.
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+export MKL_NUM_THREADS=${MKL_NUM_THREADS:-1}
+export OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS:-1}
+export NUMEXPR_NUM_THREADS=${NUMEXPR_NUM_THREADS:-1}
+export VECLIB_MAXIMUM_THREADS=${VECLIB_MAXIMUM_THREADS:-1}
+export PYTORCH_NUM_THREADS=${PYTORCH_NUM_THREADS:-1}
+
 # Colors for output
 RED='\033[1;31m'
 GREEN='\033[1;32m'

--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -689,6 +689,14 @@ py::dict MettaGrid::grid_objects() {
       obj_dict[py::str(_obs_encoder->feature_names().at(feature.feature_id))] = feature.value;
     }
 
+    if (auto* has_inventory = dynamic_cast<HasInventory*>(obj)) {
+      py::dict inventory_dict;
+      for (const auto& [resource, quantity] : has_inventory->inventory.get()) {
+        inventory_dict[py::int_(resource)] = quantity;
+      }
+      obj_dict["inventory"] = inventory_dict;
+    }
+
     // Inject agent-specific info
     if (auto* agent = dynamic_cast<Agent*>(obj)) {
       obj_dict["orientation"] = static_cast<int>(agent->orientation);
@@ -698,11 +706,6 @@ py::dict MettaGrid::grid_objects() {
       obj_dict["freeze_duration"] = agent->freeze_duration;
       obj_dict["color"] = agent->color;
 
-      py::dict inventory_dict;
-      for (const auto& [resource, quantity] : agent->inventory.get()) {
-        inventory_dict[py::int_(resource)] = quantity;
-      }
-      obj_dict["inventory"] = inventory_dict;
       // We made resource limits more complicated than this, and need to review how to expose them.
       // py::dict resource_limits_dict;
       // for (const auto& [resource, quantity] : agent->inventory.limits) {
@@ -713,11 +716,6 @@ py::dict MettaGrid::grid_objects() {
     }
 
     if (auto* converter = dynamic_cast<Converter*>(obj)) {
-      py::dict inventory_dict;
-      for (const auto& [resource, quantity] : converter->inventory.get()) {
-        inventory_dict[py::int_(resource)] = quantity;
-      }
-      obj_dict["inventory"] = inventory_dict;
       obj_dict["is_converting"] = converter->converting;
       obj_dict["is_cooling_down"] = converter->cooling_down;
       obj_dict["conversion_duration"] = converter->conversion_ticks;

--- a/packages/mettagrid/python/src/mettagrid/builder/building.py
+++ b/packages/mettagrid/python/src/mettagrid/builder/building.py
@@ -138,7 +138,7 @@ assembler_armory = AssemblerConfig(
 )
 
 
-# Chest building definitions
+# Chest building definitions. Maybe not needed beyond the raw config?
 def make_chest(
     resource_type: str,
     type_id: int,
@@ -147,9 +147,9 @@ def make_chest(
 ) -> ChestConfig:
     """Create a chest configuration for a specific resource type."""
     if deposit_positions is None:
-        deposit_positions = ["N", "S", "E", "W"]  # Default to cardinal directions
+        deposit_positions = []  # Default to no deposit positions
     if withdrawal_positions is None:
-        withdrawal_positions = ["N", "S", "E", "W"]  # Default to cardinal directions
+        withdrawal_positions = []  # Default to no withdrawal positions
 
     return ChestConfig(
         type_id=type_id,
@@ -160,17 +160,4 @@ def make_chest(
 
 
 # Example chest configurations
-chest_ore_red = make_chest("ore_red", 20)
-chest_ore_blue = make_chest("ore_blue", 21)
-chest_ore_green = make_chest("ore_green", 22)
-chest_battery_red = make_chest("battery_red", 23)
-chest_battery_blue = make_chest("battery_blue", 24)
-chest_battery_green = make_chest("battery_green", 25)
-
-# Special chest that only allows deposits from North and withdrawals from South
-chest_depot = ChestConfig(
-    type_id=26,
-    resource_type="ore_red",
-    deposit_positions=["N"],
-    withdrawal_positions=["S"],
-)
+chest_heart = make_chest("heart", 20, deposit_positions=["N"], withdrawal_positions=["S"])

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -324,8 +324,8 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
                 type_id=object_config.type_id,
                 type_name=object_type,
                 resource_type=resource_type_id,
-                deposit_positions=set(expand_position_patterns(object_config.deposit_positions)),
-                withdrawal_positions=set(expand_position_patterns(object_config.withdrawal_positions)),
+                deposit_positions=set(FIXED_POSITIONS.index(pos) for pos in object_config.deposit_positions),
+                withdrawal_positions=set(FIXED_POSITIONS.index(pos) for pos in object_config.withdrawal_positions),
                 tag_ids=tag_ids,
             )
             objects_cpp_params[object_type] = cpp_chest_config

--- a/packages/mettagrid/python/src/mettagrid/util/char_encoder.py
+++ b/packages/mettagrid/python/src/mettagrid/util/char_encoder.py
@@ -28,6 +28,7 @@ NAME_TO_CHAR: dict[str, list[str]] = {
     "factory": ["F"],
     "temple": ["T"],
     "converter": ["c"],
+    "chest": ["C"],
 }
 
 CHAR_TO_NAME: dict[str, str] = {}

--- a/packages/mettagrid/tests/test_chest.py
+++ b/packages/mettagrid/tests/test_chest.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from mettagrid.config.mettagrid_config import ChestConfig, MettaGridConfig
+from mettagrid.core import MettaGridCore
+from mettagrid.mettagrid_c import dtype_actions
+
+
+class TestChest:
+    """Test chest deposit and withdrawal functionality."""
+
+    def test_chest_deposit(self):
+        """Test that deposit/withdrawal only work from configured positions."""
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+            [
+                ["#", "#", "#", "#", "#"],
+                ["#", ".", "@", ".", "#"],
+                ["#", ".", "C", ".", "#"],
+                ["#", ".", ".", ".", "#"],
+                ["#", "#", "#", "#", "#"],
+            ]
+        )
+
+        cfg.game.resource_names = ["gold"]
+        cfg.game.agent.initial_inventory = {"gold": 5}
+
+        # Configure chest with specific positions only
+        cfg.game.objects["chest"] = ChestConfig(
+            type_id=10,
+            resource_type="gold",
+            deposit_positions=["N"],  # Only from north
+            withdrawal_positions=["S"],  # Only from south
+        )
+
+        cfg.game.actions.move.enabled = True
+
+        env = MettaGridCore(cfg)
+        obs, info = env.reset()
+
+        gold_idx = env.resource_names.index("gold")
+        move_idx = env.action_names.index("move")
+
+        # Agent starts at (3,2), chest is at (2,2)
+        # Agent is south of chest (withdrawal position)
+
+        # Try to move south (to chest position) - should trigger deposit
+        actions = np.array([[move_idx, 1]], dtype=dtype_actions)  # Move south
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Check deposit happened
+        grid_objects = env.grid_objects
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+        chest = next(obj for _obj_id, obj in grid_objects.items() if obj["type"] == 10)
+
+        assert agent["inventory"][gold_idx] == 4, f"Agent should have 4 gold. Has {agent['inventory'].get(gold_idx, 0)}"
+        assert chest["inventory"][gold_idx] == 1, f"Chest should have 1 gold. Has {chest['inventory'].get(gold_idx, 0)}"
+
+        # Move around to south position to withdraw
+        actions = np.array([[move_idx, 2]], dtype=dtype_actions)  # Move west
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Then south
+        actions = np.array([[move_idx, 1]], dtype=dtype_actions)  # Move south
+        obs, rewards, terminals, truncations, info = env.step(actions)
+        actions = np.array([[move_idx, 1]], dtype=dtype_actions)  # Move south
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Then east to be south of chest
+        actions = np.array([[move_idx, 3]], dtype=dtype_actions)  # Move east
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Now move north to chest (from withdrawal position)
+        actions = np.array([[move_idx, 0]], dtype=dtype_actions)  # Move north
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Check withdrawal happened
+        grid_objects_after = env.grid_objects
+        agent_after = next(obj for _obj_id, obj in grid_objects_after.items() if "agent_id" in obj)
+        chest_after = next(obj for _obj_id, obj in grid_objects_after.items() if obj["type"] == 10)
+
+        assert agent_after["inventory"][gold_idx] == 5, (
+            f"Agent should have 5 gold after withdrawal, has {agent_after['inventory'].get(gold_idx, 0)}"
+        )
+        assert chest_after["inventory"][gold_idx] == 0, (
+            f"Chest should have 0 gold after withdrawal, has {chest_after['inventory'].get(gold_idx, 0)}"
+        )

--- a/packages/mettagrid/tests/test_chest.py
+++ b/packages/mettagrid/tests/test_chest.py
@@ -51,8 +51,12 @@ class TestChest:
         agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
         chest = next(obj for _obj_id, obj in grid_objects.items() if obj["type"] == 10)
 
-        assert agent["inventory"][gold_idx] == 4, f"Agent should have 4 gold. Has {agent['inventory'].get(gold_idx, 0)}"
-        assert chest["inventory"][gold_idx] == 1, f"Chest should have 1 gold. Has {chest['inventory'].get(gold_idx, 0)}"
+        assert agent["inventory"].get(gold_idx, 0) == 4, (
+            f"Agent should have 4 gold. Has {agent['inventory'].get(gold_idx, 0)}"
+        )
+        assert chest["inventory"].get(gold_idx, 0) == 1, (
+            f"Chest should have 1 gold. Has {chest['inventory'].get(gold_idx, 0)}"
+        )
 
         # Move around to south position to withdraw
         actions = np.array([[move_idx, 2]], dtype=dtype_actions)  # Move west
@@ -77,9 +81,9 @@ class TestChest:
         agent_after = next(obj for _obj_id, obj in grid_objects_after.items() if "agent_id" in obj)
         chest_after = next(obj for _obj_id, obj in grid_objects_after.items() if obj["type"] == 10)
 
-        assert agent_after["inventory"][gold_idx] == 5, (
+        assert agent_after["inventory"].get(gold_idx, 0) == 5, (
             f"Agent should have 5 gold after withdrawal, has {agent_after['inventory'].get(gold_idx, 0)}"
         )
-        assert chest_after["inventory"][gold_idx] == 0, (
+        assert chest_after["inventory"].get(gold_idx, 0) == 0, (
             f"Chest should have 0 gold after withdrawal, has {chest_after['inventory'].get(gold_idx, 0)}"
         )


### PR DESCRIPTION
This is a workaround for what I think is a race condition in `mettagrid/core.py`'s `step` that Alex ran into: https://github.com/Metta-AI/metta/actions/runs/18112849469/job/51542675109?pr=2932

Why I think it's a race condition issue:
- [Last Python frame](https://github.com/Metta-AI/metta/actions/runs/18112849469/job/51542675109?pr=2932#step:6:1448) before the crash is mettagrid/core.py::step called from tests/test_chest.py::TestChest::test_chest_deposit
- Only one of the four xdist worker (gw3) dies. Others finish. implies no cross-process issues/corruption
- no errors locally

This PR sets native thread pools to 1 worker when running mettagrid tests

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211503321931703)