### PR TITLE
Add initial protocols

### DIFF
--- a/packages/cogames/src/cogames/cogs_vs_clips/protocols.py
+++ b/packages/cogames/src/cogames/cogs_vs_clips/protocols.py
@@ -28,13 +28,13 @@ def standard_charging_recipe() -> RecipeConfig:
 # Carbon takes time.
 def standard_carbon_recipe() -> RecipeConfig:
     return RecipeConfig(
-        output_resources={"carbon": 5},
+        output_resources={"carbon": 4},
     )
 
 
 def low_carbon_recipe() -> RecipeConfig:
     return RecipeConfig(
-        output_resources={"carbon": 2},
+        output_resources={"carbon": 1},
     )
 
 

--- a/packages/cogames/src/cogames/cogs_vs_clips/protocols.py
+++ b/packages/cogames/src/cogames/cogs_vs_clips/protocols.py
@@ -1,0 +1,81 @@
+from mettagrid.config.mettagrid_config import RecipeConfig
+
+
+def standard_heart_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        input_resources={"carbon": 20, "oxygen": 20, "germanium": 5, "silicon": 50, "energy": 20},
+        output_resources={"heart": 1},
+        cooldown=1,
+    )
+
+
+# We might want this to just make more hearts, but agent inventory is limited, so cheaper is better.
+def low_germanium_heart_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        input_resources={"carbon": 20, "oxygen": 20, "germanium": 3, "silicon": 50, "energy": 20},
+        output_resources={"heart": 1},
+        cooldown=1,
+    )
+
+
+def standard_charging_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"energy": 50},
+        cooldown=10,
+    )
+
+
+# Carbon takes time.
+def standard_carbon_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"carbon": 5},
+    )
+
+
+def low_carbon_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"carbon": 2},
+    )
+
+
+# Oxygen refreshes somewhat slowly and takes space.
+def standard_oxygen_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"oxygen": 100},
+        cooldown=200,
+    )
+
+
+def low_oxygen_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"oxygen": 10},
+        cooldown=40,
+    )
+
+
+# Silicon is plentiful but requires energy / work and need a lot.
+def standard_silicon_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        input_resources={"energy": 25},
+        output_resources={"silicon": 25},
+    )
+
+
+def low_silicon_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        input_resources={"energy": 25},
+        output_resources={"silicon": 10},
+    )
+
+
+# Germanium is rare and exhausts / regenerates slowly.
+def standard_germanium_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"germanium": 1},
+    )
+
+
+def low_germanium_recipe() -> RecipeConfig:
+    return RecipeConfig(
+        output_resources={"germanium": 1},
+    )

--- a/packages/cogames/src/cogames/cogs_vs_clips/stations.py
+++ b/packages/cogames/src/cogames/cogs_vs_clips/stations.py
@@ -109,7 +109,7 @@ def carbon_ex_dep() -> AssemblerConfig:
         type_id=19,
         map_char="K",
         render_symbol="⬛",
-        max_uses=50,
+        max_uses=100,
         recipes=[
             (["Any"], protocols.low_carbon_recipe()),
         ],
@@ -122,6 +122,7 @@ def oxygen_ex_dep() -> AssemblerConfig:
         type_id=18,
         map_char="Q",
         render_symbol="⬜",
+        max_uses=10,
         allow_partial_usage=True,
         recipes=[
             (["Any"], protocols.low_oxygen_recipe()),
@@ -148,6 +149,7 @@ def silicon_ex_dep() -> AssemblerConfig:
         type_id=16,
         map_char="V",
         render_symbol="🔹",
+        max_uses=10,
         recipes=[
             (
                 ["Any"],

--- a/packages/cogames/src/cogames/cogs_vs_clips/stations.py
+++ b/packages/cogames/src/cogames/cogs_vs_clips/stations.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from mettagrid.config.mettagrid_config import AssemblerConfig, ChestConfig, RecipeConfig
+from cogames.cogs_vs_clips import protocols
+from mettagrid.config.mettagrid_config import AssemblerConfig, ChestConfig
 
 resources = [
     "energy",
@@ -22,14 +23,12 @@ def charger(max_uses: Optional[int] = None) -> AssemblerConfig:
         type_id=5,
         map_char="H",
         render_symbol="⚡",
+        allow_partial_usage=True,  # can use it while its on cooldown
         max_uses=max_uses or 0,
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    output_resources={"energy": 50},
-                    cooldown=1,
-                ),
+                protocols.standard_charging_recipe(),
             )
         ],
     )
@@ -46,9 +45,7 @@ def carbon_extractor(max_uses: Optional[int] = None) -> AssemblerConfig:
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    output_resources={"carbon": 5},
-                ),
+                protocols.standard_carbon_recipe(),
             )
         ],
     )
@@ -66,10 +63,7 @@ def oxygen_extractor(max_uses: Optional[int] = None) -> AssemblerConfig:
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    output_resources={"oxygen": 100},
-                    cooldown=100,
-                ),
+                protocols.standard_oxygen_recipe(),
             )
         ],
     )
