### PR TITLE
Add a naive clipping system

### DIFF
--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -252,7 +252,10 @@ MettaGrid::MettaGrid(const GameConfig& game_config, const py::list map, unsigned
   set_buffers(observations, terminals, truncations, rewards);
 
   // Initialize global systems
-  if (_game_config.clipper_recipe && _game_config.clipper_clip_rate > 0.0f) {
+  if (_game_config.clipper_clip_rate > 0.0f) {
+    if (!_game_config.clipper_recipe) {
+      throw std::runtime_error("Clipper clip rate is greater than 0.0f, but no clipper recipe is provided");
+    }
     _clipper = std::make_unique<Clipper>(_game_config.clipper_recipe, _game_config.clipper_clip_rate);
   }
 }

--- a/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.cpp
@@ -253,7 +253,7 @@ MettaGrid::MettaGrid(const GameConfig& game_config, const py::list map, unsigned
 
   // Initialize global systems
   if (_game_config.clipper_recipe && _game_config.clipper_clip_rate > 0.0f) {
-    _clipper = std::make_unique<ClipperSystem>(_game_config.clipper_recipe, _game_config.clipper_clip_rate);
+    _clipper = std::make_unique<Clipper>(_game_config.clipper_recipe, _game_config.clipper_clip_rate);
   }
 }
 

--- a/packages/mettagrid/cpp/bindings/mettagrid_c.hpp
+++ b/packages/mettagrid/cpp/bindings/mettagrid_c.hpp
@@ -24,6 +24,7 @@
 #include "core/types.hpp"
 #include "objects/assembler.hpp"
 #include "objects/chest.hpp"
+#include "systems/clipper.hpp"
 #include "systems/packed_coordinate.hpp"
 
 // Forward declarations of existing C++ classes
@@ -164,6 +165,9 @@ private:
   // Inventory regeneration
   std::map<InventoryItem, InventoryQuantity> _inventory_regen_amounts;
   unsigned int _inventory_regen_interval;
+
+  // Global systems
+  std::unique_ptr<Clipper> _clipper;
 
   void init_action_handlers();
   void add_agent(Agent* agent);

--- a/packages/mettagrid/cpp/include/mettagrid/config/mettagrid_config.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/config/mettagrid_config.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "core/types.hpp"
+#include "objects/recipe.hpp"
 
 // Forward declarations
 struct ActionConfig;
@@ -49,6 +50,10 @@ struct GameConfig {
   // term, this is a straightforward patch.
   std::map<InventoryItem, InventoryQuantity> inventory_regen_amounts = {};  // Resources to regenerate and their amounts
   unsigned int inventory_regen_interval = 0;                                // Interval in timesteps (0 = disabled)
+
+  // Global clipper settings
+  std::shared_ptr<Recipe> clipper_recipe = nullptr;
+  float clipper_clip_rate = 0.0f;
 };
 
 namespace py = pybind11;
@@ -90,7 +95,11 @@ inline void bind_game_config(py::module& m) {
 
                     // Inventory regeneration
                     const std::map<InventoryItem, InventoryQuantity>&,
-                    unsigned int>(),
+                    unsigned int,
+
+                    // Clipper
+                    const std::shared_ptr<Recipe>&,
+                    float>(),
            py::arg("num_agents"),
            py::arg("max_steps"),
            py::arg("episode_truncates"),
@@ -112,7 +121,11 @@ inline void bind_game_config(py::module& m) {
 
            // Inventory regeneration
            py::arg("inventory_regen_amounts") = std::map<InventoryItem, InventoryQuantity>(),
-           py::arg("inventory_regen_interval") = 0)
+           py::arg("inventory_regen_interval") = 0,
+
+           // Clipper
+           py::arg("clipper_recipe") = std::shared_ptr<Recipe>(nullptr),
+           py::arg("clipper_clip_rate") = 0.0f)
       .def_readwrite("num_agents", &GameConfig::num_agents)
       .def_readwrite("max_steps", &GameConfig::max_steps)
       .def_readwrite("episode_truncates", &GameConfig::episode_truncates)
@@ -139,7 +152,11 @@ inline void bind_game_config(py::module& m) {
 
       // Inventory regeneration
       .def_readwrite("inventory_regen_amounts", &GameConfig::inventory_regen_amounts)
-      .def_readwrite("inventory_regen_interval", &GameConfig::inventory_regen_interval);
+      .def_readwrite("inventory_regen_interval", &GameConfig::inventory_regen_interval)
+
+      // Clipper
+      .def_readwrite("clipper_recipe", &GameConfig::clipper_recipe)
+      .def_readwrite("clipper_clip_rate", &GameConfig::clipper_clip_rate);
 }
 
 #endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_CONFIG_METTAGRID_CONFIG_HPP_

--- a/packages/mettagrid/cpp/include/mettagrid/systems/clipper.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/systems/clipper.hpp
@@ -1,0 +1,32 @@
+#ifndef PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_SYSTEMS_CLIPPER_HPP_
+#define PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_SYSTEMS_CLIPPER_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "core/grid.hpp"
+#include "objects/assembler.hpp"
+
+class Clipper {
+public:
+  std::shared_ptr<Recipe> recipe;
+  float clip_rate;
+
+  Clipper(std::shared_ptr<Recipe> recipe_ptr, float rate) : recipe(std::move(recipe_ptr)), clip_rate(rate) {}
+
+  void clip_at_random(Grid& grid, std::mt19937& rng) {
+    if (!recipe || clip_rate <= 0.0f) return;
+    for (size_t obj_id = 1; obj_id < grid.objects.size(); obj_id++) {
+      auto* obj = grid.object(static_cast<GridObjectId>(obj_id));
+      if (!obj) continue;
+      if (auto* assembler = dynamic_cast<Assembler*>(obj)) {
+        if (assembler->is_clipped) continue;
+        if (std::generate_canonical<float, 10>(rng) < clip_rate) {
+          assembler->becomeClipped(std::vector<std::shared_ptr<Recipe>>{recipe});
+        }
+      }
+    }
+  }
+};
+
+#endif  // PACKAGES_METTAGRID_CPP_INCLUDE_METTAGRID_SYSTEMS_CLIPPER_HPP_

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -314,6 +314,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             cpp_assembler_config.recipes = cpp_recipes
             cpp_assembler_config.allow_partial_usage = object_config.allow_partial_usage
             cpp_assembler_config.max_uses = object_config.max_uses
+            cpp_assembler_config.exhaustion = object_config.exhaustion
             objects_cpp_params[object_type] = cpp_assembler_config
         elif isinstance(object_config, ChestConfig):
             # Convert resource type name to ID

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -164,6 +164,13 @@ class AssemblerConfig(Config):
         ),
     )
     max_uses: int = Field(default=0, ge=0, description="Maximum number of uses (0 = unlimited)")
