### PR TITLE
fix: bundle Nim bindings with mettagrid

### DIFF
--- a/packages/mettagrid/MANIFEST.in
+++ b/packages/mettagrid/MANIFEST.in
@@ -9,4 +9,5 @@ recursive-include cpp *.cpp *.hpp *.bazel BUILD
 recursive-include benchmarks *.cpp *.py BUILD
 recursive-include tests *.cpp *.py BUILD
 recursive-include lint *.sh *.bzl BUILD
+recursive-include nim *.nim *.nims *.cfg *.txt *.yaml *.json *.png *.ttf *.html *.js *.css *.svg *.ico *.wasm *.md *.so *.dylib *.dll
 

--- a/packages/mettagrid/MANIFEST.in
+++ b/packages/mettagrid/MANIFEST.in
@@ -9,5 +9,7 @@ recursive-include cpp *.cpp *.hpp *.bazel BUILD
 recursive-include benchmarks *.cpp *.py BUILD
 recursive-include tests *.cpp *.py BUILD
 recursive-include lint *.sh *.bzl BUILD
-recursive-include nim *.nim *.nims *.cfg *.txt *.yaml *.json *.png *.ttf *.html *.js *.css *.svg *.ico *.wasm *.md *.so *.dylib *.dll
-
+graft nim/mettascope
+prune nim/mettascope/nimbledeps
+prune nim/mettascope/dist
+prune nim/mettascope/build

--- a/packages/mettagrid/bazel_build.py
+++ b/packages/mettagrid/bazel_build.py
@@ -27,6 +27,8 @@ from setuptools.dist import Distribution
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 METTASCOPE_DIR = PROJECT_ROOT / "nim" / "mettascope"
+PYTHON_PACKAGE_DIR = PROJECT_ROOT / "python" / "src" / "mettagrid"
+METTASCOPE_PACKAGE_DIR = PYTHON_PACKAGE_DIR / "nim" / "mettascope"
 
 
 def _run_bazel_build() -> None:
@@ -159,11 +161,29 @@ def _nim_artifacts_up_to_date() -> bool:
     return oldest_output_mtime >= latest_source_mtime
 
 
+def _sync_mettascope_package_data() -> None:
+    """Ensure Nim artifacts are vendored inside the Python package."""
+
+    destination_root = METTASCOPE_PACKAGE_DIR
+    destination_root.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination_root.exists():
+        shutil.rmtree(destination_root)
+
+    shutil.copytree(
+        METTASCOPE_DIR,
+        destination_root,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "nimbledeps", "dist", "build"),
+    )
+
+
 def _run_mettascope_build() -> None:
     """Build Nim artifacts when cache misses."""
 
     if _nim_artifacts_up_to_date():
         print("Skipping Nim build; artifacts up to date.")
+        _sync_mettascope_package_data()
         return
 
     # Check if nim and nimble are available
@@ -189,6 +209,7 @@ def _run_mettascope_build() -> None:
             print(f"Mettascope build {cmd} STDOUT:", file=sys.stderr)
             raise RuntimeError("Mettascope build failed")
     print("Successfully built mettascope")
+    _sync_mettascope_package_data()
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):

--- a/packages/mettagrid/pyproject.toml
+++ b/packages/mettagrid/pyproject.toml
@@ -65,7 +65,7 @@ where = ["python/src", "cpp/src"]
 include = ["mettagrid", "mettagrid.*"]
 
 [tool.setuptools.package-data]
-"mettagrid" = ["py.typed", "*.so", "*.pyi", "*.pyd", "*.dylib"]
+"mettagrid" = ["py.typed", "*.so", "*.pyi", "*.pyd", "*.dylib", "nim/mettascope/**/*"]
 
 [tool.uv.sources]
 metta-common = { workspace = true }

--- a/packages/mettagrid/python/src/mettagrid/mettascope.py
+++ b/packages/mettagrid/python/src/mettagrid/mettascope.py
@@ -14,8 +14,9 @@ from typing import TYPE_CHECKING
 
 # Find the nim/mettascope/bindings/generated directory
 # This is relative to the mettagrid package root
-package_root = Path(__file__).parent.parent.parent.parent  # Up to packages/mettagrid
-nim_bindings_path = package_root / "nim" / "mettascope" / "bindings" / "generated"
+package_root = Path(__file__).resolve().parent
+nim_root = package_root / "nim" / "mettascope"
+nim_bindings_path = nim_root / "bindings" / "generated"
 
 # Type stubs for static analysis
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ else:
 
             # Re-export the functions and classes
             def init(replay):
-                return mettascope2.init(data_dir=str(package_root / "nim" / "mettascope" / "data"), replay=replay)
+                return mettascope2.init(data_dir=str(nim_root / "data"), replay=replay)
 
             render = mettascope2.render
             Mettascope2Error = mettascope2.Mettascope2Error

--- a/packages/mettagrid/python/src/mettagrid/nim/__init__.py
+++ b/packages/mettagrid/python/src/mettagrid/nim/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored Nim artifacts for mettascope runtime support."""


### PR DESCRIPTION
## Summary
- copy the generated Nim bindings and assets into the Python package during the Bazel build, so wheels ship with mettascope
- declare the vendored Nim tree as package data and adjust MANIFEST to include it in sdists
- load mettascope bindings relative to the installed package instead of looking outside the wheel

## Testing
- uv build packages/mettagrid
- python -c "import zipfile;print([n for n in zipfile.ZipFile('dist/mettagrid-0.2.0.15.post1.dev4+gefac8e7ea-cp311-cp311-macosx_26_0_arm64.whl').namelist() if n.startswith('mettagrid/nim/mettascope/bindings')][:5])"
- on EC2: pip install --force-reinstall --no-deps ./mettagrid-0.2.0.15.post1.dev4+gefac8e7ea-cp312-cp312-manylinux_2_34_x86_64.whl && python -c "import mettagrid.mettascope as ms;print(hasattr(ms,'init'))"],

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211528879219499)