### PR TITLE
Increase aws integration token lifetime for spacelift integration

### DIFF
--- a/devops/tf/spacelift/aws.tf
+++ b/devops/tf/spacelift/aws.tf
@@ -45,8 +45,9 @@ resource "aws_iam_role_policy_attachment" "spacelift_poweruser" {
 # Register the integration with Spacelift
 # (Will be available at https://metta-ai.app.spacelift.io/cloud-integrations)
 resource "spacelift_aws_integration" "softmax" {
-  name     = local.aws_integration_name
-  role_arn = aws_iam_role.spacelift.arn
+  name             = local.aws_integration_name
+  role_arn         = aws_iam_role.spacelift.arn
+  duration_seconds = 3600 # default is 15 min, which is too short for some resources, for example RDS databases
 }
 
 import {


### PR DESCRIPTION
Spacelift itself would default to one hour, but turns out [Spacelift provider](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/aws_integration) defaults to 15 min, which caused issues with creating postgres databases: spacelift started to terraform them, succeeded, then immediately timeouted.

On retry, it marked the database as tainted, and restarted again, indefinitely.

I already updated this in spacelift settings (this stack is just to avoid configuring some spacelift settings through its web UI), so, not urgent.

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211572188751287)