### PR TITLE
[MettaScope] agent pathing fixes and destination bumping

### DIFF
--- a/packages/mettagrid/nim/mettascope/bindings/bindings.nim
+++ b/packages/mettagrid/nim/mettascope/bindings/bindings.nim
@@ -54,6 +54,7 @@ proc render(currentStep: int, replayStep: string): RenderResponse =
         return
       mainLoop()
       if requestPython:
+        onRequestPython()
         for action in requestActions:
           result.actions.add(ActionRequest(
             agentId: action.agentId,

--- a/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
@@ -54,29 +54,56 @@ proc processActions*() =
   if not (play or requestPython):
     return
   
-  for agentId, path in agentPaths:
+  var agentIds: seq[int] = @[]
+  for agentId in agentPaths.keys:
+    agentIds.add(agentId)
+  
+  for agentId in agentIds:
+    if not agentPaths.hasKey(agentId) and not (agentDestinations.hasKey(agentId) and agentDestinations[agentId].len > 0):
+      continue
+    
+    let agent = getAgentById(agentId)
+    let currentPos = agent.location.at(step).xy
+    
+    if agentDestinations.hasKey(agentId) and agentDestinations[agentId].len > 0:
+      let dest = agentDestinations[agentId][0]
+
+      # If this is a 'bump' destination and we are adjacent to it, bump it once.
+      if dest.destinationType == Bump and currentPos in findAdjacentWalkable(dest.pos):
+        # TODO: Chests have special behavior.
+        #   You must deposit on the right side and take out on the left side.
+        #   This is not implemented yet.
+        let dx = dest.pos.x - currentPos.x
+        let dy = dest.pos.y - currentPos.y
+        let targetOrientation = getOrientationFromDelta(dx.int, dy.int)
+        queueAction(agentId, replay.moveActionId, targetOrientation.int)
+        # after bumping, the current destination is fulfilled.
+        agentDestinations[agentId].delete(0)
+        agentPaths.del(agentId)
+        # if there's another destination, pathfind to it.
+        if agentDestinations[agentId].len > 0:
+          recomputePath(agentId, currentPos)
+        continue
+    
+    if not agentPaths.hasKey(agentId):
+      continue
+    let path = agentPaths[agentId]
+    
     if path.len > 1:
-      var agent: Entity = nil
-      for obj in replay.objects:
-        if obj.isAgent and obj.agentId == agentId:
-          agent = obj
-          break
-      
-      if agent != nil:
-        let currentPos = agent.location.at(step).xy
-        
-        if path[0] == currentPos:
-          if path.len > 1:
-            let nextPos = path[1]
-            let dx = nextPos.x - currentPos.x
-            let dy = nextPos.y - currentPos.y
-            let orientation = getOrientationFromDelta(dx.int, dy.int)
-            queueAction(agentId, replay.moveActionId, orientation.int)
-            agentPaths[agentId].delete(0)
-          else:
-            recomputePath(agentId, currentPos)
+      # If we are still on the expected path, continue moving.
+      # otherwise, assume something is blocking the path and recompute.
+      if path[0] == currentPos:
+        if path.len > 1:
+          let nextPos = path[1]
+          let dx = nextPos.x - currentPos.x
+          let dy = nextPos.y - currentPos.y
+          let orientation = getOrientationFromDelta(dx.int, dy.int)
+          queueAction(agentId, replay.moveActionId, orientation.int)
+          agentPaths[agentId].delete(0)
         else:
           recomputePath(agentId, currentPos)
+      else:
+        recomputePath(agentId, currentPos)
   
   if actionQueue.len > 0:
     for agentId, action in actionQueue:

--- a/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
@@ -33,7 +33,7 @@ proc getOrientationFromDelta(dx, dy: int): Orientation =
     return N
 
 proc processActions*() =
-  ## Process pathfinding and send actions. Called on step change.
+  ## Process pathfinding and send actions for the current step while in play mode.
   if not (play or requestPython):
     return
   

--- a/packages/mettagrid/nim/mettascope/src/mettascope/common.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/common.nim
@@ -97,6 +97,14 @@ type
     agentId*: int
     actionId*: int
     argument*: int
+  
+  DestinationType* = enum
+    Move # Move to a specific position.
+    Bump # Bump an object at a specific position to interact with it.
+  
+  Destination* = object
+    pos*: IVec2
+    destinationType*: DestinationType
 
 var
   requestActions*: seq[ActionRequest]
@@ -109,7 +117,7 @@ var
   ## Path queue for each agent. Maps agentId to a sequence of grid positions.
   agentPaths* = initTable[int, seq[IVec2]]()
   ## Destination queue for each agent. Maps agentId to a sequence of destinations.
-  agentDestinations* = initTable[int, seq[IVec2]]()
+  agentDestinations* = initTable[int, seq[Destination]]()
 
 proc at*[T](sequence: seq[T], step: int): T =
   # Get the value at the given step.
@@ -143,3 +151,24 @@ proc logicalMousePos*(window: Window): Vec2 =
 
 proc logicalMouseDelta*(window: Window): Vec2 =
   window.mouseDelta.vec2 / window.contentScale
+
+proc getAgentById*(agentId: int): Entity =
+  ## Get an agent by ID. Asserts the agent exists.
+  for obj in replay.objects:
+    if obj.isAgent and obj.agentId == agentId:
+      return obj
+  raise newException(ValueError, "Agent with ID " & $agentId & " does not exist")
+
+proc getObjectById*(objectId: int): Entity =
+  ## Get an object by ID. Asserts the object exists.
+  for obj in replay.objects:
+    if obj.id == objectId:
+      return obj
+  raise newException(ValueError, "Object with ID " & $objectId & " does not exist")
+
+proc getObjectAtLocation*(pos: IVec2): Entity =
+  ## Get the first object at the given position. Returns nil if no object is there.
+  for obj in replay.objects:
+    if obj.location.at(step).xy == pos:
+      return obj
+  return nil

--- a/packages/mettagrid/nim/mettascope/src/mettascope/timeline.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/timeline.nim
@@ -26,9 +26,12 @@ var
   nodeScrubber: Node
 
 proc onStepChanged*() =
-  ## Must be called when the step changes so that UI is updated.
+  ## Called after the step changes so that UI is updated.
   echo "step: ", step
   updateObjectInfo()
+
+proc onRequestPython*() =
+  ## Called before requesting Python to process the next step.
   processActions()
 
 proc bindTimelineNodes() =


### PR DESCRIPTION
- Implement 2 destination types, pathing and bumping
  - containers are special and will probably need special logic in the future to make smarter? currently agents path to the nearest adjacent tile. but this doesn't work for containers that well because of the special directions.
- fix the '1 step delay' for pathing.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211539337318768)