### PR TITLE
Fix mettagrid release CI

### DIFF
--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +68,7 @@ jobs:
         env:
           CIBW_BUILD: "cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux* *i686"
-          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
+          CIBW_ARCHS_MACOS: "arm64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
           CIBW_BEFORE_ALL_LINUX: |
             python3 -m pip install "pip<25"

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -69,7 +69,7 @@ jobs:
           CIBW_BUILD: "cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux* *i686"
           CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
           CIBW_BEFORE_ALL_LINUX: |
             python3 -m pip install "pip<25"
             curl -sSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -75,8 +75,18 @@ jobs:
             curl -sSL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
             chmod +x /usr/local/bin/bazelisk
             ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
-          CIBW_BEFORE_ALL_MACOS: python3 -m pip install "pip<25"
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
+            export CHOOSENIM_NO_ANALYTICS=1
+            curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+            export PATH="$HOME/.nimble/bin:$PATH"
+          CIBW_ENVIRONMENT_LINUX: PATH="$HOME/.nimble/bin:$PATH"
+          CIBW_BEFORE_ALL_MACOS: |
+            python3 -m pip install "pip<25"
+            export CHOOSENIM_NO_ANALYTICS=1
+            curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+            export PATH="$HOME/.nimble/bin:$PATH"
+          CIBW_ENVIRONMENT_MACOS: |
+            MACOSX_DEPLOYMENT_TARGET=11.0
+            PATH="$HOME/.nimble/bin:$PATH"
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
           CI: "true"
         with:

--- a/.github/workflows/release-mettagrid.yml
+++ b/.github/workflows/release-mettagrid.yml
@@ -84,9 +84,7 @@ jobs:
             export CHOOSENIM_NO_ANALYTICS=1
             curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
             export PATH="$HOME/.nimble/bin:$PATH"
-          CIBW_ENVIRONMENT_MACOS: |
-            MACOSX_DEPLOYMENT_TARGET=11.0
-            PATH="$HOME/.nimble/bin:$PATH"
+          CIBW_ENVIRONMENT_MACOS: PATH="$HOME/.nimble/bin:$PATH" MACOSX_DEPLOYMENT_TARGET=11.0
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
           CI: "true"
         with:


### PR DESCRIPTION
## Summary
- install Nim via choosenim in the mettagrid release workflow on all OSes
- switch linux wheel builds to manylinux_2_34 as nim builds need a newer glibc 
- export the Nimble bin path via cibuildwheel environment vars so nim is visible during the wheel build
- remove Intel Mac support as the builds take forever and no one uses them anyway 

## Problems
Builds now take significantly longer, particularly for intel Macs. 
<img width="1022" height="442" alt="8b4be1d2-30f1-480a-bc13-9235034770ff" src="https://github.com/user-attachments/assets/ff170909-1f42-4f7f-a34b-3b202a62159f" />

## Testing
- workflow_dispatch: https://github.com/Metta-AI/metta/actions/runs/18142147007

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211516150320077)