### PR TITLE
Fix mettascope path resolution to locate nim bindings correctly

### DIFF
--- a/packages/mettagrid/python/src/mettagrid/mettascope.py
+++ b/packages/mettagrid/python/src/mettagrid/mettascope.py
@@ -13,9 +13,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 # Find the nim/mettascope/bindings/generated directory
-# This is relative to the mettagrid package root
+# This is in the nim package, not the python package
 package_root = Path(__file__).resolve().parent
-nim_root = package_root / "nim" / "mettascope"
+# Navigate up to the packages directory and then into the nim package
+packages_dir = package_root.parent.parent.parent.parent
+nim_root = packages_dir / "mettagrid" / "nim" / "mettascope"
 nim_bindings_path = nim_root / "bindings" / "generated"
 
 # Type stubs for static analysis


### PR DESCRIPTION
### TL;DR

Fixed the path resolution for nim bindings in [mettascope.py](http://mettascope.py)

### What changed?

Updated the path resolution logic in [mettascope.py](http://mettascope.py) to correctly locate the nim bindings. Instead of looking for the nim directory within the python package, the code now navigates up to the packages directory and then into the mettagrid/nim/mettascope path.

### How to test?

1. Import the mettagrid package in a Python environment
2. Verify that the mettascope module loads correctly without path resolution errors
3. Check that the nim bindings are properly located and loaded

### Why make this change?

The previous implementation incorrectly assumed that the nim directory was located within the python package. This fix properly navigates to the actual location of the nim bindings in the project structure, ensuring that the Python code can correctly find and load the necessary nim components.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211529522598014)