### PR TITLE
Allow resource group limits

### DIFF
--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -209,7 +209,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
                 configured_resources.add(key)
             elif isinstance(key, tuple):
                 # Grouped resources with shared limit
-                resource_ids = [resource_name_to_id[name] for name in key if name in resource_name_to_id]
+                resource_ids = [resource_name_to_id[name] for name in key]
                 if resource_ids:
                     limits_list.append([resource_ids, limit_value])
                     configured_resources.update(key)

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -205,9 +205,8 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
         for key, limit_value in agent_props["resource_limits"].items():
             if isinstance(key, str):
                 # Single resource limit
-                if key in resource_name_to_id:
-                    limits_list.append([[resource_name_to_id[key]], limit_value])
-                    configured_resources.add(key)
+                limits_list.append([[resource_name_to_id[key]], limit_value])
+                configured_resources.add(key)
             elif isinstance(key, tuple):
                 # Grouped resources with shared limit
                 resource_ids = [resource_name_to_id[name] for name in key if name in resource_name_to_id]

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -197,15 +197,30 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             if resource_name in resource_name_to_id
         ]
 
-        inventory_config = CppInventoryConfig(
-            limits=[
-                [
-                    [resource_name_to_id[resource_name]],
-                    agent_props["resource_limits"].get(resource_name, default_resource_limit),
-                ]
-                for resource_name in resource_names
-            ]
-        )
+        # Build inventory config with support for grouped limits
+        limits_list = []
+
+        # First, handle explicitly configured limits (both individual and grouped)
+        configured_resources = set()
+        for key, limit_value in agent_props["resource_limits"].items():
+            if isinstance(key, str):
+                # Single resource limit
+                if key in resource_name_to_id:
+                    limits_list.append([[resource_name_to_id[key]], limit_value])
+                    configured_resources.add(key)
+            elif isinstance(key, tuple):
+                # Grouped resources with shared limit
+                resource_ids = [resource_name_to_id[name] for name in key if name in resource_name_to_id]
+                if resource_ids:
+                    limits_list.append([resource_ids, limit_value])
+                    configured_resources.update(key)
+
+        # Add default limits for unconfigured resources
+        for resource_name in resource_names:
+            if resource_name not in configured_resources:
+                limits_list.append([[resource_name_to_id[resource_name]], default_resource_limit])
+
+        inventory_config = CppInventoryConfig(limits=limits_list)
 
         agent_cpp_params = {
             "freeze_duration": agent_props["freeze_duration"],

--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_config.py
@@ -50,7 +50,10 @@ class AgentConfig(Config):
     """Python agent configuration."""
 
     default_resource_limit: int = Field(default=255, ge=0)
-    resource_limits: dict[str, int] = Field(default_factory=dict)
+    resource_limits: dict[str | tuple[str, ...], int] = Field(
+        default_factory=dict,
+        description="Resource limits - keys can be single resource names or tuples of names for shared limits",
+    )
     freeze_duration: int = Field(default=10, ge=-1)
     rewards: AgentRewards = Field(default_factory=AgentRewards)
     action_failure_penalty: float = Field(default=0, ge=0)


### PR DESCRIPTION
We previously built a way to have resource group limits, but didn't push the configuration out so it could be used. This PR does that.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211518998077774)