### PR TITLE
fix tests passing but still exit code 143 because of OOM and/or division by 0

### DIFF
--- a/packages/cogames/src/cogames/train.py
+++ b/packages/cogames/src/cogames/train.py
@@ -164,10 +164,18 @@ def train(
             amended_minibatch_size,
         )
 
+    effective_timesteps = max(num_steps, amended_batch_size)
+    if effective_timesteps != num_steps:
+        logger.info(
+            "Raising total_timesteps from %s to %s to keep it >= batch_size",
+            num_steps,
+            effective_timesteps,
+        )
+
     train_args = dict(
         env=env_name,
         device=device.type,
-        total_timesteps=num_steps,
+        total_timesteps=effective_timesteps,
         minibatch_size=amended_minibatch_size,
         batch_size=amended_batch_size,
         data_dir=str(checkpoints_path),

--- a/packages/cogames/src/cogames/train.py
+++ b/packages/cogames/src/cogames/train.py
@@ -27,6 +27,10 @@ def train(
     batch_size: int,
     minibatch_size: int,
     game_name: Optional[str] = None,
+    *,
+    vector_num_envs: Optional[int] = None,
+    vector_batch_size: Optional[int] = None,
+    vector_num_workers: Optional[int] = None,
 ) -> None:
     import pufferlib.pytorch  # noqa: F401 - ensure modules register with torch
     import pufferlib.vector
@@ -44,7 +48,7 @@ def train(
         # TODO(jsuarez): Fix multiprocessing backend
         backend = pufferlib.vector.Serial
 
-    desired_workers = 8
+    desired_workers = vector_num_workers if vector_num_workers is not None else 8
     cpu_cores = None
     try:
         import psutil
@@ -69,12 +73,26 @@ def train(
         backend = pufferlib.vector.Serial
         num_workers = 1
 
-    envs_per_worker = max(1, 256 // num_workers)
-    vector_batch_size = max(128, envs_per_worker)
+    num_envs = vector_num_envs if vector_num_envs is not None else 256
+
+    envs_per_worker = max(1, num_envs // num_workers)
+    base_batch_size = vector_batch_size if vector_batch_size is not None else 128
+    vector_batch_size = max(base_batch_size, envs_per_worker)
+    remainder = vector_batch_size % envs_per_worker
+    if remainder:
+        vector_batch_size += envs_per_worker - remainder
+
+    logger.debug(
+        "Vec env config: num_envs=%s, num_workers=%s, batch_size=%s (envs/worker=%s)",
+        num_envs,
+        num_workers,
+        vector_batch_size,
+        envs_per_worker,
+    )
 
     vecenv = pufferlib.vector.make(
         env_creator,
-        num_envs=256,
+        num_envs=num_envs,
         num_workers=num_workers,
         batch_size=vector_batch_size,
         backend=backend,

--- a/packages/cogames/tests/test_train_integration.py
+++ b/packages/cogames/tests/test_train_integration.py
@@ -38,8 +38,11 @@ def test_train_simple_policy(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=256,
-        minibatch_size=256,
+        batch_size=128,
+        minibatch_size=128,
+        vector_num_envs=32,
+        vector_batch_size=32,
+        vector_num_workers=1,
     )
 
     # Check that checkpoints were created
@@ -65,8 +68,11 @@ def test_train_lstm_policy(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=256,
-        minibatch_size=256,
+        batch_size=128,
+        minibatch_size=128,
+        vector_num_envs=32,
+        vector_batch_size=32,
+        vector_num_workers=1,
     )
 
     # Check that checkpoints were created
@@ -98,8 +104,11 @@ def test_train_and_load_policy_data(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=256,
-        minibatch_size=256,
+        batch_size=128,
+        minibatch_size=128,
+        vector_num_envs=32,
+        vector_batch_size=32,
+        vector_num_workers=1,
     )
 
     # Find the saved checkpoint
@@ -146,8 +155,11 @@ def test_train_lstm_and_load_policy_data(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=256,
-        minibatch_size=256,
+        batch_size=128,
+        minibatch_size=128,
+        vector_num_envs=32,
+        vector_batch_size=32,
+        vector_num_workers=1,
     )
 
     # Find the saved checkpoint

--- a/packages/cogames/tests/test_train_integration.py
+++ b/packages/cogames/tests/test_train_integration.py
@@ -38,10 +38,10 @@ def test_train_simple_policy(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=128,
-        minibatch_size=128,
-        vector_num_envs=32,
-        vector_batch_size=32,
+        batch_size=4,
+        minibatch_size=4,
+        vector_num_envs=1,
+        vector_batch_size=1,
         vector_num_workers=1,
     )
 
@@ -68,10 +68,10 @@ def test_train_lstm_policy(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=128,
-        minibatch_size=128,
-        vector_num_envs=32,
-        vector_batch_size=32,
+        batch_size=4,
+        minibatch_size=4,
+        vector_num_envs=1,
+        vector_batch_size=1,
         vector_num_workers=1,
     )
 
@@ -104,10 +104,10 @@ def test_train_and_load_policy_data(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=128,
-        minibatch_size=128,
-        vector_num_envs=32,
-        vector_batch_size=32,
+        batch_size=4,
+        minibatch_size=4,
+        vector_num_envs=1,
+        vector_batch_size=1,
         vector_num_workers=1,
     )
 
@@ -155,10 +155,10 @@ def test_train_lstm_and_load_policy_data(test_env_config, temp_checkpoint_dir):
         num_steps=1000,
         checkpoints_path=temp_checkpoint_dir,
         seed=42,
-        batch_size=128,
-        minibatch_size=128,
-        vector_num_envs=32,
-        vector_batch_size=32,
+        batch_size=4,
+        minibatch_size=4,
+        vector_num_envs=1,
+        vector_batch_size=1,
         vector_num_workers=1,
     )
 


### PR DESCRIPTION
- Added keyword-only knobs on cogames.train.train so callers can shrink the vectorised rollout (vector_num_envs, vector_batch_size, vector_num_workers). We normalise these inputs, round the per-worker batch once, and log the final config (packages/cogames/src/cogames/train.py#L31, packages/cogames/src/cogames/train.py#L76). This lets CI use far lighter settings without
  hitting PufferLib’s guards or overloading runners.
  - Updated the integration tests to pass leaner values (32 envs, batch/minibatch 128, single worker) and to fan out vector observations deterministically using NumPy, keeping inference validations intact while dramatically cutting RAM/CPU demand (packages/cogames/tests/test_train_integration.py#L43, packages/cogames/tests/test_train_integration.py#L120).
  - The ZeroDivisionError came from PuffeRL’s annealing step computing self.epoch / self.total_epochs after total_epochs had been floored to zero when total_timesteps < batch_size. Our wrapper now bumps total_timesteps up to at least the adjusted batch_size, so total_epochs is never zero (packages/cogames/src/cogames/train.py#L156).
  - Added optional keyword overrides for the vecenv (num envs, batch size, workers) and use them in the integration tests to run the smallest PufferLib-compliant configuration: one env, one worker, PPO batch/minibatch 4. This keeps memory pressure low while still satisfying the divisibility rules (packages/cogames/src/cogames/train.py#L31, packages/cogames/tests/
  test_train_integration.py#L43).
  - Tweaked test observation handling to iterate cleanly over per-agent arrays via NumPy so inference checks match the vectorised rollout format (packages/cogames/tests/test_train_integration.py#L120).
  - Tests run: uv run pytest packages/cogames/tests/test_train_integration.py -vv

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211516758282943)