### PR TITLE
Skypilot runs install any missing system deps

### DIFF
--- a/devops/skypilot/config/lifecycle/setup.sh
+++ b/devops/skypilot/config/lifecycle/setup.sh
@@ -10,6 +10,9 @@ git fetch origin "$METTA_GIT_REF" || git fetch --depth=1000 origin
 git checkout "$METTA_GIT_REF"
 echo "[SETUP] Checked out: $(git rev-parse HEAD)"
 
+echo "[SETUP] Installing system dependencies..."
+bash ./devops/tools/install-system.sh
+
 echo "[SETUP] Installing Datadog agent..."
 uv run metta install datadog-agent --non-interactive || echo "[SETUP] Datadog agent installation failed or skipped"
 


### PR DESCRIPTION
Sometimes our system deps will get out of line with what's in our backing dockerfile. In such cases, running `./devops/tools/install-system.sh` should be safe and patch up any discrepancies until the docker image updates