### PR TITLE
bring back asan in debug

### DIFF
--- a/packages/mettagrid/.bazelrc
+++ b/packages/mettagrid/.bazelrc
@@ -28,6 +28,7 @@ build:dbg --copt=-fstack-protector-strong
 build:dbg --linkopt=-fsanitize=address
 build:dbg --linkopt=-fsanitize=undefined
 build:dbg --linkopt=-fsanitize=float-divide-by-zero
+build:dbg --test_env=ASAN_OPTIONS=detect_leaks=0
 
 # Test configuration
 test --test_output=errors

--- a/packages/mettagrid/.bazelrc
+++ b/packages/mettagrid/.bazelrc
@@ -20,6 +20,14 @@ build:dbg --compilation_mode=dbg
 build:dbg --copt=-O0
 build:dbg --copt=-g
 build:dbg --strip=never
+build:dbg --copt=-fsanitize=address
+build:dbg --copt=-fsanitize=undefined
+build:dbg --copt=-fsanitize=float-divide-by-zero
+build:dbg --copt=-fno-sanitize-recover=all
+build:dbg --copt=-fstack-protector-strong
+build:dbg --linkopt=-fsanitize=address
+build:dbg --linkopt=-fsanitize=undefined
+build:dbg --linkopt=-fsanitize=float-divide-by-zero
 
 # Test configuration
 test --test_output=errors

--- a/packages/mettagrid/Makefile
+++ b/packages/mettagrid/Makefile
@@ -19,89 +19,89 @@ help:
 
 # Debug build
 build:
-	@echo "🔨 Building debug..."
+	@echo "Building debug..."
 	bazel build --config=dbg //:mettagrid_c
 
 # Production release build
 build-prod:
-	@echo "🔨 Building release..."
+	@echo "Building release..."
 	bazel build --config=opt //:mettagrid_c
 
 # Build and run benchmarks
 benchmark:
-	@echo "🔨 Building C++ benchmarks..."
+	@echo "Building C++ benchmarks..."
 	bazel build --config=opt //benchmarks:test_mettagrid_env_benchmark
-	@echo "📂 Creating build-release directory..."
+	@echo "Creating build-release directory..."
 	mkdir -p build-release
-	@echo "📋 Copying benchmark binaries..."
+	@echo "Copying benchmark binaries..."
 	cp -f bazel-bin/benchmarks/test_mettagrid_env_benchmark build-release/
 	chmod +x build-release/test_mettagrid_env_benchmark
-	@echo "🏃 Running C++ benchmarks..."
+	@echo "Running C++ benchmarks..."
 	# Note: Using the copied binary instead of 'bazel run' to avoid Python environment issues
-	./build-release/test_mettagrid_env_benchmark || echo "⚠️  C++ benchmark failed - this may be due to Python environment issues"
-	@echo "🏃 Running Python benchmarks..."
+	./build-release/test_mettagrid_env_benchmark || echo "C++ benchmark failed - this may be due to Python environment issues"
+	@echo "Running Python benchmarks..."
 	uv run pytest benchmarks/test_mettagrid_env_benchmark.py -v --benchmark-only
 
 # Run unit tests
 test: build
-	@echo "🧪 Running unit tests..."
+	@echo "Running unit tests..."
 	bazel test --config=dbg //tests:tests_all
 
 # Generate coverage report
 coverage:
-	@echo "🔨 Building with coverage..."
-	@echo "⚠️  Note: C++ coverage on macOS is currently not supported by bazel"
+	@echo "Building with coverage..."
+	@echo "Note: C++ coverage on macOS is currently not supported by bazel"
 	@echo "    Running tests instead..."
 	bazel test //tests:tests_all
-	@echo "✅ Tests completed successfully"
+	@echo "Tests completed successfully"
 	@echo "    For Python coverage, use: make pytest-coverage"
 
 # Alias for clang_tidy that only fails on errors (not warnings)
 tidy:
-	@echo "🔍 Running clang-tidy (errors only)..."
+	@echo "Running clang-tidy (errors only)..."
 	@bazel test //lint:clang_tidy --test_output=errors  --nocache_test_results
-	@echo "✅ Clang-tidy check complete (use 'make tidy-verbose' to see all warnings)"
+	@echo "Clang-tidy check complete (use 'make tidy-verbose' to see all warnings)"
 
 # Run clang-tidy with full output showing all warnings
 tidy-verbose:
