### PR TITLE
[MettaScope] handle ctrl-c from Nim DLL

### DIFF
--- a/packages/mettagrid/nim/mettascope/bindings/bindings.nim
+++ b/packages/mettagrid/nim/mettascope/bindings/bindings.nim
@@ -13,8 +13,17 @@ type
     shouldClose*: bool
     actions*: seq[ActionRequest]
 
+proc ctrlCHandler() {.noconv.} =
+  ## Handle ctrl-c signal to exit cleanly.
+  echo "\nNim DLL caught ctrl-c, exiting..."
+  if not window.isNil:
+    window.close()
+  quit(0)
+
+
 proc init(dataDir: string, replay: string): RenderResponse =
   try:
+    setControlCHook(ctrlCHandler)
     result = RenderResponse(shouldClose: false, actions: @[])
     #echo "Replay from python: ", replay
     echo "Data dir: ", dataDir


### PR DESCRIPTION
- my understanding is that the default python sigint handler has to run on the main thread, which gets blocked by the dll.
- Implement a Nim Ctrl-c handler to shut down the application, it doesn't have to care about python threads or locks or anything.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211547878234746)