+    exhaustion: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Exhaustion rate - cooldown multiplier grows by (1 + exhaustion) after each use (0 = no exhaustion)"
+        ),
+    )
 
 
 class ChestConfig(Config):

--- a/packages/mettagrid/python/src/mettagrid/mettagrid_c.pyi
+++ b/packages/mettagrid/python/src/mettagrid/mettagrid_c.pyi
@@ -125,6 +125,17 @@ class ActionConfig:
     required_resources: dict[int, int]
     consumed_resources: dict[int, float]
 
+class Recipe:
+    def __init__(
+        self,
+        input_resources: dict[int, int] = {},
+        output_resources: dict[int, int] = {},
+        cooldown: int = 0,
+    ) -> None: ...
+    input_resources: dict[int, int]
+    output_resources: dict[int, int]
+    cooldown: int
+
 class AttackActionConfig(ActionConfig):
     def __init__(
         self,

--- a/packages/mettagrid/python/src/mettagrid/mettagrid_c.pyi
+++ b/packages/mettagrid/python/src/mettagrid/mettagrid_c.pyi
@@ -170,10 +170,15 @@ class GameConfig:
         actions: dict[str, ActionConfig],
         objects: dict[str, GridObjectConfig],
         resource_loss_prob: float = 0.0,
+        tag_id_map: dict[int, str] | None = None,
         track_movement_metrics: bool = False,
         recipe_details_obs: bool = False,
         allow_diagonals: bool = False,
         reward_estimates: Optional[dict[str, float]] = None,
+        inventory_regen_amounts: dict[int, int] | None = None,
+        inventory_regen_interval: int = 0,
+        clipper_recipe: Optional[Recipe] = None,
+        clipper_clip_rate: float = 0.0,
     ) -> None: ...
     num_agents: int
     max_steps: int
@@ -189,6 +194,11 @@ class GameConfig:
     recipe_details_obs: bool
     allow_diagonals: bool
     reward_estimates: Optional[dict[str, float]]
+    tag_id_map: dict[int, str]
+    inventory_regen_amounts: dict[int, int]
+    inventory_regen_interval: int
+    clipper_recipe: Optional[Recipe]
+    clipper_clip_rate: float
 
 class MettaGrid:
     obs_width: int


### PR DESCRIPTION
Adds a bare bones clipping system which we can iterate on.

This clips Assemblers at a fixed rate, with no consideration of position / time / proximity to other clipped Assemblers.

It also takes a single Recipe, so everything will be unclipped the same way.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211513062020729)