### PR TITLE
Make assemblers clippable

### DIFF
--- a/packages/mettagrid/cpp/include/mettagrid/objects/constants.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/constants.hpp
@@ -48,7 +48,8 @@ constexpr ObservationType Glyph = 11;
 constexpr ObservationType VisitationCounts = 12;
 constexpr ObservationType Tag = 13;
 constexpr ObservationType CooldownRemaining = 14;
-constexpr ObservationType ObservationFeatureCount = 15;
+constexpr ObservationType Clipped = 15;
+constexpr ObservationType ObservationFeatureCount = 16;
 }  // namespace ObservationFeature
 
 const ObservationType InventoryFeatureOffset = ObservationFeature::ObservationFeatureCount;
@@ -70,7 +71,8 @@ inline const std::map<ObservationType, std::string>& GetFeatureNames() {
       {ObservationFeature::Glyph, "agent:glyph"},
       {ObservationFeature::VisitationCounts, "agent:visitation_counts"},
       {ObservationFeature::Tag, "tag"},
-      {ObservationFeature::CooldownRemaining, "cooldown_remaining"}};
+      {ObservationFeature::CooldownRemaining, "cooldown_remaining"},
+      {ObservationFeature::Clipped, "clipped"}};
   return feature_names;
 }
 
@@ -94,7 +96,8 @@ inline const std::map<ObservationType, float>& GetFeatureNormalizations() {
       {ObservationFeature::Glyph, 255.0},
       {ObservationFeature::VisitationCounts, 1000.0},
       {ObservationFeature::Tag, 10.0},
-      {ObservationFeature::CooldownRemaining, 255.0}};
+      {ObservationFeature::CooldownRemaining, 255.0},
+      {ObservationFeature::Clipped, 1.0}};
   return feature_normalizations;
 }
 


### PR DESCRIPTION
This adds an ability for assemblers to become clipped. This gives them a second set of recipes that take precedence, and unclips them if one of those recipes is successful.

This is different than the plan we'd discussed, where we replace the objects in the grid -- but in our current design, only assemblers need to be clippable, and this is definitely simpler than the version that involves replacement.

Right now there's nothing in the game that would cause assemblers to _become_ clipped, so that's still needed.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211506173640416)