@@ -86,10 +80,7 @@ def germanium_extractor(max_uses: Optional[int] = None) -> AssemblerConfig:
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    output_resources={"germanium": 1},
-                    cooldown=250,
-                ),
+                protocols.standard_germanium_recipe(),
             )
         ],
     )
@@ -106,11 +97,7 @@ def silicon_extractor(max_uses: Optional[int] = None) -> AssemblerConfig:
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    input_resources={"energy": 25},
-                    output_resources={"silicon": 25},
-                    cooldown=1,
-                ),
+                protocols.standard_silicon_recipe(),
             )
         ],
     )
@@ -124,7 +111,7 @@ def carbon_ex_dep() -> AssemblerConfig:
         render_symbol="⬛",
         max_uses=50,
         recipes=[
-            (["Any"], RecipeConfig(output_resources={"carbon": 1}, cooldown=1)),
+            (["Any"], protocols.low_carbon_recipe()),
         ],
     )
 
@@ -135,10 +122,9 @@ def oxygen_ex_dep() -> AssemblerConfig:
         type_id=18,
         map_char="Q",
         render_symbol="⬜",
-        max_uses=5,
         allow_partial_usage=True,
         recipes=[
-            (["Any"], RecipeConfig(output_resources={"oxygen": 20}, cooldown=20)),
+            (["Any"], protocols.low_oxygen_recipe()),
         ],
     )
 
@@ -149,9 +135,9 @@ def germanium_ex_dep() -> AssemblerConfig:
         type_id=20,
         map_char="Y",
         render_symbol="🟪",
-        max_uses=5,
+        max_uses=10,
         recipes=[
-            (["Any"], RecipeConfig(output_resources={"germanium": 1}, cooldown=1)),
+            (["Any"], protocols.low_germanium_recipe()),
         ],
     )
 
@@ -162,15 +148,10 @@ def silicon_ex_dep() -> AssemblerConfig:
         type_id=16,
         map_char="V",
         render_symbol="🔹",
-        max_uses=5,
         recipes=[
             (
                 ["Any"],
-                RecipeConfig(
-                    input_resources={"energy": 25},
-                    output_resources={"silicon": 10},
-                    cooldown=1,
-                ),
+                protocols.low_silicon_recipe(),
             )
         ],
     )
@@ -244,36 +225,44 @@ def assembler() -> AssemblerConfig:
         render_symbol="🔄",
         recipes=[
             (
-                ["E"],
-                RecipeConfig(
-                    input_resources={"energy": 3},
-                    output_resources={"heart": 1},
-                    cooldown=1,
-                ),
+                ["Any"],
+                protocols.standard_heart_recipe(),
             ),
             (
-                ["N"],
-                RecipeConfig(
-                    input_resources={"germanium": 1},
-                    output_resources={"decoder": 1},
-                    cooldown=1,
-                ),
+                ["Any", "Any"],
+                protocols.low_germanium_heart_recipe(),
             ),
-            (
-                ["S"],
-                RecipeConfig(
-                    input_resources={"carbon": 3},
-                    output_resources={"modulator": 1},
-                    cooldown=1,
-                ),
-            ),
-            (
-                ["W"],
-                RecipeConfig(
-                    input_resources={"oxygen": 3},
-                    output_resources={"scrambler": 1},
-                    cooldown=1,
-                ),
-            ),
+            # (
+            #     ["E"],
+            #     RecipeConfig(
+            #         input_resources={"energy": 3},
+            #         output_resources={"heart": 1},
+            #         cooldown=1,
+            #     ),
+            # ),
+            # (
+            #     ["N"],
+            #     RecipeConfig(
+            #         input_resources={"germanium": 1},
+            #         output_resources={"decoder": 1},
+            #         cooldown=1,
+            #     ),
+            # ),
+            # (
+            #     ["S"],
+            #     RecipeConfig(
+            #         input_resources={"carbon": 3},
+            #         output_resources={"modulator": 1},
+            #         cooldown=1,
+            #     ),
+            # ),
+            # (
+            #     ["W"],
+            #     RecipeConfig(
+            #         input_resources={"oxygen": 3},
+            #         output_resources={"scrambler": 1},
+            #         cooldown=1,
+            #     ),
+            # ),
         ],
     )


### PR DESCRIPTION
Creates a protocol file and balances the depleted resources.

Tested this on training_facility_1 and it felt about right:

- To get oxygen, I needed to collect once, and then drop by again later to collect again.
- To get carbon, I needed to just sit there and farm.
- To get silicon, I needed to make trips between the extractor and the recharger.
- To get germanium, I just needed to pick it up. But it was the thing that ran out.

If I just used one agent, I could farm 2 hearts. If I used 2, I could farm 3 hearts.

Other thoughts:

- It's annoying that other agents being around extractors means I can't use them.
- It's annoying that I can't see the recipes on the assembler / extractors.
- The balance of germanium feels sort of off. On the one hand, I like the idea of "you use one germanium". On the other, I want to have it so two cogs cooperating can get more hearts; and that means they need to pay less germanium per heart.
- I think what I want for germanium is to have recipes that exhaust. But you have different recipes for different numbers of agents. So basically, you can search and find a germanium extractor, and get one germanium. And then you can bring a friend and get a second germanium. Or something like that.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211530079792502)