### PR TITLE
hotfix: handle early termination error

### DIFF
--- a/devops/skypilot/config/monitors/cluster_stop_monitor.sh
+++ b/devops/skypilot/config/monitors/cluster_stop_monitor.sh
@@ -23,6 +23,11 @@ while true; do
     kill -TERM "${WRAPPER_PID}" 2> /dev/null || true
     break
   fi
+
+  if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting cluster stop monitor"
+    exit 0
+  fi
 done
 
 echo "[INFO] Cluster-stop monitor exiting"

--- a/devops/skypilot/config/monitors/cluster_stop_monitor.sh
+++ b/devops/skypilot/config/monitors/cluster_stop_monitor.sh
@@ -26,7 +26,7 @@ while true; do
 
   if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
     echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting cluster stop monitor"
-    exit 0
+    break
   fi
 done
 

--- a/devops/skypilot/config/monitors/heartbeat_monitor.sh
+++ b/devops/skypilot/config/monitors/heartbeat_monitor.sh
@@ -55,6 +55,11 @@ while true; do
     initiate_shutdown "heartbeat_timeout"
     break
   fi
+
+  if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
+    exit 0
+  fi
 done
 
 echo "[INFO] Heartbeat monitor exiting"

--- a/devops/skypilot/config/monitors/heartbeat_monitor.sh
+++ b/devops/skypilot/config/monitors/heartbeat_monitor.sh
@@ -57,8 +57,8 @@ while true; do
   fi
 
   if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
-    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
-    exit 0
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat monitor"
+    break
   fi
 done
 

--- a/devops/skypilot/config/monitors/test_job_restart_monitor.sh
+++ b/devops/skypilot/config/monitors/test_job_restart_monitor.sh
@@ -55,6 +55,11 @@ while true; do
     initiate_shutdown "force_restart_test"
     break
   fi
+
+  if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
+    exit 0
+  fi
 done
 
 echo "[INFO] Test Job Restart monitor exiting"

--- a/devops/skypilot/config/monitors/test_job_restart_monitor.sh
+++ b/devops/skypilot/config/monitors/test_job_restart_monitor.sh
@@ -57,8 +57,8 @@ while true; do
   fi
 
   if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
-    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
-    exit 0
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting test job restart monitor"
+    break
   fi
 done
 

--- a/devops/skypilot/config/monitors/timeout_monitor.sh
+++ b/devops/skypilot/config/monitors/timeout_monitor.sh
@@ -53,6 +53,11 @@ while true; do
     initiate_shutdown "max_runtime_reached"
     break
   fi
+
+  if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
+    exit 0
+  fi
 done
 
 echo "[INFO] Timeout monitor exiting"

--- a/devops/skypilot/config/monitors/timeout_monitor.sh
+++ b/devops/skypilot/config/monitors/timeout_monitor.sh
@@ -55,8 +55,8 @@ while true; do
   fi
 
   if ! kill -0 "$WRAPPER_PID" 2>/dev/null; then
-    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting heartbeat  monitor"
-    exit 0
+    echo "[INFO] Wrapper PID $WRAPPER_PID is no longer running, exiting timeout monitor"
+    break
   fi
 done
 


### PR DESCRIPTION
Recently, an OpenGL library issue on main caused training jobs to exit earlier than expected. Because the wrapper process terminated before the monitors could trigger shutdown, the heartbeat/timeout monitors were left running without a valid WRAPPER_PID. This led to clusters continuing to run and incur cost even though the training job itself had failed.

The crash happened because libGL.so.1 wasn’t present in the runtime. When training launched, a Nim/Python module tried dlopen("libGL.so.1") and failed very early. This meant:

- The wrapper started monitors.
- The training command (./devops/run.sh …) crashed immediately.
- WRAPPER_PID disappeared before monitors noticed.
- Heartbeat/timeout monitors kept running, orphaned.

This PR adds a short-term robustness patch to the Bash monitors. Specifically, the monitors now check whether the wrapper process is still alive and exit cleanly if it is not. This prevents “orphaned” monitors and reduces the risk of jobs being left in a billing state.

The long-term plan is to replace these Bash monitors with a Python implementation in #2384. Until then, this patch closes the gap and hardens the current system against similar failures.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211541679943424)