### PR TITLE
Fix pufferlib-core release wheels

### DIFF
--- a/.github/workflows/release-pufferlib-core.yml
+++ b/.github/workflows/release-pufferlib-core.yml
@@ -29,8 +29,8 @@ permissions:
   deployments: write
 
 jobs:
-  build:
-    name: Build distributions
+  build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,19 +41,47 @@ jobs:
         with:
           python-version: "3.11.7"
       - name: Install build tooling
-        run: python -m pip install --upgrade pip build twine
-      - name: Build distributions
-        run: python -m build --outdir dist packages/pufferlib-core
-      - name: Check distributions
-        run: python -m twine check dist/*
+        run: python -m pip install --upgrade pip build
+      - name: Build sdist
+        run: python -m build --sdist --outdir dist packages/pufferlib-core
       - uses: actions/upload-artifact@v4
         with:
-          name: pufferlib-core-dist
-          path: dist/*
+          name: pufferlib-core-sdist
+          path: dist/*.tar.gz
+
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.7"
+      - name: Install cibuildwheel
+        run: python -m pip install --upgrade pip cibuildwheel
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse packages/pufferlib-core
+        env:
+          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_SKIP: "*-musllinux* *-win32 *-win_amd64 *-manylinux_ppc64le *-manylinux_s390x"
+          CIBW_TEST_SKIP: "*"
+          CIBW_ARCHS_MACOS: "arm64"
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+          CI: "true"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pufferlib-core-wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
 
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build-sdist, build-wheels]
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'yes' }}
     runs-on: ubuntu-latest
     environment:
@@ -65,10 +93,17 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: pufferlib-core-dist
           path: dist
+          merge-multiple: true
       - name: List distributions
         run: ls -l dist
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.7"
+      - name: Install Twine
+        run: python -m pip install --upgrade pip twine
+      - name: Check distributions
+        run: python -m twine check dist/*
       - name: Create deployment record
         id: create_deployment
         uses: actions/github-script@v7

--- a/.github/workflows/release-pufferlib-core.yml
+++ b/.github/workflows/release-pufferlib-core.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse packages/pufferlib-core
         env:
-          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_BUILD: "cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp311-macosx_arm64 cp312-macosx_arm64"
           CIBW_SKIP: "*-musllinux* *-win32 *-win_amd64 *-manylinux_ppc64le *-manylinux_s390x"
           CIBW_TEST_SKIP: "*"
           CIBW_ARCHS_MACOS: "arm64"


### PR DESCRIPTION
## Summary
- build manylinux-friendly wheels with cibuildwheel so PyPI accepts the artifacts
- split the workflow into dedicated sdist + wheel jobs and keep publishing logic intact
- restrict mac builds to arm64 to avoid cross-compilation failures

## Testing
- not run (workflow change only)
