### PR TITLE
chore: ignore nim runtime files for ruff

### DIFF
--- a/.ruffignore
+++ b/.ruffignore
@@ -1,0 +1,1 @@
+.nim_runtime


### PR DESCRIPTION
## Summary
- add .ruffignore so ruff skips generated .nim_runtime cache

## Testing
- ruff check

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211516368501341)