### PR TITLE
install nim in slim dockerfile

### DIFF
--- a/devops/docker/Dockerfile.slim
+++ b/devops/docker/Dockerfile.slim
@@ -23,6 +23,12 @@ COPY --from=ghcr.io/astral-sh/uv:0.8.13 /uv /uvx /bin/
 
 COPY .python-version pyproject.toml uv.lock ./
 RUN uv python install
+
+# Install any missing system deps
+COPY devops/tools/install-system.sh /usr/local/bin/install-system.sh
+RUN chmod +x /usr/local/bin/install-system.sh
+RUN /usr/local/bin/install-system.sh
+
 COPY packages/mettagrid/pyproject.toml packages/mettagrid/
 COPY app_backend/pyproject.toml app_backend/
 COPY common/pyproject.toml common/


### PR DESCRIPTION
uv sync now requires nim is installed. `install-system.sh` handles this, and we could run that at the start of every skypilot run, but probably better to put it in the base dockerfile