### PR TITLE
fix: rm reference to removed action

### DIFF
--- a/packages/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
+++ b/packages/mettagrid/benchmarks/test_mettagrid_env_benchmark.cpp
@@ -55,7 +55,6 @@ GameConfig CreateBenchmarkConfig(size_t num_agents) {
   actions_cfg.push_back({"swap", action_cfg});
   actions_cfg.push_back({"put_items", action_cfg});
   actions_cfg.push_back({"get_items", action_cfg});
-  actions_cfg.push_back({"change_color", action_cfg});
   actions_cfg.push_back({"change_glyph", change_glyph_cfg});
 
   std::map<std::string, std::shared_ptr<GridObjectConfig>> objects_cfg;


### PR DESCRIPTION
we removed `change_color` but did not update the mettagrid benchmark

[Asana Task](https://app.asana.com/1/1209016784099267/project/1210348820405981/task/1211572313329377)