### PR TITLE
mapgen SceneConfig.transform parameter - rotate and transpose scenes

### DIFF
--- a/experiments/user/berekuk.py
+++ b/experiments/user/berekuk.py
@@ -1,0 +1,25 @@
+import random
+
+from mettagrid import MettaGridConfig
+from mettagrid.mapgen.mapgen import MapGen
+from mettagrid.mapgen.scene import GridTransform
+from mettagrid.mapgen.scenes.inline_ascii import InlineAscii
+
+
+def mapgen_transform_demo() -> MettaGridConfig:
+    mg_config = MettaGridConfig()
+    mg_config.game.num_agents = 0
+    mg_config.game.map_builder = MapGen.Config(
+        num_agents=mg_config.game.num_agents,
+        border_width=1,
+        instance=InlineAscii.Config(
+            data="""
+.....
+.#...
+.###.
+.....
+            """,
+            transform=random.choice(list(GridTransform)),
+        ),
+    )
+    return mg_config

--- a/packages/mettagrid/python/src/mettagrid/map_builder/__init__.py
+++ b/packages/mettagrid/python/src/mettagrid/map_builder/__init__.py
@@ -1,10 +1,11 @@
 """Map builder module for MettaGrid."""
 
-from .map_builder import AnyMapBuilderConfig, GameMap, MapBuilder, MapBuilderConfig
+from .map_builder import AnyMapBuilderConfig, GameMap, MapBuilder, MapBuilderConfig, MapGrid
 
 __all__ = [
     "GameMap",
     "MapBuilder",
     "MapBuilderConfig",
     "AnyMapBuilderConfig",
+    "MapGrid",
 ]

--- a/packages/mettagrid/python/src/mettagrid/mapgen/area.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/area.py
@@ -22,6 +22,7 @@ class Area:
     x: int
     y: int
 
+    # Note that areas are not transform-aware. So `scene.area.width` doesn't always match `scene.width`.
     width: int
     height: int
 
@@ -34,6 +35,26 @@ class Area:
     @classmethod
     def root_area_from_grid(cls, grid: MapGrid) -> Area:
         return cls(outer_grid=grid, x=0, y=0, width=grid.shape[1], height=grid.shape[0])
+
+    def make_subarea(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        tags: list[str] | None = None,
+    ) -> Area:
+        if width > self.width or height > self.height:
+            raise ValueError(f"Area {self.width}x{self.height} is too large for sub-area {width}x{height}")
+
+        return Area(
+            outer_grid=self.outer_grid,
+            x=x + self.x,
+            y=y + self.y,
+            width=width,
+            height=height,
+            tags=tags or [],
+        )
 
     def as_dict(self) -> dict:
         return {

--- a/packages/mettagrid/python/src/mettagrid/mapgen/area.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/area.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from mettagrid.base_config import Config
+from mettagrid.map_builder.map_builder import MapGrid
+
+
+@dataclass
+class Area:
+    """
+    A sub-area of the map grid.
+    """
+
+    # Full outer grid.
+    # Useful when area is transformed or when the scene needs to be transplanted.
+    # Scenes shouldn't use this field directly; instead, they should use the `self.grid` property.
+    outer_grid: MapGrid
+
+    # Absolute coordinates relative to the outer grid.
+    x: int
+    y: int
+
+    width: int
+    height: int
+
+    tags: list[str] = field(default_factory=list)
+
+    @property
+    def grid(self) -> MapGrid:
+        return self.outer_grid[self.y : self.y + self.height, self.x : self.x + self.width]
+
+    @classmethod
+    def root_area_from_grid(cls, grid: MapGrid) -> Area:
+        return cls(outer_grid=grid, x=0, y=0, width=grid.shape[1], height=grid.shape[0])
+
+    def as_dict(self) -> dict:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+            "tags": self.tags,
+        }
+
+    def transplant_to_grid(self, grid: MapGrid, shift_x: int, shift_y: int, copy_grid: bool):
+        original_grid = self.grid
+        self.outer_grid = grid
+        self.x += shift_x
+        self.y += shift_y
+        if copy_grid:
+            self.grid[:] = original_grid
+
+
+class AreaWhere(Config):
+    tags: list[str] = []
+
+
+class AreaQuery(Config):
+    limit: int | None = None
+    offset: int | None = None
+    lock: str | None = None
+    where: Literal["full"] | AreaWhere | None = None
+    order_by: Literal["random", "first", "last"] = "random"

