### PR TITLE
[MettaScope] allow for repeat destinations

### DIFF
--- a/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/actions.nim
@@ -36,25 +36,25 @@ proc processActions*() =
   ## Process pathfinding and send actions for the current step while in play mode.
   if not (play or requestPython):
     return
-  
+
   var agentIds: seq[int] = @[]
   for agentId in agentPaths.keys:
     agentIds.add(agentId)
-  
+
   for agentId in agentIds:
     if not agentPaths.hasKey(agentId):
       continue
-    
+
     let agent = getAgentById(agentId)
     let currentPos = agent.location.at(step).xy
     let pathActions = agentPaths[agentId]
-    
+
     if pathActions.len == 0:
       agentPaths.del(agentId)
       continue
-    
+
     let nextAction = pathActions[0]
-    
+
     case nextAction.actionType
     of PathMove:
       # Execute movement action.
@@ -70,6 +70,10 @@ proc processActions*() =
         if dest.destinationType == Move and nextAction.pos == dest.pos:
           # Completed this Move destination.
           agentDestinations[agentId].delete(0)
+          if dest.repeat:
+            # Re-queue this destination at the end.
+            agentDestinations[agentId].add(dest)
+            recomputePath(agentId, nextAction.pos)
     of PathBump:
       # Execute bump action.
       let targetOrientation = getOrientationFromDelta(nextAction.bumpDir.x.int, nextAction.bumpDir.y.int)
@@ -78,13 +82,18 @@ proc processActions*() =
       agentPaths[agentId].delete(0)
       # Remove the corresponding destination.
       if agentDestinations.hasKey(agentId) and agentDestinations[agentId].len > 0:
+        let dest = agentDestinations[agentId][0]
         agentDestinations[agentId].delete(0)
+        if dest.repeat:
+          # Re-queue this destination at the end.
+          agentDestinations[agentId].add(dest)
+          recomputePath(agentId, currentPos)
 
 proc agentControls*() =
   ## Manual controls with WASD for selected agent.
   if selection != nil and selection.isAgent:
     let agent = selection
-    
+
     # Move
     if window.buttonPressed[KeyW] or window.buttonPressed[KeyUp]:
       sendAction(agent.agentId, replay.moveActionId, N.int)

--- a/packages/mettagrid/nim/mettascope/src/mettascope/common.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/common.nim
@@ -97,20 +97,21 @@ type
     agentId*: int
     actionId*: int
     argument*: int
-  
+
   DestinationType* = enum
     Move # Move to a specific position.
     Bump # Bump an object at a specific position to interact with it.
-  
+
   Destination* = object
     pos*: IVec2
     destinationType*: DestinationType
     approachDir*: IVec2 ## Direction to approach from for Bump actions (e.g., ivec2(-1, 0) means approach from the left).
-  
+    repeat*: bool ## If true, this destination will be re-queued at the end when completed.
+
   PathActionType* = enum
     PathMove # Move to a position.
     PathBump # Bump at current position.
-  
+
   PathAction* = object
     actionType*: PathActionType
     pos*: IVec2 ## Target position for PathMove, or bump target for PathBump.

--- a/packages/mettagrid/nim/mettascope/src/mettascope/worldmap.nim
+++ b/packages/mettagrid/nim/mettascope/src/mettascope/worldmap.nim
@@ -28,6 +28,7 @@ proc useSelections*(panel: Panel) =
     window.buttonDown[KeyLeftControl] or window.buttonDown[KeyRightControl]
 
   let shiftDown = window.buttonDown[KeyLeftShift] or window.buttonDown[KeyRightShift]
+  let rDown = window.buttonDown[KeyR]
 
   # Track mouse down position to distinguish clicks from drags.
   if window.buttonPressed[MouseLeft] and not modifierDown:
@@ -88,7 +89,7 @@ proc useSelections*(panel: Panel) =
               else:
                 approachDir = ivec2(0, -1)  # Clicked top, approach from top.
 
-        let destination = Destination(pos: gridPos, destinationType: destType, approachDir: approachDir)
+        let destination = Destination(pos: gridPos, destinationType: destType, approachDir: approachDir, repeat: rDown)
 
         if shiftDown:
           # Queue up additional destinations.


### PR DESCRIPTION
- holding down `r` while shift-clicking (or command-clicking) multiple destinations will set up those destinations to be repeated, allowing an agent to loop actions.

<img width="1579" height="1068" alt="Screenshot From 2025-10-03 16-27-56" src="https://github.com/user-attachments/assets/7bcd3fc8-b562-4704-a3f1-1a765638300a" />


[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211548897040001)