### PR TITLE
Allow assemblers to be used while cooling down

### DIFF
--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -1,7 +1,6 @@
 #ifndef PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_ASSEMBLER_HPP_
 #define PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_OBJECTS_ASSEMBLER_HPP_
 
-#include <cmath>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -114,14 +113,6 @@ public:
   // Usage tracking
   unsigned int uses_count;  // Current number of times used
   unsigned int max_uses;    // Maximum number of uses (0 = unlimited)
-
-  // Exhaustion tracking
-  float exhaustion;           // Exhaustion rate (0 = no exhaustion)
-  float cooldown_multiplier;  // Current cooldown multiplier from exhaustion
-
-  // Usage tracking
-  unsigned int max_uses;    // Maximum number of uses (0 = unlimited)
-  unsigned int uses_count;  // Current number of times used
 
   // Exhaustion tracking
   float exhaustion;           // Exhaustion rate (0 = no exhaustion)
@@ -268,32 +259,6 @@ public:
     if (!grid || !current_timestep_ptr) {
       return false;
     }
-<<<<<<< HEAD
-    // Check if max uses has been reached
-    if (max_uses > 0 && uses_count >= max_uses) {
-      return false;
-    }
-    if (cooldown_remaining() > 0) {
-      return false;
-    }
-    const Recipe* recipe = get_current_recipe();
-    if (!recipe || (recipe->input_resources.empty() && recipe->output_resources.empty())) {
-      return false;
-    }
-    std::vector<Agent*> surrounding_agents = get_surrounding_agents();
-    if (!can_afford_recipe(*recipe, surrounding_agents)) {
-      return false;
-    }
-    consume_resources_for_recipe(*recipe, surrounding_agents);
-    give_output_to_agent(*recipe, actor);
-
-    // Apply cooldown with exhaustion multiplier
-    if (recipe->cooldown > 0) {
-      unsigned int adjusted_cooldown = static_cast<unsigned int>(recipe->cooldown * cooldown_multiplier);
-      cooldown_end_timestep = *current_timestep_ptr + adjusted_cooldown;
-    }
-
-=======
 
     if (max_uses > 0 && uses_count >= max_uses) {
       return false;
@@ -328,7 +293,6 @@ public:
       cooldown_end_timestep = *current_timestep_ptr + adjusted_cooldown;
     }
 
->>>>>>> be32742e73 (allow usage while cooling down)
     // If we were clipped and successfully used an unclip recipe, become unclipped. Also, don't count this as a use.
     if (is_clipped) {
       is_clipped = false;

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -271,7 +271,7 @@ public:
     }
 
     const Recipe* original_recipe = get_current_recipe();
-    if (!original_recipe || (original_recipe->input_resources.empty() && original_recipe->output_resources.empty())) {
+    if (!original_recipe) {
       return false;
     }
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -287,11 +287,8 @@ public:
     consume_resources_for_recipe(recipe_to_use, surrounding_agents);
     give_output_to_agent(recipe_to_use, actor);
 
-    // Apply cooldown with exhaustion multiplier
-    if (recipe_to_use.cooldown > 0) {
-      unsigned int adjusted_cooldown = static_cast<unsigned int>(recipe_to_use.cooldown * cooldown_multiplier);
-      cooldown_end_timestep = *current_timestep_ptr + adjusted_cooldown;
-    }
+    unsigned int adjusted_cooldown = static_cast<unsigned int>(recipe_to_use.cooldown * cooldown_multiplier);
+    cooldown_end_timestep = *current_timestep_ptr + adjusted_cooldown;
 
     // If we were clipped and successfully used an unclip recipe, become unclipped. Also, don't count this as a use.
     if (is_clipped) {
@@ -305,9 +302,6 @@ public:
         cooldown_multiplier *= (1.0f + exhaustion);
       }
     }
-
-    cooldown_duration = recipe_to_use.cooldown;
-    cooldown_end_timestep = *current_timestep_ptr + recipe_to_use.cooldown;
     return true;
   }
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -287,8 +287,8 @@ public:
     consume_resources_for_recipe(recipe_to_use, surrounding_agents);
     give_output_to_agent(recipe_to_use, actor);
 