--- a/packages/mettagrid/python/src/mettagrid/mapgen/area.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/area.py
@@ -46,6 +46,11 @@ class Area:
     ) -> Area:
         if width > self.width or height > self.height:
             raise ValueError(f"Area {self.width}x{self.height} is too large for sub-area {width}x{height}")
+        if x + width > self.width or y + height > self.height:
+            raise ValueError(
+                f"Subarea at ({x},{y}) with size {width}x{height} extends beyond parent area boundaries"
+                " {self.width}x{self.height}"
+            )
 
         return Area(
             outer_grid=self.outer_grid,

--- a/packages/mettagrid/python/src/mettagrid/mapgen/load.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/load.py
@@ -1,10 +1,7 @@
-import numpy as np
-
 from mettagrid.map_builder.map_builder import GameMap, MapBuilder, MapBuilderConfig
+from mettagrid.mapgen.area import Area
 from mettagrid.mapgen.scene import SceneConfig
 from mettagrid.mapgen.utils.storable_map import StorableMap
-
-from .types import Area
 
 
 # Note that this class can't be a scene, because the width and height come from the stored data.
@@ -29,7 +26,7 @@ class Load(MapBuilder):
         area = Area.root_area_from_grid(grid)
 
         if self.config.extra_root is not None:
-            root_scene = self.config.extra_root.create(area, np.random.default_rng())
+            root_scene = self.config.extra_root.create_root(area)
             root_scene.render_with_children()
 
         return GameMap(grid=grid)

--- a/packages/mettagrid/python/src/mettagrid/mapgen/mapgen.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/mapgen.py
@@ -217,11 +217,13 @@ class MapGen(MapBuilder):
                         raise ValueError(
                             "width and height must be provided if the instance scene has no intrinsic size"
                         )
+                    if instance_scene_config.transform.transpose:
+                        intrinsic_size = intrinsic_size[::-1]
                     self.height, self.width = intrinsic_size
 
                 instance_grid = create_grid(self.height, self.width)
                 instance_area = Area.root_area_from_grid(instance_grid)
-                instance_scene = instance_scene_config.create(instance_area, self.rng)
+                instance_scene = instance_scene_config.create_root(instance_area, self.rng)
                 instance_scene.render_with_children()
                 self.instance_scene_factories.append(TransplantScene.Config(scene=instance_scene))
             else:
@@ -364,7 +366,7 @@ class MapGen(MapBuilder):
 
         root_scene_cfg = self.get_root_scene_cfg()
 
-        self.root_scene = root_scene_cfg.create(self.inner_area, self.rng)
+        self.root_scene = root_scene_cfg.create_root(self.inner_area, self.rng)
         self.root_scene.render_with_children()
 
         return GameMap(self.guarded_grid())

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scene.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scene.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from enum import Enum
-from typing import Any, ClassVar, Generic, TypeVar, get_args, get_origin
+from enum import StrEnum, auto
+from typing import Any, ClassVar, Final, Generic, TypeVar, get_args, get_origin
 
 import numpy as np
 from pydantic import model_serializer
@@ -12,16 +12,27 @@ from mettagrid.mapgen.area import Area, AreaQuery
 from mettagrid.util.module import load_symbol
 
 
-class GridTransform(Enum):
-    # Tuples: transpose, flip_v, flip_h
-    IDENTITY = (False, False, False)
-    ROT_90 = (True, False, True)
-    ROT_180 = (False, True, True)
-    ROT_270 = (True, True, False)
-    FLIP_H = (False, False, True)
-    FLIP_V = (False, True, False)
-    TRANSPOSE = (True, False, False)
-    TRANSPOSE_ALT = (True, True, True)
+class GridTransform(StrEnum):
+    IDENTITY = auto()
+    ROT_90 = auto()
+    ROT_180 = auto()
+    ROT_270 = auto()
+    FLIP_H = auto()
+    FLIP_V = auto()
+    TRANSPOSE = auto()
+    TRANSPOSE_ALT = auto()
+
+    @property
+    def transpose(self) -> bool:
+        return TRANSFORM_FLAGS[self][0]
+
+    @property
+    def flip_v(self) -> bool:
+        return TRANSFORM_FLAGS[self][1]
+
+    @property
+    def flip_h(self) -> bool:
+        return TRANSFORM_FLAGS[self][2]
 
     def inverse(self):
         if self == GridTransform.ROT_90:
@@ -30,18 +41,6 @@ class GridTransform(Enum):
             return GridTransform.ROT_90
         else:
             return self
-
-    @property
-    def transpose(self):
-        return self.value[0]
-
-    @property
-    def flip_v(self):
-        return self.value[1]
-
-    @property
-    def flip_h(self):
-        return self.value[2]
 
     def apply(self, grid: MapGrid) -> MapGrid:
         """
@@ -87,6 +86,18 @@ class GridTransform(Enum):
                 return transform
 
         raise RuntimeError("Composition not found")  # Should never happen
+
+
+TRANSFORM_FLAGS: Final[dict[GridTransform, tuple[bool, bool, bool]]] = {
+    GridTransform.IDENTITY: (False, False, False),
+    GridTransform.ROT_90: (True, False, True),
+    GridTransform.ROT_180: (False, True, True),
+    GridTransform.ROT_270: (True, True, False),
+    GridTransform.FLIP_H: (False, False, True),
+    GridTransform.FLIP_V: (False, True, False),
+    GridTransform.TRANSPOSE: (True, False, False),
+    GridTransform.TRANSPOSE_ALT: (True, True, True),
+}
 
 
 class SceneConfig(Config):

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/auto.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/auto.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from mettagrid.base_config import Config
+from mettagrid.mapgen.area import AreaWhere
 from mettagrid.mapgen.random.float import FloatDistribution
 from mettagrid.mapgen.random.int import IntDistribution
 from mettagrid.mapgen.scene import ChildrenAction, Scene, SceneConfig
@@ -11,7 +12,6 @@ from mettagrid.mapgen.scenes.random import Random
 from mettagrid.mapgen.scenes.random_objects import RandomObjects
 from mettagrid.mapgen.scenes.random_scene import RandomScene, RandomSceneCandidate
 from mettagrid.mapgen.scenes.room_grid import RoomGrid
-from mettagrid.mapgen.types import AreaWhere
 
 
 class AutoConfigLayout(Config):

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/bsp.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/bsp.py
@@ -3,8 +3,8 @@ from typing import Literal, Tuple
 
 import numpy as np
 
+from mettagrid.map_builder import MapGrid
 from mettagrid.mapgen.scene import Scene, SceneConfig
-from mettagrid.mapgen.types import MapGrid
 
 logger = logging.getLogger(__name__)
 

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/copy_grid.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/copy_grid.py
@@ -1,7 +1,7 @@
 from pydantic import ConfigDict, Field
 
+from mettagrid.map_builder import MapGrid
 from mettagrid.mapgen.scene import Scene, SceneConfig
-from mettagrid.mapgen.types import MapGrid
 
 
 class CopyGridConfig(SceneConfig):

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/maze.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/maze.py
@@ -3,9 +3,9 @@ from typing import Literal, TypeAlias, Union
 
 import numpy as np
 
+from mettagrid.map_builder import MapGrid
 from mettagrid.mapgen.random.int import IntConstantDistribution, IntDistribution
 from mettagrid.mapgen.scene import Scene, SceneConfig
-from mettagrid.mapgen.types import MapGrid
 
 Anchor = Union[
     Literal["top-left"],

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/mirror.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/mirror.py
@@ -2,8 +2,8 @@ from typing import Literal
 
 from pydantic import ConfigDict, Field
 
+from mettagrid.mapgen.area import AreaWhere
 from mettagrid.mapgen.scene import ChildrenAction, Scene, SceneConfig
-from mettagrid.mapgen.types import AreaWhere
 
 Symmetry = Literal["horizontal", "vertical", "x4"]
 

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/multi_left_and_right.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/multi_left_and_right.py
@@ -1,9 +1,9 @@
 from numpy import random
 
+from mettagrid.mapgen.area import AreaWhere
 from mettagrid.mapgen.scene import ChildrenAction, Scene, SceneConfig
 from mettagrid.mapgen.scenes.random import Random
 from mettagrid.mapgen.scenes.room_grid import RoomGrid
-from mettagrid.mapgen.types import AreaWhere
 
 
 class MultiLeftAndRightConfig(SceneConfig):

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/transplant_scene.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/transplant_scene.py
@@ -1,10 +1,8 @@
 import copy
-from typing import Callable
 
 from pydantic import ConfigDict, Field
 
 from mettagrid.mapgen.scene import Scene, SceneConfig
-from mettagrid.mapgen.types import MapGrid
 
 
 class TransplantSceneConfig(SceneConfig):
@@ -12,13 +10,6 @@ class TransplantSceneConfig(SceneConfig):
 
     # Scene that will be transplanted.
     scene: Scene = Field(exclude=True)
-
-    # Callback to get the full outer grid.
-    # Why? Because in MapGen class it's convenient to pass scene configs around, and we don't have the final grid yet
-    # when we construct the config for this scene.
-    # Sorry about the complexity; it might be possible to implement `transplant_to_grid` without having the full outer
-    # grid object, but it's *much* easier when we have it.
-    get_grid: Callable[[], MapGrid] = Field(exclude=True)
 
 
 class TransplantScene(Scene[TransplantSceneConfig]):
@@ -36,6 +27,6 @@ class TransplantScene(Scene[TransplantSceneConfig]):
 
         scene_copy = copy.deepcopy(self.config.scene)
         scene_copy.transplant_to_grid(
-            self.config.get_grid(), self.area.x - self.config.scene.area.x, self.area.y - self.config.scene.area.y
+            self.area.outer_grid, self.area.x - self.config.scene.area.x, self.area.y - self.config.scene.area.y
         )
         self.children.append(scene_copy)

--- a/packages/mettagrid/python/src/mettagrid/mapgen/scenes/transplant_scene.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/scenes/transplant_scene.py
@@ -20,7 +20,7 @@ class TransplantScene(Scene[TransplantSceneConfig]):
     """
 
     def render(self):
-        if self.width != self.config.scene.width or self.height != self.config.scene.height:
+        if self.width != self.config.scene.area.width or self.height != self.config.scene.area.height:
             raise ValueError(
                 "TransplantScene can only be used with scenes that have the same width and height as the parent grid"
             )

--- a/packages/mettagrid/python/src/mettagrid/mapgen/types.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/types.py
@@ -1,88 +1,9 @@
-from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 
 import numpy as np
 import numpy.typing as npt
-
-from mettagrid.base_config import Config
 
 # We store maps as 2D arrays of object names.
 # "empty" means an empty cell; "wall" means a wall, etc.
 MapGrid: TypeAlias = npt.NDArray[np.str_]
 map_grid_dtype = np.dtype("<U20")
-
-
-@dataclass
-class Area:
-    # absolute coordinates
-    x: int
-    y: int
-
-    width: int
-    height: int
-
-    # slice of the outer grid (must match `width` and `height`)
-    grid: MapGrid
-
-    tags: list[str]
-
-    @classmethod
-    def root_area_from_grid(cls, grid: MapGrid) -> "Area":
-        return cls(x=0, y=0, width=grid.shape[1], height=grid.shape[0], grid=grid, tags=[])
-
-    def as_dict(self) -> dict:
-        return {
-            "x": self.x,
-            "y": self.y,
-            "width": self.width,
-            "height": self.height,
-            "tags": self.tags,
-        }
-
-    def transplant_to_grid(self, grid: MapGrid, shift_x: int, shift_y: int):
-        self.x += shift_x
-        self.y += shift_y
-        self.grid = grid[self.y : self.y + self.height, self.x : self.x + self.width]
-
-    def __getitem__(self, key) -> "Area":
-        # TODO - I think this method doesn't support negative indices.
-        # (written by Claude)
-
-        if isinstance(key, tuple) and len(key) == 2:
-            row_slice, col_slice = key
-        elif isinstance(key, (int, slice)):
-            row_slice = key
-            col_slice = slice(None)
-        else:
-            raise TypeError("Area indices must be integers or slices")
-
-        # Convert integers to slice objects
-        if isinstance(row_slice, int):
-            row_slice = slice(row_slice, row_slice + 1)
-        if isinstance(col_slice, int):
-            col_slice = slice(col_slice, col_slice + 1)
-
-        # Get the sliced grid
-        sliced_grid = self.grid[row_slice, col_slice]
-
-        # Calculate new coordinates
-        row_start = row_slice.start if row_slice.start is not None else 0
-        col_start = col_slice.start if col_slice.start is not None else 0
-
-        new_x = self.x + col_start
-        new_y = self.y + row_start
-        new_height, new_width = sliced_grid.shape
-
-        return Area(x=new_x, y=new_y, width=new_width, height=new_height, grid=sliced_grid, tags=self.tags.copy())
-
-
-class AreaWhere(Config):
-    tags: list[str] = []
-
-
-class AreaQuery(Config):
-    limit: int | None = None
-    offset: int | None = None
-    lock: str | None = None
-    where: Literal["full"] | AreaWhere | None = None
-    order_by: Literal["random", "first", "last"] = "random"

--- a/packages/mettagrid/python/src/mettagrid/mapgen/utils/ascii_grid.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/utils/ascii_grid.py
@@ -1,3 +1,4 @@
+from mettagrid.map_builder.utils import create_grid
 from mettagrid.mapgen.types import MapGrid
 
 DEFAULT_CHAR_TO_NAME: dict[str, str] = {
@@ -64,7 +65,6 @@ def print_grid(grid: MapGrid, name_to_char: dict[str, str], border: bool = True)
 
 def lines_to_grid(lines: list[str], char_to_name: dict[str, str]) -> MapGrid:
     """Convert lines of text to a grid using the provided char-to-name mapping."""
-    from mettagrid.map_builder.utils import create_grid
 
     grid = create_grid(len(lines), len(lines[0]))
     for r, line in enumerate(lines):

--- a/packages/mettagrid/python/src/mettagrid/mapgen/utils/storable_map.py
+++ b/packages/mettagrid/python/src/mettagrid/mapgen/utils/storable_map.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import yaml
 from typing_extensions import TypedDict
 
-from mettagrid.map_builder.map_builder import MapBuilderConfig
+from mettagrid.map_builder import MapBuilderConfig
 from mettagrid.mapgen.mapgen import MapGen
 from mettagrid.mapgen.types import MapGrid
 from mettagrid.mapgen.utils.ascii_grid import default_char_to_name, grid_to_lines, lines_to_grid

--- a/packages/mettagrid/python/src/mettagrid/test_support/mapgen.py
+++ b/packages/mettagrid/python/src/mettagrid/test_support/mapgen.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from mettagrid.map_builder.utils import create_grid
@@ -14,7 +13,7 @@ def render_scene(
 ):
     grid = create_grid(shape[0], shape[1])
     area = Area.root_area_from_grid(grid)
-    scene = scene_cfg.create(area, np.random.default_rng())
+    scene = scene_cfg.create_root(area)
     scene.render_with_children()
     return scene
 

--- a/packages/mettagrid/python/src/mettagrid/test_support/mapgen.py
+++ b/packages/mettagrid/python/src/mettagrid/test_support/mapgen.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 
 from mettagrid.map_builder.utils import create_grid
+from mettagrid.mapgen.area import Area
 from mettagrid.mapgen.scene import Scene, SceneConfig
-from mettagrid.mapgen.types import Area, MapGrid
+from mettagrid.mapgen.types import MapGrid
 from mettagrid.mapgen.utils.ascii_grid import add_pretty_border, char_grid_to_lines, default_char_to_name, grid_to_lines
 
 

--- a/packages/mettagrid/tests/mapgen/scenes/test_layout.py
+++ b/packages/mettagrid/tests/mapgen/scenes/test_layout.py
@@ -1,7 +1,7 @@
 import pytest
 
+from mettagrid.mapgen.area import AreaQuery, AreaWhere
 from mettagrid.mapgen.scenes.layout import Layout, LayoutArea
-from mettagrid.mapgen.types import AreaQuery, AreaWhere
 from mettagrid.test_support.mapgen import render_scene
 
 # -----------------------------------------------------------------------------

--- a/packages/mettagrid/tests/mapgen/scenes/test_room_grid.py
+++ b/packages/mettagrid/tests/mapgen/scenes/test_room_grid.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from mettagrid.mapgen.area import AreaQuery
 from mettagrid.mapgen.scenes.room_grid import RoomGrid
-from mettagrid.mapgen.types import AreaQuery
 from mettagrid.test_support.mapgen import assert_grid, render_scene
 
 

--- a/packages/mettagrid/tests/mapgen/test_scene.py
+++ b/packages/mettagrid/tests/mapgen/test_scene.py
@@ -26,7 +26,7 @@ def make_scene(children_actions: list[ChildrenAction]):
         ]
     )
     area = Area.root_area_from_grid(grid)
