### PR TITLE
amend batch size and num workers in cogames, edit tests to be reasonable, types smaller

### DIFF
--- a/packages/cogames/src/cogames/train.py
+++ b/packages/cogames/src/cogames/train.py
@@ -69,11 +69,14 @@ def train(
         backend = pufferlib.vector.Serial
         num_workers = 1
 
+    envs_per_worker = max(1, 256 // num_workers)
+    vector_batch_size = max(128, envs_per_worker)
+
     vecenv = pufferlib.vector.make(
         env_creator,
         num_envs=256,
         num_workers=num_workers,
-        batch_size=128,
+        batch_size=vector_batch_size,
         backend=backend,
         env_kwargs={
             "cfg": env_cfg,

--- a/packages/cogames/tests/test_train_integration.py
+++ b/packages/cogames/tests/test_train_integration.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
@@ -114,12 +115,12 @@ def test_train_and_load_policy_data(test_env_config, temp_checkpoint_dir):
     obs, _ = env.reset()
     # Handle dict-based (per-agent) or array observations where axis 0 indexes agents
     if isinstance(obs, dict):
-        agent_items = obs.items()
+        agent_items = list(obs.items())
     else:
-        obs_array = torch.as_tensor(obs)
+        obs_array = np.asarray(obs)
         obs_dims = len(env.single_observation_space.shape)
         if obs_array.ndim > obs_dims:
-            agent_items = enumerate(obs_array)
+            agent_items = [(idx, obs_array[idx]) for idx in range(obs_array.shape[0])]
         else:
             agent_items = [(0, obs_array)]
 
@@ -161,12 +162,12 @@ def test_train_lstm_and_load_policy_data(test_env_config, temp_checkpoint_dir):
     # Verify the policy can be used for inference with state
     obs, _ = env.reset()
     if isinstance(obs, dict):
-        agent_items = obs.items()
+        agent_items = list(obs.items())
     else:
-        obs_array = torch.as_tensor(obs)
+        obs_array = np.asarray(obs)
         obs_dims = len(env.single_observation_space.shape)
         if obs_array.ndim > obs_dims:
-            agent_items = enumerate(obs_array)
+            agent_items = [(idx, obs_array[idx]) for idx in range(obs_array.shape[0])]
         else:
             agent_items = [(0, obs_array)]
 

--- a/packages/mettagrid/python/src/mettagrid/types.py
+++ b/packages/mettagrid/python/src/mettagrid/types.py
@@ -1,64 +1,38 @@
-"""Validation functions for MettaGrid observation and action spaces.
+"""Runtime helpers for validating MettaGrid gymnasium spaces."""
 
-Type definitions are in mettagrid.core (MettaGridObservation, MettaGridAction).
-This module provides runtime validation for gymnasium spaces.
-"""
+from __future__ import annotations
+
+from typing import TypeVar, cast
 
 import numpy as np
 from gymnasium import spaces
 
+SpaceT = TypeVar("SpaceT", bound=spaces.Space)
+
+
+def _require_space(space: spaces.Space, kind: type[SpaceT], label: str) -> SpaceT:
+    if not isinstance(space, kind):
+        raise TypeError(
+            f"MettaGrid {label} space must be {kind.__name__}, got {type(space).__name__}",
+        )
+    return cast(SpaceT, space)
+
 
 def validate_observation_space(space: spaces.Space) -> None:
-    """Validate that the observation space conforms to MettaGrid requirements.
-
-    MettaGrid expects observations to be Box spaces with uint8 dtype.
-
-    Args:
-        space: The observation space to validate
-
-    Raises:
-        TypeError: If the space does not conform to expected type
-    """
-    if not isinstance(space, spaces.Box):
-        raise TypeError(f"MettaGrid observation space must be Box, got {type(space).__name__}")
-    if space.dtype != np.uint8:
-        raise TypeError(f"MettaGrid observation space must have dtype uint8, got {space.dtype}")
+    box = _require_space(space, spaces.Box, "observation")
+    if box.dtype != np.uint8:
+        raise TypeError(
+            f"MettaGrid observation space must have dtype uint8, got {box.dtype}",
+        )
 
 
 def validate_action_space(space: spaces.Space) -> None:
-    """Validate that the action space conforms to MettaGrid requirements.
-
-    MettaGrid expects actions to be MultiDiscrete spaces.
-
-    Args:
-        space: The action space to validate
-
-    Raises:
-        TypeError: If the space does not conform to expected type
-    """
-    if not isinstance(space, spaces.MultiDiscrete):
-        raise TypeError(f"MettaGrid action space must be MultiDiscrete, got {type(space).__name__}")
+    _require_space(space, spaces.MultiDiscrete, "action")
 
 
 def get_observation_shape(space: spaces.Box) -> tuple[int, ...]:
-    """Extract the shape of observations from the observation space.
-
-    Args:
-        space: The observation space
-
-    Returns:
-        Tuple representing the observation shape
-    """
     return tuple(space.shape)
 
 
 def get_action_nvec(space: spaces.MultiDiscrete) -> np.ndarray:
-    """Extract the nvec array from the action space.
-
-    Args:
-        space: The action space
-
-    Returns:
-        Array of action dimension sizes
-    """
     return space.nvec


### PR DESCRIPTION
- Aligned vectorized env construction with PufferLib’s own divisibility rule by computing vector_batch_size = max(128, envs_per_worker) before the factory call,
  then preserving the downstream guard that bumps PPO batch_size to cover every agent and keeps it divisible per worker (packages/cogames/src/cogames/train.py#L72-
  L155).
  - Updated the integration tests to recognize vectorized observations that come back as agent-first arrays: for both Simple and LSTM policies we now fan
  out axis 0 (using numpy, matching the env output type) before invoking each agent policy, so inference matches what training sees (packages/cogames/tests/
  test_train_integration.py#L120-L178).
  - Tests run: uv run pytest packages/cogames/tests/test_train_integration.py::test_train_simple_policy -vv; uv run pytest packages/cogames/tests/
  test_train_integration.py -k policy_data -vv

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211516411926970)