-    unsigned int adjusted_cooldown = static_cast<unsigned int>(recipe_to_use.cooldown * cooldown_multiplier);
-    cooldown_end_timestep = *current_timestep_ptr + adjusted_cooldown;
+    cooldown_duration = static_cast<unsigned int>(recipe_to_use.cooldown * cooldown_multiplier);
+    cooldown_end_timestep = *current_timestep_ptr + cooldown_duration;
 
     // If we were clipped and successfully used an unclip recipe, become unclipped. Also, don't count this as a use.
     if (is_clipped) {

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler_config.hpp
@@ -19,6 +19,7 @@ struct AssemblerConfig : public GridObjectConfig {
         recipe_details_obs(false),
         input_recipe_offset(0),
         output_recipe_offset(0),
+        allow_partial_usage(false),
         max_uses(0),         // 0 means unlimited uses
         exhaustion(0.0f) {}  // 0 means no exhaustion
 
@@ -30,6 +31,8 @@ struct AssemblerConfig : public GridObjectConfig {
   ObservationType input_recipe_offset;
   ObservationType output_recipe_offset;
 
+  // Allow partial usage during cooldown
+  bool allow_partial_usage;
   // Maximum number of uses (0 = unlimited)
   unsigned int max_uses;
 
@@ -50,6 +53,7 @@ inline void bind_assembler_config(py::module& m) {
       .def_readwrite("tag_ids", &AssemblerConfig::tag_ids)
       .def_readwrite("recipes", &AssemblerConfig::recipes)
       .def_readwrite("recipe_details_obs", &AssemblerConfig::recipe_details_obs)
+      .def_readwrite("allow_partial_usage", &AssemblerConfig::allow_partial_usage)
       .def_readwrite("max_uses", &AssemblerConfig::max_uses)
       .def_readwrite("exhaustion", &AssemblerConfig::exhaustion);
 }

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -312,6 +312,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
                 type_id=object_config.type_id, type_name=object_type, tag_ids=tag_ids
             )
             cpp_assembler_config.recipes = cpp_recipes
+            cpp_assembler_config.allow_partial_usage = object_config.allow_partial_usage
             cpp_assembler_config.max_uses = object_config.max_uses
             objects_cpp_params[object_type] = cpp_assembler_config
         elif isinstance(object_config, ChestConfig):

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -135,6 +135,13 @@ class AssemblerConfig(Config):
     type_id: int = Field(default=0, ge=0, le=255)
     recipes: list[tuple[list[Position], RecipeConfig]] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list, description="Tags for this object instance")
+    allow_partial_usage: bool = Field(
+        default=False,
+        description=(
+            "Allow assembler to be used during cooldown with scaled resource requirements/outputs. "
+            "This makes less sense if the assembler has multiple recipes."
+        ),
+    )
     max_uses: int = Field(default=0, ge=0, description="Maximum number of uses (0 = unlimited)")
 
 

--- a/packages/mettagrid/python/src/mettagrid/util/char_encoder.py
+++ b/packages/mettagrid/python/src/mettagrid/util/char_encoder.py
@@ -29,6 +29,7 @@ NAME_TO_CHAR: dict[str, list[str]] = {
     "temple": ["T"],
     "converter": ["c"],
     "chest": ["C"],
+    "assembler": ["Z"],
 }
 
 CHAR_TO_NAME: dict[str, str] = {}

--- a/packages/mettagrid/tests/test_assembler_partial_usage.py
+++ b/packages/mettagrid/tests/test_assembler_partial_usage.py
@@ -115,10 +115,23 @@ class TestAssemblerPartialUsage:
         assert iron_consumed == 20, f"Should consume 20 iron at full usage, consumed {iron_consumed}"
         assert steel_produced == 10, f"Should produce 10 steel at full usage, produced {steel_produced}"
 
+        # Verify assembler is on cooldown (should have 100 tick cooldown)
+        assembler = next((obj for _obj_id, obj in grid_objects.items() if obj.get("type_name") == "assembler"), None)
+        if assembler:
+            cooldown_remaining = assembler.get("cooldown_remaining", 0)
+            assert cooldown_remaining == 100, f"Assembler should have 100 tick cooldown, has {cooldown_remaining}"
+
         # Test at 12% progress (12 ticks into 100 tick cooldown)
         for _ in range(12):
             actions = np.array([[noop_idx, 0]], dtype=dtype_actions)
             obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Verify cooldown has decreased to 88 ticks remaining
+        grid_objects = env.grid_objects
+        assembler = next((obj for _obj_id, obj in grid_objects.items() if obj.get("type_name") == "assembler"), None)
+        if assembler:
+            cooldown_remaining = assembler.get("cooldown_remaining", 0)
+            assert cooldown_remaining == 88, f"After 12 ticks, cooldown should be 88, has {cooldown_remaining}"
 
         iron_before = agent["inventory"][iron_idx]
         steel_before = agent["inventory"][steel_idx]

--- a/packages/mettagrid/tests/test_assembler_partial_usage.py
+++ b/packages/mettagrid/tests/test_assembler_partial_usage.py
@@ -1,0 +1,143 @@
+import numpy as np
+
+from mettagrid.config.mettagrid_config import AssemblerConfig, MettaGridConfig, RecipeConfig
+from mettagrid.core import MettaGridCore
+from mettagrid.mettagrid_c import dtype_actions
+
+
+class TestAssemblerPartialUsage:
+    """Test assembler partial usage during cooldown functionality."""
+
+    def test_partial_usage_disabled(self):
+        """Test that assemblers cannot be used during cooldown when allow_partial_usage is False."""
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+            [
+                ["#", "#", "#", "#"],
+                ["#", "@", "Z", "#"],
+                ["#", "#", "#", "#"],
+            ]
+        )
+
+        cfg.game.resource_names = ["iron", "steel"]
+        cfg.game.agent.initial_inventory = {"iron": 100, "steel": 0}
+
+        # Configure assembler with partial usage disabled
+        cfg.game.objects["assembler"] = AssemblerConfig(
+            type_id=20,
+            name="no_partial_assembler",
+            recipes=[(["W"], RecipeConfig(input_resources={"iron": 10}, output_resources={"steel": 5}, cooldown=10))],
+            allow_partial_usage=False,  # Disable partial usage
+        )
+
+        cfg.game.actions.move.enabled = True
+        cfg.game.actions.noop.enabled = True
+
+        env = MettaGridCore(cfg)
+        obs, info = env.reset()
+
+        iron_idx = env.resource_names.index("iron")
+        steel_idx = env.resource_names.index("steel")
+        move_idx = env.action_names.index("move")
+        noop_idx = env.action_names.index("noop")
+
+        # First usage
+        actions = np.array([[move_idx, 3]], dtype=dtype_actions)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        grid_objects = env.grid_objects
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+
+        assert agent["inventory"][iron_idx] == 90, "Agent should have 90 iron after first use"
+        assert agent["inventory"][steel_idx] == 5, "Agent should have 5 steel after first use"
+
+        # Wait 5 ticks (50% cooldown)
+        for _ in range(5):
+            actions = np.array([[noop_idx, 0]], dtype=dtype_actions)
+            obs, rewards, terminals, truncations, info = env.step(actions)
+
+        # Try to use during cooldown (should fail)
+        actions = np.array([[move_idx, 1]], dtype=dtype_actions)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        grid_objects = env.grid_objects
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+
+        # Resources should be unchanged
+        assert agent["inventory"][iron_idx] == 90, (
+            f"Iron should remain at 90 (usage blocked), has {agent['inventory'].get(iron_idx, 0)}"
+        )
+        assert agent["inventory"][steel_idx] == 5, (
+            f"Steel should remain at 5 (usage blocked), has {agent['inventory'].get(steel_idx, 0)}"
+        )
+
+    def test_partial_usage_scaling(self):
+        """Test resource scaling at different cooldown progress levels."""
+        cfg = MettaGridConfig.EmptyRoom(num_agents=1, with_walls=True).with_ascii_map(
+            [
+                ["#", "#", "#", "#"],
+                ["#", "@", "Z", "#"],
+                ["#", "#", "#", "#"],
+            ]
+        )
+
+        cfg.game.resource_names = ["iron", "steel"]
+        cfg.game.agent.initial_inventory = {"iron": 100, "steel": 0}
+
+        # Recipe: 20 iron -> 10 steel, 100 tick cooldown
+        cfg.game.objects["assembler"] = AssemblerConfig(
+            type_id=20,
+            name="scaling_assembler",
+            recipes=[(["W"], RecipeConfig(input_resources={"iron": 20}, output_resources={"steel": 10}, cooldown=100))],
+            allow_partial_usage=True,
+        )
+
+        cfg.game.actions.move.enabled = True
+        cfg.game.actions.noop.enabled = True
+
+        env = MettaGridCore(cfg)
+        obs, info = env.reset()
+
+        iron_idx = env.resource_names.index("iron")
+        steel_idx = env.resource_names.index("steel")
+        move_idx = env.action_names.index("move")
+        noop_idx = env.action_names.index("noop")
+
+        # First full usage
+        actions = np.array([[move_idx, 3]], dtype=dtype_actions)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        grid_objects = env.grid_objects
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+
+        iron_consumed = 100 - agent["inventory"][iron_idx]
+        steel_produced = agent["inventory"][steel_idx]
+
+        assert iron_consumed == 20, f"Should consume 20 iron at full usage, consumed {iron_consumed}"
+        assert steel_produced == 10, f"Should produce 10 steel at full usage, produced {steel_produced}"
+
+        # Test at 12% progress (12 ticks into 100 tick cooldown)
+        for _ in range(12):
+            actions = np.array([[noop_idx, 0]], dtype=dtype_actions)
+            obs, rewards, terminals, truncations, info = env.step(actions)
+
+        iron_before = agent["inventory"][iron_idx]
+        steel_before = agent["inventory"][steel_idx]
+
+        actions = np.array([[move_idx, 3]], dtype=dtype_actions)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        grid_objects = env.grid_objects
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+
+        # At 10% progress:
+        # Input: 20 * 0.12 = 2.4, rounded up = 3
+        # Output: 10 * 0.12 = 1.2, rounded down = 1
+        iron_consumed_12 = iron_before - agent["inventory"][iron_idx]
+        steel_produced_12 = agent["inventory"][steel_idx] - steel_before
+
+        assert iron_consumed_12 == 3, (
+            f"Should consume 3 iron at 12% progress (20*0.12 rounded up), consumed {iron_consumed_12}"
+        )
+        assert steel_produced_12 == 1, (
+            f"Should produce 1 steel at 12% progress (10*0.12 rounded down), produced {steel_produced_12}"
+        )


### PR DESCRIPTION
As per the title. This allows assemblers to be used in a way that's similar to them refilling and then being drained.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211503836665360)