### PR TITLE
support cogames.cogs_vs_clips.scenarios.games in gridworks

### DIFF
--- a/gridworks/src/app/configs/view/[name]/ConfigViewScreen.tsx
+++ b/gridworks/src/app/configs/view/[name]/ConfigViewScreen.tsx
@@ -4,6 +4,7 @@ import { ConfigViewer } from "@/components/ConfigViewer";
 import { Tab, Tabs } from "@/components/Tabs";
 import { Config } from "@/lib/api";
 
+import { ExploreNamedMettaGridConfigs } from "./ExploreNamedMettaGridConfigs";
 import { ExploreSimulations } from "./ExploreSimulations";
 import { MapSection } from "./MapSection";
 import { RunToolSection } from "./RunToolSection";
@@ -18,6 +19,18 @@ export const ConfigViewScreen: FC<{ cfg: Config }> = ({ cfg }) => {
       content: (
         <div className="pt-4">
           <ExploreSimulations cfg={cfg} />
+        </div>
+      ),
+    });
+  }
+
+  if (cfg.maker.kind === "Dict[str, MettaGridConfig]") {
+    tabs.push({
+      id: "explore",
+      label: "Explore",
+      content: (
+        <div className="pt-4">
+          <ExploreNamedMettaGridConfigs cfg={cfg} />
         </div>
       ),
     });

--- a/gridworks/src/app/configs/view/[name]/ExploreNamedMettaGridConfigs.tsx
+++ b/gridworks/src/app/configs/view/[name]/ExploreNamedMettaGridConfigs.tsx
@@ -1,0 +1,82 @@
+"use client";
+import clsx from "clsx";
+import { FC, useMemo, useState } from "react";
+import z from "zod/v4";
+
+import { ConfigViewer } from "@/components/ConfigViewer";
+import { Tabs } from "@/components/Tabs";
+import { Config } from "@/lib/api";
+
+import { MapSection } from "./MapSection";
+
+const namedMettaGridConfigsSchema = z.record(z.string(), z.unknown());
+
+export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
+  const [selectedConfig, setSelectedConfig] = useState<string | null>(null);
+
+  const selectedSimulationConfig = useMemo(() => {
+    return selectedConfig
+      ? namedMettaGridConfigsSchema.parse(cfg.config.value)[selectedConfig]
+      : null;
+  }, [cfg.config.value, selectedConfig]);
+
+  const namedMettaGridConfigs = namedMettaGridConfigsSchema.parse(
+    cfg.config.value
+  );
+
+  return (
+    <div className="flex gap-8">
+      <div>
+        <h2 className="mb-2 ml-4 font-semibold">Simulations</h2>
+        <div className="flex flex-col">
+          {Object.keys(namedMettaGridConfigs).map((name) => (
+            <div
+              key={name}
+              className={clsx(
+                "cursor-pointer rounded-md px-4 py-1 text-sm",
+                selectedConfig === name ? "bg-blue-200" : "hover:bg-blue-100"
+              )}
+              onClick={() => setSelectedConfig(name)}
+            >
+              {name}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex-1">
+        {selectedConfig && selectedSimulationConfig ? (
+          <Tabs
+            topPadding
+            tabs={[
+              {
+                id: "map",
+                label: "Map",
+                content: (
+                  <MapSection
+                    key={selectedConfig}
+                    cfg={cfg}
+                    name={selectedConfig!}
+                  />
+                ),
+              },
+              {
+                id: "config",
+                label: "Config",
+                content: (
+                  <ConfigViewer
+                    key={selectedConfig}
+                    value={selectedSimulationConfig}
+                  />
+                ),
+              },
+            ]}
+          ></Tabs>
+        ) : (
+          <div className="pt-4 text-center text-gray-500">
+            No config selected
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/gridworks/src/app/configs/view/[name]/ExploreNamedMettaGridConfigs.tsx
+++ b/gridworks/src/app/configs/view/[name]/ExploreNamedMettaGridConfigs.tsx
@@ -12,13 +12,13 @@ import { MapSection } from "./MapSection";
 const namedMettaGridConfigsSchema = z.record(z.string(), z.unknown());
 
 export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
-  const [selectedConfig, setSelectedConfig] = useState<string | null>(null);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
 
-  const selectedSimulationConfig = useMemo(() => {
-    return selectedConfig
-      ? namedMettaGridConfigsSchema.parse(cfg.config.value)[selectedConfig]
+  const selectedConfig = useMemo(() => {
+    return selectedName
+      ? namedMettaGridConfigsSchema.parse(cfg.config.value)[selectedName]
       : null;
-  }, [cfg.config.value, selectedConfig]);
+  }, [cfg.config.value, selectedName]);
 
   const namedMettaGridConfigs = namedMettaGridConfigsSchema.parse(
     cfg.config.value
@@ -27,16 +27,16 @@ export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
   return (
     <div className="flex gap-8">
       <div>
-        <h2 className="mb-2 ml-4 font-semibold">Simulations</h2>
+        <h2 className="mb-2 ml-4 font-semibold">Configs</h2>
         <div className="flex flex-col">
           {Object.keys(namedMettaGridConfigs).map((name) => (
             <div
               key={name}
               className={clsx(
                 "cursor-pointer rounded-md px-4 py-1 text-sm",
-                selectedConfig === name ? "bg-blue-200" : "hover:bg-blue-100"
+                name === selectedName ? "bg-blue-200" : "hover:bg-blue-100"
               )}
-              onClick={() => setSelectedConfig(name)}
+              onClick={() => setSelectedName(name)}
             >
               {name}
             </div>
@@ -44,7 +44,7 @@ export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
         </div>
       </div>
       <div className="flex-1">
-        {selectedConfig && selectedSimulationConfig ? (
+        {selectedName && selectedConfig ? (
           <Tabs
             topPadding
             tabs={[
@@ -53,9 +53,9 @@ export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
                 label: "Map",
                 content: (
                   <MapSection
-                    key={selectedConfig}
+                    key={selectedName}
                     cfg={cfg}
-                    name={selectedConfig!}
+                    name={selectedName!}
                   />
                 ),
               },
@@ -64,8 +64,9 @@ export const ExploreNamedMettaGridConfigs: FC<{ cfg: Config }> = ({ cfg }) => {
                 label: "Config",
                 content: (
                   <ConfigViewer
-                    key={selectedConfig}
-                    value={selectedSimulationConfig}
+                    key={selectedName}
+                    value={selectedConfig}
+                    kind="MettaGridConfig"
                   />
                 ),
               },

--- a/gridworks/src/components/ConfigViewer/schema.ts
+++ b/gridworks/src/components/ConfigViewer/schema.ts
@@ -34,6 +34,13 @@ function parseKind(kind: string): JsonSchema {
   if (listMatch) {
     return { type: "array", items: parseKind(listMatch[1]) };
   }
+  const dictMatch = kind.match(/^Dict\[str, (\w+)\]$/);
+  if (dictMatch) {
+    return {
+      type: "object",
+      additionalProperties: parseKind(dictMatch[1]),
+    };
+  }
   return { $ref: "#/$defs/" + kind };
 }
 

--- a/gridworks/src/lib/draw/Drawer.ts
+++ b/gridworks/src/lib/draw/Drawer.ts
@@ -1,4 +1,4 @@
-import { loadMettaTileSets } from "./mettaTileSets";
+import { loadMettaTileSets, TILE_NAMES } from "./mettaTileSets";
 import { TileSetCollection } from "./TileSetCollection";
 
 // based on mettascope's colorFromId
@@ -20,31 +20,9 @@ type ObjectDrawer = ObjectLayer[];
 
 const objectDrawers: Record<string, ObjectDrawer> = {
   empty: [],
-  wall: [{ tile: "wall" }],
-  block: [{ tile: "block" }],
-  altar: [{ tile: "altar" }],
-  armory: [{ tile: "armory" }],
-  factory: [{ tile: "factory" }],
-  charger: [{ tile: "charger" }],
-  lab: [{ tile: "lab" }],
-  lasery: [{ tile: "lasery" }],
-  temple: [{ tile: "temple" }],
-  mine_red: [{ tile: "mine_red" }],
-  mine_blue: [{ tile: "mine_blue" }],
-  mine_green: [{ tile: "mine_green" }],
-  generator_red: [{ tile: "generator_red" }],
-  generator_blue: [{ tile: "generator_blue" }],
-  generator_green: [{ tile: "generator_green" }],
-  carbon_extractor: [{ tile: "carbon_extractor" }],
-  oxygen_extractor: [{ tile: "oxygen_extractor" }],
-  germanium_extractor: [{ tile: "germanium_extractor" }],
-  silicon_extractor: [{ tile: "silicon_extractor" }],
-  chest: [{ tile: "block" }], // TODO: create chest.png asset
-  // depleted variants reuse base extractor tiles for now
-  carbon_ex_dep: [{ tile: "carbon_ex_dep" }],
-  oxygen_ex_dep: [{ tile: "oxygen_ex_dep" }],
-  germanium_ex_dep: [{ tile: "germanium_ex_dep" }],
-  silicon_ex_dep: [{ tile: "silicon_ex_dep" }],
+  ...Object.fromEntries(
+    TILE_NAMES.map((tile) => [tile, [{ tile }] as ObjectDrawer])
+  ),
   "agent.agent": [{ tile: "agent" }],
   "agent.team_1": [{ tile: "agent", modulate: colorFromId(0) }],
   "agent.team_2": [{ tile: "agent", modulate: colorFromId(1) }],

--- a/gridworks/src/lib/draw/mettaTileSets.ts
+++ b/gridworks/src/lib/draw/mettaTileSets.ts
@@ -1,7 +1,7 @@
 import { TileSet, TileSetSource } from "./TileSet";
 import { TileSetCollection } from "./TileSetCollection";
 
-const sources = [
+export const TILE_NAMES = [
   "altar",
   "armory",
   "factory",
@@ -18,17 +18,29 @@ const sources = [
   "oxygen_extractor",
   "germanium_extractor",
   "silicon_extractor",
+  "clipped_carbon_extractor",
+  "clipped_oxygen_extractor",
+  "clipped_germanium_extractor",
+  "clipped_silicon_extractor",
   "oxygen_ex_dep",
   "carbon_ex_dep",
   "germanium_ex_dep",
   "silicon_ex_dep",
+  "assembler",
+  "chest",
+  "chest_carbon",
+  "chest_oxygen",
+  "chest_germanium",
+  "chest_silicon",
   "lab",
   "lasery",
   "temple",
   "wall",
   "block",
-  "agent",
-].map(
+  // doesn't include "agent", it's special
+];
+
+const sources = [...TILE_NAMES, "agent"].map(
   (name) =>
     ({
       src: `/mettascope-assets/objects/${name}.png`,

--- a/metta/gridworks/common.py
+++ b/metta/gridworks/common.py
@@ -7,7 +7,7 @@ class ErrorResult(TypedDict):
     error: str
 
 
-def dump_config_with_implicit_info(config: Config | list[Config]) -> dict:
+def dump_config_with_implicit_info(config: Config | list[Config] | dict[str, Config]) -> dict:
     fields_unset: list[str] = []
 
     def traverse(obj: Config, prefix: str = ""):
@@ -27,6 +27,9 @@ def dump_config_with_implicit_info(config: Config | list[Config]) -> dict:
     if isinstance(config, list):
         for item in config:
             traverse(item)
+    elif isinstance(config, dict):
+        for key, value in config.items():
+            traverse(value, key)
     else:
         traverse(config)
 

--- a/metta/gridworks/configs/registry.py
+++ b/metta/gridworks/configs/registry.py
@@ -151,8 +151,6 @@ class ConfigMakerRegistry:
                 assert hover_result is not None
 
                 return_type = hover_value_to_return_type(hover_result["contents"]["value"])
-                if "scenarios" in str(file_path):
-                    logger.warning(return_type)
 
                 validated_return_type = check_return_type(return_type)
                 if not validated_return_type:

--- a/metta/gridworks/configs/registry.py
+++ b/metta/gridworks/configs/registry.py
@@ -19,6 +19,7 @@ ConfigMakerKind = Literal[
     "MettaGridConfig",
     "SimulationConfig",
     "List[SimulationConfig]",
+    "Dict[str, MettaGridConfig]",
     "TrainTool",
     "PlayTool",
     "ReplayTool",
@@ -29,7 +30,7 @@ ConfigMakerKind = Literal[
 
 def hover_value_to_return_type(hover_value: str) -> str:
     post_arrow = hover_value.split(" -> ")[1]
-    match = re.match(r"^[\w\[\]]+", post_arrow)
+    match = re.match(r"([lL]ist\[\w+\]|[dD]ict\[\w+, \w+\]|\w+)", post_arrow)
     if match:
         return match.group(0)
     else:
@@ -39,6 +40,7 @@ def hover_value_to_return_type(hover_value: str) -> str:
 def check_return_type(return_type: str) -> ConfigMakerKind | None:
     # normalize
     return_type = re.sub(r"\blist\b", "List", return_type)
+    return_type = re.sub(r"\bdict\b", "Dict", return_type)
     if return_type in get_args(ConfigMakerKind):
         return cast(ConfigMakerKind, return_type)
 
@@ -86,29 +88,30 @@ class ConfigMaker:
 class ConfigMakerRegistry:
     """Registry of all config makers."""
 
-    def __init__(self, root_dir: Path | None = None):
-        if not root_dir:
+    def __init__(self, root_dirs: list[Path] | None = None):
+        if not root_dirs:
             repo_root = get_repo_root()
-            root_dir = repo_root / "experiments"
+            root_dirs = [repo_root / "experiments"]
         else:
-            root_dir = root_dir.resolve()
+            root_dirs = [root_dir.resolve() for root_dir in root_dirs]
 
         self.lsp_client = LSPClient()
 
         # Load all config makers
         # TODO - implement reloading (full and maybe incremental based on file modification time)
         config_makers: list[ConfigMaker] = []
-        for py_file in root_dir.rglob("*.py"):
-            if py_file.name == "__init__.py":
-                continue
+        for root_dir in root_dirs:
+            for py_file in root_dir.rglob("*.py"):
+                if py_file.name == "__init__.py":
+                    continue
 
-            try:
-                file_config_makers = self.load_file_config_makers(py_file)
-                config_makers.extend(file_config_makers)
-            except Exception as e:
-                logger.info(f"Error getting config makers from {py_file}: {e}")
-                # Skip files that can't be parsed or processed
-                continue
+                try:
+                    file_config_makers = self.load_file_config_makers(py_file)
+                    config_makers.extend(file_config_makers)
+                except Exception as e:
+                    logger.info(f"Error getting config makers from {py_file}: {e}")
+                    # Skip files that can't be parsed or processed
+                    continue
 
         self._config_makers = config_makers
         self._config_makers_index = {maker.path(): maker for maker in config_makers}
@@ -123,7 +126,7 @@ class ConfigMakerRegistry:
                 # Top-level function
                 function_defs.append(node)
 
-        logging.debug(f"Found {len(function_defs)} function definitions in {file_path}")
+        logging.info(f"Found {len(function_defs)} function definitions in {file_path}")
 
         # TODO - what if the code changes between `ast.parse` and `get_hover_bulk`?
         # Should we pre-open the file with LSP during loading?
@@ -134,17 +137,22 @@ class ConfigMakerRegistry:
             # an individual node; if this becomes too fragile, we'll need either a third-party library, or regexes).
             [(node.lineno - 1, node.col_offset + 4) for node in function_defs],
         )
-        logging.debug(f"Found {len(hover_results)} hover results in {file_path}")
+        logging.info(f"Found {len(hover_results)} hover results in {file_path}")
 
         for node, hover_result in zip(function_defs, hover_results, strict=True):
             # Create full module path
             rel_file_path = file_path.relative_to(get_repo_root())
             module_path = str(rel_file_path.with_suffix("")).replace("/", ".")
             full_path = f"{module_path}.{node.name}"
+            if full_path.startswith("packages.cogames.src."):
+                full_path = full_path.replace("packages.cogames.src.", "")
 
             try:
                 assert hover_result is not None
+
                 return_type = hover_value_to_return_type(hover_result["contents"]["value"])
+                if "scenarios" in str(file_path):
+                    logger.warning(return_type)
 
                 validated_return_type = check_return_type(return_type)
                 if not validated_return_type:

--- a/metta/gridworks/routes/configs.py
+++ b/metta/gridworks/routes/configs.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import APIRouter, HTTPException
 
 from metta.cogworks.curriculum.curriculum import CurriculumConfig
+from metta.common.util.fs import get_repo_root
 from metta.gridworks.common import ErrorResult, dump_config_with_implicit_info
 from metta.gridworks.configs.registry import ConfigMaker, ConfigMakerKind, ConfigMakerRegistry
 from metta.sim.simulation_config import SimulationConfig
@@ -21,7 +22,13 @@ logger = logging.getLogger(__name__)
 def make_configs_router() -> APIRouter:
     router = APIRouter(prefix="/configs", tags=["configs"])
 
-    registry = ConfigMakerRegistry()
+    repo_root = get_repo_root()
+    registry = ConfigMakerRegistry(
+        root_dirs=[
+            repo_root / "experiments",
+            repo_root / "packages/cogames/src/cogames",
+        ]
+    )
 
     def get_config_maker_or_404(path: str) -> ConfigMaker:
         cfg = registry.get_by_path(path)
@@ -45,21 +52,23 @@ def make_configs_router() -> APIRouter:
             status_code=400, detail=f"Config of type {type(cfg)} can't be converted to a MapBuilderConfig"
         )
 
-    def config_to_map_builder_by_name(cfg: Config | list[Config], name: str) -> AnyMapBuilderConfig:
+    def config_to_map_builder_by_name(cfg: Config | list[Config] | dict[str, Config], name: str) -> AnyMapBuilderConfig:
         if isinstance(cfg, EvaluateTool):
             return config_to_map_builder_by_name(list(cfg.simulations), name)
 
         if isinstance(cfg, ReplayTool) or isinstance(cfg, PlayTool):
             return config_to_map_builder_by_name(cfg.sim, name)
 
-        if not isinstance(cfg, list):
+        if isinstance(cfg, list):
+            for c in cfg:
+                if not isinstance(c, SimulationConfig):
+                    raise HTTPException(status_code=400, detail="Config must be a list[SimulationConfig]")
+                if c.name == name:
+                    return config_to_map_builder(c)
+        elif isinstance(cfg, dict) and name in cfg:
+            return config_to_map_builder(cfg[name])
+        else:
             raise HTTPException(status_code=400, detail="Config must be a list")
-
-        for c in cfg:
-            if not isinstance(c, SimulationConfig):
-                raise HTTPException(status_code=400, detail="Config must be a list[SimulationConfig]")
-            if c.name == name:
-                return config_to_map_builder(c)
 
         raise HTTPException(status_code=404, detail=f"Config of type {type(cfg)} doesn't have map for name {name}")
 

--- a/tests/gridworks/configs/test_registry.py
+++ b/tests/gridworks/configs/test_registry.py
@@ -4,6 +4,6 @@ from metta.gridworks.configs.registry import ConfigMakerRegistry
 
 
 def test_registry():
-    registry = ConfigMakerRegistry(root_dir=Path("tests/gridworks/configs/fixtures"))
+    registry = ConfigMakerRegistry(root_dirs=[Path("tests/gridworks/configs/fixtures")])
 
     assert registry.size() > 0


### PR DESCRIPTION
Gridworks now scans `cogames` package and supports `Dict[str, MettaGridConfig]` config makers:

![Screenshot 2025-10-06 at 1.01.07 AM.png](https://app.graphite.dev/user-attachments/assets/ce242569-f7b7-43d5-b12d-895d7af0fa0c.png)

In addition, I cleaned up the tiles code to support all new cogames tiles.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211556897327739)