### PR TITLE
Prevent assembler activation if it would not cause output

### DIFF
--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -84,6 +84,16 @@ private:
     }
   }
 
+  // Returns true if the recipe yields any positive output amount (legacy name retained for compatibility)
+  bool recipe_has_positive_output(const Recipe& recipe) const {
+    for (const auto& [item, amount] : recipe.output_resources) {
+      if (amount > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 public:
   // Consume resources from surrounding agents for the given recipe
   // Intended to be private, but made public for testing. We couldn't get `friend` to work as expected.
@@ -303,6 +313,9 @@ public:
 
     std::vector<Agent*> surrounding_agents = get_surrounding_agents();
     if (!can_afford_recipe(recipe_to_use, surrounding_agents)) {
+      return false;
+    }
+    if (!recipe_has_positive_output(recipe_to_use)) {
       return false;
     }
     consume_resources_for_recipe(recipe_to_use, surrounding_agents);

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -310,8 +310,8 @@ public:
     if (progress < 1.0f && allow_partial_usage) {
       recipe_to_use = scale_recipe_for_partial_usage(*original_recipe, progress);
 
-      // Prevent usage when partial usage would yield no output
-      if (!recipe_has_positive_output(recipe_to_use)) {
+      // Prevent usage that would yield no outputs only because of partial-usage rounding them down
+      if (!recipe_has_positive_output(recipe_to_use) && recipe_has_positive_output(*original_recipe)) {
         return false;
       }
     }

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -309,13 +309,13 @@ public:
     Recipe recipe_to_use = *original_recipe;
     if (progress < 1.0f && allow_partial_usage) {
       recipe_to_use = scale_recipe_for_partial_usage(*original_recipe, progress);
+      if (!recipe_has_positive_output(recipe_to_use)) {
+        return false;
+      }
     }
 
     std::vector<Agent*> surrounding_agents = get_surrounding_agents();
     if (!can_afford_recipe(recipe_to_use, surrounding_agents)) {
-      return false;
-    }
-    if (!recipe_has_positive_output(recipe_to_use)) {
       return false;
     }
     consume_resources_for_recipe(recipe_to_use, surrounding_agents);

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -309,6 +309,8 @@ public:
     Recipe recipe_to_use = *original_recipe;
     if (progress < 1.0f && allow_partial_usage) {
       recipe_to_use = scale_recipe_for_partial_usage(*original_recipe, progress);
+
+      // Prevent usage when partial usage would yield no output
       if (!recipe_has_positive_output(recipe_to_use)) {
         return false;
       }

--- a/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
+++ b/packages/mettagrid/cpp/include/mettagrid/objects/assembler.hpp
@@ -310,8 +310,11 @@ public:
     if (progress < 1.0f && allow_partial_usage) {
       recipe_to_use = scale_recipe_for_partial_usage(*original_recipe, progress);
 
-      // Prevent usage that would yield no outputs only because of partial-usage rounding them down
-      if (!recipe_has_positive_output(recipe_to_use) && recipe_has_positive_output(*original_recipe)) {
+      // Prevent usage that would yield no outputs (and would only serve to burn inputs and increment uses_count)
+      // Do not prevent usage if:
+      // - the unscaled recipe does not have outputs
+      // - usage would unclip the assembler; the unscaled unclipping recipe may happen to include outputs
+      if (!recipe_has_positive_output(recipe_to_use) && recipe_has_positive_output(*original_recipe) && !is_clipped) {
         return false;
       }
     }

--- a/packages/mettagrid/tests/test_assembler_partial_usage.py
+++ b/packages/mettagrid/tests/test_assembler_partial_usage.py
@@ -142,7 +142,7 @@ class TestAssemblerPartialUsage:
         grid_objects = env.grid_objects()
         agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
 
-        # At 10% progress:
+        # At 12% progress:
         # Input: 20 * 0.12 = 2.4, rounded up = 3
         # Output: 10 * 0.12 = 1.2, rounded down = 1
         iron_consumed_12 = iron_before - agent["inventory"][iron_idx]
@@ -153,4 +153,23 @@ class TestAssemblerPartialUsage:
         )
         assert steel_produced_12 == 1, (
             f"Should produce 1 steel at 12% progress (10*0.12 rounded down), produced {steel_produced_12}"
+        )
+
+        # Verify that assembler does not trigger when partial usage would yield no output
+        iron_before = agent["inventory"][iron_idx]
+        steel_before = agent["inventory"][steel_idx]
+        # At 1% progress:
+        # Input: 20 * 0.01 = 0.2, rounded up = 1
+        # Output: 10 * 0.01 = 0.1, rounded down = 0
+
+        actions = np.array([[move_idx, 3]], dtype=dtype_actions)
+        obs, rewards, terminals, truncations, info = env.step(actions)
+
+        grid_objects = env.grid_objects()
+        agent = next(obj for _obj_id, obj in grid_objects.items() if "agent_id" in obj)
+        iron_consumed_01 = iron_before - agent["inventory"][iron_idx]
+        steel_produced_01 = agent["inventory"][steel_idx] - steel_before
+
+        assert iron_consumed_01 == 0 and steel_produced_01 == 0, (
+            "Assembler should not activate when partial-usage output would be zero"
         )


### PR DESCRIPTION
Partial-use assemblers that produce outputs when not on-cooldown could produce no output if triggered early enough into their cooldown window.

This PR prevents usage that would yield no outputs (and would only serve to burn inputs and increment uses_count). It does not prevent usage if:
- the unscaled recipe does not have outputs
- usage would unclip the assembler; the unscaled unclipping recipe can technically include outputs

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211549338328854)