### PR TITLE
fix: rm `exec bash` from sandbox run scripts

### DIFF
--- a/devops/skypilot/config/sandbox.yaml
+++ b/devops/skypilot/config/sandbox.yaml
@@ -35,7 +35,7 @@ run: |
   fi
   . .venv/bin/activate
 
-  echo "[SETUP] Setting up Python environment..."
+  echo "Setting up Python environment..."
   uv sync
 
   bash ./devops/skypilot/config/lifecycle/configure_environment.sh
@@ -43,8 +43,7 @@ run: |
   METTA_ENV_FILE="$(uv run ./common/src/metta/common/util/constants.py METTA_ENV_FILE)"
   source "$METTA_ENV_FILE"
 
-  echo "Starting bash shell..."
-  exec bash
+  echo "Sandbox setup complete. Ready for SSH."
 
 envs:
   GITHUB_REPOSITORY: Metta-AI/metta

--- a/devops/skypilot/config/sandbox_cheap.yaml
+++ b/devops/skypilot/config/sandbox_cheap.yaml
@@ -1,7 +1,7 @@
 resources:
   cloud: aws
   region: us-east-1
-  instance_type: m6i.2xlarge  # 8 vCPUs, 32GB RAM (~$0.384/hour on-demand)
+  instance_type: m6i.2xlarge # 8 vCPUs, 32GB RAM (~$0.384/hour on-demand)
   cpus: 8+
   memory: 32+
   image_id: docker:metta:latest
@@ -40,7 +40,7 @@ run: |
   fi
   . .venv/bin/activate
 
-  echo "[SETUP] Setting up Python environment..."
+  echo "Setting up Python environment..."
   uv sync
 
   bash ./devops/skypilot/config/lifecycle/configure_environment.sh
@@ -48,8 +48,7 @@ run: |
   METTA_ENV_FILE="$(uv run ./common/src/metta/common/util/constants.py METTA_ENV_FILE)"
   source "$METTA_ENV_FILE"
 
-  echo "Starting bash shell..."
-  exec bash
+  echo "Sandbox setup complete. Ready for SSH."
 
 envs:
   GITHUB_REPOSITORY: Metta-AI/metta


### PR DESCRIPTION

This PR removes the trailing `exec bash` line from the `run:` block in both `sandbox.yaml` and `sandbox_cheap.yaml`.

### ✅ Why this change?

`exec bash` was added to these scripts about ~4 months ago but it does not seem to be needed and recently started **causing SSH sessions to hang without a prompt**.

We’re not entirely sure what changed — possibilities include:

* A SkyPilot update affecting container or TTY management
* A runtime behavior change in how the `run:` block is handled

Regardless, the container's PID 1 ends up being `bash`, which **hijacks the TTY** and blocks interactive login via `ssh`.

### 🔧 Fix

We now end the `run:` block cleanly with:

```bash
echo "Sandbox setup complete. Ready for SSH."
```

This allows:

* SkyPilot to mark the job as complete
* PID 1 to be released
* SSH to spawn a proper interactive login shell

### 🔒 Impact

No functionality loss. The sandbox cluster still:

* Runs all setup steps (venv, syncing, config scripts)
* Starts up fully
* Allows interactive SSH as expected