-    scene = MockScene.Config(seed=42, children=children_actions).create(area=area, rng=np.random.default_rng())
+    scene = MockScene.Config(seed=42, children=children_actions).create_root(area=area)
     # Create some test areas with different tags
     scene.make_area(0, 0, 3, 2, tags=["tag1", "tag2", "scene1"])  # ABC / FGH
     scene.make_area(1, 2, 2, 2, tags=["tag2", "tag3", "scene2"])  # LM / QR

--- a/packages/mettagrid/tests/mapgen/test_scene.py
+++ b/packages/mettagrid/tests/mapgen/test_scene.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 
+from mettagrid.mapgen.area import Area, AreaQuery, AreaWhere
 from mettagrid.mapgen.scene import ChildrenAction, Scene, SceneConfig
-from mettagrid.mapgen.types import Area, AreaQuery, AreaWhere
 
 
 class MockConfig(SceneConfig):

--- a/packages/mettagrid/tests/mapgen/test_transform.py
+++ b/packages/mettagrid/tests/mapgen/test_transform.py
@@ -1,0 +1,229 @@
+import numpy as np
+
+from mettagrid.map_builder.utils import create_grid
+from mettagrid.mapgen.area import AreaQuery, AreaWhere
+from mettagrid.mapgen.scene import ChildrenAction, GridTransform, Scene, SceneConfig
+from mettagrid.test_support.mapgen import assert_raw_grid, render_scene
+
+
+class SerifConfig(SceneConfig):
+    pass
+
+
+class SerifScene(Scene[SerifConfig]):
+    def render(self):
+        self.grid[1, 0] = "wall"
+        self.make_area(1, 1, self.width - 2, self.height - 2, tags=["inner"])
+
+
+class TestGridTransformClass:
+    def test_identity(self):
+        assert GridTransform.IDENTITY.compose(GridTransform.IDENTITY) == GridTransform.IDENTITY
+        assert GridTransform.IDENTITY.compose(GridTransform.ROT_90) == GridTransform.ROT_90
+
+    def test_rot_composition(self):
+        assert GridTransform.ROT_90.compose(GridTransform.ROT_90) == GridTransform.ROT_180
+        assert GridTransform.ROT_90.compose(GridTransform.ROT_180) == GridTransform.ROT_270
+        assert GridTransform.ROT_90.compose(GridTransform.ROT_270) == GridTransform.IDENTITY
+
+    def test_inverse(self):
+        assert GridTransform.IDENTITY.inverse() == GridTransform.IDENTITY
+        assert GridTransform.ROT_90.inverse() == GridTransform.ROT_270
+        assert GridTransform.ROT_180.inverse() == GridTransform.ROT_180
+        assert GridTransform.ROT_270.inverse() == GridTransform.ROT_90
+        assert GridTransform.FLIP_H.inverse() == GridTransform.FLIP_H
+        assert GridTransform.FLIP_V.inverse() == GridTransform.FLIP_V
+        assert GridTransform.TRANSPOSE_ALT.inverse() == GridTransform.TRANSPOSE_ALT
+        assert GridTransform.TRANSPOSE.inverse() == GridTransform.TRANSPOSE
+
+    def test_apply(self):
+        grid = np.array([[0, 1, 2], [3, 4, 5]])
+        np.testing.assert_array_equal(GridTransform.ROT_90.apply(grid), np.array([[3, 0], [4, 1], [5, 2]]))
+
+    def test_apply_to_coords(self):
+        grid = create_grid(4, 5)
+
+        # .....
+        # #....
+        # .....
+        # .....
+        assert GridTransform.IDENTITY.apply_to_coords(grid, 0, 1) == (0, 1)
+
+        # ..#.
+        # ....
+        # ....
+        # ....
+        # ....
+        assert GridTransform.ROT_90.apply_to_coords(grid, 0, 1) == (2, 0)
+
+        # .....
+        # .....
+        # ....#
+        # .....
+        assert GridTransform.ROT_180.apply_to_coords(grid, 0, 1) == (4, 2)
+
+        # ....
+        # ....
+        # ....
+        # ....
+        # .#..
+        assert GridTransform.ROT_270.apply_to_coords(grid, 0, 1) == (1, 4)
+
+        # .....
+        # ....#
+        # .....
+        # .....
+        assert GridTransform.FLIP_H.apply_to_coords(grid, 0, 1) == (4, 1)
+
+        # .....
+        # .....
+        # #....
+        # .....
+        assert GridTransform.FLIP_V.apply_to_coords(grid, 0, 1) == (0, 2)
+
+        # .#..
+        # ....
+        # ....
+        # ....
+        # ....
+        assert GridTransform.TRANSPOSE.apply_to_coords(grid, 0, 1) == (1, 0)
+
+        # ....
+        # ....
+        # ....
+        # ....
+        # ..#.
+        assert GridTransform.TRANSPOSE_ALT.apply_to_coords(grid, 0, 1) == (2, 4)
+
+
+class TestTransformBasic:
+    def test_default(self):
+        scene = render_scene(SerifScene.Config(), (4, 5))
+        assert_raw_grid(
+            # we have to use outer grid instead of assert_grid(scene, ...) because the grid is transformed
+            scene.area.outer_grid,
+            """
+                .....
+                #....
+                .....
+                .....
+            """,
+        )
+
+    def test_rot90(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.ROT_90), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                ...#.
+                .....
+                .....
+                .....
+            """,
+        )
+
+    def test_rot180(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.ROT_180), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....
+                .....
+                ....#
+                .....
+            """,
+        )
+
+    def test_rot270(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.ROT_270), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....
+                .....
+                .....
+                .#...
+            """,
+        )
+
+    def test_flip_h(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.FLIP_H), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....
+                ....#
+                .....
+                .....
+            """,
+        )
+
+    def test_flip_v(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.FLIP_V), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....
+                .....
+                #....
+                .....
+            """,
+        )
+
+    def test_transpose_alt(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.TRANSPOSE), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .#...
+                .....
+                .....
+                .....
+            """,
+        )
+
+    def test_transpose(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.TRANSPOSE_ALT), (4, 5))
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....
+                .....
+                .....
+                ...#.
+            """,
+        )
+
+
+class TestSubarea:
+    def test_area(self):
+        scene = render_scene(SerifScene.Config(transform=GridTransform.ROT_90), (4, 5))
+        assert scene.area.width == 5
+        assert scene.area.height == 4
+        child_area = scene.select_areas(AreaQuery())[0]
+        assert child_area.width == 3
+        assert child_area.height == 2
+
+    def test_nested_transforms(self):
+        scene = render_scene(
+            SerifScene.Config(
+                transform=GridTransform.ROT_90,
+                children=[
+                    ChildrenAction(
+                        scene=SerifScene.Config(transform=GridTransform.ROT_90), where=AreaWhere(tags=["inner"])
+                    )
+                ],
+            ),
+            (6, 7),
+        )
+        assert_raw_grid(
+            scene.area.outer_grid,
+            """
+                .....#.
+                .......
+                .......
+                .....#.
+                .......
+                .......
+            """,
+        )


### PR DESCRIPTION
Via [https://app.asana.com/1/1209016784099267/project/1210151704713430/task/12112492728156cg97?focus=true](https://app.asana.com/1/1209016784099267/project/1210151704713430/task/1211249272815697?focus=true)

Initially I thought that this could be a scene, similar to `scenes.Mirror`. But turns out that approach doesn't quite work when the grid is rectangular.

So I ended up doing a deeper mapgen integration:

- all scene configs can be parameterized with `transform=GridTransform.ROT_90` (or other values) enum
- `scene.render()` renders to the grid that is transformed in this way
- nested transformations work
- `scene.area.grid` now doesn't match `scene.grid` (areas are not transform-aware; scene grids are)

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211503815680888)