### PR TITLE
Pass through the exhaustion flag

### DIFF
--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -314,6 +314,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             cpp_assembler_config.recipes = cpp_recipes
             cpp_assembler_config.allow_partial_usage = object_config.allow_partial_usage
             cpp_assembler_config.max_uses = object_config.max_uses
+            cpp_assembler_config.exhaustion = object_config.exhaustion
             objects_cpp_params[object_type] = cpp_assembler_config
         elif isinstance(object_config, ChestConfig):
             # Convert resource type name to ID

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -164,6 +164,13 @@ class AssemblerConfig(Config):
         ),
     )
     max_uses: int = Field(default=0, ge=0, description="Maximum number of uses (0 = unlimited)")
+    exhaustion: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Exhaustion rate - cooldown multiplier grows by (1 + exhaustion) after each use (0 = no exhaustion)"
+        ),
+    )
 
 
 class ChestConfig(Config):


### PR DESCRIPTION
We added an exhaustion setting for converters, but the flag didn't make it to mettagrid_config due to a botched merge. This fixes that.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211512647890587)