-	@echo "🔍 Running clang-tidy with full output..."
+	@echo "Running clang-tidy with full output..."
 	@bazel test //lint:clang_tidy --test_output=all --nocache_test_results
 
 # Formatting
 format-check:
-	@echo "🔎 Checking code formatting..."
+	@echo "Checking code formatting..."
 	@clang-format --dry-run --Werror -style=file $(shell find src include tests -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.hpp')
-	@echo "✅ All files are correctly formatted"
+	@echo "All files are correctly formatted"
 
 format-fix:
-	@echo "🛠️  Reformatting code..."
+	@echo "Reformatting code..."
 	@clang-format -i -style=file $(shell find src include tests -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.hpp')
-	@echo "✅ Code reformatted"
+	@echo "Code reformatted"
 
 # Python
 install:
-	@echo "📦 Installing package..."
+	@echo "Installing package..."
 	@cd ../.. && uv sync --active --inexact --frozen
 
 pytest:
-	@echo "🐍 Preparing environment for Python tests (ASAN disabled)..."
+	@echo "Preparing environment for Python tests (ASAN disabled)..."
 	@cd ../.. && DEBUG= uv sync --active --inexact --frozen
-	@echo "🔧 Building C++ extension without ASAN (opt config)..."
+	@echo "Building C++ extension without ASAN (opt config)..."
 	@cd ../.. && PYTHONPATH=packages/mettagrid DEBUG= uv run python -c "import bazel_build as bb; bb._run_bazel_build()"
-	@echo "🐍 Running Python tests (ASAN disabled)..."
+	@echo "Running Python tests (ASAN disabled)..."
 	@cd ../.. && DEBUG= uv run pytest packages/mettagrid/tests
 
 pytest-coverage:
-	@echo "🐍 Preparing environment for Python tests (ASAN disabled)..."
+	@echo "Preparing environment for Python tests (ASAN disabled)..."
 	@cd ../.. && DEBUG= uv sync --active --inexact --frozen
-	@echo "🔧 Building C++ extension without ASAN (opt config)..."
+	@echo "Building C++ extension without ASAN (opt config)..."
 	@cd ../.. && PYTHONPATH=packages/mettagrid DEBUG= uv run python -c "import bazel_build as bb; bb._run_bazel_build()"
-	@echo "📊 Running Python tests with coverage (ASAN disabled)..."
+	@echo "Running Python tests with coverage (ASAN disabled)..."
 	@cd ../.. && DEBUG= uv run pytest packages/mettagrid/tests --cov=mettagrid --cov-report=term-missing --cov-report=html:packages/mettagrid/htmlcov
 
 # Cleanup
 clean:
-	@echo "🧹 Cleaning build artifacts..."
+	@echo "Cleaning build artifacts..."
 	bazel clean
 	rm -rf .venv uv.lock
 	rm -f coverage.info *.gcda *.gcno *.profraw *.profdata

--- a/packages/mettagrid/Makefile
+++ b/packages/mettagrid/Makefile
@@ -45,7 +45,7 @@ benchmark:
 # Run unit tests
 test: build
 	@echo "🧪 Running unit tests..."
-	bazel test //tests:tests_all
+	bazel test --config=dbg //tests:tests_all
 
 # Generate coverage report
 coverage:
@@ -83,13 +83,21 @@ install:
 	@echo "📦 Installing package..."
 	@cd ../.. && uv sync --active --inexact --frozen
 
-pytest: install
-	@echo "🐍 Running Python tests..."
-	@cd ../.. && uv run pytest packages/mettagrid/tests
+pytest:
+	@echo "🐍 Preparing environment for Python tests (ASAN disabled)..."
+	@cd ../.. && DEBUG= uv sync --active --inexact --frozen
+	@echo "🔧 Building C++ extension without ASAN (opt config)..."
+	@cd ../.. && PYTHONPATH=packages/mettagrid DEBUG= uv run python -c "import bazel_build as bb; bb._run_bazel_build()"
+	@echo "🐍 Running Python tests (ASAN disabled)..."
+	@cd ../.. && DEBUG= uv run pytest packages/mettagrid/tests
 
-pytest-coverage: install
-	@echo "📊 Running Python tests with coverage..."
-	@cd ../.. && uv run pytest packages/mettagrid/tests --cov=mettagrid --cov-report=term-missing --cov-report=html:packages/mettagrid/htmlcov
+pytest-coverage:
+	@echo "🐍 Preparing environment for Python tests (ASAN disabled)..."
+	@cd ../.. && DEBUG= uv sync --active --inexact --frozen
+	@echo "🔧 Building C++ extension without ASAN (opt config)..."
+	@cd ../.. && PYTHONPATH=packages/mettagrid DEBUG= uv run python -c "import bazel_build as bb; bb._run_bazel_build()"
+	@echo "📊 Running Python tests with coverage (ASAN disabled)..."
+	@cd ../.. && DEBUG= uv run pytest packages/mettagrid/tests --cov=mettagrid --cov-report=term-missing --cov-report=html:packages/mettagrid/htmlcov
 
 # Cleanup
 clean:

--- a/packages/mettagrid/Makefile
+++ b/packages/mettagrid/Makefile
@@ -52,7 +52,7 @@ coverage:
 	@echo "Building with coverage..."
 	@echo "Note: C++ coverage on macOS is currently not supported by bazel"
 	@echo "    Running tests instead..."
-	bazel test //tests:tests_all
+	bazel test --config=dbg //tests:tests_all
 	@echo "Tests completed successfully"
 	@echo "    For Python coverage, use: make pytest-coverage"
 

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -33,6 +33,7 @@ private:
         }
       }
     }
