### PR TITLE
Assume bencher exists for upload-benchmarks github workflow

### DIFF
--- a/.github/workflows/coverage-benchmarks.yml
+++ b/.github/workflows/coverage-benchmarks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/coverage-benchmarks.yml
+++ b/.github/workflows/coverage-benchmarks.yml
@@ -250,7 +250,6 @@ jobs:
           fi
 
       - name: Check for significant performance changes
-        if: secrets.BENCHER_API_TOKEN != ''
         uses: ./.github/actions/call-bencher-api
         with:
           bencher_token: ${{ secrets.BENCHER_API_TOKEN }}


### PR DESCRIPTION
To fix our code coverage github workflow. And allow it to be run manually, not just on merge-to-main

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211569670681412)