### PR TITLE
Cleans up mettagrid_c_config

### DIFF
--- a/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
+++ b/packages/mettagrid/python/src/mettagrid/config/mettagrid_c_config.py
@@ -181,20 +181,16 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
         team_names = {0: "red", 1: "blue", 2: "green", 3: "yellow", 4: "purple", 5: "orange"}
         group_name = team_names.get(team_id, f"team_{team_id}")
         # Convert tag names to IDs for first agent in team
-        tag_ids = [tag_name_to_id[tag] for tag in first_agent.tags if tag in tag_name_to_id]
+        tag_ids = [tag_name_to_id[tag] for tag in first_agent.tags]
 
         # Convert soul bound resources from names to IDs
         soul_bound_resources = [
-            resource_name_to_id[resource_name]
-            for resource_name in agent_props.get("soul_bound_resources", [])
-            if resource_name in resource_name_to_id
+            resource_name_to_id[resource_name] for resource_name in agent_props.get("soul_bound_resources", [])
         ]
 
         # Convert shareable resources from names to IDs
         shareable_resources = [
-            resource_name_to_id[resource_name]
-            for resource_name in agent_props.get("shareable_resources", [])
-            if resource_name in resource_name_to_id
+            resource_name_to_id[resource_name] for resource_name in agent_props.get("shareable_resources", [])
         ]
 
         # Build inventory config with support for grouped limits
@@ -252,21 +248,13 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
     for object_type, object_config in game_config.objects.items():
         if isinstance(object_config, ConverterConfig):
             # Convert tag names to IDs
-            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags if tag in tag_name_to_id]
+            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags]
 
             cpp_converter_config = CppConverterConfig(
                 type_id=object_config.type_id,
                 type_name=object_type,
-                input_resources={
-                    resource_name_to_id[k]: v
-                    for k, v in object_config.input_resources.items()
-                    if v > 0 and k in resource_name_to_id
-                },
-                output_resources={
-                    resource_name_to_id[k]: v
-                    for k, v in object_config.output_resources.items()
-                    if v > 0 and k in resource_name_to_id
-                },
+                input_resources={resource_name_to_id[k]: v for k, v in object_config.input_resources.items()},
+                output_resources={resource_name_to_id[k]: v for k, v in object_config.output_resources.items()},
                 max_output=object_config.max_output,
                 max_conversions=object_config.max_conversions,
                 conversion_ticks=object_config.conversion_ticks,
@@ -279,7 +267,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             objects_cpp_params[object_type] = cpp_converter_config
         elif isinstance(object_config, WallConfig):
             # Convert tag names to IDs
-            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags if tag in tag_name_to_id]
+            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags]
 
             cpp_wall_config = CppWallConfig(
                 type_id=object_config.type_id,
@@ -299,16 +287,8 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
 
                 # Create C++ recipe
                 cpp_recipe = CppRecipe(
-                    input_resources={
-                        resource_name_to_id[k]: v
-                        for k, v in recipe_config.input_resources.items()
-                        if v > 0 and k in resource_name_to_id
-                    },
-                    output_resources={
-                        resource_name_to_id[k]: v
-                        for k, v in recipe_config.output_resources.items()
-                        if v > 0 and k in resource_name_to_id
-                    },
+                    input_resources={resource_name_to_id[k]: v for k, v in recipe_config.input_resources.items()},
+                    output_resources={resource_name_to_id[k]: v for k, v in recipe_config.output_resources.items()},
                     cooldown=recipe_config.cooldown,
                 )
 
@@ -322,7 +302,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
                 cpp_recipes[byte_pattern] = recipe
 
             # Convert tag names to IDs
-            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags if tag in tag_name_to_id]
+            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags]
 
             cpp_assembler_config = CppAssemblerConfig(
                 type_id=object_config.type_id, type_name=object_type, tag_ids=tag_ids
@@ -338,7 +318,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
             resource_type_id = resource_name_to_id.get(object_config.resource_type, 0)
 
             # Convert tag names to IDs
-            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags if tag in tag_name_to_id]
+            tag_ids = [tag_name_to_id[tag] for tag in object_config.tags]
 
             cpp_chest_config = CppChestConfig(
                 type_id=object_config.type_id,
@@ -389,19 +369,13 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
                 f"Either add these resources to resource_names or disable the action."
             )
 
-        consumed_resources = {
-            resource_name_to_id[k]: float(v)
-            for k, v in action_config["consumed_resources"].items()
-            if k in resource_name_to_id
-        }
+        consumed_resources = {resource_name_to_id[k]: float(v) for k, v in action_config["consumed_resources"].items()}
 
         required_source = action_config.get("required_resources")
         if not required_source:
             required_source = {k: math.ceil(v) for k, v in action_config["consumed_resources"].items()}
 
-        required_resources = {
-            resource_name_to_id[k]: int(math.ceil(v)) for k, v in required_source.items() if k in resource_name_to_id
-        }
+        required_resources = {resource_name_to_id[k]: int(math.ceil(v)) for k, v in required_source.items()}
 
         action_cpp_params = {
             "consumed_resources": consumed_resources,
@@ -410,9 +384,7 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
 
         if action_name == "attack":
             action_cpp_params["defense_resources"] = {
-                resource_name_to_id[k]: v
-                for k, v in action_config["defense_resources"].items()
-                if k in resource_name_to_id
+                resource_name_to_id[k]: v for k, v in action_config["defense_resources"].items()
             }
             actions_cpp_params[action_name] = CppAttackActionConfig(**action_cpp_params)
         elif action_name == "change_glyph":
@@ -447,16 +419,8 @@ def convert_to_cpp_game_config(mettagrid_config: dict | GameConfig):
     if game_config.clipper is not None:
         clipper: ClipperConfig = game_config.clipper
         clipper_recipe = CppRecipe(
-            input_resources={
-                resource_name_to_id[k]: v
-                for k, v in clipper.recipe.input_resources.items()
-                if v > 0 and k in resource_name_to_id
-            },
-            output_resources={
-                resource_name_to_id[k]: v
-                for k, v in clipper.recipe.output_resources.items()
-                if v > 0 and k in resource_name_to_id
-            },
+            input_resources={resource_name_to_id[k]: v for k, v in clipper.recipe.input_resources.items()},
+            output_resources={resource_name_to_id[k]: v for k, v in clipper.recipe.output_resources.items()},
             cooldown=clipper.recipe.cooldown,
         )
         game_cpp_params["clipper"] = CppClipperConfig(


### PR DESCRIPTION
The main thing this does is remove a number of guards we don't want, where we silently filter resources that don't exist in the current environment. Instead, we want to fail.

This also remove checks to filter out when values are non-positive. Mostly, this removes zero-valued entries. It's at least sort of good to remove zero-valued entries; but we shouldn't be having zero-valued entries, so the filtering code feels like sort of low-valued noise.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211526503869765)