+
     return positions;
   }
 

--- a/packages/mettagrid/tests/BUILD
+++ b/packages/mettagrid/tests/BUILD
@@ -6,8 +6,7 @@ COPTS = [
     "-std=c++20",
     "-fvisibility=hidden",
     "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION",
-    "-O3",
-    "-DNDEBUG",
+    "-fsanitize=address",
 ]
 
 # C++ test binaries that link with Python
@@ -15,6 +14,7 @@ cc_binary(
     name="test_stats_tracker_bin",
     srcs=["test_stats_tracker.cpp"],
     copts=COPTS + ["-Icpp/include/mettagrid", "-Itests"],
+    linkopts=["-fsanitize=address"],
     linkstatic=False,
     deps=[
         "//:mettagrid_lib",
@@ -27,6 +27,7 @@ cc_binary(
     name="test_grid_object_bin",
     srcs=["test_grid_object.cpp"],
     copts=COPTS + ["-Icpp/include/mettagrid", "-Itests"],
+    linkopts=["-fsanitize=address"],
     linkstatic=False,
     deps=[
         "//:mettagrid_lib",
@@ -47,6 +48,7 @@ cc_binary(
     name="test_mettagrid_bin",
     srcs=["test_mettagrid.cpp"] + [":mettagrid_sources"],
     copts=COPTS + ["-Icpp/include/mettagrid", "-Icpp", "-Itests"],
+    linkopts=["-fsanitize=address"],
     linkstatic=False,
     deps=[
         "//:mettagrid_lib",  # For pybind11 headers
@@ -59,6 +61,7 @@ cc_binary(
     name="test_observations_bin",
     srcs=["test_observations.cpp"],
     copts=COPTS + ["-Icpp/include/mettagrid", "-Itests"],
+    linkopts=["-fsanitize=address"],
     linkstatic=False,
     deps=[
         "//:mettagrid_lib",
@@ -71,6 +74,7 @@ cc_binary(
     name="test_clipper_bin",
     srcs=["test_clipper.cpp"],
     copts=COPTS + ["-Icpp/include/mettagrid", "-Itests"],
+    linkopts=["-fsanitize=address"],
     linkstatic=False,
     deps=[
         "//:mettagrid_lib",
@@ -125,7 +129,7 @@ py_test(
     size="small",
 )
 
-# Test suite that r n  all tests
+# Test suite that runs all tests
 test_suite(
     name="tests_all",
     tests=[


### PR DESCRIPTION
We lost asan when moving from bazel to cmake. Now we bring it back.

Attempted to run msan as well, but it had issues with gtest, and has been abandoned for now. It was not previously used.

This runs only for `cd packages/mettagrid && make test`, it does NOT run for any `pytest`.

Tested by putting a memory error in assembler.hpp, which asan caught in `cd packages/mettagrid && make test`.
